### PR TITLE
docs: improve workflow and intercom guides

### DIFF
--- a/packages/coding-agent/docs/docs.json
+++ b/packages/coding-agent/docs/docs.json
@@ -32,6 +32,7 @@
           "extensions",
           "skills",
           "subagents",
+          "intercom",
           "workflows",
           "prompt-templates",
           "themes",

--- a/packages/coding-agent/docs/intercom.md
+++ b/packages/coding-agent/docs/intercom.md
@@ -1,0 +1,477 @@
+---
+title: "Intercom"
+description: "Direct messaging between Atomic sessions on the same machine"
+---
+
+> Atomic sessions can talk to each other. Press ALT+M to message another session, or ask the agent to coordinate with a peer.
+
+# Intercom
+
+Atomic bundles `@bastani/intercom`, a first-party extension for direct 1:1 messaging between Atomic sessions on the same machine. Send context, findings, or requests from one session to another — whether you're driving the conversation or letting agents coordinate. Connections are lazy and tool-driven: the extension registers its commands and tools at startup, but a session does not connect until you or the model actually invoke Intercom. No separate install is needed.
+
+**Key capabilities:**
+- **Session messaging** - `send`, `ask` (blocking, 10-minute timeout), `reply`, `pending`, `list`, and `status` via the `intercom` tool
+- **Session discovery** - List connected sessions with name, short ID, working directory, model, and live status
+- **Keyboard overlay** - ALT+M or `/intercom` opens a session picker and compose overlay
+- **Attachments** - Share `file`, `snippet`, and `context` payloads between sessions
+- **Subagent escalation** - Delegated children get a `contact_supervisor` tool for decisions, structured interviews, and progress updates
+- **Run notifications** - Workflows and subagents deliver async results and control notices to a parent session over Intercom
+- **Bundled skill** - `/skill:intercom` provides planner-worker and escalation-handling patterns
+
+**Example use cases:**
+- Planner–worker splits across two terminals
+- Research → implementation context handoffs
+- Supervisor decisions and structured interviews for delegated subagents
+- Async workflow/subagent completion and needs-attention notices
+- Pair debugging between sessions
+
+## Table of Contents
+
+- [Quick Start](#quick-start)
+  - [From the Keyboard](#from-the-keyboard)
+  - [From the Agent](#from-the-agent)
+  - [Receiving Messages](#receiving-messages)
+- [How Connection Works](#how-connection-works)
+- [The intercom Tool](#the-intercom-tool)
+  - [Actions](#actions)
+  - [Targeting Sessions](#targeting-sessions)
+  - [send vs ask vs reply](#send-vs-ask-vs-reply)
+  - [Attachments](#attachments)
+- [Coordination Patterns](#coordination-patterns)
+- [Subagent Escalation: contact_supervisor](#subagent-escalation-contact_supervisor)
+  - [When the Tool Appears](#when-the-tool-appears)
+  - [The Three Reasons](#the-three-reasons)
+  - [What the Supervisor Sees](#what-the-supervisor-sees)
+  - [Structured Interview Replies](#structured-interview-replies)
+- [Workflow and Subagent Notifications](#workflow-and-subagent-notifications)
+  - [Workflow Delivery Modes](#workflow-delivery-modes)
+  - [Subagent Control Notices](#subagent-control-notices)
+  - [Delivery Ordering](#delivery-ordering)
+- [Configuration](#configuration)
+- [Keyboard Shortcuts](#keyboard-shortcuts)
+- [How It Works](#how-it-works)
+- [Intercom vs Shared-Room Messengers](#intercom-vs-shared-room-messengers)
+- [Limitations](#limitations)
+- [Related Docs](#related-docs)
+
+## Quick Start
+
+### From the Keyboard
+
+Press **ALT+M** or run `/intercom` to open the session list overlay:
+
+1. **Select a session** — Use arrow keys to pick a target session
+2. **Compose message** — Write your message in the compose overlay
+3. **Send** — Enter Send · Escape Cancel
+
+Sent messages are recorded in session history and confirmed with a notification.
+
+### From the Agent
+
+The agent can list sessions and send messages using the `intercom` tool. Tool calls and results render as compact transcript rows so send/ask/reply flows are easy to scan:
+
+```typescript
+// List active sessions
+intercom({ action: "list" })
+// → **Current session:**
+// → • executor (20d43841) — ~/projects/api (claude-sonnet-4) [self, idle]
+// → **Other sessions:**
+// → • research (6332faab) — ~/projects/api (claude-sonnet-4) [same cwd, thinking]
+
+// Send a message
+intercom({ action: "send", to: "research", message: "Check if UserService.validate() handles null" })
+// → Message sent to research
+
+// The short ID printed by list is also a valid target
+intercom({ action: "ask", to: "6332faab", message: "Which validation path should I use?" })
+
+// Check connection status
+intercom({ action: "status" })
+// → Connected: Yes, Session ID: abc123, Active sessions: 3
+
+// Send with attachments (code snippets, files, or context)
+intercom({
+  action: "send",
+  to: "worker",
+  message: "Here's the fix:",
+  attachments: [{
+    type: "snippet",
+    name: "auth.ts",
+    language: "typescript",
+    content: "function validate(user: User) { ... }"
+  }]
+})
+```
+
+### Receiving Messages
+
+When a message arrives, it appears inline in your chat with the sender's info and a reply hint:
+
+```
+**From research** (~/projects/api)
+
+To reply, use the intercom tool: intercom({ action: "reply", message: "..." })
+
+Found the issue — UserService.validate() doesn't check for null input.
+See auth.ts:142-156.
+```
+
+The reply hint (enabled by default) points to `intercom({ action: "reply", ... })`, so recipients never need raw sender or `replyTo` IDs. Idle recipients get a new turn immediately; busy interactive recipients receive the message once they go idle. Attachment content is included in the agent-visible body, and messages are rendered inline and stored in Atomic session history.
+
+## How Connection Works
+
+Intercom connections are tool-driven. Sessions keep the lightweight wrapper unloaded until the model or user invokes an Intercom tool, `/intercom`, or the ALT+M overlay. Merely launching a foreground or background delegated child does not connect either session. Concurrent first-use callers share one import and connection attempt, and lazy broker state is leased to the active session generation and cleaned up on shutdown or replacement.
+
+A session becomes intercom-connected when all of these are true:
+
+- the intercom extension is loaded in that session
+- `enabled` is not set to `false` in `~/.atomic/agent/intercom/config.json` (or the legacy `~/.pi/agent/intercom/config.json` fallback)
+- the model or user has invoked an Intercom tool, `/intercom`, or the ALT+M overlay in that session
+- the local broker is running or can be auto-started
+
+The session list only shows intercom-connected sessions, not every open Atomic process on the machine.
+
+Name sessions with `/name` so they can target each other (for example `/name planner` and `/name worker`). If a session is unnamed, Intercom exposes a runtime-only fallback alias like `subagent-chat-1a2b3c4d` so other sessions can still target it. That alias is not persisted as the session title, so resume pickers keep showing the transcript snippet instead of a generic name.
+
+## The intercom Tool
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `action` | string | `"list"`, `"send"`, `"ask"`, `"reply"`, `"pending"`, or `"status"` |
+| `to` | string | Exact session name, exact full ID, or unique ID prefix (for send/ask, or to disambiguate reply) |
+| `message` | string | Message text (for send/ask/reply) |
+| `attachments` | array | Optional `file`, `snippet`, or `context` attachments |
+| `replyTo` | string | Optional message ID for threading or replying to an `ask` |
+
+### Actions
+
+| Action | Behavior |
+|--------|----------|
+| `list` | Returns the current session plus other active intercom-connected sessions with name, short ID, working directory, model, and live status (`idle`, `thinking`, or `tool:<name>`, derived from lifecycle events). Every displayed short ID is a valid target. |
+| `send` | Fire-and-forget delivery. Requires `to` and `message`; returns delivery confirmation or the delivery-failure reason. Cannot message the current session. |
+| `ask` | Sends a message and blocks until the recipient replies (10-minute timeout). The reply is returned as the tool result, so the agent continues in the same turn. |
+| `reply` | Replies to the intercom-triggered message of the current turn; otherwise falls back to the single unresolved inbound ask. With multiple pending asks, pass `to` or inspect with `pending` first. |
+| `pending` | Lists unresolved inbound asks with sender, message ID, elapsed time, and a short preview. |
+| `status` | Shows connection status, session ID, and the total count of active sessions. |
+
+Sent and received messages are recorded in session history as `intercom_sent` / `intercom_received` entries.
+
+### Targeting Sessions
+
+Target lookup resolves an exact full ID first, then an exact case-insensitive name, then a unique session-ID prefix. If a prefix matches multiple sessions, Intercom reports every match and asks for a longer ID or exact name instead of guessing. Resolving a prefix to the current session triggers the normal self-target rejection ("Cannot message the current session").
+
+### send vs ask vs reply
+
+**`send`** is fire-and-forget — the tool returns immediately after delivery. By default it sends immediately, including in interactive sessions. If you want an approval dialog before non-reply sends, set `confirmSend: true` in config; replies that include `replyTo` still skip confirmation so reply-hint flows continue without an extra approval step.
+
+**`ask`** sends the message and blocks until the recipient responds (10-minute timeout). The reply comes back as the tool result, so the agent continues in the same turn with full context. No confirmation dialog — if you're asking and waiting, the intent is clear. Only one pending `ask` is allowed per session at a time; if several blocking requests race (parallel `ask` calls, or `ask` alongside `contact_supervisor`), one wins the reservation and each other call returns a normal "Already waiting for a reply" tool error without disturbing the pending ask.
+
+**`reply`** is receiver-side sugar for replying to an inbound ask. In the turn triggered by an incoming intercom message, `intercom({ action: "reply", message: "..." })` targets that exact sender and message automatically. If you reply later, it falls back to the single unresolved inbound ask; with multiple pending asks, use `pending` to inspect them and pass `to` to disambiguate. Under the hood this is still a normal `send` with the exact `replyTo` value.
+
+### Attachments
+
+`send`, `ask`, and `reply` accept an `attachments` array of `{ type, name, content, language? }` objects where `type` is `"file"`, `"snippet"`, or `"context"`. Attachment content is included in the recipient's agent-visible message body. Attachments are supported in the protocol but not in the ALT+M compose overlay.
+
+## Coordination Patterns
+
+The most natural use of Intercom is splitting a task between two sessions — one holds the big picture, the other does the hands-on work. Open two terminals, start Atomic in each, and name them so they can find each other:
+
+```
+# Terminal 1                    # Terminal 2
+/name planner                   /name worker
+```
+
+Verify they see each other with `intercom({ action: "list" })`, then coordinate:
+
+```typescript
+// Planner delegates with send (fire-and-forget)
+intercom({
+  action: "send",
+  to: "worker",
+  message: "Task-3: Add retry logic to API client. Key files: src/api/client.ts, src/api/types.ts. Ask if anything's unclear."
+})
+
+// Worker hits an ambiguity — asks and waits
+intercom({
+  action: "ask",
+  to: "planner",
+  message: "Should retry apply to all endpoints or just idempotent ones? Also, max retry count and backoff strategy?"
+})
+// → Reply from planner: Only GET/PUT/DELETE — never POST. Max 3 retries, exponential backoff starting at 100ms.
+// Worker continues implementing with the answer, same turn, full context.
+```
+
+| Pattern | Action | Why |
+|---------|--------|-----|
+| **Task delegation** | Planner uses `send` | Fire-and-forget. Planner doesn't need to wait for an ack. |
+| **Clarification request** | Worker uses `ask` | Worker needs the answer to proceed. Blocks until reply. |
+| **Discovery escalation** | Worker uses `ask` | Worker needs approval before changing course. |
+| **Completion report** | Worker uses `ask` | Planner might have follow-up instructions or the next task. |
+
+The bundled `intercom` skill (`/skill:intercom`) has copy-paste ready patterns for planner-worker delegation, status checks, natural replies, broadcasting to multiple workers, attachments, and handling subagent escalations on the orchestrator side.
+
+**Recommended:** Add this snippet to your project's `AGENTS.md` to help agents understand when to coordinate across sessions:
+
+```xml
+<intercom>
+Coordinate with other local Atomic sessions on related codebases. Use `/skill:intercom` for patterns.
+
+**When:** Same codebase (parallel work), reference codebase (consulting patterns), related repos (shared libraries).
+
+**Not when:** Unrelated codebases, trivial questions, or when you can proceed independently.
+
+**Principle:** Prefer `send` for notifications; `ask` only when blocked waiting for input.
+</intercom>
+```
+
+## Subagent Escalation: contact_supervisor
+
+When Atomic's [subagent runtime](/subagents) spawns a delegated child with bridge metadata, the child session gets a subagent-only `contact_supervisor` tool in addition to the regular `intercom` tool. Normal sessions never see `contact_supervisor`.
+
+### When the Tool Appears
+
+`contact_supervisor` only registers when the subagent runtime sets all of these environment variables:
+
+- `ATOMIC_SUBAGENT_ORCHESTRATOR_TARGET` — the supervisor session name or ID
+- `ATOMIC_SUBAGENT_RUN_ID` — the run identifier
+- `ATOMIC_SUBAGENT_CHILD_AGENT` — the agent type
+- `ATOMIC_SUBAGENT_CHILD_INDEX` — the child index within the run
+
+Legacy `PI_SUBAGENT_*` bridge metadata remains compatible. The optional `ATOMIC_SUBAGENT_INTERCOM_SESSION_NAME` variable sets the delegated child's session name. If required variables are missing, the session falls back to the regular `intercom` tool.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `reason` | string | `"need_decision"` (blocking), `"interview_request"` (blocking structured questions), or `"progress_update"` (fire-and-forget) |
+| `message` | string | The decision request, optional interview note, or progress update |
+| `interview` | object | Required for `interview_request`: `{ title?, description?, questions: [...] }` |
+
+### The Three Reasons
+
+| Reason | Behavior | Use When |
+|--------|----------|----------|
+| `need_decision` | Sends a formatted ask to the supervisor and blocks until it replies (10-minute timeout) | The subagent is blocked, uncertain, needs approval, or faces a product/API/scope decision |
+| `interview_request` | Sends structured questions and blocks until the supervisor replies | The subagent needs multiple machine-readable answers from the supervisor in one exchange |
+| `progress_update` | Fire-and-forget update to the supervisor | Meaningful progress or unexpected discoveries that change the plan |
+
+Do not use `contact_supervisor` for routine completion handoffs — return the final subagent result normally. Blocking calls share the same single reply-waiter reservation as `ask`, with the same "Already waiting for a reply" semantics.
+
+```typescript
+// Blocked subagent asks for guidance
+contact_supervisor({
+  reason: "need_decision",
+  message: "The auth service returns 403 instead of 401 for expired tokens. Should I treat 403 as a re-auth trigger or a hard failure?"
+})
+// → Reply from supervisor: Treat 403 as re-auth trigger. Update the token refresh logic.
+
+// Fire-and-forget progress update
+contact_supervisor({
+  reason: "progress_update",
+  message: "Discovered the bug is in the retry wrapper, not the API client. Fixing the wrapper will also close issue #42."
+})
+// → Progress update sent to supervisor planner
+```
+
+### What the Supervisor Sees
+
+The supervisor receives a formatted message with run metadata:
+
+```
+**From subagent-worker-78f659a3-1**
+
+Subagent needs a supervisor decision.
+Run: 78f659a3
+Agent: worker
+Child index: 0
+
+Which API should I use?
+```
+
+Reply hints work the same as regular `intercom` ask/reply flows. The supervisor replies with `intercom({ action: "reply", message: "..." })` and the subagent receives the answer as the tool result.
+
+### Structured Interview Replies
+
+`interview_request` questions use the shape `{ id, type, question, options?, context? }` where `type` is `single`, `multi`, `text`, `image`, or `info` (`info` questions are context-only and need no response):
+
+```typescript
+contact_supervisor({
+  reason: "interview_request",
+  message: "Please answer these before I continue the migration.",
+  interview: {
+    title: "API migration choices",
+    questions: [
+      { id: "api", type: "single", question: "Which API should I target?", options: ["Stable API", "Experimental API"] },
+      { id: "constraints", type: "text", question: "What constraints should I preserve?" }
+    ]
+  }
+})
+```
+
+The supervisor message includes the structured questions plus a fenced JSON answer example using this stable shape:
+
+```json
+{
+  "responses": [
+    { "id": "api", "value": "Stable API" },
+    { "id": "constraints", "value": "Keep the public error shape unchanged." }
+  ]
+}
+```
+
+The supervisor can reply with plain JSON or a fenced `json` block. If the reply matches the `{ "responses": [...] }` shape and references valid question ids/options, the child tool result includes it in `details.structuredReply` while still showing the raw reply text; parse errors are surfaced in `details.structuredReplyParseError`.
+
+## Workflow and Subagent Notifications
+
+Intercom is also the delivery channel for async run results and control notices from [workflows](/workflows) and [subagents](/subagents).
+
+### Workflow Delivery Modes
+
+Programmatic `workflow()` calls accept an `intercom` option that controls how async direct-run results and control notices reach a parent session:
+
+```typescript
+workflow({
+  tasks: [{ agent: "worker", task: "..." }],
+  async: true,
+  intercom: { delivery: "result" },
+})
+```
+
+| Option | Values | Meaning |
+|--------|--------|---------|
+| `enabled` | boolean | `false` forces delivery off; `true` resolves to `control-and-result` |
+| `delivery` | `"off"` \| `"notify"` \| `"result"` \| `"control-and-result"` | Explicit delivery mode; wins over `enabled` |
+| `parentSession` | string | Target session for delivery; resolved from args or the Intercom port when omitted |
+| `notifyOn` | array | Control events to deliver: `"active_long_running"`, `"needs_attention"`, `"completed"`, `"failed"` |
+
+When neither `enabled` nor `delivery` is set, async direct `parallel`/`chain` runs default to `control-and-result` when Intercom is available; otherwise delivery is off. Treat Intercom payloads from async direct runs as user-visible workflow output.
+
+While a workflow stage generation is open, incoming Intercom messages are admitted through the stage session's native steering/follow-up queue; late messages surface once through the main-chat notification path.
+
+### Subagent Control Notices
+
+The `subagent` tool's `control` options select which control events notify the parent and over which channels:
+
+- **`notifyOn`** — defaults to `["active_long_running", "needs_attention"]`
+- **`notifyChannels`** — defaults to `["event", "async", "intercom"]` (all that are available)
+
+Async subagent result delivery over Intercom is confirmation-based and preserves a successful delivery phase across watcher replacement. Each delegated child gets a deterministic Intercom target derived from its run/agent/index identity, and run results report those targets ("Run intercom target" / "Previous intercom target"; targets may be inactive after completion). `subagent({ action: "doctor" })` reports Intercom bridge availability and whether Intercom is enabled in config.
+
+If live child-to-parent coordination is needed, invoke `intercom({ action: "status" })` in the parent before launching; the child connects on its first `contact_supervisor` or `intercom` call. Fresh child processes receive the bundled Intercom wrapper through normal package discovery unless an explicit `extensions` allowlist excludes it.
+
+### Delivery Ordering
+
+During a foreground subagent run, Atomic probes for the exact live foreground owner before delivery: the matching child reserves the request, accepts a generation-scoped detach commit, and acknowledges it before messages enter the parent's model-visible steering queue. Blocking calls stay alive until the exact threaded reply; cancellation or replacement invalidates stale handshakes.
+
+For delegated background children, queued messages and terminal lifecycle notices are ordered per child: pre-terminal messages are admitted FIFO and atomically together with the paused, completed, or failed notice, exact terminal-identity deduplication prevents double admission, failed dispatches remain retryable, and correlated ask replies bypass unrelated queued sends. See [Subagents](/subagents) for the full coordination contract.
+
+## Configuration
+
+Create `~/.atomic/agent/intercom/config.json`. The legacy `~/.pi/agent/intercom/config.json` fallback is read when the Atomic config is absent:
+
+```json
+{
+  "brokerCommand": "npx",
+  "brokerArgs": ["--no-install", "tsx"],
+  "confirmSend": false,
+  "enabled": true,
+  "replyHint": true,
+  "status": "researching"
+}
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `brokerCommand` | `"npx"` | Command used to start the local broker process; the default sentinel is hardened internally to avoid PATH lookup |
+| `brokerArgs` | `["--no-install", "tsx"]` | Arguments passed to `brokerCommand` before the broker script path |
+| `confirmSend` | `false` | Show a confirmation dialog before non-reply sends from an interactive session with UI |
+| `enabled` | `true` | Enable/disable intercom entirely |
+| `replyHint` | `true` | Include reply instruction in incoming messages |
+| `status` | — | Optional custom status suffix shown after the automatic lifecycle status, for example `thinking · researching` |
+
+The default `npx --no-install tsx` pair is a compatibility sentinel: Intercom recognizes it and starts the broker through the current Atomic runtime (`process.execPath`). Node-based installs use that runtime with a resolved `tsx` CLI, falling back to Atomic's bundled `jiti` loader when `tsx` is unavailable; Bun source-checkout runs use the current Bun executable directly; standalone Atomic binaries re-enter the split launcher through a narrow internal broker handoff. Default startup therefore does not rely on `npx`, `tsx`, or `bun` being on `PATH`. Explicit custom broker commands still work — for example, to intentionally use Bun from `PATH`:
+
+```json
+{
+  "brokerCommand": "bun",
+  "brokerArgs": []
+}
+```
+
+Config validation is strict: every field is checked, and if the file is not valid JSON or any field has an invalid value, the whole config is rejected — an error is logged and all defaults are used.
+
+Intercom publishes live session status automatically: sessions register as `idle`, switch to `thinking` while the agent is running, show `tool:<name>` during tool execution, and return to `idle` on completion. A configured `status` is appended as context instead of replacing the lifecycle status.
+
+## Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| ALT+M | Open session list overlay |
+| ↑/↓ | Navigate session list |
+| Enter | Select session / Send message |
+| Escape | Cancel / Close overlay |
+
+## How It Works
+
+```mermaid
+graph TB
+    subgraph A["Atomic Session A"]
+        A1[Intercom Client]
+        A2[intercom tool]
+        A3[UI overlays]
+    end
+
+    subgraph Broker["Intercom Broker"]
+        B1[Session Registry]
+        B2[Message Router]
+    end
+
+    subgraph B["Atomic Session B"]
+        B3[Intercom Client]
+        B4[intercom tool]
+        B5[UI overlays]
+    end
+
+    A1 <-->|Local Socket/Pipe| B1
+    B1 --- B2
+    B2 <-->|Local Socket/Pipe| B3
+```
+
+The broker is a standalone process that manages session registration and message routing. It auto-spawns when the first intercom-enabled session needs it and exits 5 seconds after the last connected session disconnects; clients reconnect automatically if the broker restarts. A spawn lock keyed by PID and timestamp prevents duplicate brokers when multiple sessions start at once.
+
+Transport is local IPC only — a Unix domain socket on macOS/Linux or a named pipe on Windows — using length-prefixed JSON (4-byte length + payload) with request correlation for session listing, explicit delivery failures, and validation of malformed or out-of-order messages. `ask` stays client-side: the broker routes plain messages, and the client waits for the matching reply before returning it as the tool result.
+
+Runtime files live under the active agent directory — `~/.atomic/agent/intercom/` by default, or below `ATOMIC_CODING_AGENT_DIR` when set (the legacy `PI_CODING_AGENT_DIR` alias is honored when the Atomic variable is unset):
+
+- `broker.sock` — Unix domain socket (macOS/Linux; Windows uses a named pipe instead)
+- `broker-launch.vbs` — Windows helper script to launch the broker without a console window
+- `broker.pid` — Broker process ID
+- `broker.spawn.lock` — Short-lived lock used to avoid duplicate auto-spawns
+- `config.json` — User configuration
+
+Async extension work (startup, inbound flushes, reconnects, overlays, and relays) no-ops if the session shuts down or reloads before it settles.
+
+## Intercom vs Shared-Room Messengers
+
+| Aspect | Intercom | Shared-room messengers |
+|--------|----------|------------------------|
+| **Model** | Direct 1:1 messaging | Shared chat room |
+| **Primary use** | User orchestrating sessions | Autonomous agent swarms |
+| **Discovery** | Broker-based (real-time) | File-based registry |
+| **Messages** | Private, session-to-session | Broadcast to all agents |
+| **Persistence** | In Atomic session history | Shared coordination files |
+
+Use a shared-room messenger for multi-agent swarms working on one shared task. Use Intercom when you want to manually coordinate your own sessions or have one agent reach out to another specific session.
+
+## Limitations
+
+- **Same machine only** — Uses local sockets/pipes, no network support
+- **No dedicated intercom log** — Messages are kept in session history; there is no separate intercom transcript or inbox
+- **No attachments UI** — `file`, `snippet`, and `context` attachments are supported in the protocol, but not in the compose overlay
+- **Only connected sessions appear** — The list shows sessions that have connected to the broker, not every open Atomic process
+- **Broker lifecycle** — The broker auto-spawns on first use and exits when idle; sessions reconnect automatically if it restarts
+
+## Related Docs
+
+- [Subagents](/subagents) for delegated child runs, foreground coordination, and result delivery.
+- [Workflows](/workflows) for multi-stage automation and async run notifications.
+- [Skills](/skills) for reusable instructions like `/skill:intercom`.
+- [Usage](/usage) for environment variables and the bundled-extension overview.

--- a/packages/coding-agent/docs/subagents.md
+++ b/packages/coding-agent/docs/subagents.md
@@ -37,7 +37,7 @@ Subagents now run and return their results directly. Atomic does not infer accep
 
 ## Foreground supervisor coordination
 
-When a foreground child sends `intercom.ask`, `intercom.send`, or `contact_supervisor` coordination, Atomic first probes for the exact foreground owner. Only an exact live child reserves the request; Atomic then sends a generation-scoped detach commit and waits for that child to acknowledge it before placing the message in the parent's model-visible steering queue. Unmatched and background-child messages retain the existing queued-until-idle behavior. Blocking `need_decision` and `interview_request` calls remain actionable through Intercom's pending/reply tracker, and the exact threaded reply resumes the retained child without delayed duplicate delivery.
+When a foreground child sends `intercom.ask`, `intercom.send`, or `contact_supervisor` coordination, Atomic first probes for the exact foreground owner. Only an exact live child reserves the request; Atomic then sends a generation-scoped detach commit and waits for that child to acknowledge it before placing the message in the parent's model-visible steering queue. Unmatched and background-child messages retain the existing queued-until-idle behavior. Blocking `need_decision` and `interview_request` calls remain actionable through [Intercom](/intercom)'s pending/reply tracker, and the exact threaded reply resumes the retained child without delayed duplicate delivery.
 
 Only the matching foreground child releases the parent `subagent` tool. It stays alive under the normal watchdog, cancellation, drain, and stdio cleanup lifecycle; its eventual completion replaces the detached placeholder. Fire-and-forget `intercom.send` and `progress_update` also release foreground supervision promptly, but do not create a reply waiter.
 
@@ -259,5 +259,6 @@ Because the effort travels with each model string, every primary and fallback ca
 ## Related docs
 
 - [Workflows](/workflows) for multi-stage reusable automation.
+- [Intercom](/intercom) for cross-session messaging and supervisor escalation.
 - [Skills](/skills) for reusable instructions invoked with `/skill:<name>`.
 - [Settings](/settings) for user and project configuration.

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -292,10 +292,10 @@ atomic --tools read,search,find,ls -p "Review the code"
 | `PI_CACHE_RETENTION` | Provider/upstream-specific prompt-cache retention knob; set to `long` where supported |
 | `VISUAL`, `EDITOR` | External editor for CTRL+G |
 
-`PI_*` aliases are also supported for app-specific `ATOMIC_*` variables for legacy compatibility. For example, intercom honors `PI_CODING_AGENT_DIR` when `ATOMIC_CODING_AGENT_DIR` is unset and still reads legacy `~/.pi/agent/intercom/config.json` when the Atomic config is absent. `PI_CACHE_RETENTION` is not one of those aliases and has no `ATOMIC_*` equivalent. Use `PI_CACHE_RETENTION=long` when configuring prompt-cache retention for providers/upstreams that support long-lived caches. Intercom's default broker starter works across Node-based installs, Bun source checkouts, and standalone Atomic binaries without requiring `npx`, `tsx`, or `bun` to be present on `PATH`; custom broker commands remain explicit opt-in overrides.
+`PI_*` aliases are also supported for app-specific `ATOMIC_*` variables for legacy compatibility. For example, [Intercom](/intercom) honors `PI_CODING_AGENT_DIR` when `ATOMIC_CODING_AGENT_DIR` is unset and still reads legacy `~/.pi/agent/intercom/config.json` when the Atomic config is absent. `PI_CACHE_RETENTION` is not one of those aliases and has no `ATOMIC_*` equivalent. Use `PI_CACHE_RETENTION=long` when configuring prompt-cache retention for providers/upstreams that support long-lived caches. Intercom's default broker starter works across Node-based installs, Bun source checkouts, and standalone Atomic binaries without requiring `npx`, `tsx`, or `bun` to be present on `PATH`; custom broker commands remain explicit opt-in overrides.
 
 ## Design Principles
 
-Atomic keeps the core CLI small, while this distribution bundles first-party package extensions for workflows, subagents, MCP, web access, and intercom. Other workflows can still be installed as extensions or packages, or handled externally with tools such as containers and tmux.
+Atomic keeps the core CLI small, while this distribution bundles first-party package extensions for workflows, subagents, MCP, web access, and [intercom](/intercom). Other workflows can still be installed as extensions or packages, or handled externally with tools such as containers and tmux.
 
 For the full rationale, read the [blog post](https://mariozechner.at/posts/2025-11-30-pi-coding-agent/).

--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -2,13 +2,9 @@
 
 # Workflows
 
-Workflows are how Atomic runs executable engineering loops: reusable multi-stage automation with tracked stages, parallel branches, artifacts, human input, live status, checkpoints, and resumable background execution.
+Atomic uses workflows to run executable engineering loops: reusable multi-stage automation with tracked stages, parallel branches, artifacts, human input, live status, checkpoints, and resumable background execution.
 
-Default to a workflow for non-trivial work and for requests with inherent structure plus a verifiable objective. That includes implementation, build, debugging, bug fixes, migrations, features, scoped multi-file edits, and docs/code changes where validation matters, as well as work with dependencies, handoffs, review gates, uncertainty, measurable done criteria, or evidence requirements. Direct chat remains appropriate for tiny, deterministic, low-risk answers or edits where tracking clearly adds more overhead than value.
-
-Workflow-first does not mean builtin-only or monolithic. Use named builtin, project, user, or package workflows when they fit; use direct `task`, `tasks`, and `chain` modes for simple one-off tracked shapes; and author a custom TypeScript `workflow({...})` inline with normal coding tools whenever the task needs richer branching, dynamic fan-out, artifacts, structured outputs, child workflows, human input, gates, retries, or loops. Workflow definitions are composable TypeScript modules: import reusable project/package workflows or builtins from `@bastani/workflows/builtin`, then nest them with `ctx.workflow(childDefinition, { inputs, stageName })`. Children may import further children up to `maxDepth`, and their stages, HIL prompts, controls, checkpoints, and declared outputs appear in the expanded parent graph. Atomic can write the definition, reload workflow resources, and run it for the current task.
-
-Loop or stop-condition phrasing is an especially strong workflow signal: `do X until Y`, `repeat until`, `iterate until`, `review/fix until passing`, `run checks and fix until green`, and `keep going until done` already define control flow and convergence criteria that should be tracked.
+Default to a workflow for non-trivial work with a verifiable objective — see [When to Use Workflows](#when-to-use-workflows) for the decision signals, execution shapes, and exceptions.
 
 **Key capabilities:**
 - **Tracked stages** - Name each step and inspect it in workflow status and graph views
@@ -16,6 +12,7 @@ Loop or stop-condition phrasing is an especially strong workflow signal: `do X u
 - **Context handoffs** - Pass summaries, artifacts, files, and schema-backed structured results between stages
 - **Human input** - Pause for `ctx.ui.input`, `confirm`, `select`, `editor`, or custom TUI widget decisions during a run
 - **Resumable control** - Interrupt, pause, quit, resume, or connect to workflow runs
+- **Intercom run notifications** - Deliver async run results and control notices (long-running, needs-attention, completed, failed) to a parent session over [Intercom](/intercom)
 - **Artifacts** - Save large outputs to files instead of pushing everything through model context
 - **Verification and gates** - Preserve evidence, run checks, and stop for human approval where reliability matters
 - **Model fallback chains** - Retry important stages on fallback models when providers fail
@@ -23,7 +20,7 @@ Loop or stop-condition phrasing is an especially strong workflow signal: `do X u
 
 **Example use cases:**
 - Well-defined autonomous jobs that benefit materially from durable execution state
-- Long-running or background-oriented work with explicit completion criteria
+- Long-running or background work with explicit completion criteria
 - Codebase research with parallel local and external research stages
 - Review/fix loops with independent reviewers and a synthesis stage
 - Release planning with human approval gates
@@ -34,36 +31,38 @@ Loop or stop-condition phrasing is an especially strong workflow signal: `do X u
 ## Table of Contents
 
 - [Quick Start](#quick-start)
-- [Built-in Workflows](#built-in-workflows)
 - [When to Use Workflows](#when-to-use-workflows)
+- [Built-in Workflows](#built-in-workflows)
+- [Writing a Workflow](#writing-a-workflow)
+- [The `workflow()` Definition](#the-workflow-definition)
+- [WorkflowContext](#workflowcontext)
+- [Task and Stage Options](#task-and-stage-options)
+- [StageContext](#stagecontext)
+- [Result Types](#result-types)
 - [Workflow Starter Patterns](#workflow-starter-patterns)
-- [Choosing an Execution Shape](#choosing-an-execution-shape)
-- [Atomic vs Claude Code Dynamic Workflows](#atomic-vs-claude-code-dynamic-workflows)
-- [Workflow Locations](#workflow-locations)
-- [Workflow Configuration](#workflow-configuration)
-- [Package Setup](#package-setup)
-- [Settings](#settings)
 - [Running Workflows](#running-workflows)
 - [Workflow Commands](#workflow-commands)
 - [Monitor and Control Runs](#monitor-and-control-runs)
 - [Lifecycle Notices and Human Input](#lifecycle-notices-and-human-input)
+- [Durable Workflows and Cross-Session Resume](#durable-workflows-and-cross-session-resume)
 - [Direct One-Off Runs](#direct-one-off-runs)
-- [Fast Inference for Workflow Stages](#fast-inference-for-workflow-stages)
-- [Writing a Workflow](#writing-a-workflow)
-- [Migrating from the `defineWorkflow()` Builder API](#migrating-from-the-defineworkflow-builder-api)
-- [Workflow Primitives](#workflow-primitives)
-- [Task and Stage Options](#task-and-stage-options)
+- [Workflow Locations](#workflow-locations)
+- [Reloading workflow resources](#reloading-workflow-resources)
+- [Workflow Configuration](#workflow-configuration)
+- [Settings](#settings)
+- [Package Setup](#package-setup)
 - [Programmatic Usage](#programmatic-usage)
+- [Fast Inference for Workflow Stages](#fast-inference-for-workflow-stages)
 - [Context Engineering](#context-engineering)
+- [Migrating from the `defineWorkflow()` Builder API](#migrating-from-the-defineworkflow-builder-api)
 - [Design Checklist](#design-checklist)
 - [Common Mistakes](#common-mistakes)
 - [Workflow Best Practices](#workflow-best-practices)
 
 ## Quick Start
 
-On a fresh first run with no prior Atomic startup state, Atomic shows a one-time explanation after any What's New notes and directly above the normal input box describing Atomic as a verifiable coding agent runtime for building and running agent workflows you can feel confident in. It no longer intercepts the first message, saves a pasted seed, routes to `goal` or `ralph`, raises reasoning, or requires `/chat` to use normal chat. Type a normal message or slash command immediately; run `/login` first if no provider is connected, use `/atomic` for guides, `/workflow list` to discover built-ins, or launch a workflow command directly when you already know what you want.
 
-The fastest way to get a workflow running is to **describe it in natural language** and let Atomic write it for you. If you'd rather write the TypeScript yourself, jump to [Or hand-write the TypeScript](#or-hand-write-the-typescript) below.
+To start a workflow quickly, **describe it in natural language** and let Atomic write it. If you'd rather write the TypeScript yourself, jump to [Or hand-write the TypeScript](#or-hand-write-the-typescript) below.
 
 ### Just describe it
 
@@ -75,7 +74,7 @@ text input `path` and runs a single fresh-context task that reads the file,
 then returns { explanation } summarizing purpose, risks, and key symbols.
 ```
 
-A more realistic request looks like:
+For example:
 
 ```text
 Create a reusable Atomic workflow called review-changes.
@@ -98,14 +97,13 @@ Atomic will:
 
 - ask clarifying questions when stage purpose, inputs, models, or handoffs are ambiguous,
 - write a `.atomic/workflows/<name>.ts` file using `workflow({...})`,
-- pick `ctx.task` / `ctx.chain` / `ctx.parallel` / `ctx.ui` per the [primitives](#workflow-primitives) and [task options](#task-and-stage-options) reference, and
+- pick `ctx.task` / `ctx.chain` / `ctx.parallel` / `ctx.ui` per the [WorkflowContext primitives](#workflowcontext) and [task options](#task-and-stage-options) reference, and
 - run `/workflow reload` so Atomic rediscovers the workflow resource and you can launch it immediately.
 
-Atomic does not use the long-running `/goal` workflow by default for first-time workflow creation. If you explicitly choose `/goal` for reviewer-gated implementation, keep the objective tightly scoped with concrete done criteria and validation steps, and monitor the run with workflow status/connect controls rather than manual sleep-and-poll loops.
 
-The same plain-chat approach works for editing or hardening an existing workflow — ask Atomic to add a stage, switch a model, save artifacts, or wire in a human approval gate.
+You can also edit or harden an existing workflow in plain chat — ask Atomic to add a stage, switch a model, save artifacts, or wire in a human approval gate.
 
-Then list and run it like any other workflow:
+List and run it like any other workflow:
 
 ```text
 /workflow list
@@ -113,7 +111,7 @@ Then list and run it like any other workflow:
 /workflow <name> key=value ...
 ```
 
-Named workflow runs are background-oriented. After launch, expect a run id and monitor it with `/workflow status <run-id>`, F2, or `/workflow connect <run-id>`.
+Named workflow runs execute in the background. After launch, expect a run id and monitor it with `/workflow status <run-id>`, F2, or `/workflow connect <run-id>`.
 
 While a workflow is running, the visible below-editor `BACKGROUND` panel advances its elapsed label every second from the moment the run starts; it does not require opening or switching to the orchestrator. Updates repaint the existing mounted panel in place, paused timers stay frozen, and terminal cards retain their short recent-run expiry.
 
@@ -155,15 +153,152 @@ Run `/workflow reload` or restart Atomic, then list and run it:
 /workflow explain-file path="src/index.ts"
 ```
 
-See [Writing a Workflow](#writing-a-workflow) for the full `workflow({...})` API and [Workflow Primitives](#workflow-primitives) for `ctx.task` / `ctx.chain` / `ctx.parallel` / `ctx.stage` / `ctx.ui`.
+See [Writing a Workflow](#writing-a-workflow) for the full `workflow({...})` API and [WorkflowContext](#workflowcontext) for `ctx.task` / `ctx.chain` / `ctx.parallel` / `ctx.stage` / `ctx.ui`.
+
+## When to Use Workflows
+
+Workflows are the default execution path when a request is non-trivial or combines inherent structure with a verifiable objective — implementation, build, debugging, bug fixes, migrations, features, scoped multi-file edits, docs/code changes where validation matters, and work with dependencies, handoffs, review gates, uncertainty, measurable done criteria, or evidence requirements. Choose a workflow before direct chat when the prompt includes any of these signals:
+
+- implementation, build, debugging/diagnosis, bug-fix, migration, new-feature, scoped multi-file, or validated docs/code work
+- multiple subtasks, dependencies, handoffs, uncertainty, or parallel/sequential stages
+- review, validation, QA, approval, evidence, or human-input gates
+- long-running or resumable background execution, saved artifacts, or important model fallback chains
+- reusable automation or an explicit loop/stop condition (see the signal phrases below)
+
+Loop or stop-condition phrasing is an especially strong workflow signal: `do X until Y`, `repeat until`, `iterate until`, `review/fix until passing`, `run checks and fix until green`, and `keep going until done` define control flow and convergence criteria that should be tracked.
+
+Use direct chat only for tiny, deterministic, low-risk answers or edits where stage tracking clearly costs more than it adds, typically a single-file/no-test/no-review change. Decide inline versus workflow before the first tool call; reconnaissance is already inline execution. Once workflow fit is clear, limit pre-workflow reconnaissance to the few reads needed to sharpen the objective and validation criteria, and put deeper research or behavior probing inside the run.
+
+Workflow-first does not require builtins, monolithic workflows, or a force-fit builtin: a builtin that matches 60% of the task and fights the other 40% is worse than a small custom graph. Discover named builtin, project, user, and package workflows; use direct `task`, `tasks`, or `chain` calls for simple tracked shapes; or author a task-specific TypeScript `workflow({...})` inline with normal coding tools whenever the task needs richer branching, dynamic fan-out, artifacts, structured outputs, child workflows, human input, gates, retries, or loops.
+
+Rich custom workflows can compose the [starter patterns](#workflow-starter-patterns): classify and branch at runtime, fan out and synthesize artifacts, run worker/verifier/reducer repair cycles, generate and filter or tournament-rank candidates, and loop until explicit evidence says the work is done. Workflow definitions are composable TypeScript modules — see [Workflow Composition](#workflow-composition). Atomic can write the definition, reload workflow resources, and run it for the current task; the workflow tool has no create action.
+
+If inline work drifts past roughly ten exploratory tool calls without an artifact, edit, or commit, or repeats a "verify one more thing" loop, save the findings to a context file and hand the task to the best-fit named or custom workflow through `reads`. Sunk research is transferable, not a reason to continue inline.
+
+| User goal | Use |
+|-----------|-----|
+| Run, inspect, connect to, pause, interrupt, quit, resume, or check status for an existing workflow | `/workflow ...` or `workflow({ action: ... })` |
+| Run an autonomous job that materially benefits from a durable goal ledger, bounded worker turns, named validation, and reviewer-gated completion | `/workflow goal objective="..."` so Atomic captures receipts, gates completion through reviewers, stops as `complete`, `blocked`, or `needs_human`, and can optionally run a final PR handoff with `create_pr=true` after approval |
+| Run an autonomous job that materially benefits from a durable research-first pipeline, delegated implementation, and iterative review | `/workflow ralph prompt="..."` so Atomic can transform the prompt into a research question, research the codebase first, delegate implementation through sub-agents, review, and iterate; prompt text alone does not opt in to PR creation, so add `create_pr=true` only when you want the final `pull-request` stage and `pr_report` |
+| Create or edit reusable automation | a TypeScript workflow definition exported from `workflow({...})` |
+| Track one-off work without saving a workflow file | direct `workflow({ task })`, `workflow({ tasks })`, or `workflow({ chain })` calls |
+| Make a workflow robust | design the stage graph, context handoffs, artifacts, validation gates, model fallbacks, and human approval points before coding |
+
+### Choosing an Execution Shape
+
+"Use a workflow" is not one decision — it covers several execution shapes with different costs and guarantees. This section is written as agent-facing guidance: it is the self-prompt an orchestrating agent should run before the first tool call on a new request, and it doubles as documentation for humans who want to steer that choice explicitly.
+
+The shapes, cheapest first:
+
+| Shape | What it is | Guarantees you gain | Cost you pay |
+|---|---|---|---|
+| **Inline** | Answer or edit directly in the current session. | Lowest latency, zero ceremony. | No tracking, no gates, no isolation, easy to drift. |
+| **Inline + subagents** | Bounded specialist delegation (locate/analyze/research/debug passes, noisy command investigation, parallel read-only fanouts) while the parent keeps control and synthesizes. | Context isolation for noisy or parallel evidence-gathering. | No completion gate, no durable stages; the parent is the only reviewer. |
+| **Direct one-off shapes** | `workflow({ task })`, `workflow({ tasks })`, or `workflow({ chain })` without saving a definition. | Stage tracking, artifacts, model fallbacks, monitoring, resume. | Linear/parallel control flow only; no custom branching or loops. |
+| **Named workflows** | Installed builtin, project, user, or package workflows (`goal`, `ralph`, `deep-research-codebase`, `open-claude-design`, ...). | A proven graph: bounded loops, reviewer gates, ledgers, evidence contracts, tuned model chains. | The task must actually match the graph's objective and inputs. |
+| **Custom workflow** | A task-specific TypeScript `workflow({...})` authored inline, composing the starter patterns. | Exactly the control flow the task needs: runtime branching, dynamic fan-out, custom gates, tournaments, bounded loops. | Authoring and reload time; you own the design quality. |
+| **Composed/nested workflows** | A custom parent that imports proven definitions and calls `ctx.workflow(child)`. | Reuse of hardened children (research, review loops) inside custom control flow, within `maxDepth`. | Parent/child input-output contracts must be mapped deliberately. |
+
+#### The self-prompt
+
+Ask these questions in order and stop at the first shape that satisfies every remaining requirement. Decide before the first tool call and state the decision; reconnaissance already counts as inline execution.
+
+1. **Is the outcome provable?** If success can be stated as evidence (tests green, artifact exists, behavior demonstrated, reviewer approves), the task fits a workflow. If no proof is possible or needed, inline is probably fine.
+2. **Is there structure?** Multiple subtasks, dependencies, handoffs, or parallel slices rule out inline execution. A single focused evidence-gathering pass does not.
+3. **Is there a loop or gate?** Any "until Y", "fix until passing", review/approval gate, or unknown-length repair cycle requires a workflow that enforces the stop condition, never an improvised inline retry loop or a stretched subagent chain.
+4. **Is it one task or a queue of tasks?** "Address all open issues" or "fix every ticket assigned to me" is a factory request, not one workflow. Enumerate and dependency-classify the items first, then follow [Task queues and software factories](#task-queues-and-software-factories): independent items become separate per-item runs; dependent items share one composed graph.
+5. **Does an installed graph already fit?** If a named workflow's objective and inputs cover essentially the whole task, run it. Do not force-fit a partial match ([When to Use Workflows](#when-to-use-workflows)).
+6. **Does the control flow need shapes builtins don't offer?** Runtime classification, per-item dynamic fan-out, generate-and-filter, tournaments, or domain-specific gates mean authoring a custom workflow from the starter patterns.
+7. **Does a proven graph already solve a sub-problem?** Nest it with `ctx.workflow(...)` instead of re-authoring its prompts and gates. Use composition instead of duplication whenever you can cleanly map the child's input/output contract.
+8. **Is it only specialist evidence-gathering?** If the parent keeps control, no completion gate is needed, and the work is bounded (a debug pass, a parallel research fanout, one noisy investigation), inline subagents are enough — and cheaper than a workflow.
+9. **Is it truly tiny?** Deterministic, low-risk, single-file/no-test/no-review — answer or edit inline and stop.
+
+#### Scoring rubric
+
+When the ladder is ambiguous, score the task on six dimensions (0–2 each):
+
+| Dimension | 0 | 1 | 2 |
+|---|---|---|---|
+| **Structure** | one action | a few sequential steps | many steps, dependencies, or parallel slices |
+| **Verifiability** | no objective check | spot-checkable | provable by tests, builds, artifacts, or review evidence |
+| **Iteration** | one pass suffices | may need one repair round | unknown-length loop until evidence passes |
+| **Risk** | trivial, reversible | scoped multi-file change | regressions, migrations, releases, or user-visible behavior |
+| **Duration** | seconds to minutes | tens of minutes | long-running, background, or resumable across sessions |
+| **Isolation** | one context is fine | one noisy investigation to quarantine | many slices needing clean contexts or adversarial independence |
+
+Interpretation:
+
+- **0–3 total:** inline. Adding stages creates more work than value.
+- **4–6 total, Iteration ≤ 1, no gate:** inline subagents (parent-controlled) or a direct one-off `task`/`tasks`/`chain` when tracking and artifacts help.
+- **7+ total, or Iteration = 2, or Verifiability = 2 with a review/approval gate:** a real workflow. Prefer a named workflow when one fits the whole task; otherwise author a custom graph, nesting proven children where sub-problems overlap.
+- **Any single hard signal overrides the arithmetic:** an explicit loop/stop condition, an approval or evidence gate, or a request for durable/background execution puts the task in workflow territory regardless of total score.
+
+The rubric prevents two common misuses: using parent-controlled subagent calls for an ad hoc implement→review→retry pipeline (that is adversarial verification without an engine — use a workflow and let its stages delegate specialists), and unbounded inline reconnaissance — apply the ten-call rule from [When to Use Workflows](#when-to-use-workflows): save findings to a context file and hand off through `reads`.
+
+#### Task queues and software factories
+
+Some requests are not one task but a queue of them: "address all open issues", "fix every Linear ticket assigned to me", "burn down the TODO backlog", "upgrade every service to the new SDK". These fire-and-forget factory requests need a separate decision step because one monolithic workflow would process the queue serially in a single growing context.
+
+**Triage the queue before choosing the shape.** The first action is always a cheap enumeration-and-dependency pass, not implementation: list the items (issue tracker query, ticket API, grep for TODOs), then classify how they relate:
+
+- **Independent items** — different subsystems, no shared files, no ordering constraints, each individually verifiable.
+- **Dependent items** — one blocks another, they touch the same files/modules, they share a migration or API change, or their acceptance criteria reference each other.
+- **Clustered** — the queue splits into groups: dependencies inside a group, independence between groups.
+
+**Independent items → many small runs, not one big one.** Spawn one workflow run per item (typically `goal` with the item's text as the objective and acceptance criteria, `create_pr=true` for per-item PRs), each in its own `git_worktree_dir`, running in the background. One run per item provides what a monolith cannot:
+
+- **Isolation:** a hard item that stalls or fails does not affect the remaining ones; each run resumes, retries, or can be stopped independently.
+- **Clean contexts:** every item starts with fresh context focused on its own objective instead of receiving the transcripts of twenty finished tickets.
+- **Independent evidence:** per-item reviewer gates, receipts, and PRs that a human can merge or reject one at a time.
+- **Real parallelism:** runs proceed concurrently, up to the number you choose to run at once (worktrees prevent filesystem collisions).
+
+Dispatch a bounded number at a time (for example 3–5 concurrent runs), wait for lifecycle notices, then dispatch the next wave — and report the dispatch plan (item → run id → worktree) so the queue is auditable.
+
+**Dependent items → one graph that encodes the ordering.** When items block each other or share a change surface, isolation no longer helps — separate runs could modify the same files or rely on outdated assumptions. Encode the dependency structure explicitly instead:
+
+- **A composed parent workflow** that nests a proven child (for example `ctx.workflow(goal, ...)` per item) in dependency order, passing each item's outputs/artifacts to its dependents — the preferred form, because each item still gets its own bounded loop and reviewer gate while the parent owns sequencing.
+- **A single monolithic workflow** only when the items share enough dependencies to form one task with subtasks (one migration touching every call site is one task, not a queue).
+
+**Clustered queues → both.** Compose within a cluster, fan out across clusters: each cluster becomes one run (a composed parent or a single `goal` objective covering the cluster), and independent clusters are dispatched as parallel background runs in waves.
+
+The self-prompt for factory requests, condensed: **enumerate → classify dependencies → fan out runs where independent, compose graphs where dependent → dispatch in bounded waves → report the plan.** When dependency classification is uncertain, prefer smaller independent runs and let per-item reviewer gates catch collisions — a rejected PR is cheaper than a monolith that applied a bad assumption throughout the queue.
+
+#### Prompting the choice
+
+Humans can steer the shape directly. The most direct controls, in rough order of effect:
+
+- **Name the shape or workflow.** "Do this inline", "use subagents to investigate", "run the goal workflow", or "write a custom workflow for this" overrides the agent's own scoring.
+- **State acceptance criteria.** Verbatim acceptance criteria make the objective provable, which both selects workflow execution and sets the immutable contract that `goal`/`ralph` reviewers enforce.
+- **State the loop.** "Iterate until tests pass", "review and fix until approved" — loop wording is a hard workflow signal and defines the stop condition.
+- **State the evidence.** Asking for a PR, a QA video, test output, or reviewer sign-off tells the agent which gates the graph needs.
+- **State the boundary.** "Work in a separate worktree", "don't create the PR yet", or "stop after implementation" separates the implementation loop from explicitly authorized final actions.
+- **State the queue policy.** For factory requests, say how to split and gate the queue: "one workflow and PR per issue", "these three tickets depend on each other — do them in order in one run", "triage first and show me the dependency plan before dispatching", or "no more than three runs at a time". Absent a policy, the agent triages dependencies itself and defaults to independent per-item runs with per-item evidence.
+
+Absent these levers, the agent applies the self-prompt and rubric above — so a prompt that mentions none of them is delegating the shape decision, not avoiding it.
+
+### Atomic vs Claude Code Dynamic Workflows
+
+Claude Code Dynamic Workflows and Atomic address a similar problem: important software engineering work is too large for one agent pass, so the system should split the job into stages, run agents in parallel, verify the result, and keep enough state to finish long-running work.
+
+Atomic's category is broader and more explicit: it is the loop engine for engineering work. The difference is who controls the process and how much of the loop you can inspect, version, extend, and connect to your stack.
+
+| Dimension | Atomic | Claude Code Dynamic Workflows |
+| --- | --- | --- |
+| Core idea | Open-source, repo-native loop engine for coding agents. You can run built-ins, tell the coding agent to use a workflow for a task, describe new loops in natural language for Atomic to scaffold dynamically, or version them as explicit TypeScript files. | Claude dynamically creates orchestration scripts for a task and fans work out to many parallel Claude subagents. |
+| Best fit | Teams that want repeatable software engineering loops they can inspect, version, extend, connect to tools, and run across providers. | Claude Code users who want Claude to decide when a task needs a larger dynamic workflow and orchestrate it automatically. |
+| Workflow control | The process is explicit: stages, inputs, handoffs, retries, artifacts, model choices, checkpoints, and human gates are part of the workflow definition. | The process is generated dynamically by Claude for the current task, with confirmation before the first workflow run. |
+| Models | Model-agnostic. Atomic connects directly to supported API-key and subscription providers, and workflows can use model fallback chains. | Claude-first. Availability is tied to Claude Code, Claude plans, and Anthropic-supported API/cloud channels. |
+| Extensibility | Built on Pi extensions: add tools, TUI, MCP, web access, intercom, skills, prompt templates, themes, custom providers, and packaged workflows. | Optimized for Claude Code's built-in dynamic orchestration experience rather than an open extension SDK you own in-repo. |
+| Artifacts and auditability | Research docs, specs, logs, transcripts, reviewer notes, check output, and final summaries can live in the repo or workflow run directory. | Progress is saved and resumable, but the orchestration is primarily a Claude Code runtime behavior. |
+| Cost/scale posture | You choose the graph and concurrency. Atomic can be small and deterministic, or broad when you intentionally design a larger workflow. | Designed for large fan-outs, including tens to hundreds of subagents; Anthropic notes it can consume substantially more tokens than a typical Claude Code session. |
 
 ## Built-in Workflows
 
 Atomic bundles four workflows that cover the most common multi-stage jobs. They are available in every session — no install step required. Use `/workflow list` to confirm they are loaded, and `/workflow inputs <name>` to see the exact inputs in your environment.
 
-These same builtin workflows are also available to workflow authors as workflow definitions. Import them from `@bastani/workflows/builtin` and pass the definition directly to `ctx.workflow(...)` when one workflow should call `deep-research-codebase`, `goal`, `ralph`, `open-claude-design`, or another builtin as a nested child workflow. See [Workflow Composition](#workflow-composition) for full examples alongside user-defined child workflows.
+Workflow authors can also use these builtins as workflow definitions. Import them from `@bastani/workflows/builtin` and pass the definition directly to `ctx.workflow(...)` when one workflow should call `deep-research-codebase`, `goal`, `ralph`, `open-claude-design`, or another builtin as a nested child workflow. See [Workflow Composition](#workflow-composition) for full examples alongside user-defined child workflows.
 
-For the builtin result tables below, `deep-research-codebase`, `goal`, and `ralph` explicitly declare `outputs: { result: Type.String(...) }` and return a `result` key from `run`, so `result` is part of their declared output contract. Every output a workflow exposes — including `result` — must be declared in `outputs` and returned from `run` or supplied to `ctx.exit({ outputs })`; Atomic no longer adds any automatic `result` output.
+For the builtin result tables below, `deep-research-codebase`, `goal`, and `ralph` explicitly declare `outputs: { result: Type.Optional(Type.String(...)) }`, so `result` is an optional part of their declared output contracts and may be omitted, including after an intentional early exit. Like every workflow output, `result` must be declared in `outputs` and returned from `run` or supplied to `ctx.exit({ outputs })` when present — see [Outputs](#outputs); Atomic adds no automatic `result` output.
 
 | Workflow | What it does | When to use |
 |---|---|---|
@@ -214,7 +349,7 @@ Output locations and result fields:
 | `max_concurrency` | Concurrency limit used for the run. |
 | `history` | Prior-research/history overview included in the final synthesis. |
 
-The dated Markdown report is intended for people to read and commit or share. The hidden artifact directory keeps large scout, history, and specialist handoff files available for audit without cluttering the visible research index.
+People can read, commit, or share the dated Markdown report. The hidden artifact directory keeps large scout, history, and specialist handoff files available for audit without cluttering the visible research index.
 
 ### `goal`
 
@@ -241,21 +376,47 @@ Run examples:
 /workflow goal objective="Fix the flaky package install test in an isolated worktree and run the focused regression" git_worktree_dir=../atomic-goal-install-wt base_branch=main
 ```
 
-`goal` uses the raw `objective` exactly as supplied as the operative objective recorded in the ledger and stores `acceptance_criteria` as the immutable literal contract (defaulting to the objective when omitted); it does not run an initial prompt-refinement stage. It creates an OS-temp `goal-ledger.json` artifact, renders goal-continuation context for each worker turn, writes the latest worker receipt to `worker-receipt.md`, and appends receipts, reviewer decisions, blockers, reducer decisions, and lifecycle events to the ledger. Worker and reviewer prompts (and the model-facing ledger artifact) deliberately omit the current turn/attempt number so the worker focuses on completing the objective rather than pacing itself to the workflow budget. The objective is treated as user-provided data, not higher-priority instructions. By default `goal` does not start the final `pull-request` stage, and `pr_report` is omitted. Prompt text alone does not opt in. Pass `create_pr=true` only when you explicitly want the final stage to inspect provider credentials and attempt provider-appropriate PR/MR/review creation, such as GitHub `gh`, Azure Repos `az repos pr create`, or Sapling/Phabricator tooling, after Goal reaches `complete` within `max_turns`. Goal worker and reviewer prompts explicitly tell intermediate stages to ignore PR-creation requests; only the final `pull-request` stage may attempt that handoff.
+`goal` uses the raw `objective` exactly as supplied as the operative objective recorded in the ledger and stores `acceptance_criteria` as the immutable literal contract (defaulting to the objective when omitted); it does not run an initial prompt-refinement stage. It creates an OS-temp `goal-ledger.json` artifact, renders goal-continuation context for each worker turn, writes the latest worker receipt to `worker-receipt.md`, and appends receipts, reviewer decisions, blockers, reducer decisions, and lifecycle events to the ledger.
 
-Set `git_worktree_dir` when you want Goal's worker and reviewer stages isolated in a reusable Git worktree. Relative paths resolve from the invoking repository root, existing same-repository worktree roots are reused, and missing paths are created from `base_branch`. Goal preserves the invoking repo-relative cwd inside the worktree, so launching from `repo/packages/api` with `git_worktree_dir=../repo-wt` runs stages from `../repo-wt/packages/api`. If the run is resumed later with `/workflow resume`, Atomic reuses the original invocation cwd and recorded reusable-worktree metadata instead of resolving the worktree path from the resumed chat's current cwd. Slow Git subprocesses can run for up to 60 seconds before Atomic reports an explicit Git timeout diagnostic.
+Worker and reviewer prompts (and the model-facing ledger artifact) deliberately omit the current turn/attempt number so the worker focuses on completing the objective rather than pacing itself to the workflow budget. Worker and reviewer prompts treat the objective as user-provided data, not higher-priority instructions. By default `goal` does not start the final `pull-request` stage, and `pr_report` is omitted. Prompt text alone does not opt in.
 
-Write the `objective` like a compact acceptance spec. Say what should exist when the run is done, how you want testing handled, which command(s) or manual checks matter, and what outcome proves completion. The workflow is intentionally lean: it does not first generate an RFC or migration plan, so the developer-supplied objective is where scope, validation, and completion criteria belong.
+Pass `create_pr=true` only when you explicitly want the final stage to inspect provider credentials and attempt provider-appropriate PR/MR/review creation, such as GitHub `gh`, Azure Repos `az repos pr create`, or Sapling/Phabricator tooling, after Goal reaches `complete` within `max_turns`. Goal worker and reviewer prompts explicitly tell intermediate stages to ignore PR-creation requests; only the final `pull-request` stage may attempt that handoff.
 
-Goal worker/reviewer prompts treat the objective and acceptance criteria as the sole literal source of truth: if follow-up deltas, language specs, upstream issues, in-repo comments, or best practices conflict with explicit wording, reviewers surface the conflict instead of silently implementing external knowledge. Reviewer findings carry `objective_alignment` (`required_by_objective`, `consistent_with_objective`, `beyond_objective`, or `contradicts_objective`); `beyond_objective` and `contradicts_objective` findings are reported but do not block completion and must not be promoted into follow-up objectives without reconciling them against the acceptance criteria. Severity labels alone never dismiss objective-relevant findings: `required_by_objective` findings block at any priority (P3 included), while `consistent_with_objective` P3 nice-to-haves stay non-blocking. Review decisions also include `requirements_traceability`, a clause-by-clause evidence map over every explicit objective/acceptance-criteria requirement. Findings and traceability are audit evidence that drive how each reviewer derives its authoritative `stop_review_loop` boolean; the harness gates approval on that boolean alone, and reviewers are explicitly told that process-only clauses (reviewer quorum/approval counts, and the authorized post-approval PR/MR/review final action when `create_pr=true`) must never hold the flag at `false`. Passing worker-authored tests or snapshots alone is circular evidence unless tied to independent current-state proof.
+Set `git_worktree_dir` when you want Goal's worker and reviewer stages isolated in a reusable Git worktree. Relative paths resolve from the invoking repository root, existing same-repository worktree roots are reused, and missing paths are created from `base_branch`. Goal preserves the invoking repo-relative cwd inside the worktree, so launching from `repo/packages/api` with `git_worktree_dir=../repo-wt` runs stages from `../repo-wt/packages/api`.
 
-The worker may claim readiness, but it cannot finalize completion. Workers start from an observable acceptance/contract matrix derived from the literal objective/acceptance criteria (one row per clause, each mapped to the concrete check that proves it), and are prompted to model states, transitions, and invariants explicitly when the work is stateful. Reviewer findings from the latest round are consolidated into a deduplicated cross-reviewer batch persisted in the round artifact (`consolidated_findings` in `review-round-latest.json`), and the next worker turn is instructed to plan and repair the whole batch — with durable regression evidence for reproduced findings — rather than fixing one finding per turn. Workers and reviewers are prompted to verify user-visible behavior end-to-end when practical, using `playwright-cli`-skilled subagents for web/frontend flows that may depend on backend/API behavior and tmux-skilled subagents for TUI or terminal-app scenarios. They must assume credentials/auth/environment access exists until concrete checks plus an actual app/flow launch attempt prove otherwise; skipped E2E is valid only when exact attempted commands and observed failure output are recorded. Goal reviewers also look for any QA E2E video referenced by the ledger or receipt and must inspect the actual video before treating it as proof. Three reviewers independently inspect the ledger, worker receipt, repository state, and diff against `base_branch`; each starts in a clean, non-forked context, matching Ralph's reviewer context behavior, and every Goal reviewer uses Ralph's `reviewer-a` model chain with Claude Fable 5 as the primary model. Each reviewer is instructed to first derive its own adversarial check list from the literal contract — boundary/edge/negative probes plus state/transition/invariant probes — before relying on the worker receipt or worker-authored tests, and each returns structured JSON with findings, evidence, verification still remaining, and an optional blocker. A TypeScript reducer marks the goal complete when reviewer quorum approves via the `stop_review_loop` booleans, marks blocked only when the same dependency/tool blocker repeats for the blocker threshold, continues while quorum is missing (recording the reviewers' remaining work in the decision reason), and returns `needs_human` when `max_turns` is exhausted or worker execution fails, so the bounded loop always stops with an inspectable reason.
+If the run is resumed later with `/workflow resume`, Atomic reuses the original invocation cwd and recorded reusable-worktree metadata instead of resolving the worktree path from the resumed chat's current cwd. Slow Git subprocesses can run for up to 60 seconds before Atomic reports an explicit Git timeout diagnostic.
 
-At the start of every Goal review, each concurrent reviewer uses Intercom to initialize/check coordination and discover the sibling reviewers in the same workflow run. Before validation, reviewers communicate their plans and intended ownership, claim expensive or lock-prone checks, and serialize commands that can conflict in a shared checkout or environment, including full test suites, build or test commands, package-manager operations, browser/E2E sessions, migrations, and generated-artifact steps. They announce each coordinated check's start and completion, release every claimed resource and send siblings an explicit resource-release update, and share reusable command outcomes/evidence where appropriate. This operational coordination prevents collisions and duplicate conflicting work; it does not replace independent patch inspection, analysis, or each reviewer's own verdict.
+Write the `objective` as a compact acceptance spec. Define the desired end state, required testing, relevant commands or manual checks, and the outcome that proves completion. The workflow is intentionally lean: it does not first generate an RFC or migration plan, so the developer-supplied objective is where scope, validation, and completion criteria belong.
 
-When Goal's reducer returns `needs_human`, `blocked`, or another incomplete status, the top-level workflow run is not reported as a successful completion. `/workflow status` and lifecycle notices surface it as blocked/failed according to the run's terminal condition. Atomic also preserves structured recoverable failure metadata from the run's blocking stage (`failedStageId`) or run-level failure metadata, so auth, rate-limit, and provider fallback exhaustion remains blocked/resumable even if the workflow later returns ordinary outputs instead of a reserved `status` value. Tolerated branch failures from non-fail-fast parallel work do not reclassify an otherwise completed run.
+Goal worker/reviewer prompts treat the objective and acceptance criteria as the sole literal source of truth: if follow-up deltas, language specs, upstream issues, in-repo comments, or best practices conflict with explicit wording, reviewers surface the conflict instead of silently implementing external knowledge.
 
-Every Goal review round also persists an explicit convergence summary. Each reviewer record and review artifact distinguishes schema-parse status from the review verdict with `parsed`, `approved`, `stopReviewLoop`, `nextAction`, `finalActionRemaining`, and `diagnostics` fields; malformed or missing structured reviewer output is reported as a parse failure rather than as an ordinary finding/rejection. When `create_pr=true`, reviewers are told that PR/MR/review creation is a post-approval final action: if implementation and validation requirements are proven and only PR creation remains, the implementation can approve with `finalActionRemaining: true` and `nextAction: "pull-request"` instead of consuming another worker turn. The ledger's reducer decision repeats the same concise fields for the controller outcome, so a successful quorum records `approved: true`, `stopReviewLoop: true`, and `nextAction: "pull-request"` when `create_pr=true` (otherwise `"finish"`) before any final handoff runs.
+Reviewer findings carry `objective_alignment` (`required_by_objective`, `consistent_with_objective`, `beyond_objective`, or `contradicts_objective`); `beyond_objective` and `contradicts_objective` findings are reported but do not block completion and must not be promoted into follow-up objectives without reconciling them against the acceptance criteria. Severity labels alone never dismiss objective-relevant findings: `required_by_objective` findings block at any priority (P3 included), while `consistent_with_objective` P3 nice-to-haves stay non-blocking.
+
+Review decisions also include `requirements_traceability`, a clause-by-clause evidence map over every explicit objective/acceptance-criteria requirement. Findings and traceability are audit evidence that drive how each reviewer derives its authoritative `stop_review_loop` boolean; the harness gates approval on that boolean alone, and Goal tells reviewers that process-only clauses (reviewer quorum/approval counts, and the authorized post-approval PR/MR/review final action when `create_pr=true`) must never hold the flag at `false`.
+
+Passing worker-authored tests or snapshots alone is circular evidence unless tied to independent current-state proof.
+
+The worker may claim readiness, but it cannot finalize completion. Before implementing, Goal prompts the worker to derive an observable acceptance/contract matrix from the literal objective/acceptance criteria (one row per clause, each mapped to the concrete check that proves it) and to model states, transitions, and invariants explicitly when the work is stateful.
+
+Goal consolidates the latest reviewer findings into a deduplicated cross-reviewer batch persisted in the round artifact (`consolidated_findings` in `review-round-latest.json`), and the next worker prompt instructs the worker to plan and repair the whole batch — with durable regression evidence for reproduced findings — rather than fixing one finding per turn. Goal prompts workers and reviewers to verify user-visible behavior end-to-end when practical, using `playwright-cli`-skilled subagents for web/frontend flows that may depend on backend/API behavior and tmux-skilled subagents for TUI or terminal-app scenarios.
+
+They must assume credentials/auth/environment access exists until concrete checks plus an actual app/flow launch attempt prove otherwise; reviewers accept skipped E2E only when the worker records the exact attempted commands and observed failure output. Goal reviewers also look for any QA E2E video referenced by the ledger or receipt and must inspect the actual video before treating it as proof.
+
+Three reviewers independently inspect the ledger, worker receipt, repository state, and diff against `base_branch`; each starts in a clean, non-forked context, matching Ralph's reviewer context behavior, and every Goal reviewer uses Ralph's `reviewer-a` model chain with Claude Fable 5 as the primary model.
+
+Goal instructs each reviewer to first derive its own adversarial check list from the literal contract — boundary/edge/negative probes plus state/transition/invariant probes — before relying on the worker receipt or worker-authored tests, and each returns structured JSON with findings, evidence, verification still remaining, and an optional blocker.
+
+A TypeScript reducer marks the goal complete when reviewer quorum approves via the `stop_review_loop` booleans, marks blocked only when the same dependency/tool blocker repeats for the blocker threshold, continues while quorum is missing (recording the reviewers' remaining work in the decision reason), and returns `needs_human` when `max_turns` is exhausted or worker execution fails, so the bounded loop always stops with an inspectable reason.
+
+At the start of every Goal review, each concurrent reviewer uses [Intercom](/intercom) to initialize/check coordination and discover the sibling reviewers in the same workflow run. Before validation, reviewers communicate their plans and intended ownership, claim expensive or lock-prone checks, and serialize commands that can conflict in a shared checkout or environment, including full test suites, build or test commands, package-manager operations, browser/E2E sessions, migrations, and generated-artifact steps.
+
+They announce each coordinated check's start and completion, release every claimed resource and send siblings an explicit resource-release update, and share reusable command outcomes/evidence where appropriate. This operational coordination prevents collisions and duplicate conflicting work; it does not replace independent patch inspection, analysis, or each reviewer's own verdict.
+
+When Goal's reducer returns `needs_human`, `blocked`, or another incomplete status, Atomic does not report the top-level workflow run as successful. `/workflow status` and lifecycle notices surface it as blocked/failed according to the run's terminal condition. Atomic also preserves structured recoverable failure metadata from the run's blocking stage (`failedStageId`) or run-level failure metadata, so auth, rate-limit, and provider fallback exhaustion remains blocked/resumable even if the workflow later returns ordinary outputs instead of a reserved `status` value. Tolerated branch failures from non-fail-fast parallel work do not reclassify an otherwise completed run.
+
+Each Goal review round persists a convergence summary. Each reviewer record and review artifact distinguishes schema-parse status from the review verdict with `parsed`, `approved`, `stopReviewLoop`, `nextAction`, `finalActionRemaining`, and `diagnostics` fields; each reports malformed or missing structured reviewer output as a parse failure rather than as an ordinary finding/rejection.
+
+When `create_pr=true`, reviewers are told that PR/MR/review creation is a post-approval final action: if implementation and validation requirements are proven and only PR creation remains, the implementation can approve with `finalActionRemaining: true` and `nextAction: "pull-request"` instead of consuming another worker turn. The ledger's reducer decision repeats the same concise fields for the controller outcome, so a successful quorum records `approved: true`, `stopReviewLoop: true`, and `nextAction: "pull-request"` when `create_pr=true` (otherwise `"finish"`) before any final handoff runs.
 
 Result fields:
 
@@ -297,11 +458,35 @@ Run examples:
 /workflow ralph prompt="Safely implement the API refactor" git_worktree_dir=../atomic-ralph-api-wt base_branch=main
 ```
 
-Each `ralph` run uses the raw `prompt` exactly as supplied as the operative objective for research, orchestration, and review, and stores `acceptance_criteria` as the immutable literal contract (defaulting to the prompt when omitted). Shared literal-contract prompt language forbids adding behaviors, restrictions, or error conditions beyond the prompt/acceptance criteria and requires surfacing conflicts with external knowledge; Ralph does not run an initial prompt-refinement stage. Each iteration transforms that raw prompt with `/skill:prompt-engineer Transform the following user request into a codebase and online research question which can be thoroughly explored: ...` (`research-prompt-refinement`), researches that transformed question with `/skill:research-codebase ...`, and writes the findings under `research/`. The research, orchestrator, and reviewer prompts carry `acceptance_criteria` next to the literal contract, so orchestrators should pass the ORIGINAL task text when launching follow-up Ralph runs from reviewer findings. The orchestrator starts from an observable acceptance/contract matrix derived from the literal prompt/acceptance criteria (one row per clause mapped to the concrete observable check that proves it) and is prompted to model states, transitions, and invariants explicitly when the work is stateful; it treats the research artifact as its primary implementation context, initializes/updates an OS-temp implementation notes file while generating verifiable evidence for any claims it records in the notes and reviewer artifacts, delegates implementation through sub-agents, repairs unresolved reviewer findings as one consolidated batch (with durable regression evidence for reproduced findings) rather than one finding per iteration, and asks two independent reviewers (`reviewer-a` and `reviewer-b`) to inspect the patch directly against `base_branch`. The reviewer fan-out runs reviewers on different primary model families (Claude Fable 5 and GPT-5.5 Codex, with shared fallbacks) so the adversarial review gets cross-model coverage instead of repeated passes from one model, and each reviewer is instructed to first derive its own adversarial check list from the literal contract — boundary/edge/negative probes plus state/transition/invariant probes — before relying on the implementation notes, orchestrator report, or worker-authored tests. Ralph's orchestrator and reviewers are prompted to verify user-visible behavior end-to-end when practical, using `playwright-cli`-skilled subagents for web/frontend flows that may depend on backend/API behavior and tmux-skilled subagents for TUI or terminal-app scenarios. They must assume credentials/auth/environment access exists until concrete checks plus an actual app/flow launch attempt prove otherwise; skipped E2E is valid only when exact attempted commands and observed failure output are recorded. For UI-applicable or full-stack changes, the orchestrator runs a `playwright-cli` end-to-end QA pass and records a reviewable proof video (referenced in the implementation notes and surfaced as `qa_video_path`); reviewers receive that path and must inspect the actual video before treating it as proof. When `create_pr=true`, the final `pull-request` stage attaches or links that video to the created PR/MR/review after reviewer approval. If reviewers find issues, the next `research-prompt-refinement` and research stages receive the review artifact path (whose `review-round-latest.json` now also carries a deduplicated cross-reviewer `consolidated_findings` batch) so follow-up research can address unresolved findings, and research stages fork from prior research session data when available. The loop stops only when both reviewers independently approve or `max_loops` is reached, so the bounded loop always stops with an inspectable review round. Ralph findings include the same `objective_alignment` classification used by Goal, and each reviewer derives a single authoritative `stop_review_loop` boolean from that evidence: `required_by_objective` findings mean `false` at any priority (P3 included, because severity labels alone never dismiss objective-relevant findings), `consistent_with_objective` P0/P1/P2 findings mean `false` while P3 remains a non-blocking nice-to-have, and `beyond_objective`/`contradicts_objective` findings are surfaced but non-blocking so they are not silently converted into new requirements. The loop gate approves deterministically on `stop_review_loop=true` plus a null `reviewer_error` (parse failures count as non-approval) without recomputing approval from the findings arrays. Ralph review decisions also include `requirements_traceability`, a clause-by-clause evidence map over every explicit prompt/acceptance-criteria requirement kept as audit evidence for deriving the flag; reviewers are explicitly told that process-only clauses (reviewer quorum, and the authorized post-approval PR/MR/review final action when `create_pr=true`) must never hold the flag at `false`. Worker-authored tests or snapshots passing are circular evidence unless tied to independent current-state proof. By default Ralph does not start the final `pull-request` stage, and `pr_report` is omitted. Prompt text alone does not opt in. Pass `create_pr=true` only when you explicitly want the final `pull-request` stage to inspect provider credentials and attempt provider-appropriate PR/MR/review creation, such as GitHub `gh`, Azure Repos `az repos pr create`, or Sapling/Phabricator tooling; Ralph's own PR-creation instructions live in that final stage and run only after approval.
+Each `ralph` run uses the raw `prompt` exactly as supplied as the operative objective for research, orchestration, and review, and stores `acceptance_criteria` as the immutable literal contract (defaulting to the prompt when omitted). Shared literal-contract prompt language forbids adding behaviors, restrictions, or error conditions beyond the prompt/acceptance criteria and requires surfacing conflicts with external knowledge; Ralph does not run an initial prompt-refinement stage.
 
-At the start of every Ralph review, each concurrent reviewer uses Intercom to initialize/check coordination and discover the sibling reviewer in the same workflow run. Before validation, reviewers communicate their plans and intended ownership, claim expensive or lock-prone checks, and serialize commands that can conflict in a shared checkout or environment, including full test suites, build or test commands, package-manager operations, browser/E2E sessions, migrations, and generated-artifact steps. They announce each coordinated check's start and completion, release every claimed resource and send the sibling an explicit resource-release update, and share reusable command outcomes/evidence where appropriate. This operational coordination prevents collisions and duplicate conflicting work; it does not replace independent patch inspection, analysis, or each reviewer's own verdict.
+Each iteration transforms that raw prompt with `/skill:prompt-engineer Transform the following user request into a codebase and online research question which can be thoroughly explored: ...` (`research-prompt-refinement`), researches that transformed question with `/skill:research-codebase ...`, and writes the findings under `research/`. The research, orchestrator, and reviewer prompts carry `acceptance_criteria` next to the literal contract, so orchestrators should pass the ORIGINAL task text when launching follow-up Ralph runs from reviewer findings.
 
-Each Ralph review artifact and `review-round-latest.json` includes a `convergence_decision` summary with `parsed`, `approved`, `stopReviewLoop`, `nextAction`, `finalActionRemaining`, and `diagnostics`. This makes malformed or missing structured reviewer output visible as a parse failure, separate from a parsed reviewer rejection or blocking finding. When `create_pr=true`, reviewers are told that PR/MR/review creation is a post-approval final action: if implementation and validation requirements are proven and only PR creation remains, the implementation can approve with `finalActionRemaining: true` and `nextAction: "pull-request"` instead of consuming another orchestration iteration. When both reviewers converge, the latest round records `approved: true`, `stopReviewLoop: true`, and `nextAction: "pull-request"` when `create_pr=true` (otherwise `"finish"`), and the implementation loop stops before the final handoff stage.
+Before implementing, Ralph prompts the orchestrator to derive an observable acceptance/contract matrix from the literal prompt/acceptance criteria (one row per clause mapped to the concrete observable check that proves it) and to model states, transitions, and invariants explicitly when the work is stateful.
+
+It treats the research artifact as its primary implementation context, initializes/updates an OS-temp implementation notes file while generating verifiable evidence for any claims it records in the notes and reviewer artifacts, delegates implementation through sub-agents, repairs unresolved reviewer findings as one consolidated batch (with durable regression evidence for reproduced findings) rather than one finding per iteration, and asks two independent reviewers (`reviewer-a` and `reviewer-b`) to inspect the patch directly against `base_branch`.
+
+The reviewer fan-out runs reviewers on different primary model families (Claude Fable 5 and GPT-5.5 Codex, with shared fallbacks) so the adversarial review gets cross-model coverage instead of repeated passes from one model, and Ralph instructs each reviewer to first derive its own adversarial check list from the literal contract — boundary/edge/negative probes plus state/transition/invariant probes — before relying on the implementation notes, orchestrator report, or worker-authored tests.
+
+Ralph prompts its orchestrator and reviewers to verify user-visible behavior end-to-end when practical, using `playwright-cli`-skilled subagents for web/frontend flows that may depend on backend/API behavior and tmux-skilled subagents for TUI or terminal-app scenarios. They must assume credentials/auth/environment access exists until concrete checks plus an actual app/flow launch attempt prove otherwise; reviewers accept skipped E2E only when the orchestrator records the exact attempted commands and observed failure output.
+
+For UI-applicable or full-stack changes, the orchestrator runs a `playwright-cli` end-to-end QA pass and records a reviewable proof video (referenced in the implementation notes and surfaced as `qa_video_path`); reviewers receive that path and must inspect the actual video before treating it as proof. When `create_pr=true`, the final `pull-request` stage attaches or links that video to the created PR/MR/review after reviewer approval.
+
+If reviewers find issues, the next `research-prompt-refinement` and research stages receive the review artifact path (whose `review-round-latest.json` carries a deduplicated cross-reviewer `consolidated_findings` batch) so follow-up research can address unresolved findings, and research stages fork from prior research session data when available. The loop stops only when both reviewers independently approve or `max_loops` is reached, so the bounded loop always stops with an inspectable review round.
+
+Ralph findings include the same `objective_alignment` classification used by Goal, and each reviewer derives a single authoritative `stop_review_loop` boolean from that evidence: `required_by_objective` findings mean `false` at any priority (P3 included, because severity labels alone never dismiss objective-relevant findings), `consistent_with_objective` P0/P1/P2 findings mean `false` while P3 remains a non-blocking nice-to-have, and `beyond_objective`/`contradicts_objective` findings are surfaced but non-blocking so they are not silently converted into new requirements.
+
+The loop gate approves deterministically on `stop_review_loop=true` plus a null `reviewer_error` (parse failures count as non-approval) without recomputing approval from the findings arrays. Ralph review decisions also include `requirements_traceability`, a clause-by-clause evidence map over every explicit prompt/acceptance-criteria requirement kept as audit evidence for deriving the flag; reviewers are explicitly told that process-only clauses (reviewer quorum, and the authorized post-approval PR/MR/review final action when `create_pr=true`) must never hold the flag at `false`.
+
+Passing worker-authored tests or snapshots is circular evidence unless tied to independent current-state proof. By default Ralph does not start the final `pull-request` stage, and `pr_report` is omitted. Prompt text alone does not opt in. Pass `create_pr=true` only when you explicitly want the final `pull-request` stage to inspect provider credentials and attempt provider-appropriate PR/MR/review creation, such as GitHub `gh`, Azure Repos `az repos pr create`, or Sapling/Phabricator tooling; Ralph's own PR-creation instructions live in that final stage and run only after approval.
+
+At the start of every Ralph review, each concurrent reviewer uses Intercom to initialize/check coordination and discover the sibling reviewer in the same workflow run. Before validation, reviewers communicate their plans and intended ownership, claim expensive or lock-prone checks, and serialize commands that can conflict in a shared checkout or environment, including full test suites, build or test commands, package-manager operations, browser/E2E sessions, migrations, and generated-artifact steps.
+
+They announce each coordinated check's start and completion, release every claimed resource and send the sibling an explicit resource-release update, and share reusable command outcomes/evidence where appropriate. This operational coordination prevents collisions and duplicate conflicting work; it does not replace independent patch inspection, analysis, or each reviewer's own verdict.
+
+Each Ralph review artifact and `review-round-latest.json` includes a `convergence_decision` summary with `parsed`, `approved`, `stopReviewLoop`, `nextAction`, `finalActionRemaining`, and `diagnostics`. This distinguishes malformed or missing structured reviewer output from a parsed reviewer rejection or blocking finding by reporting it as a parse failure.
+
+When `create_pr=true`, reviewers are told that PR/MR/review creation is a post-approval final action: if implementation and validation requirements are proven and only PR creation remains, the implementation can approve with `finalActionRemaining: true` and `nextAction: "pull-request"` instead of consuming another orchestration iteration. When both reviewers converge, the latest round records `approved: true`, `stopReviewLoop: true`, and `nextAction: "pull-request"` when `create_pr=true` (otherwise `"finish"`), and the implementation loop stops before the final handoff stage.
 
 Set `git_worktree_dir` when you want Ralph's worker stages isolated in a reusable Git worktree. Relative paths resolve from the invoking repository root, existing same-repository worktree roots are reused, and missing paths are created from `base_branch`. Ralph preserves the invoking repo-relative cwd inside the worktree, so launching from `repo/packages/api` with `git_worktree_dir=../repo-wt` runs stages from `../repo-wt/packages/api`.
 
@@ -322,7 +507,9 @@ Result fields:
 | `review_report` | Compact reference to the latest reviewer payload artifact. |
 | `review_report_path` | JSON artifact path for the latest Ralph review round. |
 
-When a clearly delegated autonomous implementation materially benefits from a durable research-first pipeline, a suitable flow is `/skill:research-codebase` → `/skill:create-spec` → `/workflow ralph prompt="Implement specs/2026-03-rate-limit.md and validate the documented burst behavior"`. Ralph can start from a spec path, GitHub issue, or crisp ticket description, then uses that prompt as-is, researches as needed, delegates through sub-agents, reviews, records a QA proof video for UI/full-stack changes when practical, and iterates. Use `/workflow goal` when an autonomous job instead materially benefits from a durable goal ledger, bounded worker turns, and reviewer-gated completion; give it a concrete objective and add `create_pr=true` only when you want Goal's final `pull-request` stage after approval. Task size alone does not select either workflow.
+For a delegated autonomous implementation that materially benefits from a durable research-first pipeline, use `/skill:research-codebase` → `/skill:create-spec` → `/workflow ralph prompt="Implement specs/2026-03-rate-limit.md and validate the documented burst behavior"`. Ralph can start from a spec path, GitHub issue, or crisp ticket description; it uses that prompt as-is, researches the task, delegates through sub-agents, reviews, records a QA proof video for UI/full-stack changes when practical, and iterates.
+
+Use `/workflow goal` when an autonomous job instead materially benefits from a durable goal ledger, bounded worker turns, and reviewer-gated completion; give it a concrete objective and add `create_pr=true` only when you want Goal's final `pull-request` stage after approval. Task size alone does not select either workflow.
 
 ### `open-claude-design`
 
@@ -334,7 +521,7 @@ Inputs:
 | `discover_references` | boolean | no | `true` | Discover beautiful, current reference designs (Awwwards, recent.design, Dribbble, Monet, Motionsites) and feed them to generation. Set `false` to skip the network/browser reference pass. |
 | `max_refinements` | number | no | `3` | Maximum generate/user-feedback loop iterations. |
 
-The output type (`prototype`, `wireframe`, `page`, `component`, `theme`, `tokens`) and any reference designs are **not** inputs — the discovery stage asks for them. There is no `design_system` input; the project's `DESIGN.md`/`PRODUCT.md` are established/loaded automatically.
+The output type (`prototype`, `wireframe`, `page`, `component`, `theme`, `tokens`) and any reference designs are **not** inputs — the discovery stage asks for them. There is no `design_system` input; the workflow establishes or loads the project's `DESIGN.md`/`PRODUCT.md` automatically.
 
 Result fields:
 
@@ -357,16 +544,24 @@ Result fields:
 
 `open-claude-design` has no `result` output; it exposes only the declared fields listed above. Use the declared `artifact` and `handoff` fields for generated content.
 
-**Combined discovery/init.** The workflow's first and only front-door stage runs `/skill:impeccable shape` and `/skill:impeccable init` together. It interviews you (via the structured question tool) about what you want to build, the **output type** (`prototype`, `wireframe`, `page`, `component`, `theme`, or `tokens`), and which **references** to emulate (URLs, local file paths, screenshots, or design docs). Then, in the same `discovery` stage, impeccable init performs its own `PRODUCT.md`/`DESIGN.md` detection and creates or reconciles those files as needed. The references you name take **precedence over `DESIGN.md`/`PRODUCT.md`** during generation (the design system fills gaps the references don't cover, and `PRODUCT.md` still governs strategic register/voice). Headless runs infer a defensible brief, output type, references, and project-context assumptions rather than blocking.
+**Combined discovery/init.** The workflow's first and only front-door stage runs `/skill:impeccable shape` and `/skill:impeccable init` together. It interviews you (via the structured question tool) about what you want to build, the **output type** (`prototype`, `wireframe`, `page`, `component`, `theme`, or `tokens`), and which **references** to emulate (URLs, local file paths, screenshots, or design docs). Then, in the same `discovery` stage, impeccable init detects `PRODUCT.md`/`DESIGN.md` and creates or reconciles those files as needed.
+
+The references you name take **precedence over `DESIGN.md`/`PRODUCT.md`** during generation (the design system fills gaps the references don't cover, and `PRODUCT.md` still governs strategic register/voice). Headless runs infer a defensible brief, output type, references, and project-context assumptions rather than blocking.
 
 **Context and reference phase.** Design-system/reference research runs first, then gallery reference discovery uses those findings before the generator consumes the combined context:
 
 - *Design-system/reference research* — three parallel passes (`ds-locator` / `ds-analyzer` / `ds-patterns`) extract the project's design-system evidence and also handle user-provided references. URL references are captured with browser/screenshot tooling where available; local files, screenshots, and design docs are parsed by the applicable `ds-*` pass. Their extracted requirements feed the generator and **take precedence over `DESIGN.md`/`PRODUCT.md`**. There are no separate `web-capture-*`, `file-parser-*`, or `design-system-builder` stages.
-- *Reference discovery* (gated by `discover_references=true`, the default) — after the `ds-*` passes complete, the `reference-discovery` stage receives their evidence plus the `PRODUCT.md`/`DESIGN.md` init summary. It uses the `playwright-cli` skill to browse five curated galleries — [Awwwards](https://www.awwwards.com/websites/), [recent.design](https://recent.design/), [Dribbble recents](https://dribbble.com/shots/recent), [Monet](https://www.monet.design/c), and [Motionsites](https://motionsites.ai/) — then **clicks into the standout work** and, ideally, **records a scroll-through video of each real design page so its animations are captured** (with a full-page screenshot as a supplement/fallback) plus the real destination URL (it does not just screenshot the gallery thumbnails; web-search fallback when the browser is unavailable). It then asks which curated reference direction you prefer; if none align, it asks you to provide a reference image, screenshot, URL, or local path for best results. The curated **references brief** is persisted to `<artifact_dir>/references.md` and threaded into the generator (`reference_inspiration`) and refinement. Set `discover_references=false` to skip it.
+- *Reference discovery* (gated by `discover_references=true`, the default) — after the `ds-*` passes complete, the `reference-discovery` stage receives their evidence plus the `PRODUCT.md`/`DESIGN.md` init summary.
+  - It uses the `playwright-cli` skill to browse five curated galleries: [Awwwards](https://www.awwwards.com/websites/), [recent.design](https://recent.design/), [Dribbble recents](https://dribbble.com/shots/recent), [Monet](https://www.monet.design/c), and [Motionsites](https://motionsites.ai/).
+  - It then **opens the strongest selected designs** and, ideally, **records a scroll-through video of each real design page so its animations are captured**. A full-page screenshot is a supplement or fallback, and the real destination URL is retained; it does not just screenshot gallery thumbnails, with web search as the fallback when the browser is unavailable.
+  - It asks which curated reference direction you prefer. If none align, it asks you to provide a reference image, screenshot, URL, or local path for best results.
+  - The workflow persists the curated **references brief** to `<artifact_dir>/references.md` and passes it to the generator (`reference_inspiration`) and refinement. Set `discover_references=false` to skip it.
 
-**Generate/user-feedback loop.** Refinement is intentionally simple and mirrors Ralph's implement/reviewer rhythm: `generate-1` writes the first `preview.html`, `user-feedback-1` opens that preview with `/skill:impeccable live`, and any captured `live_changes`, `user_notes`, or `annotated_snapshot` feed the next forked `generate-*` stage. Generator and feedback stages keep separate session lineages: each later `generate-*` forks from the previous generate session, `user-feedback-1` starts its own feedback chain, and each later `user-feedback-*` forks only from the previous feedback session rather than falling back to generator sessions. When a `user-feedback-*` stage captures no meaningful feedback, the loop exports immediately. Export is deliberately just `exporter` followed by `final-display`; there is no pre-export scan, forced-fix stage, or export gate. Captured feedback is persisted as durable artifacts under `<artifact_dir>/feedback/iteration-<n>.md` / `.json` (plus a best-effort copy of the annotated snapshot, constrained to files within the project/artifact dir). If captured notes fail to thread into the next generate prompt, the run fails loudly rather than silently generating without user feedback.
+**Generate/user-feedback loop.** Refinement is intentionally simple and mirrors Ralph's implement/reviewer rhythm: `generate-1` writes the first `preview.html`, `user-feedback-1` opens that preview with `/skill:impeccable live`, and any captured `live_changes`, `user_notes`, or `annotated_snapshot` feed the next forked `generate-*` stage. Generator and feedback stages keep separate session lineages: each later `generate-*` forks from the previous generate session, `user-feedback-1` starts its own feedback chain, and each later `user-feedback-*` forks only from the previous feedback session rather than falling back to generator sessions.
 
-**Browser requirement.** open-claude-design is browser-centric (the discovery/preview review and the `live` QA loop need the `playwright-cli` skill's browser). If the browser cannot be made available, the workflow exits cleanly up front — surfacing the would-be artifact paths and install instructions — rather than generating a design you could not review interactively. (This early exit is skipped under the test harness so headless test runs still complete.)
+When a `user-feedback-*` stage captures no meaningful feedback, the loop exports immediately. The workflow deliberately runs only `exporter`, followed by `final-display`; there is no pre-export scan, forced-fix stage, or export gate. The workflow saves captured feedback as durable artifacts under `<artifact_dir>/feedback/iteration-<n>.md` / `.json` (plus a best-effort copy of the annotated snapshot, constrained to files within the project/artifact dir). If captured notes fail to thread into the next generate prompt, the run fails with an explicit error rather than silently generating without user feedback.
+
+**Browser requirement.** open-claude-design is browser-centric (the discovery/preview review and the `live` QA loop need the `playwright-cli` skill's browser). If no browser is available, the workflow exits cleanly before generation and reports the would-be artifact paths and install instructions rather than generating a design you could not review interactively. (The test harness skips this early exit so headless test runs still complete.)
 
 Run examples:
 
@@ -377,11 +572,11 @@ Run examples:
 /workflow open-claude-design prompt="Design a marketing landing page" discover_references=false
 ```
 
-The discovery interview asks for the output type and any reference URLs/files, so you no longer pass `output_type`, `reference`, or `design_system` on the command line.
+The discovery interview asks for the output type and any reference URLs/files, so do not pass `output_type`, `reference`, or `design_system` on the command line.
 
 ### Launching with natural language
 
-You can also kick off a built-in workflow by describing the task in chat. Atomic picks the matching workflow and fills in inputs from your request:
+You can also start a built-in workflow by describing the task in chat. Atomic picks the matching workflow and fills in inputs from your request:
 
 ```text
 Run a deep codebase research workflow on how the rate limiter behaves under burst traffic.
@@ -399,878 +594,9 @@ Use the ralph workflow to research a database-layer migration, implement it, rev
 Run open-claude-design to refresh the settings page hierarchy as a page.
 ```
 
-If required inputs are missing or ambiguous, Atomic will either ask or open the inline input picker before launching.
+If required inputs are missing or ambiguous, Atomic asks for missing inputs or opens the inline input picker before launching.
 
-### Monitor and steer a built-in run
-
-Named runs go to the background. Common controls:
-
-```text
-/workflow status                       # list retained active and terminal runs
-/workflow connect <run-id>             # graph viewer, including terminal runs
-/workflow attach <run-id> <stage>      # chat with a single stage
-/workflow interrupt <run-id>           # pause resumably
-/workflow resume <run-id> [stage] msg  # forward a steer message and resume
-/workflow quit <run-id>                # pause gracefully and keep the run resumable
-/workflows [run-id]                    # retained alias for /workflow resume (history picker)
-```
-
-`/workflows` (plural) is a retained alias for `/workflow resume`. With no argument it opens the DBOS-backed resume/history picker; with a run id it resumes that run directly. Ctrl+D deletes a highlighted inactive durable or completed row after confirmation. Deletion rechecks same-process activity and the authoritative DBOS status, refuses a `running` workflow, and leaves host and stage chat transcripts untouched.
-
-The history surface matches `/resume` retention semantics: eligible runs remain searchable regardless of age or count, with no automatic history garbage collection. DBOS/Postgres is the only workflow catalog, so listing, targeted lookup, completed inspection, and deletion query current database records directly. The picker mounts before asynchronous catalog hydration completes and merges DBOS rows when ready.
-
-Graceful quit is idempotent for an already-paused resumable run. If a run is waiting on `ctx.ui`, quit preserves its current DBOS prompt reservation. Answers cannot advance paused workflow code until explicit resume; checkpointing the answer releases exactly that reservation generation. Concurrent and nested prompts use composed scopes and independent DBOS reservation tokens.
-
-When a paused stage is resumed, whether or not the resume includes a message, Atomic first lets the stage answer any non-empty resume message and then (if the stage has not already finalized) injects `Continue where you left off. If you believe you are finished with your original task (or a redefined task if the user told you), stop.` into the same stage session before normal stage completion/readiness handling. This re-drives an interrupted no-message resume before result harvesting, keeps interrupted work moving without asking you to type a continuation prompt, and prevents stages that already finished their scoped work from overstepping.
-
-The same continuation applies to user messages queued into a live streaming stage. Steering a turn (Enter in an attached stage chat), queueing a follow-up (Ctrl+F), or using `workflow({ action: "send" })` with `steer`/`followUp` delivery arms the identical continuation prompt, which Atomic injects once when the interrupted turn ends — even if several messages were queued during that turn — so a steered stage returns to its original (or user-redefined) objective instead of stopping after answering the queued message. Messages delivered to an idle stage start a fresh user turn and receive no continuation nudge, and the injection is suppressed for aborted runs and finalized or fail-fast-skipped stages.
-
-When several paused stages resume together, Atomic settles every acknowledgement and then re-reads the actual stage/control state. A late rejection after its stage visibly starts counts as resumed and is not retried; genuinely paused failures remain available for a later resume. The run and durable root follow visible running work, while slash/tool output reports acknowledgement or durable-transition failures as partial progress instead of a no-op. If local resume succeeds but persisting the durable running transition fails, a later resume request retries reconciliation while the durable handle remains paused. A terminal run cannot be revived by a late acknowledgement.
-
-Durable `/workflow resume` preserves completed stage metadata, active-stage elapsed time, total run elapsed time, and graph topology. While an LM stage or task is active, repeated durable checkpoints refresh its accumulated pause-adjusted duration even when its session file does not change, and refresh the run's total accumulated elapsed time alongside it; graceful quit and recoverable failure additionally persist the exact run total at the boundary. Each new Atomic process that reopens the unfinished session mid-chat starts from the latest saved baseline and uses the same continuation prompt shown above, so repeated process-boundary resumes keep status, graph, stored, and lifecycle duration cumulative without double-counting pauses from earlier process segments — a resumed mid-running stage timer continues from its previously accumulated elapsed time instead of restarting at zero, and the total workflow duration shown in the main-chat dashboard and status surfaces reports prior-session elapsed plus current-session elapsed. Replayed `ctx.stage`, `ctx.task`, `ctx.chain`, `ctx.parallel`, and child-workflow checkpoints keep their original summaries, timing, session/model metadata, and parallel fanout parentage instead of appearing as freshly flattened replay nodes.
-
-**Post-mortem chat vs. execution resume.** These are distinct operations. *Resuming workflow execution* (`/workflow resume`) is for paused, interrupted, recoverably failed, or unfinished durable work; it may replay checkpoints, continue an incomplete stage, and dispatch remaining DAG work. *Opening a post-mortem chat* reopens one terminal agent stage's retained conversation for follow-up only — it never resumes, retries, rewinds, or otherwise changes workflow execution. Any eligible terminal agent stage with a valid retained session opens as an interactive post-mortem chat regardless of how you reach it: same-process `task`/`tasks`/`chain` stages, completed-workflow inspection, generic `/workflow attach` / `/workflow connect`, restored/replayed durable snapshots after a restart, and `workflow({ action: "send" })`. Explicit `/workflow attach <root-run> <nested-stage>` targets are resolved through the expanded graph and routed to the child run that owns the stage while the overlay remains rooted on the requested graph; the resolved owner is preserved when sibling child workflows reuse the same local stage ID. When a nested stage is reopened after a restart or from another checkout, its session cwd comes from the durable root workflow (resolved workflow cwd first, then original invocation cwd) while stage-control ownership remains with the actual child run. Follow-up turns are appended in place to the stage's retained session (no separate fork), so the agent may still invoke its ordinary tools and cause side effects; only the workflow DAG, run/stage status, results, timings, checkpoints, and topology are immutable. Every host session replacement or shutdown invalidates post-mortem handles, including a session whose lazy reopen is still pending: if creation finishes after the boundary, Atomic disposes the newly created session and rejects the already-submitted prompt before it can execute. A stage stays a **read-only transcript** when it has no valid retained agent session — prompt/HIL and boundary/summary nodes, skipped nodes without a completed conversation, non-terminal handle-less stages (another process may still own the session), and missing/malformed/deleted session files. When a known stage cannot be reopened, the attached chat shows the complete `SESSION UNAVAILABLE` explanation down to the supported 40-column minimum instead of incorrectly labeling an invalid file as an archived transcript. Recoverably failed stages keep their execution-resume semantics and are not silently reopened as post-mortem chat.
-
-Completed stages also remain addressable by blocking `intercom.ask` calls from sibling workflow stages. If an ask reaches a completed target with a retained conversation, Atomic automatically schedules one serialized post-mortem turn in that exact conversation; no manual `workflow send` follow-up is needed. The target sees the original ask and its normal `intercom.reply` remains correlated to the originating child session and message ID, so the parent chat or another session cannot satisfy the waiter. Late-message routing uses single-owner claiming: after the workflow post-mortem router claims a completed-stage ask and assigns its completion promise, later listeners preserve that claim, making bundled extension registration order irrelevant. This reopens conversation only: the workflow DAG and terminal stage snapshot remain completed and are never resumed or re-dispatched. If the target run/stage was deleted, lacks a valid retained conversation, is non-resumable, or fails to reopen, the caller receives a bounded actionable `intercom.ask` tool error instead of waiting indefinitely.
-
-Workflow stage sessions and first-party subagent transcripts created inside them are classified as **internal** at creation and excluded from the standard `/resume`, `atomic -r`, `--continue`, and global history surfaces. Fork-context stages and subagents inherit the owning run/stage marker in their initial JSONL header, avoiding a briefly visible ordinary session. They remain resumable and inspectable through the workflow-specific commands and tool actions shown here (`/workflow resume`, `/workflow attach`, `workflow({ action: "status" | "stages" | "stage" | "resume" })`), which read the run/stage store and its `sessionFile` links directly. Passing a stage session's file path to `--session` still opens it explicitly. Classification requires exact `internal: true` plus complete run/stage metadata; malformed legacy markers and ordinary user forks remain in standard history. Legacy workflow sessions created before this marker behavior lack provable ownership and continue to appear until they age out.
-
-Human-in-the-loop prompts from `ctx.ui.input`, `ctx.ui.confirm`, `ctx.ui.select`, `ctx.ui.editor`, and `ctx.ui.custom<T>` appear as awaiting-input nodes in the workflow graph viewer, not as chat modals — use `/workflow connect <run-id>` (or F2), then press Enter on the focused node or click a visible graph node directly to focus and open/attach it for local answers.
-
-`ctx.ui.custom<T>(factory, options?)` reuses Atomic's TUI component path: the factory receives the same real `(tui, theme, keybindings, done)` types as extension `ctx.ui.custom`, and the workflow resumes with the value passed to `done(value)`. Use `options.label` for a safe display-only graph/status label and `options.replayIdentity` when widget semantics can change without the callsite changing. Do not put secrets in labels or replay identities; only a hash of the identity is stored, and label text is not part of replay identity. Inline connected rendering is supported; `overlay: true` is rejected clearly because nested workflow graph overlays are not safely supported yet.
-
-Prompt answers are replayable only while the source run remains in the live in-memory store. `StageSnapshot.promptAnswerState` is snapshot-safe metadata for continuation: `available` means a matching live answer can be replayed, `unavailable` means the matching prompt node exists but its private answer was purged, and `ambiguous` means multiple matching prompt nodes exist so Atomic asks again. The raw answer lives in a private `PromptAnswerRecord` ledger, is never written to snapshots or persistence, and remains resident in memory until the answer is cleared, the run is removed, or the store is cleared. Prompt replay keys include the prompt kind, message text, select choices, input/editor initial value, custom prompt identity hash, and hashed author callsite, so changing any of those inputs may intentionally re-ask on continuation. An empty `ctx.ui.select(..., [])` has no answerable choices and throws before creating a prompt node. Arbitrary custom-widget answers cannot be supplied through `workflow send`; focus the `custom` awaiting-input node in the interactive graph instead.
-
-## When to Use Workflows
-
-Workflows are the default execution path when a request is non-trivial or combines inherent structure with a verifiable objective. Choose a workflow before direct chat when the prompt includes any of these signals:
-
-- implementation, build, debugging/diagnosis, bug-fix, migration, new-feature, scoped multi-file, or validated docs/code work
-- multiple subtasks, dependencies, handoffs, uncertainty, or parallel/sequential stages
-- review, validation, QA, approval, evidence, or human-input gates
-- long-running or resumable background execution, saved artifacts, or important model fallback chains
-- reusable automation or a loop/stop condition such as `do X until Y`, `review/fix until passing`, or `run checks and fix until green`
-
-Use direct chat only for tiny, deterministic, low-risk answers or edits where stage tracking clearly costs more than it adds, typically a single-file/no-test/no-review change. Decide inline versus workflow before the first tool call; reconnaissance is already inline execution. Once workflow fit is clear, limit pre-workflow reconnaissance to the few reads needed to sharpen the objective and validation criteria, and put deeper research or behavior probing inside the run.
-
-Do not confuse workflow-first with force-fitting a builtin. Discover named builtin, project, user, and package workflows; use direct `task`, `tasks`, or `chain` calls for simple tracked shapes; or write a task-specific TypeScript `workflow({...})` inline with normal coding tools. Rich custom workflows can compose the starter patterns below: classify and branch at runtime, fan out and synthesize artifacts, run worker/verifier/reducer repair cycles, generate and filter or tournament-rank candidates, and loop until explicit evidence says the work is done. Write the definition, reload workflow resources, and run it; the workflow tool has no create action.
-
-If inline work drifts past roughly ten exploratory tool calls without an artifact, edit, or commit, or repeats a "verify one more thing" loop, save the findings to a context file and hand the task to the best-fit named or custom workflow through `reads`. Sunk research is transferable, not a reason to continue inline.
-
-| User goal | Use |
-|-----------|-----|
-| Run, inspect, connect to, pause, interrupt, quit, resume, or check status for an existing workflow | `/workflow ...` or `workflow({ action: ... })` |
-| Run an autonomous job that materially benefits from a durable goal ledger, bounded worker turns, named validation, and reviewer-gated completion | `/workflow goal objective="..."` so Atomic captures receipts, gates completion through reviewers, stops as `complete`, `blocked`, or `needs_human`, and can optionally run a final PR handoff with `create_pr=true` after approval |
-| Run an autonomous job that materially benefits from a durable research-first pipeline, delegated implementation, and iterative review | `/workflow ralph prompt="..."` so Atomic can transform the prompt into a research question, research the codebase first, delegate implementation through sub-agents, review, and iterate; prompt text alone does not opt in to PR creation, so add `create_pr=true` only when you want the final `pull-request` stage and `pr_report` |
-| Create or edit reusable automation | a TypeScript workflow definition exported from `workflow({...})` |
-| Track one-off work without saving a workflow file | direct `workflow({ task })`, `workflow({ tasks })`, or `workflow({ chain })` calls |
-| Make a workflow robust | design the stage graph, context handoffs, artifacts, validation gates, model fallbacks, and human approval points before coding |
-
-## Workflow Starter Patterns
-
-When a workflow is larger than a single tracked task, start by choosing a small control-flow pattern before writing prompts. Naming the pattern keeps the stage graph understandable, makes validation gates explicit, and helps reviewers see why work is split across model sessions.
-
-These patterns are composable. For example, a migration workflow might use **fan-out-and-synthesize** to fix many call sites, then **adversarial verification** to review each patch, and finally **loop until done** while tests still fail.
-
-| Pattern | Use it when | Atomic shape |
-|---|---|---|
-| **Classify-and-act** | Inputs arrive in different categories and each category needs a different path, model, tool set, or output format. | `ctx.task("classify")` → deterministic branch → category-specific `ctx.task`, `ctx.chain`, `ctx.parallel`, or child `ctx.workflow(...)`. |
-| **Fan-out-and-synthesize** | The task can be split into many independent slices that benefit from clean context windows. | `ctx.parallel([...])` with separate artifacts → synthesis barrier that reads the artifacts and merges the answer. |
-| **Adversarial verification** | Outputs need independent checking against a rubric, security rule, factual source, or acceptance contract. | Worker stage(s) → fresh-context verifier stage(s) → reducer that accepts, rejects, or asks for repair. |
-| **Generate-and-filter** | You need many candidate ideas, plans, names, fixes, or hypotheses before selecting the best few. | Generator fan-out → dedupe/filter stage → optional verifier/judge → final shortlist. |
-| **Tournament** | The whole task is subjective or approach-sensitive, and comparative judgment is more reliable than absolute scoring. | Several agents attempt the same task → pairwise judges compare results → bracket reducer returns winners. |
-| **Loop until done** | The amount of work is unknown up front, such as finding all failures, mining repeated issues, or iterating until checks pass. | Bounded loop with an explicit stop condition, progress ledger, per-iteration artifacts, and a max-iteration escape hatch. |
-
-### Pattern diagrams
-
-#### 1. Classify-and-act
-
-```text
-┌─ 1  Classify-and-act ────────────────────────────────────┐
-│                                                          │
-│                             ┌───────┐                    │
-│                         ╭──▸│agent A│                    │
-│                         │   └───────┘                    │
-│  ┌────┐  ┌──────────┐   │   ┌───────┐                    │
-│  │task│─▸│classifier│───┼──▸│agent B│ ◂ chosen           │
-│  └────┘  └──────────┘   │   └───────┘                    │
-│                         │   ┌───────┐                    │
-│                         ╰──▸│agent C│                    │
-│                             └───────┘                    │
-│                                                          │
-└──────────────────────────────────────────────────────────┘
-```
-
-Best practices:
-- Make the classifier return a structured category and confidence, not free-form prose.
-- Keep each action branch isolated with the minimum tools and context it needs.
-- Add a fallback or human-input branch for low-confidence classifications.
-
-#### 2. Fan-out-and-synthesize
-
-```text
-┌─ 2  Fan-out-and-synthesize ──────────────────────────────┐
-│                                                          │
-│            ┌───────┐                                     │
-│          ╭▸│agent 1│──╮                                  │
-│          │ └───────┘  │                                  │
-│          │ ┌───────┐  │                                  │
-│          ├▸│agent 2│──┤                                  │
-│  ┌────┐  │ └───────┘  │ ┌───────┐  ┌──────────┐          │
-│  │task│──┤ ┌───────┐  ├▸│barrier│─▸│synthesize│          │
-│  └────┘  ├▸│agent 3│──┤ └───────┘  └──────────┘          │
-│          │ └───────┘  │                                  │
-│          │ ┌───────┐  │                                  │
-│          ╰▸│agent 4│──╯                                  │
-│            └───────┘                                     │
-│                                                          │
-└──────────────────────────────────────────────────────────┘
-```
-
-Best practices:
-- Partition by files, sources, claims, candidates, or work items that can be evaluated independently.
-- Save each branch to a separate artifact and pass paths with `reads` instead of inlining all branch output.
-- Treat synthesis as a barrier: it waits for every branch, deduplicates, resolves conflicts, and cites evidence.
-
-#### 3. Adversarial verification
-
-```text
-┌─ 3  Adversarial verification ────────────────────────────┐
-│                                                          │
-│                                                          │
-│                                 ┌──────────┐             │
-│               ├────────────────▸│verifier A│             │
-│               │                 └──────────┘             │
-│  ┌──────┐     │                 ┌──────────┐             │
-│  │worker│◂────┼────────────────▸│verifier B│             │
-│  └──────┘     │                 └──────────┘             │
-│               │                 ┌──────────┐             │
-│               ├────────────────▸│verifier C│             │
-│                                 └──────────┘             │
-│                                                          │
-└──────────────────────────────────────────────────────────┘
-```
-
-Best practices:
-- Give verifiers fresh context and a concrete rubric with pass/fail evidence requirements.
-- Separate production from judgment to reduce self-preferential bias.
-- Ask verifiers to find blockers, not to rewrite the candidate unless repair is explicitly their role.
-
-#### 4. Generate-and-filter
-
-```text
-┌─ 4  Generate-and-filter ─────────────────────────────────┐
-│                                                          │
-│                                                          │
-│  ┌─────┐   ┌────┐                      ┌────┐            │
-│  │gen A│──▸│idea│───╮              ╭──▸│best│            │
-│  └─────┘   └────┘   │              │   └────┘            │
-│  ┌─────┐   ┌────┐   │  ┌──────┐    │   ┌────┐            │
-│  │gen B│──▸│idea│───┼─▸│filter│────┼──▸│best│            │
-│  └─────┘   └────┘   │  └──────┘    │   └────┘            │
-│  ┌─────┐   ┌────┐   │              │   ┌╌╌╌╌╌╌╌╌╌┐       │
-│  │gen C│──▸│idea│───╯              ╰──▸╎discarded╎       │
-│  └─────┘   └────┘                      └╌╌╌╌╌╌╌╌╌┘       │
-│                                                          │
-└──────────────────────────────────────────────────────────┘
-```
-
-Best practices:
-- Generate more candidates than you need, then filter hard by an explicit rubric.
-- Dedupe before judging so near-identical candidates do not dominate the shortlist.
-- Use this for exploration, naming, design options, hypotheses, and lightweight eval ideas.
-
-#### 5. Tournament
-
-```text
-┌─ 5  Tournament ──────────────────────────────────────────┐
-│                                                          │
-│  ┌─────────┐                                             │
-│  │attempt A│──╮  ┌───────┐                               │
-│  └─────────┘  ├─▸│judge 1│───╮                           │
-│  ┌─────────┐  │  └───────┘   │                           │
-│  │attempt B│──╯              │   ┌─────┐  ┌──────┐       │
-│  └─────────┘                 ├──▸│final│─▸│winner│       │
-│  ┌─────────┐                 │   └─────┘  └──────┘       │
-│  │attempt C│──╮  ┌───────┐   │                           │
-│  └─────────┘  ├─▸│judge 2│───╯                           │
-│  ┌─────────┐  │  └───────┘                               │
-│  │attempt D│──╯                                          │
-│  └─────────┘                                             │
-│                                                          │
-└──────────────────────────────────────────────────────────┘
-```
-
-Best practices:
-- Use pairwise comparison when absolute scores are noisy or subjective.
-- Randomize or balance presentation order where possible to reduce order bias.
-- Keep the judge rubric short and require rationale tied to observable criteria.
-
-#### 6. Loop until done
-
-```text
-┌─ 6  Loop until done ─────────────────────────────────────┐
-│                                                          │
-│      yes, spawn another                                  │
-│     ╭────────────────╮                                   │
-│     ▾                │                                   │
-│  ┌─────┐      ┌─────────────┐  no   ┌────┐               │
-│  │agent│─────▸│new findings?│──────▸│done│               │
-│  └─────┘      └─────────────┘       └────┘               │
-│                                                          │
-└──────────────────────────────────────────────────────────┘
-```
-
-Best practices:
-- Define both success and escape conditions before the loop starts.
-- Keep a durable ledger of attempted work, findings, failures, and validation evidence.
-- Bound loops by iterations, budget, or convergence criteria so they fail inspectably instead of drifting.
-
-### Choosing a starter pattern
-
-- Pick **classify-and-act** when routing correctness matters more than breadth.
-- Pick **fan-out-and-synthesize** when the work divides cleanly into independent slices.
-- Pick **adversarial verification** when the main risk is a plausible but wrong answer.
-- Pick **generate-and-filter** when the output quality depends on exploring a large option space.
-- Pick **tournament** when multiple whole-solution strategies should compete under one rubric.
-- Pick **loop until done** when the workflow should continue until evidence says it is finished, not until a preselected number of stages completes.
-
-Record the selected pattern in your spec or workflow README, then adapt the diagram to the actual stage graph. If the final design does not resemble any starter pattern, explain why in the workflow's design notes.
-
-## Choosing an Execution Shape
-
-"Use a workflow" is not one decision — it is a ladder of execution shapes with different costs and guarantees. This section is written as agent-facing guidance: it is the self-prompt an orchestrating agent should run before the first tool call on a new request, and it doubles as documentation for humans who want to steer that choice explicitly.
-
-The shapes, cheapest first:
-
-| Shape | What it is | Guarantees you gain | Cost you pay |
-|---|---|---|---|
-| **Inline** | Answer or edit directly in the current session. | Lowest latency, zero ceremony. | No tracking, no gates, no isolation, easy to drift. |
-| **Inline + subagents** | Bounded specialist delegation (locate/analyze/research/debug passes, noisy command investigation, parallel read-only fanouts) while the parent keeps control and synthesizes. | Context isolation for noisy or parallel evidence-gathering. | No completion gate, no durable stages; the parent is the only reviewer. |
-| **Direct one-off shapes** | `workflow({ task })`, `workflow({ tasks })`, or `workflow({ chain })` without saving a definition. | Stage tracking, artifacts, model fallbacks, monitoring, resume. | Linear/parallel control flow only; no custom branching or loops. |
-| **Named workflows** | Installed builtin, project, user, or package workflows (`goal`, `ralph`, `deep-research-codebase`, `open-claude-design`, ...). | A proven graph: bounded loops, reviewer gates, ledgers, evidence contracts, tuned model chains. | The task must actually match the graph's objective and inputs. |
-| **Custom workflow** | A task-specific TypeScript `workflow({...})` authored inline, composing the starter patterns. | Exactly the control flow the task needs: runtime branching, dynamic fan-out, custom gates, tournaments, bounded loops. | Authoring and reload time; you own the design quality. |
-| **Composed/nested workflows** | A custom parent that imports proven definitions and calls `ctx.workflow(child)`. | Reuse of hardened children (research, review loops) inside custom control flow, within `maxDepth`. | Parent/child input-output contracts must be mapped deliberately. |
-
-### The self-prompt
-
-Ask these questions in order and stop at the first shape that satisfies every remaining requirement. Decide before the first tool call and state the decision; reconnaissance already counts as inline execution.
-
-1. **Is the outcome provable?** If success can be stated as evidence (tests green, artifact exists, behavior demonstrated, reviewer approves), the task is workflow-shaped. If no proof is possible or needed, inline is probably fine.
-2. **Is there structure?** Multiple subtasks, dependencies, handoffs, or parallel slices push past inline. A single focused evidence-gathering pass does not.
-3. **Is there a loop or gate?** Any "until Y", "fix until passing", review/approval gate, or unknown-length repair cycle requires an engine that owns the stop condition — a workflow, never an improvised inline retry loop or a stretched subagent chain.
-4. **Is it one task or a queue of tasks?** "Address all open issues" or "fix every ticket assigned to me" is a factory request, not one workflow. Enumerate and dependency-classify the items first, then follow [Task queues and software factories](#task-queues-and-software-factories): independent items become separate per-item runs; dependent items share one composed graph.
-5. **Does an installed graph already fit?** If a named workflow's objective and inputs cover essentially the whole task, run it. Do not force-fit: a builtin that matches 60% of the task and fights the other 40% is worse than a small custom graph.
-6. **Does the control flow need shapes builtins don't offer?** Runtime classification, per-item dynamic fan-out, generate-and-filter, tournaments, or domain-specific gates mean authoring a custom workflow from the starter patterns.
-7. **Is a sub-problem already solved by a proven graph?** Nest it with `ctx.workflow(...)` instead of re-authoring its prompts and gates. Composition beats duplication whenever a child's input/output contract can be mapped cleanly.
-8. **Is it only specialist evidence-gathering?** If the parent keeps control, no completion gate is needed, and the work is bounded (a debug pass, a parallel research fanout, one noisy investigation), inline subagents are enough — and cheaper than a workflow.
-9. **Is it truly tiny?** Deterministic, low-risk, single-file/no-test/no-review — answer or edit inline and stop.
-
-### Scoring rubric
-
-When the ladder is ambiguous, score the task on six dimensions (0–2 each):
-
-| Dimension | 0 | 1 | 2 |
-|---|---|---|---|
-| **Structure** | one action | a few sequential steps | many steps, dependencies, or parallel slices |
-| **Verifiability** | no objective check | spot-checkable | provable by tests, builds, artifacts, or review evidence |
-| **Iteration** | one pass suffices | may need one repair round | unknown-length loop until evidence passes |
-| **Risk** | trivial, reversible | scoped multi-file change | regressions, migrations, releases, or user-visible behavior |
-| **Duration** | seconds to minutes | tens of minutes | long-running, background, or resumable across sessions |
-| **Isolation** | one context is fine | one noisy investigation to quarantine | many slices needing clean contexts or adversarial independence |
-
-Interpretation:
-
-- **0–3 total:** inline. Adding stages costs more than it buys.
-- **4–6 total, Iteration ≤ 1, no gate:** inline subagents (parent-controlled) or a direct one-off `task`/`tasks`/`chain` when tracking and artifacts help.
-- **7+ total, or Iteration = 2, or Verifiability = 2 with a review/approval gate:** a real workflow. Prefer a named workflow when one fits the whole task; otherwise author a custom graph, nesting proven children where sub-problems overlap.
-- **Any single hard signal overrides the arithmetic:** an explicit loop/stop condition, an approval or evidence gate, or a request for durable/background execution puts the task in workflow territory regardless of total score.
-
-Two common misuses the rubric exists to prevent: stretching parent-controlled subagent calls into an ad hoc implement→review→retry pipeline (that is adversarial verification without an engine — use a workflow and let its stages delegate specialists), and unbounded inline reconnaissance (after roughly ten exploratory calls with no artifact, write findings to a context file and hand off through `reads`; sunk research transfers, it is not a reason to stay inline).
-
-### Task queues and software factories
-
-Some requests are not one task but a queue of them: "address all open issues", "fix every Linear ticket assigned to me", "burn down the TODO backlog", "upgrade every service to the new SDK". These fire-and-forget factory requests get their own decision step, because the biggest mistake is jumping straight to one monolithic workflow that grinds through the queue serially in a single ever-growing context.
-
-**Triage the queue before choosing the shape.** The first action is always a cheap enumeration-and-dependency pass, not implementation: list the items (issue tracker query, ticket API, grep for TODOs), then classify how they relate:
-
-- **Independent items** — different subsystems, no shared files, no ordering constraints, each individually verifiable.
-- **Dependent items** — one blocks another, they touch the same files/modules, they share a migration or API change, or their acceptance criteria reference each other.
-- **Clustered** — the queue splits into groups: dependencies inside a group, independence between groups.
-
-**Independent items → many small runs, not one big one.** Spawn one workflow run per item (typically `goal` with the item's text as the objective and acceptance criteria, `create_pr=true` for per-item PRs), each in its own `git_worktree_dir`, running in the background. One run per item buys what a monolith cannot:
-
-- **Isolation:** a hard item that stalls or fails does not poison the remaining ones; each run resumes, retries, or can be stopped independently.
-- **Clean contexts:** every item starts with full attention on its own objective instead of inheriting twenty finished tickets of transcript.
-- **Independent evidence:** per-item reviewer gates, receipts, and PRs that a human can merge or reject one at a time.
-- **Real parallelism:** runs proceed concurrently, bounded by however many you choose to have in flight at once (worktrees prevent filesystem collisions).
-
-Do not spawn unbounded: dispatch in waves (for example 3–5 concurrent runs), wait for lifecycle notices, then dispatch the next wave — and report the dispatch plan (item → run id → worktree) so the queue is auditable.
-
-**Dependent items → one graph that encodes the ordering.** When items block each other or share a change surface, isolation stops being a feature — separate runs would fight over the same files or implement against stale assumptions. Encode the dependency structure explicitly instead:
-
-- **A composed parent workflow** that nests a proven child (for example `ctx.workflow(goal, ...)` per item) in dependency order, passing each item's outputs/artifacts to its dependents — the preferred form, because each item still gets its own bounded loop and reviewer gate while the parent owns sequencing.
-- **A single monolithic workflow** only when the items are so entangled they are really one task with subtasks (one migration touching every call site is one task, not a queue).
-
-**Clustered queues → both.** Compose within a cluster, fan out across clusters: each cluster becomes one run (a composed parent or a single `goal` objective covering the cluster), and independent clusters are dispatched as parallel background runs in waves.
-
-The self-prompt for factory requests, condensed: **enumerate → classify dependencies → fan out runs where independent, compose graphs where dependent → dispatch in bounded waves → report the plan.** When dependency classification is uncertain, prefer smaller independent runs and let per-item reviewer gates catch collisions — a rejected PR is cheaper than a monolith that carried a bad assumption through the whole queue.
-
-### Prompting the choice
-
-Humans can steer the shape directly. The strongest levers, in rough order of effect:
-
-- **Name the shape or workflow.** "Do this inline", "use subagents to investigate", "run the goal workflow", or "write a custom workflow for this" is honored over the agent's own scoring.
-- **State acceptance criteria.** Verbatim acceptance criteria make the objective provable, which both selects workflow execution and pins the immutable contract that `goal`/`ralph` reviewers enforce.
-- **State the loop.** "Iterate until tests pass", "review and fix until approved" — loop wording is a hard workflow signal and defines the stop condition.
-- **State the evidence.** Asking for a PR, a QA video, test output, or reviewer sign-off tells the agent which gates the graph needs.
-- **State the boundary.** "Work in a separate worktree", "don't create the PR yet", or "stop after implementation" separates the implementation loop from explicitly authorized final actions.
-- **State the queue policy.** For factory requests, say how to split and gate the queue: "one workflow and PR per issue", "these three tickets depend on each other — do them in order in one run", "triage first and show me the dependency plan before dispatching", or "no more than three runs at a time". Absent a policy, the agent triages dependencies itself and defaults to independent per-item runs with per-item evidence.
-
-Absent these levers, the agent applies the self-prompt and rubric above — so a prompt that mentions none of them is delegating the shape decision, not avoiding it.
-
-## Atomic vs Claude Code Dynamic Workflows
-
-Claude Code Dynamic Workflows and Atomic are trying to solve a similar class of problem: important software engineering work is too large for one agent pass, so the system should split the job into stages, run agents in parallel, verify the result, and keep enough state to finish long-running work.
-
-Atomic's category is broader and more explicit: it is the loop engine for engineering work. The difference is where control lives and how much of the loop you can inspect, version, extend, and connect to your stack.
-
-| Dimension | Atomic | Claude Code Dynamic Workflows |
-| --- | --- | --- |
-| Core idea | Open-source, repo-native loop engine for coding agents. You can run built-ins, tell the coding agent to use a workflow for a task, describe new loops in natural language for Atomic to scaffold dynamically, or version them as explicit TypeScript files. | Claude dynamically creates orchestration scripts for a task and fans work out to many parallel Claude subagents. |
-| Best fit | Teams that want repeatable software engineering loops they can inspect, version, extend, connect to tools, and run across providers. | Claude Code users who want Claude to decide when a task needs a larger dynamic workflow and orchestrate it automatically. |
-| Workflow control | The process is explicit: stages, inputs, handoffs, retries, artifacts, model choices, checkpoints, and human gates are part of the workflow definition. | The process is generated dynamically by Claude for the current task, with confirmation before the first workflow run. |
-| Models | Model-agnostic. Atomic connects directly to supported API-key and subscription providers, and workflows can use model fallback chains. | Claude-first. Availability is tied to Claude Code, Claude plans, and Anthropic-supported API/cloud channels. |
-| Extensibility | Built on Pi extensions: add tools, TUI, MCP, web access, intercom, skills, prompt templates, themes, custom providers, and packaged workflows. | Optimized for Claude Code's built-in dynamic orchestration experience rather than an open extension SDK you own in-repo. |
-| Artifacts and auditability | Research docs, specs, logs, transcripts, reviewer notes, check output, and final summaries can live in the repo or workflow run directory. | Progress is saved and resumable, but the orchestration is primarily a Claude Code runtime behavior. |
-| Cost/scale posture | You choose the graph and concurrency. Atomic can be small and deterministic, or broad when you intentionally design a larger workflow. | Designed for large fan-outs, including tens to hundreds of subagents; Anthropic notes it can consume substantially more tokens than a typical Claude Code session. |
-
-## Workflow Locations
-
-Atomic discovers workflow definitions in this order:
-
-| Location | Scope | Notes |
-|----------|-------|-------|
-| `.atomic/extensions/workflow/config.json` | Project | `workflows.<name>.path`; project entries override global entries |
-| `.atomic/workflows/*.{ts,js,mjs,cjs}` | Project | Legacy `.pi/workflows/` is also checked |
-| `~/.atomic/agent/extensions/workflow/config.json` | Global | `workflows.<name>.path` for user-wide configured paths |
-| `~/.atomic/agent/workflows/*.{ts,js,mjs,cjs}` | Global | Legacy `~/.pi/agent/workflows/` is also checked |
-| Installed Atomic packages | Package | Uses package metadata or conventional `workflows/` directories |
-| Bundled workflows | Built-in | Shipped with `@bastani/workflows` |
-
-A workflow module may export one default workflow definition and/or named workflow definitions. Discovery checks the default export first, then named exports.
-
-Every runtime export of a discovered workflow file is validated as a workflow definition. A named export that is not a workflow definition — a widget factory, shared constant, or utility function — is rejected with an `INVALID_DEFINITION` discovery diagnostic (`export is not an object`), even when the module also has a valid default export (the valid workflow still loads; the diagnostic flags the extra export as skipped). Type-only exports (`export type` / `export interface`) are erased at runtime and never flagged.
-
-To co-locate reusable helpers with your workflows — for example a `ctx.ui.custom<T>` widget factory you want to import in tests without running the workflow — put them in a subdirectory and import them from the workflow file. Discovery scans only the top level of each workflow directory, so subdirectories such as `.atomic/workflows/lib/` are never treated as workflow modules:
-
-```text
-.atomic/workflows/
-  release-picker.ts      # only runtime export: workflow({...})
-  lib/
-    table-selector.ts    # widget factory + helpers; not scanned by discovery
-```
-
-```ts
-// .atomic/workflows/release-picker.ts
-import { workflow } from "@bastani/workflows";
-import { Type } from "typebox";
-import { tableSelectorFactory } from "./lib/table-selector.js";
-```
-
-```ts
-// .atomic/workflows/lib/table-selector.ts
-import type { WorkflowCustomUiFactory } from "@bastani/workflows";
-
-export const tableSelectorFactory: WorkflowCustomUiFactory<{ id: string; name: string }> = (
-  tui,
-  theme,
-  _keybindings,
-  done,
-) => ({
-  render: (width) => ["..."],
-  invalidate: () => {},
-  handleInput: (data) => {
-    /* ... done({ id, name }) on Enter ... */
-  },
-});
-```
-
-Workflow files are loaded via [jiti](https://github.com/unjs/jiti), so TypeScript works without compilation.
-
-## Reloading workflow resources
-
-Run `/workflow reload` after adding, editing, renaming, or deleting workflow modules or changing workflow config. Reload rescans project and user conventional directories, legacy `.pi` locations, configured file/directory paths, and package resources without restarting Atomic. The workflow tool's `reload` action uses the same in-process path.
-
-Reload builds a complete replacement registry before publishing it. Concurrent requests are serialized and coalesced, stale discovery from an earlier session cannot overwrite newer state, and a fatal refresh failure retains the previous registry. Reload is safe while workflows are running: existing runs keep the definition and runtime snapshot they started with, while subsequent list/get/inputs/help/completion/invocation calls use the newly published registry.
-
-A successful rescan may still contain per-resource diagnostics. Both reload surfaces now show `CONFIG_INVALID`, `IMPORT_FAILED`, `INVALID_DEFINITION`, `PATH_NOT_FOUND`, and duplicate-name diagnostics instead of reporting bare success while silently skipping a resource. Valid sibling workflows remain available. Fix the reported source/path and reload again; no process restart is required.
-
-## Workflow Configuration
-
-Configured workflow paths live in workflow extension config. Project config paths are relative to the project root. Global config paths are relative to `~/.atomic/agent`.
-
-Project config:
-
-```text
-.atomic/extensions/workflow/config.json
-```
-
-Global config:
-
-```text
-~/.atomic/agent/extensions/workflow/config.json
-```
-
-Example config:
-
-```json
-{
-  "workflows": {
-    "team": { "path": "./workflows/team.ts" },
-    "shared": { "path": "/shared/team/workflows" }
-  },
-  "defaultConcurrency": 4,
-  "maxDepth": 4,
-  "persistRuns": true,
-  "statusFile": false,
-  "resumeInFlight": "ask",
-  "workflowNotifications": {
-    "enabled": true,
-    "notifyOn": ["completed", "failed", "blocked", "awaiting_input"]
-  }
-}
-```
-
-Runtime config defaults:
-
-| Key | Default | Purpose |
-|-----|---------|---------|
-| `defaultConcurrency` | `4` | Default concurrency for direct parallel/grouped execution |
-| `maxDepth` | `4` | Maximum workflow nesting depth |
-| `persistRuns` | `true` | Persist run metadata for status/resume/history |
-| `statusFile` | `false` | Write a derived status file; defaults under `.atomic/workflows/status.json` when enabled |
-| `resumeInFlight` | `"ask"` | Behavior when discovering resumable in-flight work |
-| `workflowNotifications.enabled` | `true` | Emit terminal workflow lifecycle notices into the active main chat |
-| `workflowNotifications.notifyOn` | `["completed", "failed", "blocked", "awaiting_input"]` | Lifecycle states to track; terminal `completed`/`failed`/`blocked` states create main-chat notices, while `awaiting_input` is tracked for dedupe/restore without waking the main agent |
-
-Invalid JSON or invalid shapes produce `CONFIG_INVALID` diagnostics. Missing config files are ignored.
-
-## Package Setup
-
-Atomic packages can ship workflows through package metadata or conventional directories. A package manifest can declare workflows next to extensions, skills, prompt templates, and themes:
-
-```json
-{
-  "name": "my-atomic-workflows",
-  "keywords": ["atomic-package", "pi-package"],
-  "atomic": {
-    "extensions": ["./src/index.ts"],
-    "workflows": ["./workflows"]
-  }
-}
-```
-
-Paths are relative to the package root and may use glob patterns. Include `atomic-package` for Atomic package discovery and `pi-package` when you want compatibility with existing package-gallery tooling.
-
-For new Atomic package examples, prefer `atomic.workflows` and `atomic.extensions`. `pi.workflows` and `pi.extensions` remain supported for compatibility with existing packages. Workflows can be declared with `atomic.workflows` or discovered from conventional `workflows/` / `workflow/` directories. Unlike other resource types, package workflows still fall back to conventional directories when a package manifest exists but omits the workflow key. App-level config prefers `atomicConfig` where available; legacy `piConfig` is still read as a shim.
-
-Convention directory example:
-
-```text
-my-atomic-workflows/
-  package.json
-  workflows/
-    release-plan.ts
-    review-loop.ts
-  src/
-    index.ts
-```
-
-Install packages globally or locally:
-
-```bash
-atomic install npm:my-atomic-workflows
-atomic install git:github.com/user/my-atomic-workflows
-atomic install ./local-workflow-package -l
-```
-
-By default, `atomic install` writes to global settings (`~/.atomic/agent/settings.json`). Use `-l` to write to project settings (`.atomic/settings.json`). Project settings can be committed so a team gets the same workflow package set.
-
-To temporarily try a package for one run, use `--extension` or `-e`:
-
-```bash
-atomic -e npm:my-atomic-workflows
-atomic -e ./local-workflow-package
-```
-
-Workflow stage sessions inherit the same package and temporary `-e` resource discovery snapshot as the main chat. That means a workflow loaded from an external package or directory can start stages that see the package's extensions/tools, subagents and agent definitions, skills, prompt templates, themes, workflows, and trusted borrowed project-local resources without sharing the parent chat's resource-loader instance. Passing an explicit `resourceLoader` in stage options still opts that stage out of this inheritance.
-
-## Settings
-
-Settings can list package sources directly:
-
-```json
-{
-  "packages": [
-    "npm:my-atomic-workflows@1.0.0",
-    "git:github.com/user/team-workflows@v2",
-    "./tools/local-workflows"
-  ]
-}
-```
-
-Use object form to filter which workflows load from a package:
-
-```json
-{
-  "packages": [
-    {
-      "source": "npm:my-atomic-workflows",
-      "workflows": ["workflows/*.ts", "!workflows/experimental/**"]
-    }
-  ]
-}
-```
-
-`workflows` patterns follow package filtering rules:
-
-- Omit `workflows` to load every workflow allowed by the package manifest.
-- Use `[]` to load no workflows from that package.
-- Use `!pattern` to exclude matches.
-- Use `+path` to force-include an exact path.
-- Use `-path` to force-exclude an exact path.
-
-You can also run `atomic config` to enable or disable package resources interactively. Workflow package filters are saved as `workflows` patterns in settings.
-
-## Running Workflows
-
-List or inspect unfamiliar workflows before running them. If required inputs are missing and cannot be inferred, ask for the missing values before launch:
-
-```ts
-workflow({ action: "list" })
-workflow({ action: "get", workflow: "deep-research-codebase" })
-workflow({ action: "inputs", workflow: "deep-research-codebase" })
-```
-
-The workflow tool action surface is:
-
-- discovery: `list`, `get`, `inputs`
-- execution: named `run`, plus direct one-off `task`, `tasks`, and `chain` modes
-- inspection: `status`, `stages`, `stage`, `transcript`
-- messaging and run control: `send`, `pause`, `interrupt`, `quit`, `resume`
-- rediscovery: `reload`
-
-From interactive chat, model-launched workflows run in the background so the parent chat stays available. Run `/workflow connect <run>` to see agents working and chat with and steer each stage. Named workflow launches already run in the background; direct `task`, `tasks`, and `chain` launches must pass top-level `async: true`, and their accepted raw/rendered results include the same actionable connect guidance. This rule applies only to launches, not inspection or control calls (`status`, `stages`, `stage`, `transcript`, `send`, `pause`, `resume`, `interrupt`, `quit`). A model may launch in the foreground only when the user explicitly requests it or foreground execution is technically required, and it must tell the user before launching.
-
-Run a named workflow with inputs:
-
-```ts
-workflow({
-  action: "run",
-  workflow: "deep-research-codebase",
-  inputs: { prompt: "map workflow runtime", max_concurrency: 4 },
-})
-```
-
-Slash equivalent:
-
-```text
-/workflow deep-research-codebase prompt="map workflow runtime" max_concurrency=4
-```
-
-<p align="center"><img src="images/workflow-command.png" alt="Running a Workflow Command" width="600" /></p>
-
-Input overrides are bare `key=value` tokens. Values are JSON-parsed when possible, so `count=3`, `flag=true`, and `prompt="multi word value"` preserve useful types. A whole input object can also be passed as one JSON token. Runtime validation is strict: unknown input keys, missing required values, type mismatches, and invalid `select` choices fail before a named workflow run starts or before a child workflow starts.
-
-In the TUI, `/workflow <name>` opens an input picker when the workflow declares inputs and either no arguments were supplied or required inputs are missing. Supplied values seed the picker. Pass `--no-picker` to skip that interactive flow.
-
-In non-interactive (`-p`, `--print`, or `--mode json`) sessions, named workflow dispatch waits for the terminal run snapshot and skips pickers. Because human input is runtime-only and workflows no longer carry a declaration-time HIL marker, headless dispatch does not reject a workflow just because its source contains `ctx.ui.*`. If you copy a HIL workflow example into a headless session, it can pass dispatch and then fail when execution reaches the prompt with an error such as `atomic-workflows: interactive ctx.ui.confirm is unavailable in headless (non-interactive) mode; run the workflow in interactive mode or remove the interactive prompt from this stage` (the primitive name varies, including `ctx.ui.custom`). Run those workflows interactively, or guard/remove runtime `ctx.ui.*` calls before using headless mode.
-
-<p align="center"><img src="images/workflow-input-picker.png" alt="Workflow Input Picker" width="600" /></p>
-
-## Workflow Commands
-
-```text
-/workflow list
-/workflow inputs <name>
-/workflow <name> --help
-/workflow <name> [key=value ...]
-/workflow connect [run-id]
-/workflow attach [run-id] [stage-id-or-name]
-/workflow pause [run-id] [stage-id-or-name]
-/workflow status [run-id]
-/workflow status --all
-/workflow interrupt <run-id|--all>
-/workflow quit <run-id|--all>
-/workflow resume <run-id> [stage-id-or-name] [message]
-/workflows [workflow-id-or-prefix]
-/workflow reload
-```
-
-Use `connect` for the workflow graph. Use `attach` when you want a chat pane for a specific stage. `ctrl+x` is the workflow hierarchy chord: in an attached stage chat it means **return to graph**, and in the graph it means **return to main chat**. The workflow surface handles `ctrl+x` before configurable editor or tool actions, including while a composer draft, primitive prompt, custom question, stage switcher, or legacy prompt card owns input. Leaving a stage preserves unsent composer and prompt drafts and keeps pending custom questions unresolved so they reappear when you attach again. `ctrl+d` and `q` do not navigate workflow surfaces; `ctrl+d` keeps its ordinary editor or prompt behavior where applicable, and `q` remains printable in text-owning prompts. Existing `esc`, `ctrl+c`, and graph `h` close/hide controls are unchanged. While the workflow graph is active, vertical wheel/trackpad gestures pan it up and down, and horizontal gestures pan wide graphs left and right when the terminal exposes horizontal wheel events; these gestures remain scoped to the graph instead of leaking into the main chat or terminal scrollback. Attached stage chats capture mouse/trackpad wheel events by default so scrolling stays inside the active stage transcript or prompt instead of falling through to terminal/main-chat scrollback. Live `subagent` tool calls in stage chats use the same single, parallel, and chain progress widgets as main chat, including after exiting and re-attaching to an in-flight stage; press Ctrl+O (the `app.tools.expand` binding) to expand live detail for every child, including current tool activity and artifact paths. If an async/background subagent is running while the fullscreen workflow graph is open, the graph statusline mirrors the async summary so the background run remains visible; hide the graph with `h`, leave it with `ctrl+x`, or reconnect later to return to the full below-editor async widget. Press `ctrl+t` inside an attached stage chat to toggle **copy mode**: copy mode disables workflow-chat mouse reporting so normal terminal/tmux text selection can work; press `ctrl+t` again to leave copy mode and restore transcript or prompt scrolling. Archived read-only stage transcripts expose the same footer and copy-mode status, so their text can also be selected and copied; `esc` closes the transcript and `ctrl+x` returns to the graph. While copy mode is on, wheel/trackpad gestures are handled by the terminal/tmux and may scroll terminal scrollback, so leave copy mode before using the wheel again. Use `interrupt`, `pause`, and `resume` for resumable live work; `resume` on a non-paused run reopens the saved snapshot or overlay. Use `quit` to pause a live run gracefully while preserving it for `/workflow resume`. Use `/workflow reload` after adding, editing, installing, or removing workflow resources or package manifest workflow entries and you want Atomic to rediscover them in-process. `/workflow status` lists all retained active and terminal top-level runs by default; implementation-owned nested child runs are flattened into their parent workflow rather than listed separately. `/workflow status --all` is retained as a compatibility alias.
-
-`/workflows` is the retained-run history alias for `/workflow resume`: with no id it opens the same mixed resumable/completed picker, and with an id it resumes unfinished work or opens completed inspection. It is intentionally different from `/workflow list`, which lists installed workflow definitions.
-
-At the supported 40-column terminal minimum, attached stage chats use the compact `ctrl+x graph · ctrl+t …` footer. Provider/model context may be truncated to make room, but remains separated from the hierarchy hint so the controls stay readable.
-
-<p align="center"><img src="images/workflow-graph.png" alt="Workflow Graph Viewer" width="600" /></p>
-
-Human-in-the-loop prompts from `ctx.ui.input`, `ctx.ui.confirm`, `ctx.ui.select`, `ctx.ui.editor`, and `ctx.ui.custom<T>` appear as awaiting-input nodes in the workflow UI/graph viewer, not as ordinary chat modals. Workflows do not declare HIL up front; prompt nodes are created when the runtime `ctx.ui.*` call executes. If the prompt lives inside an imported child workflow, it still appears in the same expanded parent graph so the user can focus and answer it without switching to a separate child status entry. Custom widget prompts mount inside the attached stage chat and must be completed interactively with the widget's `done(value)` callback.
-
-## Monitor and Control Runs
-
-The workflow tool exposes lifecycle controls for non-interactive use:
-
-```ts
-workflow({ action: "status" })                                  // list every session run, in-flight first
-workflow({ action: "status", statusFilter: "running" })         // filter the run listing by status
-workflow({ action: "status", statusFilter: "awaiting_input" })  // runs with a pending human prompt
-workflow({ action: "status", format: "json" })                  // structured listing for programmatic use
-workflow({ action: "status", runId: "<id-or-prefix>" })         // full detail for one run
-
-workflow({ action: "stages", runId: "<id-or-prefix>", statusFilter: "all" })
-workflow({ action: "stage", runId: "<id-or-prefix>", stageId: "review" })
-// Prefer sessionFile/transcriptPath from stages/stage; quote the exact path, preserve Windows separators, then search/read small ranges.
-workflow({ action: "transcript", runId: "<id-or-prefix>", stageId: "review" })
-// Omit tail/limit for the default 5-entry preview; pass them for quick recent-context checks.
-workflow({ action: "transcript", runId: "<id-or-prefix>", stageId: "review", tail: 40 })
-workflow({ action: "transcript", runId: "<id-or-prefix>", stageId: "review", limit: 20, includeToolOutput: true })
-
-workflow({ action: "send", runId: "<id-or-prefix>", stageId: "review", text: "please focus on tests" })
-workflow({ action: "send", runId: "<id-or-prefix>", stageId: "approval", promptId: "prompt-1", response: true, delivery: "answer" })
-workflow({ action: "send", runId: "<id-or-prefix>", stageId: "review", message: "continue with tests", delivery: "resume" })
-
-workflow({ action: "pause", runId: "<id-or-prefix>" })
-workflow({ action: "pause", runId: "<id-or-prefix>", stageId: "review" })
-
-workflow({ action: "interrupt", runId: "<id-or-prefix>" })
-workflow({ action: "interrupt", all: true })
-
-workflow({ action: "resume", runId: "<id-or-prefix>" })
-workflow({ action: "resume", runId: "<id-or-prefix>", stageId: "review", message: "continue" })
-
-workflow({ action: "quit", runId: "<id-or-prefix>" })
-workflow({ action: "quit", all: true })
-
-workflow({ action: "reload", reason: "added team workflow" })
-```
-
-Control behavior:
-
-- `runId` accepts full run ids or unique prefixes for every lifecycle and inspection action, including `status`. The abbreviated IDs printed by status surfaces are valid inputs. Exact IDs take precedence; a prefix shared by multiple runs returns an ambiguity diagnostic with longer matching prefixes instead of selecting the first run. Status lists and run pickers show top-level user-launched workflows; nested child runs are implementation details of the expanded parent graph.
-- `status` without `runId` lists every top-level run in the session with a concise per-run summary: run id plus abbreviated prefix, workflow name, run status, started/ended timing with pause-adjusted elapsed time, currently active stages, and awaiting-input details (count plus the stage, prompt id, kind, and message for each pending human prompt). In-flight runs are listed first. The summaries carry the exact identifiers that `pause`/`resume`/`interrupt`/`quit`/`send` accept, so an orchestrating agent can list runs and act on them directly.
-- `statusFilter` narrows the `status` run listing: run statuses (`pending`, `running`, `paused`, `blocked`, `completed`, `failed`, `skipped`, `cancelled`, `killed`) match runs directly, `awaiting_input` selects runs with at least one stage awaiting input or pending human prompt, and `all` (the default) includes everything.
-- `format: "json"` on data-bearing inspection actions (`status`, `stages`, `stage`, `transcript`) returns the full structured result; the default text output for `status` is the concise per-run summary list.
-- `status` / `status <runId>` show terminal `ctx.exit(...)` statuses (`completed`, `skipped`, `cancelled`, or `blocked`) and the optional exit reason when one was supplied.
-- `stages` lists stage summaries, including flattened stages from nested `ctx.workflow(...)` imports and `sessionFile`/`transcriptPath` when a stage has a persisted session. Use `statusFilter: "all"` to include completed, failed, skipped, and pending stages.
-- `stage` returns details for one stage by stage id, unique prefix, or stage name, including nested child stages shown in the expanded graph and the persisted `sessionFile` when available. Abbreviated stage IDs printed in graph/control messages use this same unique-prefix resolver; collisions return an ambiguity diagnostic rather than selecting a stage.
-- `transcript` is reference-first with a small preview by default: it returns metadata, transcript paths, and up to 5 recent entries. For targeted lookup, quote the exact `sessionFile`/`transcriptPath` value without changing platform separators (preserve Windows backslashes), search it with `rg` or `grep`, then read only small surrounding ranges. Text results include JSON-escaped `sessionFileJson`/`transcriptPathJson` lines for copy-safe path literals. Pass explicit `tail` or `limit` to override the 5-entry preview; `tail` overrides `limit`; `includeToolOutput` includes captured snapshot tool output in snapshot transcript results.
-- `send` delivery modes are `auto`, `answer`, `prompt`, `steer`, `followUp`, and `resume`. Prompt answers can include `promptId` and can carry answer content in `response`, `text`, or `message`; structured UI prompts usually prefer `response`. Follow-up messaging to completed or failed stages reuses the retained `sessionFile` when available so the conversation resumes from the archived stage transcript instead of starting empty; if no session metadata was retained, Atomic refuses the follow-up rather than silently resetting. Explicit `delivery: "resume"` or `delivery: "steer"` against a completed post-mortem stage returns a structured `noop` with guidance to use `followUp` or `prompt`; it never appends the supplied text or mutates workflow execution. Arbitrary `ctx.ui.custom<T>` widget prompts require the interactive workflow graph and return a clear unsupported message when targeted through `send`.
-- `delivery: "auto"` first answers a pending prompt, then resumes paused work, then steers a streaming stage, then queues a follow-up.
-- `pause`, `interrupt`, and `quit` can target one top-level run or `all: true`; `stageId` cannot be combined with `all: true`. Stage-scoped `pause` and `interrupt` controls can target a visible nested child stage from the expanded graph; `quit` remains run-level. Atomic routes stage controls to the owning nested run internally.
-- `interrupt` is resumable: it pauses live work when pausable stages exist and keeps the run in live history/status.
-- `pause` is useful for pausing a live run or a single live stage without treating it as a destructive abort.
-- `resume` can target a stage with `stageId`; the target may be a stage id, unique prefix, or stage name. `message` is forwarded to paused work. For a live interrupted stage, Atomic automatically injects `Continue where you left off. If you believe you are finished with your original task (or a redefined task if the user told you), stop.` after any non-empty resume-message answer—or immediately after a no-message resume—before normal readiness-gate completion when the stage has not already finalized, including when the resume-answer turn used `ask_user_question`.
-- `quit` gracefully pauses in-flight work, marks the run resumable, and leaves it available to `/workflow resume`.
-- `reload` refreshes discovered workflow resources in-process; the optional `reason` is echoed in the result.
-
-Use slash commands for graph connect and stage attach because those are interactive TUI surfaces. When a run needs user input or attention, surface that to the user instead of polling silently.
-
-## Durable Workflows and Cross-Session Resume
-
-Atomic workflows use **DBOS/Postgres as their sole persistent workflow backend**. Atomic configures and launches DBOS lazily on the first workflow action, reuses that process-wide instance, and awaits readiness before workflow execution, resume, inspection, or deletion can access durable state. `DBOS_SYSTEM_DATABASE_URL` may select an existing database; DBOS initialization, query, and write failures fail the workflow action and never select another backend.
-
-**Zero-configuration local database.** Without `DBOS_SYSTEM_DATABASE_URL`, Atomic runs DBOS against its own embedded Postgres built from npm-distributed binaries — no Docker daemon or system Postgres install. The cluster lives under `~/.atomic/postgres/v18` on dedicated port `5439`; the first workflow action initializes it once and starts it with `pg_ctl` as a detached daemon that survives Atomic exiting, is shared by every concurrent Atomic session, and is never stopped by Atomic. When the embedded binaries are unavailable for the platform, Atomic falls back to DBOS's reusable `dbos-db` Docker container; if neither is usable, the workflow action fails with one actionable message: set `DBOS_SYSTEM_DATABASE_URL` to an existing Postgres.
-
-**Multiple concurrent Atomic sessions.** Every Atomic process launches DBOS with a unique executor id, and running root workflows carry owner/heartbeat metadata refreshed by ordinary ≤30-second stage-timing checkpoints. **Running workflows are never resume targets**: a running row with a fresh heartbeat is hidden from every session's picker and refused by direct `/workflow resume <id>` — resuming a workflow that is executing elsewhere would double-dispatch it. Once the heartbeat goes stale (about two minutes after a crash), the workflow surfaces as a red `crashed` row. When two sessions race to resume the same paused workflow, a durable first-writer-wins claim decides exactly one winner; the loser reconciles to the authoritative state and reports that the workflow changed while resume was pending.
-
-### How it works
-
-- **Only `ctx.*` blocks are checkpointed**: code outside `ctx.*` is not durable.
-- **Durable side effects**: `ctx.tool` and `ctx.ui` writes are flushed before completed results are exposed, so resume does not repeat an already-completed effect.
-- **Durable graph operations**: stage, task, chain, parallel, and child-workflow checkpoints include current topology, timing, model, output, and retained chat-session references. Completed inspection reconstructs the graph directly from DBOS.
-- **DBOS-only discovery**: `/workflow resume`, `/workflows`, completed inspection, deletion, and targeted lookup hydrate/query DBOS. Session JSONL remains only a chat transcript referenced by a current checkpoint; it is not a workflow catalog or discovery source.
-- **Current format only**: Atomic encodes and decodes one current DBOS format. Prior local files and older DBOS records are not read, converted, or cleaned up. Unsupported or malformed records are ignored as foreign data.
-- **Child side-effect scoping**: nested workflow effects are checkpointed under the durable root with stable child scopes.
-- **Cross-session safety**: per-process executor identity, owner/heartbeat liveness on running handles, and claim-guarded status transitions prevent double dispatch when several Atomic sessions share the database.
-
-**Privacy and retention.** DBOS persists workflow inputs, completed tool outputs, UI responses, stage outputs, and chat-session paths. Treat the configured database as sensitive. History has no automatic age/count deletion; confirmed picker deletion removes inactive DBOS workflow state while preserving independent chat transcripts.
-
-**Resume after editing a workflow.** Replay identity combines the workflow id with stable content hashes and call order. Editing, inserting, or reordering `ctx.*` calls can intentionally invalidate matches. Finish or delete retained runs before deploying incompatible workflow changes.
-
-### `ctx.tool` — durable cached tool execution
-
-The `ctx.tool(name, args, fn, options?)` primitive runs arbitrary TypeScript code and caches the result durably. On resume, if that ordinal tool call already completed (matched by call order plus content hash of `name` + `args`), the cached result is returned without re-executing the function — ensuring completed side effects are not repeated while still allowing two intentional same-name/same-args calls in one workflow.
-
-```ts
-export default workflow({
-  name: "data-pipeline",
-  inputs: { source: Type.String() },
-  run: async (ctx) => {
-    // This side effect is cached durably. On resume, it will NOT re-execute.
-    const data = await ctx.tool(
-      "fetch-dataset",
-      { source: ctx.inputs.source },
-      async () => {
-        const res = await fetch(ctx.inputs.source);
-        return await res.text();
-      },
-      { retriesAllowed: true, maxAttempts: 3 },
-    );
-
-    // Subsequent stages use the cached result.
-    const analysis = await ctx.task("analyze", { prompt: `Analyze: ${data}` });
-    return { summary: analysis.text };
-  },
-});
-```
-
-### `/workflow resume` — cross-session resume selector
-
-The `/workflow resume` command mirrors `/resume` ergonomics and `/workflows` is its alias. With no id, it builds one newest-first picker from eligible live runs and current DBOS resumable/completed records. DBOS is the authoritative catalog; selected records are hydrated and revalidated before resume or inspection. Running workflows never appear: fresh-heartbeat rows are excluded in every session to prevent double dispatch, and stale ones surface as `crashed`. Rows carry semantic colors — completed green, paused yellow, failed/blocked/crashed red — and the open picker live-updates on local run changes plus a bounded cross-session poll, so state transitions appear (and freshly running workflows disappear) without reopening it.
-
-Only current-format DBOS records are selectable. Unsupported or malformed records remain hidden without reinterpretation.
-
-Selecting a paused, failed, blocked, or crash-recovery target follows the existing resume path unchanged: Atomic re-dispatches the workflow with its cached inputs and the **original workflow id**, so previously completed `ctx.tool`, `ctx.ui`, stage/task/chain/parallel items, and child workflow boundaries replay from durable checkpoints rather than executing again. Selecting a completed target follows a separate open path. Atomic reconstructs a completed run/stage snapshot from authoritative checkpoints, remaps persisted source-stage parent references to the reconstructed stage ids in two passes, and opens the detail/chat overlay without calling the durable resume dispatcher or re-running workflow stages, tools, tasks, prompts, or workflow code.
-
-Completed detail state is read-only. A retained stage chat may be reopened for follow-up without resuming workflow execution or mutating its DBOS handle. Current checkpoints always include supported topology; foreign checkpoints are excluded rather than displayed with inferred edges.
-
-```text
-/workflow resume                          # Mixed picker: resumable + completed
-/workflow resume <workflow-id-or-prefix> # Resume unfinished work or open completed detail/chat
-/workflows                               # Alias for the same mixed picker
-/workflows <workflow-id-or-prefix>        # Alias for targeted resume/open
-```
-
-Explicit full IDs take precedence, while prefixes resolve across top-level live, resumable durable, and completed targets as one namespace. An exact loadable paused top-level live target resumes directly from in-session state without enumerating the durable completed-history catalog; this keeps explicit live resume responsive even when retained durable history is large and preserves live-over-durable precedence for duplicate IDs. Nested child runs remain excluded from this top-level target namespace even when addressed by an exact ID. Prefixes and other targets continue through the combined catalog so ambiguity and completed-inspection behavior remain unchanged. Ambiguous prefixes use the existing-style ambiguity diagnostic. A completed backend row with no checkpoints or no usable retained stage conversation is hidden from the picker; an explicit target reports that it is stale or missing required durable checkpoint/session data. A completed run remains inspectable when at least one stage has a usable transcript; missing, empty, directory, context-empty, or partially malformed transcript paths are omitted from stage chat attachment. Validation uses the final retained transcript for a repeated stage replay key, so an obsolete superseded checkpoint path does not hide an otherwise valid completed run. Reopening inspection refreshes a changed authoritative retained-chat handle. Session-cache-only rows are likewise hidden because the backend is authoritative. Cancelled, killed, non-resumable failed, and other terminal non-success states are never added. Normal `/resume`, `atomic -r`, and `--continue` behavior for internal workflow stage sessions is unchanged.
-
-### Cancellation, failure, and retry semantics
-
-| Scenario | Behavior |
-| --- | --- |
-| **Internally cancelled workflow** | Marked `cancelled` in durable state and excluded from `/workflow resume` discovery. Start a new workflow run if you intentionally want to retry cancelled work. |
-| **Stage failure (recoverable)** | Workflow marked `failed` or `blocked` and remains resumable by default. `/workflow resume <id>` continues from the last completed checkpoint unless durable metadata explicitly sets `resumable: false`. |
-| **Stage failure (non-recoverable)** | Workflow marked `failed` or `blocked` with `resumable: false`, so it is excluded from resume discovery. |
-| **Process crash** | Workflow remains `running` in durable state. On next session start, it appears in resume discovery when it has a durable checkpoint or pending prompt. Resume re-executes from the last completed checkpoint. |
-| **`ctx.tool` retry** | When `retriesAllowed: true`, the tool function is retried with exponential backoff. Cancellation is checked before each attempt and during retry backoff, so later attempts do not run after the workflow is cancelled. After exhausting retries, the error propagates and the workflow fails. |
-| **`ctx.ui` pending prompt** | If a UI prompt was not answered before interruption, resume leaves off on that prompt — the user must answer it to continue. |
-
-### Configuring DBOS/Postgres
-
-File-backed durability is the default and requires no setup. For production-grade Postgres-backed checkpointing, set `DBOS_SYSTEM_DATABASE_URL` before starting Atomic. The DBOS SDK ships as an optional dependency of `@bastani/atomic`; if it cannot be loaded or Postgres cannot be reached, Atomic emits a warning and continues using the default per-workflow file-backed durable store under `~/.atomic/workflow-durable`.
-
-```bash
-export DBOS_SYSTEM_DATABASE_URL="postgresql://user:password@localhost:5432/atomic_dbos_sys"
-```
-
-When `/workflow resume` lists or resumes a DBOS-backed workflow in a fresh process, Atomic first hydrates its in-memory replay mirror from DBOS. Checkpoints are stored as structured, versioned DBOS outputs containing the checkpoint kind, id, tool argument hash, UI prompt hash, stage replay key, completed output, and additive versioned stage-topology metadata when available, so replay can skip completed `ctx.tool`, `ctx.ui`, `ctx.stage`, `ctx.task`, `ctx.chain`, `ctx.parallel`, and `ctx.workflow` work without relying on prior in-process state and completed inspection can rebuild the original DAG. Atomic updates the in-memory replay mirror for awaited DBOS checkpoints only after DBOS accepts the write, and root metadata is mirrored as versioned DBOS records where the latest timestamp wins during hydration. Unmarked raw-output checkpoint records remain readable as generic stage checkpoints when their workflow has compatible current metadata; marked envelopes with unsupported envelope versions are ignored rather than decoded as raw output, while unsupported or malformed additive topology fields are ignored without dropping an otherwise valid stage envelope.
-
-The default file backend needs no environment variable or database. It writes one lock-protected JSON state file per root workflow in `~/.atomic/workflow-durable`, making cross-session `/workflow resume` immediately available on a normal Atomic install while avoiding shared-state growth across unrelated workflows.
-
-## Lifecycle Notices and Human Input
-
-Atomic emits deduplicated main-chat notices when top-level workflow runs complete, fail, or end blocked. Nested child workflow completion/failure is reflected inside the expanded parent graph instead of producing separate top-level completion cards. These terminal notices are queued into the active main chat as steering/context messages (`triggerTurn: true`, `deliverAs: "steer"`) so the model can react without the user manually polling status. Awaiting-input workflow states are tracked for dedupe/restore, but they do not enqueue main-chat connect cards or wake the model; prompt state remains visible through workflow status/connect surfaces. Configure lifecycle behavior with `workflowNotifications.enabled` (default `true`) and `workflowNotifications.notifyOn` (default `["completed", "failed", "blocked", "awaiting_input"]`).
-
-Human input is runtime-only: call `ctx.ui.input`, `ctx.ui.confirm`, `ctx.ui.select`, `ctx.ui.editor`, or `ctx.ui.custom<T>` at the point where the workflow actually needs a decision. No builder-level declaration is required or supported.
-
-When a workflow needs human input, answer in the graph viewer or attached stage chat when possible:
-
-```text
-/workflow connect <run-id>
-/workflow attach <run-id> <stage-id-or-name>
-```
-
-Agents can answer primitive and structured pending prompts programmatically with `workflow({ action: "send", delivery: "answer", ... })`; use `promptId` when it is present in the stage details, and provide answer content with `response`, `text`, or `message`. Arbitrary custom TUI widget prompts intentionally refuse this path in iteration 1 because a generic `T` cannot be reconstructed safely from a non-TUI payload.
-
-If the user answers a human-in-the-loop prompt in the workflow UI or stage UI broker, the stage receives the answer directly and the active main chat receives a display-only notice (`triggerTurn: false`, `excludeFromContext: true`) containing a concise answer summary. The notice is rendered for the user and persisted for audit, but it does not wake the model, enter LLM context, or authorize answering any other workflow prompt. Prompt answers sent by the main-chat `workflow` tool are suppressed from this notice because the tool result already informs the current turn.
-
-When an interactive, non-schema workflow stage calls `ask_user_question`, Atomic waits for the stage's assistant turn to finish and then brokers the deterministic readiness question **“Are you ready to move on to the next stage?”**. This includes typed/freeform questionnaire answers reported as `details.answers[].kind === "chat"`: the assistant first gives its normal conversational response, then the stage becomes `awaiting_input` with `inputRequest.kind: "readiness_gate"` in workflow status and graph surfaces. In this chat-answer flow, choosing the ready option completes the stage and releases dependent stages; choosing the not-ready option keeps the stage open for a genuine stage-chat turn and brokers readiness again after that turn. A chat answer is never treated as an invisible stay decision. The readiness prompt can be answered in the attached stage UI or with `workflow({ action: "send", delivery: "answer", ... })`. Ordinary structured-option answers retain their existing readiness behavior. A schema-backed stage that has successfully finalized through `structured_output` is terminal and does not reopen this readiness gate.
-
-## Direct One-Off Runs
-
-Use direct workflow-native orchestration for one-off tracked work that does not need a reusable workflow file.
-
-Single tracked task:
-
-```ts
-workflow({
-  task: {
-    name: "review",
-    task: "Review this patch for API risks.",
-    context: "fresh",
-    output: "reviews/api.md",
-  },
-  async: true,
-  intercom: { delivery: "result" },
-})
-```
-
-Parallel fan-out:
-
-```ts
-workflow({
-  tasks: [
-    { name: "docs", task: "Review documentation gaps" },
-    { name: "risks", task: "Review operational risks" },
-  ],
-  concurrency: 2,
-  outputMode: "file-only",
-  async: true,
-})
-```
-
-Dependent chain:
-
-```ts
-workflow({
-  task: "Design the workflow SDK migration",
-  chain: [
-    { name: "research", task: "Research {task}" },
-    { name: "plan", task: "Plan from {previous}" },
-  ],
-  async: true,
-})
-```
-
-Mixed chain with a parallel review step:
-
-```ts
-workflow({
-  task: "map the release process",
-  chain: [
-    { name: "researcher", task: "Research {task}" },
-    {
-      parallel: [
-        { name: "risk-reviewer", task: "Review risks in {previous}" },
-        { name: "docs-reviewer", task: "Find documentation gaps in {previous}" },
-      ],
-      concurrency: 2,
-    },
-    { name: "planner", task: "Create a plan from {previous}" },
-  ],
-  async: true,
-  intercom: { delivery: "result" },
-})
-```
-
-Direct mode supports top-level/default options and per-task options such as `context`, `forkFromSessionFile`, `model`, `fallbackModels`, `thinkingLevel`, `contextWindow`, `tools`, `noTools`, `customTools`, `mcp`, `output`, `outputMode`, `reads`, `worktree`, `gitWorktreeDir`, `baseBranch`, `maxOutput`, `artifacts`, `sessionDir`, `cwd`, and `agentDir`. Direct chains also support `chainName`, `chainDir`, and `failFast`.
-
-For large fan-outs, prefer `outputMode: "file-only"` so the parent result contains compact file references instead of full output. Treat intercom payloads from async direct runs as user-visible workflow output.
-
-Worktree isolation is an explicit runtime option, not a property inferred from task text. Natural-language instructions to create or use a worktree do not enable runner isolation, and `cwd` only selects the starting directory; a write-capable direct run without a worktree option executes in that checkout. Set `worktree: true` for runner-managed temporary per-task worktrees, or set `gitWorktreeDir` for a runner-managed reusable same-repository worktree. Invalid, empty, foreign-repository, or conflicting worktree requests fail with an actionable diagnostic rather than falling back to the invoking checkout. For independent task queues, prefer one run per item with its own reusable worktree instead of a monolithic chain rooted in the primary checkout.
-
-## Fast Inference for Workflow Stages
-
-Workflow stages can opt into faster, higher-priority inference on supported providers so multi-stage runs finish sooner. This is currently delivered through Codex fast mode.
-
-### Codex fast mode
-
-Use `/fast` to manage Codex fast mode separately for normal chat and workflow-stage sessions. The settings are `codexFastMode.chat` and `codexFastMode.workflow`; workflow stages use the workflow scope, not the chat scope.
-
-Fast mode is eligible only for supported `openai/*` and `openai-codex/*` providers. It does not apply to `github-copilot/*`, Azure OpenAI, OpenRouter, or custom OpenAI-compatible providers. When applied, workflow stage displays keep the raw model id and expose `fast` as a separate marker/stage metadata indicator.
-
-Enable workflow fast mode deliberately for broad workflows: parallel fan-out and fallback attempts can multiply priority-tier requests and cost.
+Named workflows run in the background with a run id. See [Running Workflows](#running-workflows) for launch behavior, [Workflow Commands](#workflow-commands) for the common controls, and [Monitor and Control Runs](#monitor-and-control-runs) for steering, pausing, and resuming.
 
 ## Writing a Workflow
 
@@ -1350,90 +676,30 @@ Authoring basics:
 - `outputs` declares typed outputs that parent workflows receive from `ctx.workflow(childWorkflow, ...)`.
 - `run: async (ctx) => { ... }` defines the workflow body.
 
-Migrating an existing file from the removed `defineWorkflow(...).compile()` builder? See [Migrating from the `defineWorkflow()` Builder API](#migrating-from-the-defineworkflow-builder-api) for the full method-to-key mapping, a before/after walkthrough, and a conversion checklist.
+To migrate an existing file from the removed `defineWorkflow(...).compile()` builder, see [Migrating from the `defineWorkflow()` Builder API](#migrating-from-the-defineworkflow-builder-api) for the full method-to-key mapping, a before/after walkthrough, and a conversion checklist.
 
 `prompt` and `task` are aliases for task text. Prefer `prompt` inside authored workflow files because it mirrors lower-level `stage.prompt(...)`; `task` remains useful in direct tool calls and chain examples.
 
 Author workflows to create at least one tracked stage by calling `ctx.task()`, `ctx.chain()`, `ctx.parallel()`, `ctx.stage()`, or `ctx.workflow()` in the run body so each normal run has graph nodes to inspect, attach to, interrupt, resume, and render. Guard-only workflows may call `ctx.exit(...)` before creating a stage when they intentionally stop early.
 
-### Stage follow-on user messages
-
-`ctx.stage()` returns a `StageContext` with `sendUserMessage(content, options?)` for injecting a normal follow-on user turn into that stage's AgentSession. Use this when workflow code needs to continue an existing stage session after `stage.prompt(...)` has already resolved, including schema-backed stages where `prompt()` is intentionally one-shot because the structured-output tool may be called exactly once.
-
-```ts
-const gate = ctx.stage("review-gate", {
-  schema: Type.Object({ approved: Type.Boolean() }, { additionalProperties: false }),
-});
-const decision = await gate.prompt("Review the implementation and call structured_output.");
-if (!decision.approved) {
-  await gate.sendUserMessage("Explain the highest-priority changes needed before approval.");
-}
-```
-
-When the stage session is idle, `sendUserMessage()` starts the next user turn immediately and waits for that turn to finish under the normal workflow stage guard: it observes the stage concurrency limiter, workflow abort/cancellation signals, MCP scoping, readiness gates, and session metadata capture. If `sendUserMessage()` is the first live call on a `ctx.stage(...)` handle, Atomic records the stage as a normal running/completed graph node. If it is called after a prior `prompt()`/`complete()` has already completed the stage, the follow-on turn still uses internal abort/cancellation and concurrency protection while reusing the completed stage session.
-
-The `content` argument mirrors the Atomic SDK and accepts either a string or text/image content blocks such as `[{ type: "text", text: "Describe this" }, { type: "image", data: "...", mimeType: "image/png" }]` when the underlying stage session supports native user-message delivery. Non-native fallback adapters only support string content and reject text/image block arrays instead of stringifying them. Idle non-native fallback delivery sends the follow-on string to the already-selected session directly, so workflow model fallback retries are not re-run for that injected turn. When the stage is already streaming, the message is queued as a follow-up by default; pass `{ deliverAs: "steer" }` to steer the active turn instead, or `{ deliverAs: "followUp" }` to be explicit. `deliverAs` only affects streaming delivery and is a no-op for idle sessions. Follow-on turns preserve the stage's `mcp.allow` / `mcp.deny` scope for the injected user turn, just like the original `prompt()`. The older `stage.steer(text)` and `stage.followUp(text)` methods are still available for queueing while a turn is active, but they do not start a new idle turn.
-
-Externally produced traffic has a separate lifecycle rule. Intercom messages and async bash/subagent completion notices received while a workflow stage generation is still open are admitted immediately through the stage AgentSession's native steering/follow-up queue. The stage drains already-admitted work before publishing its terminal snapshot, including schema-backed turns that have already called `structured_output`. Closing the generation is atomic with admission: a notification admitted first belongs to that stage, while ordinary detached notifications arriving after close cannot reopen or mutate the completed stage and are surfaced once through the main-chat notification path instead. A blocking sibling `intercom.ask` is the deliberate exception: when the completed stage retains a valid conversation, Atomic schedules a post-mortem turn in that conversation so it can inspect the exact ask and reply, without changing terminal workflow state. Failed post-mortem admission returns a correlated actionable error to the asker. Stage completion never waits for producers that are still running; only traffic already admitted at the close boundary is drained. Explicit `sendUserMessage()` calls and post-mortem stage chat remain deliberate user/workflow-authored follow-up turns on the retained session.
-
-### Early exit with `ctx.exit()`
-
-Use `ctx.exit(options?)` when workflow code intentionally stops the current run from a helper, branch, loop, or precondition guard without classifying the run as failed. `ctx.exit()` throws an executor-owned control signal and is typed as `never`, so code after it is unreachable. In async `run` bodies, prefer `return ctx.exit(...)` when the exit is the only path so TypeScript can see the non-returning branch.
-
-```ts
-export default workflow({
-  name: "guarded-import",
-  description: "",
-  inputs: {},
-  outputs: {
-    scanned: Type.Number(),
-  },
-  run: async (ctx) => {
-    const files = await findCandidateFiles(ctx.cwd);
-    if (files.length === 0) {
-      return ctx.exit({
-        status: "skipped",
-        reason: "No matching files",
-        outputs: { scanned: 0 },
-      });
-    }
-
-    const review = await ctx.task("review", { prompt: `Review ${files.join(", ")}` });
-    return { scanned: files.length };
-  },
-});
-```
-
-`ctx.exit()` accepts `status: "completed" | "skipped" | "cancelled" | "blocked"`; it never accepts `"failed"` or `"killed"` because thrown errors and internal destructive cancellation keep those meanings. `status` defaults to `"completed"`. `reason` is persisted and shown in status surfaces, including the default `/workflow status` list and `/workflow status <runId>` detail, so do not put secrets in it. `outputs` may contain a partial subset of declared outputs; provided keys still must be declared in the workflow's `outputs` object, match their TypeBox schema, and be JSON-serializable. Missing required outputs are allowed only on the `ctx.exit(...)` path. Exited runs are terminal and not resumable; public `pause`, `interrupt`, and `quit`, plus internal destructive cancellation, keep their distinct existing behavior.
-
-The first selected `ctx.exit({ outputs })` snapshots its output payload synchronously by value before JavaScript `finally` blocks or cleanup callbacks can mutate the caller-owned object. The snapshot preserves undeclared keys and invalid values until post-cleanup validation, so deleting an undeclared key or changing an invalid value after `ctx.exit(...)` does not change the terminal validation result. If reading `status`, `reason`, or `outputs` options, or enumerating/copying the output snapshot itself, throws, Atomic still selects the exit signal, runs workflow-exit cleanup when feasible, and then records a terminal non-resumable authoring failure (`resumable: false`) if no external terminal control won first.
-
-After the first `ctx.exit(...)` wins, the executor treats that exit as a level-triggered gate. Later delayed calls to `ctx.stage`, `ctx.task`, `ctx.chain`, `ctx.parallel`, `ctx.workflow`, or graph-backed `ctx.ui.*` prompts rethrow the selected exit signal before creating stages, prompt nodes, child runs, or control handles. Retained `StageContext` handles from before the exit also become inert: `prompt`, `complete`, steering/follow-up, model/thinking controls, tree navigation, compaction, abort, and attached-pane session-realization paths refuse to touch or create an `AgentSession` after the exit is selected. `ctx.parallel` stops dequeuing queued work after exit even with `failFast: false` and limited concurrency; already-started stages and prompt nodes are finalized as `skipped` with a `workflow-exit` reason that prompt-node abort handling preserves instead of overwriting with a generic run-aborted reason.
-
-Continuation replay also observes the exit gate. Replayed `ctx.stage(...).prompt(...)`, replayed `complete(...)`, graph-backed prompt-node replay, and completed child-boundary replay re-check for a selected exit after their replay microtask and before writing a current-run completed stage end. If `ctx.exit(...)` wins that gap, the pending replay finalizer is skipped/suppressed with the workflow-exit reason instead of creating a misleading completed stage in the resumed run.
-
-The store is the terminal authority for all run-end races. `ctx.exit(...)` starts cleanup before validating exit outputs, and an internal destructive cancellation can still win the terminal `recordRunEnd` write while that cleanup is pending. When that happens, the SDK `RunResult`, `onRunEnd` callback, live store, and persisted `workflow.run.end` entries all report the canonical `killed` state; the losing `ctx.exit` status or validation failure is not returned and does not append a second run-end entry.
-
-Control-signal probing is fail-closed. When the executor inspects an arbitrary thrown value or abort reason for internal workflow-exit markers, parent-exit markers, aggregate `errors`, `cause`, `reason`, or `scope`, throwing or inaccessible accessors are treated as “no signal for that branch.” The run then continues through ordinary failure finalization, or the ordinary killed path for external abort reasons, instead of letting author-defined getters escape the executor catch path or be misclassified as `ctx.exit(...)`.
-
 ### Guiding Principles
 
-- Stage prompts should be locally scoped: describe only the current stage's objective, inputs, expected outputs, and success criteria.
-- Avoid references to other stages unless the current stage explicitly receives and needs that information.
-- Avoid workflow-specific or stage-specific vocabulary that is not explained inside the current prompt.
-- Use clear software engineering terminology in self-described prompts.
-- Avoid hard-coded regular expressions for condition matching when gating reviews or model outputs.
-- Prefer schema-backed workflow stages (`ctx.stage(..., { schema })`, `ctx.chain` items, or `ctx.parallel` items) for review/gate decisions whenever model output needs to be evaluated; a schema-enabled item receives the structured-output tool automatically.
-- Treat atomic workflow units as language model stages, not deterministic tools.
-- When deterministic gates are needed, create small dedicated stages that instruct a model to run a specific tool or perform a specific check. This keeps gates adaptive to the current codebase while preserving explicit workflow structure.
+- **Locally scoped stage prompts** - Describe only the current stage's objective, inputs, expected outputs, and success criteria. Avoid references to other stages unless the current stage explicitly receives and needs that information, and avoid workflow-specific or stage-specific vocabulary that is not explained inside the current prompt. See [Locally Scoped Stage Prompts](#locally-scoped-stage-prompts) for the expanded contract.
+- **Clear vocabulary** - Use clear software engineering terminology in self-described prompts.
+- **No regex gates** - Avoid hard-coded regular expressions that gate reviews or model outputs.
+- **Schema-backed gates** - Prefer schema-backed workflow stages (`ctx.stage(..., { schema })`, `ctx.chain` items, or `ctx.parallel` items) for review/gate decisions whenever the workflow must evaluate model output; a schema-enabled item receives the structured-output tool automatically. See [Evaluation and Quality Gates](#evaluation-and-quality-gates).
+- **Stages are model stages** - Treat atomic workflow units as language model stages, not deterministic tools.
+- **Small deterministic-gate stages** - When deterministic gates are needed, create small dedicated stages that instruct a model to run a specific tool or perform a specific check. This keeps gates adaptive to the current codebase while preserving explicit workflow structure.
 
 ### Context engineering guidance
 
-Workflow guidance should also cover the context passed between stages:
+Also document the context that stages pass to one another:
 
-- Prefer creating files or artifacts for substantial handoffs, then instruct the next stage to read the file, instead of dumping large text output directly into the next stage prompt or context.
-- Prefer forked context for non-reviewer stages so long-running implementation work can preserve coherency and continuity.
+- For substantial handoffs, create files or artifacts and tell the next stage to read them instead of putting large text outputs in its prompt or context.
+- Prefer forked context for non-reviewer stages so long-running implementation work keeps a coherent, continuous context.
 - Prefer a clean context window for reviewer stages so earlier implementation stages do not bias the reviewer. Reviewers should evaluate the supplied artifacts, changed files, tests, and explicit criteria as independently as possible.
+
+See [Context Engineering](#context-engineering) for details.
 
 ### Inputs
 
@@ -1447,9 +713,9 @@ Inputs are declared with TypeBox `Type.*` schemas in the `inputs` object. Import
 | `Type.Boolean({ default? })` | boolean | boolean |
 | `Type.Union([Type.Literal("a"), Type.Literal("b")], { default? })` | select | one of the literal strings |
 
-A `Type.Union([Type.Literal(...)])` of string literals is how a 'select' is expressed: the input picker renders those literals as the selectable choices, and runtime validation rejects any value outside them. Put `description` and `default` in the schema options object, e.g. `Type.String({ description: "…", default: "…" })`. An input is required when its schema is **not** wrapped in `Type.Optional(...)` and declares no `default`; wrap optional inputs in `Type.Optional(...)`. A `default` does not make an input optional — a defaulted input is always present after defaults are applied.
+A `Type.Union([Type.Literal(...)])` of string literals expresses a 'select': the input picker renders those literals as choices, and runtime validation rejects values outside them. Put `description` and `default` in the schema options object, e.g. `Type.String({ description: "…", default: "…" })`. An input is required when its schema is **not** wrapped in `Type.Optional(...)` and declares no `default`; wrap optional inputs in `Type.Optional(...)`. A `default` does not make an input optional — a defaulted input is always present after defaults are applied.
 
-Prefer explicit descriptions because `/workflow inputs <name>`, `/workflow <name> --help`, and the input picker show them to the user. Runtime validation uses TypeBox `Value` and is strict for both top-level named runs and `ctx.workflow(...)` child calls: Atomic rejects unknown keys, missing required values, type mismatches, non-JSON-serializable values, and union/literal values outside the declared choices before the workflow body starts. It does not coerce strings like `"3"` to numbers; pass `count=3` or JSON numbers when a schema declares `Type.Number()`.
+Prefer explicit descriptions because `/workflow inputs <name>`, `/workflow <name> --help`, and the input picker show these descriptions to users. Runtime validation uses TypeBox `Value` and is strict for both top-level named runs and `ctx.workflow(...)` child calls: Atomic rejects unknown keys, missing required values, type mismatches, non-JSON-serializable values, and union/literal values outside the declared choices before the workflow body starts. It does not coerce strings like `"3"` to numbers; pass `count=3` or JSON numbers when a schema declares `Type.Number()`.
 
 In TypeScript workflow files, entries in `inputs` also narrow `ctx.inputs` for better intellisense: required/defaulted `Type.String()` inputs are `string`, `Type.Number()` is `number`, `Type.Boolean()` is `boolean`, a `Type.Union([Type.Literal(...)])` select is the literal string union, and `Type.Optional(...)` inputs include `undefined`. Use `Static<typeof schema>` when you need the inferred TypeScript type of a schema directly.
 
@@ -1457,9 +723,15 @@ In TypeScript workflow files, entries in `inputs` also narrow `ctx.inputs` for b
 
 Workflow outputs are runtime contracts for completed workflow runs and for parent workflows that call a child with `ctx.workflow(childWorkflow, ...)`. A workflow normally returns a JSON-serializable object from `run`, and entries in the `outputs` object document, validate, and expose keys from that returned object. `ctx.exit({ outputs })` can expose a partial subset of the same declared output contract when the run intentionally stops early. Primitives, arrays, `null`, functions, symbols, `undefined` properties, `NaN`, and infinite numbers fail validation.
 
-**Return convention:** outputs are return-object keys. Atomic never infers child workflow outputs from stage names, stage order, or the final assistant message. If a parent should read `child.outputs.foo`, the child workflow's `run` must both declare `outputs: { foo: schema }` and return `{ foo: value }`. `result` is not special and is never added for you: to expose `result`, declare it in `outputs` and return `{ result }` exactly like any other output. Returning a key that is not declared in `outputs` fails the run with `atomic-workflows: workflow "<name>" returned undeclared output "<key>"; declare it in outputs or remove it from the run return`.
+**Return convention:** outputs are return-object keys. Atomic never infers child workflow outputs from stage names, stage order, or the final assistant message. If a parent should read `child.outputs.foo`, the child workflow's `run` must both declare `outputs: { foo: schema }` and return `{ foo: value }`. `result` is not special, and Atomic never adds it: to expose `result`, declare it in `outputs` and return `{ result }` exactly like any other output. Returning a key that is not declared in `outputs` fails the run with `atomic-workflows: workflow "<name>" returned undeclared output "<key>"; declare it in outputs or remove it from the run return`.
 
-**Reserved `status` output convention and structured failures:** if a workflow declares and returns a top-level `status` output with the string value `"failed"`, Atomic treats the run as failed instead of recording a successful completion. Returned `"blocked"`, `"needs_human"`, `"incomplete"`, `"active"`, and `"auth_blocked"` statuses are treated as blocked/incomplete terminal states rather than successful completions. Independently of that convention, Atomic uses structured failure metadata captured from the run's blocking stage (`failedStageId`) or run-level failure metadata to keep recoverable auth, rate-limit, and provider fallback exhaustion blocked/resumable even when the workflow did not declare a `status` output. Atomic does not infer failure state by scanning arbitrary output text or by scanning every failed stage in an otherwise completed non-fail-fast branch. When a reserved status is returned, a non-empty top-level `summary` string becomes the run reason shown in lifecycle notices and status surfaces; if it is absent, Atomic falls back to non-empty top-level `remaining_work` and then `result` text. Use the reserved `status` convention only when the workflow is intentionally reporting its own terminal state (for example, a deterministic release gate that returns `{ status: "blocked", summary: "required checks are pending" }`, or a reviewer-gated workflow that returns `{ status: "needs_human", remaining_work: "provider credentials are missing" }`). Do not use a top-level `status` field for unrelated external state such as a deployment/check you merely inspected; choose a domain-specific name like `deployment_status` or `gate_status` instead.
+**Reserved `status` output convention and structured failures:** if a workflow declares and returns a top-level `status` output with the string value `"failed"`, Atomic treats the run as failed instead of recording a successful completion. Returned `"blocked"`, `"needs_human"`, `"incomplete"`, `"active"`, and `"auth_blocked"` statuses are treated as blocked/incomplete terminal states rather than successful completions.
+
+Independently of that convention, Atomic uses structured failure metadata captured from the run's blocking stage (`failedStageId`) or run-level failure metadata to keep recoverable auth, rate-limit, and provider fallback exhaustion blocked/resumable even when the workflow did not declare a `status` output. Atomic does not infer failure state by scanning arbitrary output text or by scanning every failed stage in an otherwise completed non-fail-fast branch.
+
+When a workflow returns a reserved status, Atomic uses a non-empty top-level `summary` string as the run reason shown in lifecycle notices and status surfaces; if no non-empty value is present, Atomic falls back to non-empty top-level `remaining_work` and then `result` text. Use the reserved `status` convention only when the workflow is intentionally reporting its own terminal state (for example, a deterministic release gate that returns `{ status: "blocked", summary: "required checks are pending" }`, or a reviewer-gated workflow that returns `{ status: "needs_human", remaining_work: "provider credentials are missing" }`).
+
+Do not use a top-level `status` field for unrelated external state such as a deployment/check the workflow only inspected; choose a domain-specific name like `deployment_status` or `gate_status` instead.
 
 The `outputs` object is a schema contract, not an automatic stage selector. To expose values from any stage, capture the stage/task/child result in normal TypeScript and return it from `run` under the desired key:
 
@@ -1492,9 +764,9 @@ export default workflow({
 });
 ```
 
-There is no automatic `result` output. A workflow exposes exactly the keys it declares in `outputs` and returns from `run` — nothing more. To expose `result`, declare `outputs: { result: schema }` and return `{ result }` like any other output. If `run` returns a key that was never declared in `outputs`, the run fails with `atomic-workflows: workflow "<name>" returned undeclared output "<key>"; declare it in outputs or remove it from the run return` (for a child workflow call, `<name>` is the child's own name, and the parent surfaces the failure through the child-failure wrapper `atomic-workflows: child workflow "<childName>" (<displayName>) failed with status failed: ...`).
+Atomic never adds a `result` output. A workflow exposes only the keys it declares in `outputs` and returns from `run`. To expose `result`, declare `outputs: { result: schema }` and return `{ result }`. Returning a key not declared in `outputs` fails with the `returned undeclared output` error quoted above. For a child workflow call, `<name>` is the child's name, and the parent surfaces the failure through the child-failure wrapper described in [Workflow Composition](#workflow-composition).
 
-Outputs are declared with TypeBox `Type.*` schemas in the `outputs` object. **Prefer precise schemas.** A precise schema gives a precise `Static<>` type for the `run` return and for any parent reading `child.outputs`, and it makes runtime validation enforce the real shape instead of waving values through. Reach for `Type.Unknown()`, `Type.Any()`, `Type.Array(Type.Unknown())`, or `Type.Object({}, { additionalProperties: true })` only for genuinely dynamic data whose shape you cannot know ahead of time.
+Outputs are declared with TypeBox `Type.*` schemas in the `outputs` object. **Prefer precise schemas.** A precise schema gives a precise `Static<>` type for the `run` return and for any parent reading `child.outputs`, and it makes runtime validation enforce the real shape instead of accepting values without checking that precise shape. Reach for `Type.Unknown()`, `Type.Any()`, `Type.Array(Type.Unknown())`, or `Type.Object({}, { additionalProperties: true })` only for genuinely dynamic data whose shape you cannot know ahead of time.
 
 | TypeBox schema | Static type | Accepted runtime value |
 |---|---|---|
@@ -1510,7 +782,9 @@ Outputs are declared with TypeBox `Type.*` schemas in the `outputs` object. **Pr
 | `Type.Object({}, { additionalProperties: true })` | `Record<string, unknown>` | any JSON object (last resort, dynamic only) |
 | `Type.Unknown()` / `Type.Any()` | `unknown` / `any` | any JSON-serializable value (last resort) |
 
-Output schemas carry `description` in their options object. A declared output is required when its schema is **not** wrapped in `Type.Optional(...)`; wrap outputs that may be absent in `Type.Optional(...)`. A required output means the workflow `run` return object must contain that output before the run can complete; a missing required output fails with `missing output "<key>"`, and a declared value whose runtime type does not match the schema fails with `output "<key>" expected <type>, got <actual>`. For child workflow calls, the parent boundary fails before the parent continues. Declared outputs are validated against the declared schema with TypeBox `Value` on completion, and every returned/exposed value is recursively validated as JSON-serializable. Child output replay still performs a structured-clone safety check after JSON validation so continuation can restore completed child workflow boundaries.
+Output schemas carry `description` in their options object. A declared output is required when its schema is **not** wrapped in `Type.Optional(...)`; wrap outputs that may be absent in `Type.Optional(...)`. A required output means the workflow `run` return object must contain that output before the run can complete; a missing required output fails with `missing output "<key>"`, and a declared value whose runtime type does not match the schema fails with `output "<key>" expected <type>, got <actual>`. For child workflow calls, the parent boundary fails before the parent continues.
+
+On completion, Atomic validates declared outputs against their schemas with TypeBox `Value` and recursively checks every returned or exposed value for JSON serializability. During child output replay, Atomic also performs a structured-clone safety check after JSON validation so continuation can restore completed child workflow boundaries.
 
 #### Prefer precise schemas
 
@@ -1574,14 +848,86 @@ Tradeoff: `Type.Unsafe<T>()` does not deeply validate at runtime — it trusts t
 #### How types flow
 
 - `ctx.inputs.x` is `Static<inputSchema>` for the input you declared as `inputs: { x: schema }` — required and defaulted schemas are always present, and `Type.Optional(...)` adds `| undefined`.
-- The `run` return is checked against your declared outputs at **compile time** (a missing required output or a wrong value type is a TypeScript error) and at **runtime** via TypeBox `Value` (undeclared keys are rejected and the declared shape is enforced recursively).
+- TypeScript checks the `run` return against your declared outputs at **compile time** (a missing required output or wrong value type is a TypeScript error), and TypeBox `Value` checks it at **runtime** (rejecting undeclared keys and enforcing the declared shape recursively).
 - `ctx.workflow(child)` returns a discriminated child result. When `child.exited === false`, `child.outputs` is the child's full declared `outputs` contract; when `child.exited === true`, `child.outputs` is `Partial<TOutputs>` because child `ctx.exit({ outputs })` may intentionally provide only a subset.
 
 Use `Static<typeof schema>` (both `Static` and `TSchema` are re-exported from `@bastani/workflows`) when you need the inferred TypeScript type of a schema directly — for example to type a helper that builds an output value.
 
+### Stage follow-on user messages
+
+`ctx.stage()` returns a `StageContext` with `sendUserMessage(content, options?)` to inject a normal follow-on user turn into that stage's AgentSession. Use this when workflow code needs to continue an existing stage session after `stage.prompt(...)` has already resolved, including schema-backed stages where `prompt()` is intentionally one-shot because the structured-output tool may be called exactly once.
+
+```ts
+const gate = ctx.stage("review-gate", {
+  schema: Type.Object({ approved: Type.Boolean() }, { additionalProperties: false }),
+});
+const decision = await gate.prompt("Review the implementation and call structured_output.");
+if (!decision.approved) {
+  await gate.sendUserMessage("Explain the highest-priority changes needed before approval.");
+}
+```
+
+When the stage session is idle, `sendUserMessage()` starts the next user turn immediately and waits for that turn to finish under the normal workflow stage guard: it observes the stage concurrency limiter, workflow abort/cancellation signals, MCP scoping, readiness gates, and session metadata capture. If `sendUserMessage()` is the first live call on a `ctx.stage(...)` handle, Atomic records the stage as a normal running/completed graph node. If it is called after a prior `prompt()`/`complete()` has already completed the stage, the follow-on turn still uses internal abort/cancellation and concurrency protection while reusing the completed stage session.
+
+The `content` argument mirrors the Atomic SDK and accepts either a string or text/image content blocks such as `[{ type: "text", text: "Describe this" }, { type: "image", data: "...", mimeType: "image/png" }]` when the underlying stage session supports native user-message delivery. Non-native fallback adapters only support string content and reject text/image block arrays instead of stringifying them. Idle non-native fallback delivery sends the follow-on string to the already-selected session directly, so workflow model fallback retries are not re-run for that injected turn.
+
+When the stage is already streaming, the message is queued as a follow-up by default; pass `{ deliverAs: "steer" }` to steer the active turn instead, or `{ deliverAs: "followUp" }` to be explicit. `deliverAs` only affects streaming delivery and is a no-op for idle sessions. Follow-on turns preserve the stage's `mcp.allow` / `mcp.deny` scope for the injected user turn, just like the original `prompt()`. The older `stage.steer(text)` and `stage.followUp(text)` methods are still available for queueing while a turn is active, but they do not start a new idle turn.
+
+Externally produced traffic has a separate lifecycle rule. Intercom messages and async bash/subagent completion notices received while a workflow stage generation is still open are admitted immediately through the stage AgentSession's native steering/follow-up queue. The stage drains already-admitted work before publishing its terminal snapshot, including schema-backed turns that have already called `structured_output`.
+
+Closing the generation is atomic with admission: a notification admitted first belongs to that stage, while ordinary detached notifications arriving after close cannot reopen or mutate the completed stage and are surfaced once through the main-chat notification path instead. A blocking sibling `intercom.ask` is the deliberate exception: when the completed stage retains a valid conversation, Atomic schedules a post-mortem turn in that conversation so it can inspect the exact ask and reply without changing terminal workflow state. Failed post-mortem admission returns a correlated actionable error to the asker.
+
+Stage completion never waits for producers that are still running; only traffic already admitted at the close boundary is drained. Explicit `sendUserMessage()` calls and post-mortem stage chat remain deliberate user/workflow-authored follow-up turns on the retained session.
+
+### Early exit with `ctx.exit()`
+
+Use `ctx.exit(options?)` when workflow code intentionally stops the current run from a helper, branch, loop, or precondition guard without classifying the run as failed. `ctx.exit()` throws an executor-owned control signal and is typed as `never`, so code after it is unreachable. In async `run` bodies, prefer `return ctx.exit(...)` when the exit is the only path so TypeScript can see the non-returning branch.
+
+```ts
+export default workflow({
+  name: "guarded-import",
+  description: "",
+  inputs: {},
+  outputs: {
+    scanned: Type.Number(),
+  },
+  run: async (ctx) => {
+    const files = await findCandidateFiles(ctx.cwd);
+    if (files.length === 0) {
+      return ctx.exit({
+        status: "skipped",
+        reason: "No matching files",
+        outputs: { scanned: 0 },
+      });
+    }
+
+    const review = await ctx.task("review", { prompt: `Review ${files.join(", ")}` });
+    return { scanned: files.length };
+  },
+});
+```
+
+`ctx.exit()` accepts `status: "completed" | "skipped" | "cancelled" | "blocked"`; it never accepts `"failed"` or `"killed"` because thrown errors and internal destructive cancellation keep those meanings. `status` defaults to `"completed"`. `reason` is persisted and shown in status surfaces, including the default `/workflow status` list and `/workflow status <runId>` detail, so do not put secrets in it. `outputs` may contain a partial subset of declared outputs; provided keys still must be declared in the workflow's `outputs` object, match their TypeBox schema, and be JSON-serializable.
+
+Atomic allows missing required outputs only on the `ctx.exit(...)` path. Exited runs are terminal and not resumable; public `pause`, `interrupt`, and `quit`, plus internal destructive cancellation, keep their distinct existing behavior.
+
+The first selected `ctx.exit({ outputs })` snapshots its output payload synchronously by value before JavaScript `finally` blocks or cleanup callbacks can mutate the caller-owned object. The snapshot preserves undeclared keys and invalid values until post-cleanup validation, so deleting an undeclared key or changing an invalid value after `ctx.exit(...)` does not change the terminal validation result.
+
+If reading `status`, `reason`, or `outputs` options, or enumerating/copying the output snapshot itself, throws, Atomic still selects the exit signal, runs workflow-exit cleanup when feasible, and then records a terminal non-resumable authoring failure (`resumable: false`) if no external terminal control won first.
+
+After the first `ctx.exit(...)` wins, the executor treats that exit as a level-triggered gate. Later delayed calls to `ctx.stage`, `ctx.task`, `ctx.chain`, `ctx.parallel`, `ctx.workflow`, or graph-backed `ctx.ui.*` prompts rethrow the selected exit signal before creating stages, prompt nodes, child runs, or control handles. Retained `StageContext` handles from before the exit also become inert: `prompt`, `complete`, steering/follow-up, model/thinking controls, tree navigation, compaction, abort, and attached-pane session-realization paths refuse to touch or create an `AgentSession` after the exit is selected.
+
+`ctx.parallel` stops dequeuing queued work after exit even with `failFast: false` and limited concurrency; already-started stages and prompt nodes are finalized as `skipped` with a `workflow-exit` reason that prompt-node abort handling preserves instead of overwriting with a generic run-aborted reason.
+
+Continuation replay also observes the exit gate. Replayed `ctx.stage(...).prompt(...)`, replayed `complete(...)`, graph-backed prompt-node replay, and completed child-boundary replay re-check for a selected exit after their replay microtask and before writing a current-run completed stage end. If `ctx.exit(...)` wins that gap, the pending replay finalizer is skipped/suppressed with the workflow-exit reason instead of creating a misleading completed stage in the resumed run.
+
+The store is the terminal authority for all run-end races. `ctx.exit(...)` starts cleanup before validating exit outputs, and an internal destructive cancellation can still win the terminal `recordRunEnd` write while that cleanup is pending. When that happens, the SDK `RunResult`, `onRunEnd` callback, live store, and persisted `workflow.run.end` entries all report the canonical `killed` state; the losing `ctx.exit` status or validation failure is not returned and does not append a second run-end entry.
+
+Control-signal probing is fail-closed. When the executor inspects an arbitrary thrown value or abort reason for internal workflow-exit markers, parent-exit markers, aggregate `errors`, `cause`, `reason`, or `scope`, throwing or inaccessible accessors are treated as “no signal for that branch.” The run then continues through ordinary failure finalization, or the ordinary killed path for external abort reasons, instead of letting author-defined getters escape the executor catch path or be misclassified as `ctx.exit(...)`.
+
 ### Workflow Composition
 
-Use workflow composition when one workflow should call another reusable workflow and consume its outputs as a tracked boundary stage. The child can be a user-defined workflow from your project/package or a bundled builtin workflow. In both cases, use normal TypeScript imports: import the child workflow definition, then pass that definition directly to `ctx.workflow(workflowDefinition, options)`. Registry names, path objects, and string aliases are not accepted by `ctx.workflow(...)`.
+Use workflow composition when a workflow calls a reusable user-defined workflow from the project or package, or a bundled builtin workflow, and consumes its outputs as a tracked boundary stage. Import the child definition with a normal TypeScript import, then pass it directly to `ctx.workflow(workflowDefinition, options)`. `ctx.workflow(...)` does not accept registry names, path objects, or string aliases.
 
 For workflows intended to be called by parent workflows, declare every field a parent should rely on in the child workflow's `outputs` object, including `result`. No output exists without declaration: a child exposes exactly its declared outputs, and returning an undeclared key fails the child call.
 
@@ -1644,7 +990,7 @@ export default workflow({
 
 #### Compose with builtin workflows
 
-Builtin workflows are also exported as workflow definitions, so parent workflows can call them exactly like user-defined workflows. Use the barrel export when you want several builtins:
+Parent workflows can call exported builtin workflow definitions like user-defined workflows. Use the barrel export to import several builtins:
 
 ```ts
 import { deepResearchCodebase, goal, openClaudeDesign, ralph } from "@bastani/workflows/builtin";
@@ -1774,21 +1120,2372 @@ if (child.exited === true) {
 }
 ```
 
-A child exposes exactly its declared outputs — the keys declared in `outputs` and returned from `run` or supplied to `ctx.exit({ outputs })`. There are no implicit outputs and no raw return-object passthrough. If `run` returns a key that was not declared in `outputs`, the child run fails with `atomic-workflows: workflow "<childName>" returned undeclared output "<key>"; declare it in outputs or remove it from the run return`, and the parent surfaces that failure through the wrapper `atomic-workflows: child workflow "<childName>" (<displayName>) failed with status failed: ...`. A child with no declared outputs therefore exposes no outputs. Missing required outputs, schema type mismatches, and non-JSON-serializable returned values fail normal child completion before the parent continues; child `ctx.exit({ outputs })` allows missing required outputs but still validates every provided key and sets `child.exited === true` so parent code must handle the partial shape.
+A child exposes only outputs declared in `outputs` and returned from `run` or supplied to `ctx.exit({ outputs })`. There are no implicit outputs and no raw return-object passthrough. If `run` returns a key that was not declared in `outputs`, the child run fails with `atomic-workflows: workflow "<childName>" returned undeclared output "<key>"; declare it in outputs or remove it from the run return`, and the parent surfaces that failure through the wrapper `atomic-workflows: child workflow "<childName>" (<displayName>) failed with status failed: ...`. A child with no declared outputs therefore exposes no outputs.
 
-Only workflow definitions can be passed to `ctx.workflow(...)`. Import reusable workflows with TypeScript `import` statements first; use `/workflow` names such as `goal` only for launching named runs, not as `ctx.workflow(...)` arguments. If a module is missing or does not export a workflow definition, workflow discovery fails when loading that module. Nested child workflows count against `maxDepth` (default `4` total workflow levels).
+Missing required outputs, schema type mismatches, and non-JSON-serializable returned values fail normal child completion before the parent continues; child `ctx.exit({ outputs })` allows missing required outputs but still validates every provided key and sets `child.exited === true` so parent code must handle the partial shape.
 
-The graph includes both the parent boundary node and the imported child workflow's own stages while the child is loading/running, so the user can observe progress and interrupt sub-workflows before they complete. Completed boundaries still retain the child workflow name, child run id prefix, and exposed output count for replay/debugging. Skipped or failed boundaries do not retain child-edge metadata (`workflowChild` / `workflowChildRun`), and graph expansion ignores any stale non-completed boundary metadata from older persisted sessions instead of flattening an unrelated child run. Use `stageName` when the parent needs a more specific label, but keep it concise so the child summary remains readable in the graph.
+Pass only workflow definitions to `ctx.workflow(...)`. Import reusable workflows with TypeScript `import` statements first; use `/workflow` names such as `goal` only for launching named runs, not as `ctx.workflow(...)` arguments. If a module is missing or does not export a workflow definition, workflow discovery fails when loading that module. Nested child workflows count against `maxDepth` (default `4` total workflow levels).
 
-If a parent workflow exits through `ctx.exit(...)` while a child workflow is in flight, the parent executor only skips the parent boundary and sends the child a typed parent-exit abort reason. The hidden child executor owns child cleanup: active child stages and prompt nodes are skipped for `workflow-exit`, live child stage handles/sessions are disposed, and the child run is finalized as terminal `cancelled` (not `killed`) and non-resumable. The child executor writes each skipped child `workflow.stage.end` exactly once before its child `workflow.run.end`, and parent exit finalization waits for that child cleanup before writing the parent `workflow.run.end`, so restored sessions do not reconstruct the child as interrupted or failed. The skipped parent boundary clears any live child-run edge before store or persistence updates, so status/graph views do not display stale child stages from a boundary that did not complete. A delayed parent branch that calls `ctx.workflow(...)` after the exit gate is selected does not create a boundary or child run.
+The graph includes both the parent boundary node and the imported child workflow's own stages while the child is loading/running, so the user can observe progress and interrupt sub-workflows before they complete. Completed boundaries still retain the child workflow name, child run id prefix, and exposed output count for replay/debugging. Skipped or failed boundaries do not retain child-edge metadata (`workflowChild` / `workflowChildRun`), and graph expansion ignores any stale non-completed boundary metadata from older persisted sessions instead of flattening an unrelated child run.
+
+Use `stageName` when the parent needs a more specific label, but keep it concise so the child summary remains readable in the graph.
+
+If a parent workflow exits through `ctx.exit(...)` while a child workflow is in flight, the parent executor only skips the parent boundary and sends the child a typed parent-exit abort reason. The hidden child executor owns child cleanup: active child stages and prompt nodes are skipped for `workflow-exit`, live child stage handles/sessions are disposed, and the child run is finalized as terminal `cancelled` (not `killed`) and non-resumable.
+
+The child executor writes each skipped child `workflow.stage.end` exactly once before its child `workflow.run.end`, and parent exit finalization waits for that child cleanup before writing the parent `workflow.run.end`, so restored sessions do not reconstruct the child as interrupted or failed. The skipped parent boundary clears any live child-run edge before store or persistence updates, so status/graph views do not display stale child stages from a boundary that did not complete. A delayed parent branch that calls `ctx.workflow(...)` after the exit gate is selected does not create a boundary or child run.
 
 Continuation replay treats the parent child-workflow boundary as the durable checkpoint: a previously completed child boundary replays with the original exposed outputs and without re-running the child, while a child that failed or was interrupted before completion starts again from the beginning on continuation. If `ctx.exit(...)` wins while a completed boundary is being replayed but before replay finalization, the boundary is finalized as skipped and its preloaded child metadata is omitted from store, persistence, restore, and expanded graph views.
 
+## The `workflow()` Definition
+
+`workflow(spec)` is the only supported authoring API. It validates the schema maps, normalizes or infers the name, and returns a frozen branded definition that discovery and `ctx.workflow(...)` accept.
+
+```typescript
+function workflow<
+  const TInputs extends WorkflowInputSchemaMap = {},
+  const TOutputs extends WorkflowOutputSchemaMap = WorkflowOutputSchemaMap,
+  TActualOutputs extends WorkflowOutputsFromSchemas<TOutputs> = WorkflowOutputsFromSchemas<TOutputs>,
+>(
+  spec: AuthoredWorkflowSpec<TInputs, TOutputs, TActualOutputs>,
+): AuthoredWorkflowDefinition<TInputs, TOutputs>;
+```
+
+### `name`
+
+```typescript
+readonly name?: string;
+```
+
+The name is optional; when you omit it, Atomic infers it from the caller filename. Lookup normalization trims and lowercases the name, changes whitespace and underscores to hyphens, removes other punctuation, collapses repeated hyphens, and trims edge hyphens.
+
+### `description`
+
+```typescript
+readonly description: string;
+```
+
+Discovery and inspection surfaces show this required listing text. The compiled definition preserves it unchanged.
+
+### `inputs`
+
+```typescript
+readonly inputs?: WorkflowInputSchemaMap;
+type WorkflowInputSchemaMap = Readonly<Record<string, TSchema>>;
+```
+
+Each key maps to a TypeBox schema and becomes a typed member of `ctx.inputs`. Atomic validates inputs before the workflow body starts; see [Inputs](#inputs) for picker behavior, defaults, and runtime rules.
+
+### `outputs`
+
+```typescript
+readonly outputs: WorkflowOutputSchemaMap;
+type WorkflowOutputSchemaMap = Readonly<Record<string, TSchema>>;
+```
+
+The output schema map is required, including for outputless workflows where it is `{}`. TypeScript checks the `run` return against it at compile time, and Atomic checks it at runtime; see [Outputs](#outputs) for declaration, serialization, and child-exposure rules.
+
+### `worktreeFromInputs`
+
+```typescript
+readonly worktreeFromInputs?: {
+  readonly gitWorktreeDir: string;
+  readonly baseBranch?: string;
+};
+```
+
+The values name workflow inputs, not literal paths. The binding becomes the compiled definition's `inputBindings.worktree` default for stages and tasks.
+
+```ts
+export default workflow({
+  name: "safe-implementation",
+  description: "",
+  inputs: {
+    task: Type.String(),
+    git_worktree_dir: Type.String({ default: "" }),
+    base_branch: Type.String({ default: "origin/main" }),
+  },
+  outputs: {
+    result: Type.String({ description: "Implementation result text." }),
+  },
+  worktreeFromInputs: { gitWorktreeDir: "git_worktree_dir", baseBranch: "base_branch" },
+  run: async (ctx) => {
+    const result = await ctx.task("implement", { task: String(ctx.inputs.task) });
+    return { result: result.text };
+  },
+});
+```
+
+### `run(ctx)`
+
+```typescript
+readonly run: (
+  ctx: WorkflowRunContext<WorkflowInputsFromSchemas<TInputs>, WorkflowOutputsFromSchemas<TOutputs>>,
+) =>
+  | Promise<WorkflowRunOutputResult<TOutputs, TActualOutputs>>
+  | WorkflowRunOutputResult<TOutputs, TActualOutputs>;
+```
+
+The workflow body may be synchronous or asynchronous. Return exactly the declared output keys, or call `ctx.exit(...)` for an intentional terminal exit.
+
+### Compiled definition fields
+
+```typescript
+interface WorkflowDefinition<
+  TInputs extends WorkflowInputValues = WorkflowInputValues,
+  TOutputs extends WorkflowOutputValues = WorkflowOutputValues,
+  TRunInputs extends WorkflowInputValues = TInputs,
+  TDefinitionBrand extends object = {},
+> {
+  readonly __piWorkflow: true;
+  readonly __runInputs?: TRunInputs;
+  readonly name: string;
+  readonly normalizedName: string;
+  readonly description: string;
+  readonly inputs: WorkflowInputSchemaMap;
+  readonly outputs?: WorkflowOutputSchemaMap;
+  readonly inputBindings?: { readonly worktree?: WorkflowWorktreeInputBinding };
+  run(
+    ctx: WorkflowRunContext<TInputs, TDefinitionBrand, TOutputs>,
+  ): Promise<TOutputs> | TOutputs;
+}
+```
+
+`workflow({...})` returns definitions that narrow `outputs` to required and carry an internal nominal brand. Do not construct `__piWorkflow` objects by hand: discovery and child composition accept only definitions minted by `workflow({...})`.
+
+## WorkflowContext
+
+The `run` function receives `ctx: WorkflowRunContext`. Prefer its high-level primitives because they create tracked graph nodes and consistent handoffs.
+
+| Need | Use |
+|------|-----|
+| One LLM/session task with workflow tracking | `ctx.task(name, options)` |
+| Dependent sequential tasks | `ctx.chain(steps, options?)` |
+| Independent concurrent branches | `ctx.parallel(steps, options?)` |
+| Reusable child workflow | Call `ctx.workflow(workflowDefinition, options?)` |
+| Human input during a workflow run | `ctx.ui.input/confirm/select/editor/custom` |
+| Pure deterministic computation, parsing, or file I/O | Plain TypeScript in `run` or helpers |
+| Fine-grained session control | `ctx.stage(name, options?)` |
+
+### `ctx.inputs`
+
+```typescript
+readonly inputs: Readonly<TInputs>;
+```
+
+Typed, validated input values from the definition's `inputs` schema map. Atomic applies defaults before `run` starts.
+
+### `ctx.cwd`
+
+```typescript
+readonly cwd?: string;
+```
+
+Invocation working directory for workflow-owned artifacts. It defaults to the host process cwd when omitted.
+
+### `ctx.task(name, options)`
+
+```typescript
+ctx.task(name: string, options: WorkflowTaskOptions): Promise<WorkflowTaskResult>;
+```
+
+Creates one tracked stage, prompts its agent session, and returns a reusable task result. `options` is required and accepts `prompt` or its `task` alias plus the task and stage fields documented below.
+
+```typescript
+const review = await ctx.task("review", {
+  prompt: "Review the current patch.",
+  context: "fresh",
+});
+```
+
+### `ctx.chain(steps, options?)`
+
+```typescript
+ctx.chain(
+  steps: readonly WorkflowTaskStep[],
+  options?: WorkflowChainOptions,
+): Promise<WorkflowTaskResult[]>;
+```
+
+Runs named task steps in sequence. The first missing task uses `{task}` from chain options or the root direct task; later missing tasks use `{previous}`.
+
+### `ctx.parallel(steps, options?)`
+
+```typescript
+ctx.parallel(
+  steps: readonly WorkflowTaskStep[],
+  options?: WorkflowParallelOptions,
+): Promise<WorkflowTaskResult[]>;
+```
+
+Runs named task steps concurrently, subject to `concurrency` and `failFast`. The call snapshots the current graph frontier at fan-out, so every branch uses the same parent set even when queued or allowed to continue after a sibling failure; downstream stages depend on all settled branches.
+
+### `ctx.workflow(definition, options?)`
+
+```typescript
+ctx.workflow<
+  TChildInputs extends WorkflowInputValues,
+  TChildOutputs extends WorkflowOutputValues,
+  TChildRunInputs extends WorkflowInputValues = TChildInputs,
+>(
+  definition: WorkflowDefinition<TChildInputs, TChildOutputs, TChildRunInputs> & TDefinitionBrand,
+  ...args: WorkflowRunChildArgs<TChildRunInputs>
+): Promise<WorkflowChildResult<TChildOutputs>>;
+
+interface WorkflowRunChildOptions<TInputs extends WorkflowInputValues = WorkflowInputValues> {
+  readonly inputs?: TInputs;
+  readonly stageName?: string;
+}
+type WorkflowRequiredKeys<T extends object> = {
+  [K in keyof T]-?: {} extends Pick<T, K> ? never : K;
+}[keyof T];
+type WorkflowRunChildOptionsArgument<TInputs extends WorkflowInputValues = WorkflowInputValues> =
+  [WorkflowRequiredKeys<TInputs>] extends [never]
+    ? WorkflowRunChildOptions<TInputs>
+    : WorkflowRunChildOptions<TInputs> & { readonly inputs: TInputs };
+type WorkflowRunChildArgs<TInputs extends WorkflowInputValues = WorkflowInputValues> =
+  [WorkflowRequiredKeys<TInputs>] extends [never]
+    ? readonly [options?: WorkflowRunChildOptionsArgument<NoInfer<TInputs>>]
+    : readonly [options: WorkflowRunChildOptionsArgument<NoInfer<TInputs>>];
+```
+
+Executes an imported workflow definition behind a tracked parent boundary. The type system requires `inputs` when the child has required inputs, while `stageName` defaults to `workflow:<workflow-name>`.
+
+```typescript
+const child = await ctx.workflow(sharedResearch, {
+  inputs: { topic: ctx.inputs.topic },
+  stageName: "run shared research",
+});
+```
+
+The method accepts only branded definitions, not names, aliases, or path objects. See [Workflow Composition](#workflow-composition) for graph flattening, replay, failure, and parent-exit behavior, and [`WorkflowChildResult`](#workflowchildresult) for the discriminated result.
+
+### `ctx.stage(name, options?)`
+
+```typescript
+ctx.stage<TSchemaDef extends TSchema>(
+  name: string,
+  options: StageOptions<TSchemaDef> & { readonly schema: TSchemaDef },
+): StageContext<TSchemaDef>;
+ctx.stage(name: string, options?: StageOptions): StageContext;
+```
+
+Creates and registers a named stage synchronously; work starts when you call a method such as `prompt()` or `complete()`. Use it when `ctx.task` is too coarse and direct session control is required.
+
+### `ctx.ui`
+
+```typescript
+readonly ui: WorkflowUIContext;
+```
+
+Human-in-the-loop primitives that suspend at the callsite. They create awaiting-input graph nodes at runtime; see [Lifecycle Notices and Human Input](#lifecycle-notices-and-human-input).
+
+### `ctx.ui.input(prompt)`
+
+```typescript
+ctx.ui.input(prompt: string): Promise<string>;
+```
+
+Prompts for a text value. The promise resolves with the submitted string.
+
+### `ctx.ui.confirm(message)`
+
+```typescript
+ctx.ui.confirm(message: string): Promise<boolean>;
+```
+
+Prompts for a boolean confirmation. The promise resolves to `true` or `false`.
+
+### `ctx.ui.select(message, options)`
+
+```typescript
+ctx.ui.select<T extends string>(message: string, options: readonly T[]): Promise<T>;
+```
+
+Prompts for one string-literal option. An empty options array throws before Atomic creates a prompt node.
+
+### `ctx.ui.editor(initial?)`
+
+```typescript
+ctx.ui.editor(initial?: string): Promise<string>;
+```
+
+Opens the multiline editor and resolves with its text. Pass `initial` to seed the editor.
+
+### `ctx.ui.custom(factory, options?)`
+
+```typescript
+ctx.ui.custom<T>(
+  factory: (
+    tui: TUI,
+    theme: Theme,
+    keybindings: KeybindingsManager,
+    done: (value: T) => void,
+  ) => WorkflowCustomUiComponent | Promise<WorkflowCustomUiComponent>,
+  options?: {
+    readonly overlay?: boolean;
+    readonly signal?: AbortSignal;
+    readonly overlayOptions?: OverlayOptions | (() => OverlayOptions);
+    readonly onHandle?: (handle: OverlayHandle) => void;
+    readonly replayIdentity?: string;
+    readonly label?: string;
+  },
+): Promise<T>;
+```
+
+Builds a custom TUI component and resolves with the value passed to `done(value)`. Workflow graph hosts reject `overlay: true`; `label` is display-only and defaults to `"Custom TUI prompt"`, while `replayIdentity` should change when widget semantics change and must not contain secrets.
+
+See [Lifecycle Notices and Human Input](#lifecycle-notices-and-human-input) for replay identity, answer routing, and interactive-only constraints.
+
+### `ctx.tool(name, args, fn, options?)`
+
+```typescript
+ctx.tool<TValue extends WorkflowSerializableValue>(
+  name: string,
+  args: Readonly<Record<string, WorkflowSerializableValue>>,
+  fn: () => Promise<TValue>,
+  options?: {
+    readonly retriesAllowed?: boolean;
+    readonly maxAttempts?: number;
+    readonly intervalMs?: number;
+    readonly backoffRate?: number;
+  },
+): Promise<TValue>;
+```
+
+Runs arbitrary TypeScript code and durably caches its serializable result by call order plus the content hash of `name` and `args`. A completed call replays without rerunning `fn`, so use this primitive for durable side effects.
+
+**Options:**
+- `retriesAllowed` — retries failures when `true`; default `false`.
+- `maxAttempts` — maximum attempts when retries are enabled; default `3`.
+- `intervalMs` — initial retry interval; default `1000`.
+- `backoffRate` — retry interval multiplier; default `2`.
+
+See [`ctx.tool` — durable cached tool execution](#ctxtool--durable-cached-tool-execution) for the full example and cancellation behavior.
+
+### `ctx.exit(options?)`
+
+```typescript
+ctx.exit(options?: WorkflowExitOptions<TOutputs>): never;
+
+type WorkflowExitOutputValues<TOutputs extends WorkflowOutputValues> =
+  [keyof TOutputs] extends [never]
+    ? Readonly<Record<string, never>>
+    : Partial<TOutputs>;
+interface WorkflowExitOptions<TOutputs extends WorkflowOutputValues = WorkflowOutputValues> {
+  readonly status?: "completed" | "skipped" | "cancelled" | "blocked";
+  readonly reason?: string;
+  readonly outputs?: WorkflowExitOutputValues<TOutputs>;
+}
+```
+
+Intentionally ends the current run from any call depth. `status` defaults to `"completed"`; the runtime persists and displays `reason`, and `outputs` may provide only declared, schema-valid, serializable output keys.
+
+See [Early exit with `ctx.exit()`](#early-exit-with-ctxexit) for snapshotting, cleanup, replay, and race semantics.
+
+## Task and Stage Options
+
+`StageOptions`, task session fields, and the direct step types share the fields below. `ctx.task`, `ctx.chain`, and `ctx.parallel` inherit these options where their signatures use the corresponding option type.
+
+### `prompt` / `task`
+
+```typescript
+readonly prompt?: string;
+readonly task?: string;
+```
+
+Aliases for task text. Prefer `prompt` in authored workflow files because it mirrors `stage.prompt(...)`; `task` remains useful in direct tool calls and chains.
+
+### `previous`
+
+```typescript
+readonly previous?:
+  | WorkflowTaskContextInput
+  | readonly WorkflowTaskContextInput[];
+type WorkflowTaskContextInput = string | WorkflowTaskContext | WorkflowTaskResult;
+```
+
+Use `previous` and `{previous}` only for compact handoffs. If the prompt has no placeholder, the runtime appends the context, so a large payload can silently bloat the next prompt.
+
+For large handoffs, write artifacts to files, pass their paths with `reads`, and tell downstream stages to read only the needed sections. Put the instruction in the downstream prompt, for example `Read the file at ${artifactPath} and use only the sections needed for this stage.` Prefer `outputMode: "file-only"` when the parent needs only the artifact path.
+
+See [Compression and Artifact Handoffs](#compression-and-artifact-handoffs) and [Filesystem Context](#filesystem-context) for complete patterns.
+
+### `context` / `forkFromSessionFile`
+
+```typescript
+readonly context?: "fresh" | "fork";
+readonly forkFromSessionFile?: string;
+```
+
+Select a clean session or a forked context, with `forkFromSessionFile` naming an explicit fork source. Omitting `context` creates a fresh session unless the runtime is reopening durable state; see [Locally Scoped Stage Prompts](#locally-scoped-stage-prompts) for choosing fresh reviewer context versus coherent implementation context.
+
+### `model`
+
+```typescript
+readonly model?: WorkflowModelValue; // string or supported SDK model object
+```
+
+Selects the primary stage model. String values can carry reasoning and context-window suffixes described under [Reasoning levels](#reasoning-levels) and [Context windows](#context-windows).
+
+### `fallbackModels` / `fallbackThinkingLevels`
+
+```typescript
+readonly fallbackModels?: readonly string[];
+/** @deprecated Prefer a reasoning suffix on each fallback model. */
+readonly fallbackThinkingLevels?: readonly string[];
+```
+
+`fallbackModels` tries the primary first, each fallback in order, and then the current Atomic-selected model when available. It advances for rate limits and quota or usage-limit exhaustion, including messages such as `The usage limit has been reached` and codes such as `usage_limit_reached` or `insufficient_quota`. Auth/provider outages, unavailable models, network timeouts, generic transport errors such as `Connection error.` or `fetch failed`, and 5xx responses also advance the chain.
+
+Request/context incompatibility also advances it, including HTTP 400/413/422 bad, unprocessable, or payload-too-large requests; unsupported tools or parameters; context-length or context-window overflow; and `too large`, `invalid_request`, or `bad_request` errors. This lets the chain reach the current selected user model when no configured candidate can serve the request.
+
+Workflow-code errors, tool failures, validation failures, refusals, content-filter or safety blocks, cancellations, and task failures do not advance the chain. A reattached finished stage starts on the model that last succeeded; if that model fails retryably, the full chain restarts from the primary.
+
+### `thinkingLevel` (deprecated)
+
+```typescript
+/** @deprecated Prefer suffixing model/fallbackModels entries with `:level`. */
+readonly thinkingLevel?: WorkflowThinkingLevel;
+```
+
+Sets the default reasoning effort for candidates without a suffix. A suffix on the model string wins.
+
+### `contextWindow` / `contextWindowStrict`
+
+```typescript
+readonly contextWindow?: number;
+readonly contextWindowStrict?: boolean;
+```
+
+Applies a stage-wide context-window token budget. The runtime rejects unsupported values when `contextWindowStrict` is `true`; otherwise, the model keeps its default.
+
+### `scopedModels`
+
+```typescript
+readonly scopedModels?: readonly WorkflowScopedModel[];
+interface WorkflowScopedModel {
+  readonly model: WorkflowModelValue;
+  /** @deprecated Prefer a model-string reasoning suffix. */
+  readonly thinkingLevel?: WorkflowThinkingLevel;
+}
+```
+
+Supplies stage-scoped model objects and optional compatibility reasoning levels. The nested `thinkingLevel` field is deprecated.
+
+### `tools` / `noTools` / `excludedTools`
+
+```typescript
+readonly tools?: readonly string[];
+readonly noTools?: "all" | "builtin";
+readonly excludedTools?: readonly string[];
+```
+
+`tools` is an allowlist across built-in and bundled extension tools; list every tool the stage should see. `excludedTools` and `noTools: "all"` still win.
+
+The bundled `subagent` tool is available by default with the same five delegated-level depth guard as main chat. Bundled subagent definitions from `@bastani/subagents` are available to that tool. Explicitly list tools such as `subagent`, `web_search`, `fetch_content`, or `intercom` when using an allowlist; workflow stages running inside subagent child processes retain isolated resource discovery and the nested-depth guard.
+
+Workflow stages use the same upstream-compatible `bash` tool as normal Atomic sessions. Enabled commands run through the configured shell with the stage process permissions. There is no command-text allow/deny option: expose or hide shell access with these tool fields, prefer narrow custom tools for repeatable operations, and use a container, VM, or other sandbox for stronger isolation.
+
+### `customTools`
+
+```typescript
+readonly customTools?: readonly WorkflowCustomToolDefinition[];
+```
+
+Adds stage-local tool definitions using the Atomic tool contract. Each definition supplies its schema and execute handler.
+
+### `mcp`
+
+```typescript
+readonly mcp?: {
+  readonly allow?: readonly string[];
+  readonly deny?: readonly string[];
+};
+```
+
+Scopes MCP servers for one stage. The runtime applies the scope before execution and clears it after the stage settles; omitting `mcp` leaves server access unrestricted by workflow-stage scope.
+
+### `schema`
+
+```typescript
+readonly schema?: TSchema;
+```
+
+Enables a schema-specific, single-use final-answer tool for that item. `ctx.stage`, `ctx.task`, `ctx.chain`, and `ctx.parallel` items accept a TypeBox schema or a plain JSON Schema descriptor object. The schema may describe an object, array, or primitive, and the captured JSON value becomes the schema-backed `stage.prompt(...)` result or `WorkflowTaskResult.structured`; task text remains formatted JSON for handoffs.
+
+A schema-backed `StageContext` supports one `prompt()` call, so create another stage for another structured prompt. Missing or invalid `structured_output` calls receive up to three corrective follow-ups quoting the contract error and reminding the model to call `structured_output` instead of replying with plain JSON. An explicit tool allowlist automatically receives the final-answer tool, while items without `schema` do not.
+
+### `output` / `outputMode`
+
+```typescript
+readonly output?: string | false;
+readonly outputMode?: "inline" | "file-only";
+```
+
+Writes direct output to a path or disables output persistence with `false`. `outputMode` defaults to `inline`; `file-only` keeps the parent result compact by returning an artifact reference instead of full text and requires an output path.
+
+### `reads`
+
+```typescript
+readonly reads?: readonly string[] | false;
+```
+
+Provides files for the stage to read before running, or disables inherited reads with `false`. Paths are supplied as readonly strings.
+
+### `maxOutput`
+
+```typescript
+readonly maxOutput?: {
+  readonly bytes?: number;
+  readonly lines?: number;
+};
+```
+
+Limits inline output by bytes, lines, or both. Omitted bounds default to `204800` bytes and `5000` lines.
+
+### `artifacts`
+
+```typescript
+readonly artifacts?: boolean;
+```
+
+Controls automatic session and worktree-diff artifact collection in direct results and defaults to `true`; explicit output-file artifacts remain available when automatic collection is disabled.
+
+### `worktree`
+
+```typescript
+readonly worktree?: boolean;
+```
+
+Requests a runner-managed temporary per-task worktree in direct mode. It is mutually exclusive with `gitWorktreeDir`, and the runner cleans it up even when startup fails before the callback.
+
+### `gitWorktreeDir` / `baseBranch`
+
+```typescript
+readonly gitWorktreeDir?: string;
+readonly baseBranch?: string;
+```
+
+Selects or creates a reusable same-repository Git worktree for `ctx.stage`, `ctx.task`, `ctx.chain`, and `ctx.parallel`.
+
+- **Creation and validation:** A missing path is created with `git worktree add --detach <path> <baseBranch>`, where an omitted or blank `baseBranch` defaults to `HEAD`. Existing paths must be same-repository worktree roots outside the invoking checkout; the checkout itself, nested targets, and missing targets whose symlinked parent resolves inside it are rejected.
+- **Cwd remapping:** The default cwd preserves the invoking repository-relative subdirectory inside the worktree. Absolute cwd values inside the invoking repository are remapped, values already inside the worktree are preserved, and relative values resolve from the worktree cwd without lexical or symlink escape.
+- **Output containment:** Runner-managed reusable-worktree relative outputs follow the effective worktree cwd and cannot escape through traversal or symlinks. Temporary-worktree outputs are copied to distinct runner-owned artifact directories before cleanup, including in `file-only` mode, and Atomic rejects a pre-existing symlink or junction at the trusted artifact root. Explicit absolute outputs and nonblank explicit `chainDir` paths remain caller-selected, while blank `chainDir` is omitted.
+- **Caching and diagnostics:** Temporary isolation defaults to the runner invocation cwd, and relative task cwd values resolve there. Reusable setup is cached by canonical repository and target identity independently of equivalent path spelling or `baseBranch`, revalidates checkout identity before reuse, retries one transient timeout from read-only repository probes, and reports the exact Git command, cwd, timeout, elapsed time, exit status or signal, and spawn error details on failure.
+- **Security boundary:** Worktrees isolate checkouts and cwd, not the operating system. Use a container, VM, or another OS-enforced boundary for untrusted code that can race or mutate arbitrary paths.
+
+For lower-level integrations, [`setupGitWorktree(options)`](#setupgitworktreeoptions) returns the validated and remapped setup result.
+
+### `sessionDir`
+
+```typescript
+readonly sessionDir?: string;
+```
+
+Overrides the stage transcript directory, including for forked stages. In a headless run launched with `atomic --mode json --session-dir <dir> -p '/workflow <name> ...'`, Atomic writes the main chat transcript and every stage transcript under `<dir>`; the same inheritance applies when the non-default directory comes from `ATOMIC_CODING_AGENT_SESSION_DIR` or settings. Without a non-default host directory, stages use Atomic's global session store.
+
+### `cwd` / `agentDir`
+
+```typescript
+readonly cwd?: string;
+readonly agentDir?: string;
+```
+
+Select the stage working directory and agent configuration directory. Worktree-enabled cwd values are remapped and contained by the rules above.
+
+### Host-supplied SDK seams
+
+```typescript
+// Runtime StageOptions forwards non-workflow CreateAgentSessionOptions,
+// including these advanced host integration fields:
+readonly authStorage?: CreateAgentSessionOptions["authStorage"];
+readonly modelRegistry?: CreateAgentSessionOptions["modelRegistry"];
+readonly resourceLoader?: CreateAgentSessionOptions["resourceLoader"];
+readonly sessionManager?: SessionManager;
+readonly settingsManager?: SettingsManager;
+readonly sessionStartEvent?: CreateAgentSessionOptions["sessionStartEvent"];
+readonly orchestrationContext?: CreateAgentSessionOptions["orchestrationContext"];
+```
+
+These are advanced host-supplied SDK seams on the runtime `StageOptions` used by embedded integrations, not ordinary workflow-file defaults. The standalone workflow-package authoring declaration intentionally omits most of them and types `sessionManager` and `settingsManager` as `never`, so package-authored workflows should not pass these fields directly.
+
+The runtime strips workflow-owned fields before forwarding session options. Internal durable fields such as `resumeFromSessionFile`, `durableReplayKey`, and `durableAccumulatedDurationMs` are not public authoring options.
+
+### `name` / `count` (step items)
+
+```typescript
+interface WorkflowTaskStep extends WorkflowTaskOptions {
+  readonly name: string;
+}
+interface WorkflowDirectTaskItem extends WorkflowTaskOptions {
+  readonly name: string;
+  readonly count?: number;
+}
+```
+
+Every chain, parallel, and direct task item has a required display name. Direct items may request repeated expansion with `count`; omitting it runs the item once.
+
+### `chainName` / `chainDir`
+
+```typescript
+readonly chainName?: string;
+readonly chainDir?: string;
+```
+
+`chainName` groups direct-chain status and artifacts. `chainDir` sets the shared directory for relative reads, outputs, and worktree diffs; the runtime treats blank values as omitted.
+
+### `concurrency` / `failFast`
+
+```typescript
+readonly concurrency?: number;
+readonly failFast?: boolean;
+```
+
+`WorkflowParallelOptions` and direct options use `concurrency` to bound active tasks. When omitted, the runtime uses the workflow's `defaultConcurrency` setting, which defaults to `4`; parallel execution is fail-fast unless `failFast` is explicitly `false`.
+
+### Parallel chain-step fields
+
+```typescript
+interface WorkflowParallelChainStep {
+  readonly parallel: readonly WorkflowDirectTaskItem[];
+  readonly concurrency?: number;
+  readonly failFast?: boolean;
+  readonly worktree?: boolean;
+  readonly gitWorktreeDir?: string;
+  readonly baseBranch?: string;
+}
+```
+
+A direct chain may contain a grouped parallel step with its own concurrency, failure, and worktree defaults. Missing tasks inside the group use `{previous}`.
+
+### Stage prompt options (`StagePromptOptions`)
+
+```typescript
+interface PromptOptions {
+  readonly expandPromptTemplates?: boolean;
+  readonly images?: readonly WorkflowImageContent[];
+  readonly streamingBehavior?: "steer" | "followUp";
+  readonly source?: "interactive" | "rpc" | "extension";
+  readonly preflightResult?: (success: boolean) => void;
+}
+interface StageOutputOptions {
+  readonly output?: string | false;
+  readonly outputMode?: "inline" | "file-only";
+  readonly context?: "fresh" | "fork";
+  readonly cwd?: string;
+  readonly maxOutput?: { readonly bytes?: number; readonly lines?: number };
+  readonly artifacts?: boolean;
+  readonly sessionDir?: string;
+}
+type StagePromptOptions = PromptOptions & StageOutputOptions;
+```
+
+These options apply to `stage.prompt(...)`, not to stage creation. They control prompt expansion, images, streaming/source metadata, preflight reporting, and per-prompt output/session behavior.
+
+### Completion options (`CompleteStageOpts`)
+
+```typescript
+interface CompleteStageOpts {
+  readonly model?: WorkflowModelValue;
+  readonly maxTokens?: number;
+  readonly fallbackModels?: readonly string[];
+  readonly fallbackThinkingLevels?: readonly string[];
+}
+```
+
+These options apply to `stage.complete(...)`. `fallbackThinkingLevels` is the same deprecated compatibility helper used by stage options.
+
+### Reasoning levels
+
+Each `model` and `fallbackModels` entry accepts a `model_name:thinking_effort` suffix that sets the reasoning effort for that candidate (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`). The selected model's capability map still governs whether `xhigh` or `max` is available. The model string includes the effort, so one fallback chain can mix efforts—for example, a high-effort primary with lower-effort, cheaper fallbacks:
+
+```ts
+await ctx.task("review", {
+  task: "Review the diff",
+  model: "anthropic/claude-sonnet-4:high",
+  fallbackModels: ["openai/gpt-5:medium", "anthropic/claude-haiku-4-5:off"],
+});
+```
+
+The standalone `thinkingLevel` stage option is deprecated. It still applies as a default to any candidate without a suffix, and when both are present the suffix wins, but new workflows should fold the effort into the model strings:
+
+```diff
+-  model: "openai/gpt-5.5",
+-  fallbackModels: ["anthropic/claude-opus-4-8"],
+-  thinkingLevel: "high",
++  model: "openai/gpt-5.5:high",
++  fallbackModels: ["anthropic/claude-opus-4-8:high"],
+```
+
+This applies everywhere a stage accepts a model: direct `ctx.task`/`ctx.chain`/`ctx.parallel` options, `ctx.stage` options, builtin workflow stage definitions, and workflow parameters. `fallbackThinkingLevels` is an optional compatibility helper aligned by index to `fallbackModels`; it applies only to fallback entries that do not already carry a suffix. Each `WorkflowModelAttempt` reports the resolved model and the effective reasoning effort used for that attempt.
+
+### Context windows
+
+A `model`/`fallbackModels` entry may also request a context-window budget with a parenthesized size token in the model-name portion. Place the token *before or after* the optional `:reasoning` suffix to prevent a conflict with the reasoning level. This mirrors GitHub Copilot's `Claude Opus 4.8 (1M context)` model-name convention:
+
+```ts
+await ctx.task("review", {
+  task: "Review the diff",
+  model: "anthropic/claude-fable-5:high",
+  // The copilot opus fallback runs at its largest advertised (long-context) window.
+  // Use (long) for a size-agnostic marker, or a rounded long-tier label like (1m).
+  fallbackModels: ["github-copilot/claude-opus-4.8 (long):xhigh", "anthropic/claude-opus-4-8:xhigh"],
+});
+```
+
+The token accepts the same compact sizes as the `--context-window` flag (`1m`, `1.1m`, `936k`, `400k`, or a raw token count), plus a generic `(long)` marker, and the runtime resolves it against that specific candidate model's advertised windows:
+
+- `(long)` — a size-agnostic long-context marker that selects the model's advertised long tier regardless of its exact size, so the same token works across models with different long tiers;
+- a request at or below the model's default window keeps the default;
+- a request above the default selects the long tier — an exact supported window is used as-is, otherwise the smallest supported window at or above the request is selected, rounding **up** so a rounded marker like `(1m)` or `(1.1m)` lands on the long tier even when it sits slightly above or below the marker size (e.g. `(1m)` selects claude-opus-4.8's 1M tier and gpt-5.5's 1.05M tier; `(1.1m)` matches gpt-5.5's rounded long-tier label);
+- when the model exposes no larger tier (or is unavailable), the runtime drops the request and the session keeps the model's default (short) window—a non-strict, automatic fallback.
+
+The budget applies only to the candidate that carries the token; other primary and fallback models in the same chain are unaffected. A parenthesized token that is not a valid size (for example `(preview)`) is left attached to the model id rather than being treated as a context window. Without the token, a tiered model **pins its natural default (short) window** in a workflow stage, so a persisted interactive long-context preference does not leak into workflow runs — use the `(1m)` token or the `contextWindow` stage option to opt into long context.
+
+For stage-wide selection you can instead set the `contextWindow` (and `contextWindowStrict`) stage option, which maps to the SDK `createAgentSession` options of the same name.
+
+## StageContext
+
+`ctx.stage(name, options?)` returns direct control of a tracked stage session. The executor owns session disposal and wraps stage operations with workflow lifecycle tracking.
+
+### `stage.name`
+
+```typescript
+readonly name: string;
+```
+
+Human-readable stage name for the TUI and persisted state. It is the name passed to `ctx.stage(...)`.
+
+### `stage.prompt(text, options?)`
+
+```typescript
+stage.prompt(
+  text: string,
+  options?: StagePromptOptions,
+): Promise<WorkflowStageResult<TSchemaDef>>;
+```
+
+Sends a prompt and waits for completion. A schema-backed stage resolves to the schema's static value and is one-shot; otherwise it resolves to text.
+
+### `stage.complete(text, options?)`
+
+```typescript
+stage.complete(text: string, options?: CompleteStageOpts): Promise<string>;
+```
+
+Runs the lower-level completion adapter and returns text. Completion options can select a primary model, fallback models, deprecated fallback reasoning helpers, and `maxTokens`.
+
+### `stage.sendUserMessage(content, options?)`
+
+```typescript
+stage.sendUserMessage(
+  content: string | readonly (StageTextContent | StageImageContent)[],
+  options?: { readonly deliverAs?: "steer" | "followUp" },
+): Promise<void>;
+```
+
+Sends a normal follow-on user turn to the retained stage session. This method starts a turn immediately when the session is idle; while streaming, it queues a follow-up by default or sends steering when `deliverAs: "steer"`.
+
+Native sessions accept strings or text/image content blocks. Non-native fallback adapters accept only strings and reject block arrays; `deliverAs` affects streaming delivery only, and follow-on turns retain the stage MCP scope.
+
+Externally produced Intercom and async bash/subagent notices admitted before the generation closes drain through the same session. Traffic arriving after the atomic close boundary cannot reopen the completed stage and is surfaced once through the main-chat path instead.
+
+See [Stage follow-on user messages](#stage-follow-on-user-messages) for the full lifecycle and schema-backed example.
+
+### `stage.steer(text)` / `stage.followUp(text)`
+
+```typescript
+stage.steer(text: string): Promise<void>;
+stage.followUp(text: string): Promise<void>;
+```
+
+Queues text while a turn is active. These methods do not start a new idle turn; use `sendUserMessage()` to start one.
+
+### `stage.subscribe(listener)`
+
+```typescript
+// Standalone workflow-package authoring declaration:
+stage.subscribe(listener: (event: never) => void): () => void;
+```
+
+Subscribes to stage-session events and returns an unsubscribe function. The lean standalone authoring declaration intentionally leaves the event payload opaque; Atomic's embedded runtime surface specializes it to `AgentSessionEvent`. Call the returned function to stop receiving events.
+
+### `stage.sessionId` / `stage.sessionFile`
+
+```typescript
+readonly sessionId: string;
+readonly sessionFile: string | undefined;
+```
+
+Expose the retained session identifier and its optional transcript file. `sessionFile` is `undefined` when no file is available.
+
+### `stage.setModel(model)` / `stage.setThinkingLevel(level)` / `stage.cycleModel()` / `stage.cycleThinkingLevel()`
+
+```typescript
+stage.setModel(model: WorkflowModelValue): Promise<void>;
+stage.setThinkingLevel(level: WorkflowThinkingLevel): void;
+stage.cycleModel(): Promise<object | undefined>;
+stage.cycleThinkingLevel(): WorkflowThinkingLevel | undefined;
+```
+
+These are the externally shipped standalone authoring signatures. `WorkflowModelValue` accepts a string or supported SDK model object, and `WorkflowThinkingLevel` is `"off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max"`; Atomic's embedded runtime narrows the model arguments and cycle result to its `AgentSession` types.
+
+### `stage.agent` / `stage.model` / `stage.thinkingLevel` / `stage.messages` / `stage.isStreaming`
+
+```typescript
+readonly agent: object;
+readonly model: WorkflowModelValue | undefined;
+readonly thinkingLevel: WorkflowThinkingLevel | undefined;
+readonly messages: readonly object[];
+readonly isStreaming: boolean;
+```
+
+These members provide read-only access to the current stage-session state. The standalone authoring declaration keeps SDK-owned objects opaque, while Atomic's embedded runtime specializes these members to the corresponding `AgentSession` properties.
+
+### `stage.navigateTree(targetId, options?)`
+
+```typescript
+stage.navigateTree(
+  targetId: string,
+  options?: {
+    summarize?: boolean;
+    customInstructions?: string;
+    replaceInstructions?: boolean;
+    label?: string;
+  },
+): Promise<{ editorText?: string; cancelled: boolean }>;
+```
+
+Navigates within the current session file. The result reports cancellation and may include restored editor text.
+
+### `stage.compact()` / `stage.abortCompaction()`
+
+```typescript
+stage.compact(): Promise<object>;
+stage.abortCompaction(): void;
+```
+
+Starts compaction for the stage session or aborts an active compaction. The standalone authoring declaration keeps the result opaque; Atomic's embedded runtime specializes it to `VerbatimCompactionResult`.
+
+### `stage.abort()`
+
+```typescript
+stage.abort(): Promise<void>;
+```
+
+Aborts the stage session's current operation. The returned promise settles after the runtime processes the abort request.
+
+## Result Types
+
+Workflow primitives return serializable result contracts that carry text, structured values, artifacts, model attempts, child boundaries, and run snapshots. The root authoring declaration directly exports `WorkflowTaskResult`, `WorkflowChildResult`, `WorkflowArtifact`, `WorkflowDetails`, `RunResult`, and `StageSnapshot`; supporting conditional or union-branch aliases shown below describe the source contract but are not all separately exported by the lean standalone declaration.
+
+### `WorkflowTaskResult`
+
+```typescript
+interface WorkflowTaskContext extends WorkflowSerializableObject {
+  readonly name?: string;
+  readonly text: string;
+}
+interface WorkflowTaskResult extends WorkflowTaskContext {
+  readonly stageName: string;
+  readonly structured?: WorkflowSerializableValue;
+  readonly sessionId?: string;
+  readonly sessionFile?: string;
+  readonly artifacts?: readonly WorkflowArtifact[];
+  readonly model?: string;
+  readonly fastMode?: boolean;
+  readonly attemptedModels?: readonly string[];
+  readonly modelAttempts?: readonly WorkflowModelAttempt[];
+  readonly warnings?: readonly string[];
+}
+```
+
+`ctx.task` returns this type; `ctx.chain` and `ctx.parallel` return arrays of it. `structured` is present when the item used `schema`.
+
+```typescript
+interface WorkflowModelUsage extends WorkflowSerializableObject {
+  readonly input?: number;
+  readonly output?: number;
+  readonly cacheRead?: number;
+  readonly cacheWrite?: number;
+  readonly cost?: number;
+  readonly turns?: number;
+}
+interface WorkflowModelAttempt extends WorkflowSerializableObject {
+  readonly model: string;
+  readonly success: boolean;
+  readonly reasoningLevel?: WorkflowThinkingLevel;
+  readonly error?: string;
+  readonly usage?: WorkflowModelUsage;
+}
+```
+
+### `WorkflowDetails`
+
+```typescript
+interface WorkflowDetails extends WorkflowSerializableObject {
+  readonly mode: "named" | "single" | "parallel" | "chain" | "inspection" | "control";
+  readonly action?: "list" | "get" | "inputs" | "run" | "status" | "interrupt" | "resume";
+  readonly runId?: string;
+  readonly status: "accepted" | "running" | WorkflowExitStatus | "failed" | "killed" | "noop";
+  readonly context?: "fresh" | "fork";
+  readonly results?: readonly WorkflowTaskResult[];
+  readonly output?: WorkflowOutputValues;
+  readonly progress?: { readonly completed?: number; readonly total?: number };
+  readonly artifacts?: readonly WorkflowArtifact[];
+  readonly controlEvents?: readonly WorkflowControlEvent[];
+  readonly intercom?: WorkflowIntercomSummary;
+  readonly warnings?: readonly string[];
+  readonly message?: string;
+  readonly error?: string;
+  readonly exited?: boolean;
+  readonly exitReason?: string;
+}
+
+interface WorkflowControlEvent extends WorkflowSerializableObject {
+  readonly type?: "notify" | "needs_attention" | "interrupted" | "resumed";
+  readonly message?: string;
+}
+interface WorkflowIntercomSummary extends WorkflowSerializableObject {
+  readonly enabled?: boolean;
+  readonly delivery?: "off" | "notify" | "result" | "control-and-result";
+  readonly parentSession?: string;
+}
+```
+
+Returned by `runTask()`, `runChain()`, and `runParallel()`. Its mode-specific fields carry direct results, output and artifact summaries, control or Intercom details, warnings, and intentional-exit metadata.
+
+### `WorkflowChildResult`
+
+```typescript
+type WorkflowChildResult<
+  TOutputs extends WorkflowOutputValues = WorkflowOutputValues,
+> =
+  | WorkflowCompletedChildResult<TOutputs>
+  | WorkflowExitedChildResult<TOutputs>;
+
+interface WorkflowCompletedChildResult<
+  TOutputs extends WorkflowOutputValues = WorkflowOutputValues,
+> extends WorkflowSerializableObject {
+  readonly workflow: string;
+  readonly runId: string;
+  readonly status: "completed";
+  readonly exited: false;
+  readonly outputs: TOutputs;
+}
+interface WorkflowExitedChildResult<
+  TOutputs extends WorkflowOutputValues = WorkflowOutputValues,
+> extends WorkflowSerializableObject {
+  readonly workflow: string;
+  readonly runId: string;
+  readonly status: WorkflowExitStatus;
+  readonly exited: true;
+  readonly outputs: Partial<TOutputs>;
+  readonly exitReason?: string;
+}
+```
+
+Normal completion exposes the full declared output contract. A child that used `ctx.exit(...)`, including `status: "completed"`, exposes only a partial contract and optional exit reason; failed or internally cancelled children reject the parent call instead.
+
+### `WorkflowStageResult`
+
+```typescript
+type WorkflowStageResult<TSchemaDef extends TSchema | undefined = undefined> =
+  [TSchemaDef] extends [TSchema] ? Static<TSchemaDef> : string;
+```
+
+A schema-backed `stage.prompt()` resolves to the schema's static value. A stage without `schema` resolves to text.
+
+### `WorkflowArtifact`
+
+```typescript
+interface WorkflowArtifact extends WorkflowSerializableObject {
+  readonly kind: "output" | "session" | "diff" | "patch";
+  readonly path: string;
+  readonly taskName?: string;
+  readonly branch?: string;
+  readonly diffStat?: string;
+  readonly filesChanged?: number;
+  readonly insertions?: number;
+  readonly deletions?: number;
+}
+```
+
+Describes a persisted output, session, diff, or patch and its optional task, branch, and diff statistics. `path` and `kind` are always present.
+
+### `RunResult`
+
+```typescript
+interface RunResult<
+  TOutputs extends WorkflowOutputValues = WorkflowOutputValues,
+> extends WorkflowSerializableObject {
+  readonly runId: string;
+  readonly status: RunStatus;
+  readonly result?: Partial<TOutputs>;
+  readonly error?: string;
+  readonly exited?: boolean;
+  readonly exitReason?: string;
+  readonly stages: readonly StageSnapshot[];
+}
+interface StageSnapshot extends WorkflowSerializableObject {
+  readonly id: string;
+  readonly name: string;
+  readonly status: StageStatus;
+  readonly result?: WorkflowSerializableValue;
+  readonly error?: string;
+}
+```
+
+Programmatic `run(...)` returns this type. `exited` identifies `ctx.exit(...)` termination, and `stages` contains the final stage snapshots.
+
+
+## Workflow Starter Patterns
+
+For workflows larger than one tracked task, choose a small control-flow pattern before writing prompts. Naming the pattern keeps the stage graph understandable, makes validation gates explicit, and helps reviewers see why work is split across model sessions.
+
+These patterns are composable. For example, a migration workflow might use **fan-out-and-synthesize** to fix many call sites, then **adversarial verification** to review each patch, and finally **loop until done** while tests still fail.
+
+| Pattern | Use it when | Atomic shape |
+|---|---|---|
+| **Classify-and-act** | Inputs arrive in different categories and each category needs a different path, model, tool set, or output format. | `ctx.task("classify")` → deterministic branch → category-specific `ctx.task`, `ctx.chain`, `ctx.parallel`, or child `ctx.workflow(...)`. |
+| **Fan-out-and-synthesize** | The task can be split into many independent slices that benefit from clean context windows. | `ctx.parallel([...])` with separate artifacts → synthesis barrier that reads the artifacts and merges the answer. |
+| **Adversarial verification** | Outputs need independent checking against a rubric, security rule, factual source, or acceptance contract. | Worker stage(s) → fresh-context verifier stage(s) → reducer that accepts, rejects, or asks for repair. |
+| **Generate-and-filter** | You need many candidate ideas, plans, names, fixes, or hypotheses before selecting the best few. | Generator fan-out → dedupe/filter stage → optional verifier/judge → final shortlist. |
+| **Tournament** | The whole task is subjective or approach-sensitive, and comparative judgment is more reliable than absolute scoring. | Several agents attempt the same task → pairwise judges compare results → bracket reducer returns winners. |
+| **Loop until done** | The amount of work is unknown up front, such as finding all failures, mining repeated issues, or iterating until checks pass. | Bounded loop with an explicit stop condition, progress ledger, per-iteration artifacts, and a max-iteration escape hatch. |
+
+### Pattern diagrams
+
+#### 1. Classify-and-act
+
+```text
+┌─ 1  Classify-and-act ────────────────────────────────────┐
+│                                                          │
+│                             ┌───────┐                    │
+│                         ╭──▸│agent A│                    │
+│                         │   └───────┘                    │
+│  ┌────┐  ┌──────────┐   │   ┌───────┐                    │
+│  │task│─▸│classifier│───┼──▸│agent B│ ◂ chosen           │
+│  └────┘  └──────────┘   │   └───────┘                    │
+│                         │   ┌───────┐                    │
+│                         ╰──▸│agent C│                    │
+│                             └───────┘                    │
+│                                                          │
+└──────────────────────────────────────────────────────────┘
+```
+
+Best practices:
+- Make the classifier return a structured category and confidence, not free-form prose.
+- Keep each action branch isolated with the minimum tools and context it needs.
+- Add a fallback or human-input branch for low-confidence classifications.
+
+#### 2. Fan-out-and-synthesize
+
+```text
+┌─ 2  Fan-out-and-synthesize ──────────────────────────────┐
+│                                                          │
+│            ┌───────┐                                     │
+│          ╭▸│agent 1│──╮                                  │
+│          │ └───────┘  │                                  │
+│          │ ┌───────┐  │                                  │
+│          ├▸│agent 2│──┤                                  │
+│  ┌────┐  │ └───────┘  │ ┌───────┐  ┌──────────┐          │
+│  │task│──┤ ┌───────┐  ├▸│barrier│─▸│synthesize│          │
+│  └────┘  ├▸│agent 3│──┤ └───────┘  └──────────┘          │
+│          │ └───────┘  │                                  │
+│          │ ┌───────┐  │                                  │
+│          ╰▸│agent 4│──╯                                  │
+│            └───────┘                                     │
+│                                                          │
+└──────────────────────────────────────────────────────────┘
+```
+
+Best practices:
+- Partition by files, sources, claims, candidates, or work items that can be evaluated independently.
+- Save each branch to a separate artifact and pass paths with `reads` instead of inlining all branch output.
+- Treat synthesis as a barrier: it waits for every branch, deduplicates, resolves conflicts, and cites evidence.
+
+#### 3. Adversarial verification
+
+```text
+┌─ 3  Adversarial verification ────────────────────────────┐
+│                                                          │
+│                                                          │
+│                                 ┌──────────┐             │
+│               ├────────────────▸│verifier A│             │
+│               │                 └──────────┘             │
+│  ┌──────┐     │                 ┌──────────┐             │
+│  │worker│◂────┼────────────────▸│verifier B│             │
+│  └──────┘     │                 └──────────┘             │
+│               │                 ┌──────────┐             │
+│               ├────────────────▸│verifier C│             │
+│                                 └──────────┘             │
+│                                                          │
+└──────────────────────────────────────────────────────────┘
+```
+
+Best practices:
+- Give verifiers fresh context and a concrete rubric with pass/fail evidence requirements.
+- Separate implementation or generation from independent judgment to reduce a model's bias toward its own output.
+- Ask verifiers to find blockers and not rewrite the candidate unless you explicitly assign them to repair it.
+
+#### 4. Generate-and-filter
+
+```text
+┌─ 4  Generate-and-filter ─────────────────────────────────┐
+│                                                          │
+│                                                          │
+│  ┌─────┐   ┌────┐                      ┌────┐            │
+│  │gen A│──▸│idea│───╮              ╭──▸│best│            │
+│  └─────┘   └────┘   │              │   └────┘            │
+│  ┌─────┐   ┌────┐   │  ┌──────┐    │   ┌────┐            │
+│  │gen B│──▸│idea│───┼─▸│filter│────┼──▸│best│            │
+│  └─────┘   └────┘   │  └──────┘    │   └────┘            │
+│  ┌─────┐   ┌────┐   │              │   ┌╌╌╌╌╌╌╌╌╌┐       │
+│  │gen C│──▸│idea│───╯              ╰──▸╎discarded╎       │
+│  └─────┘   └────┘                      └╌╌╌╌╌╌╌╌╌┘       │
+│                                                          │
+└──────────────────────────────────────────────────────────┘
+```
+
+Best practices:
+- Generate more candidates than you need, then filter hard by an explicit rubric.
+- Dedupe before judging so near-identical candidates do not dominate the shortlist.
+- Use this for exploration, naming, design options, hypotheses, and lightweight eval ideas.
+
+#### 5. Tournament
+
+```text
+┌─ 5  Tournament ──────────────────────────────────────────┐
+│                                                          │
+│  ┌─────────┐                                             │
+│  │attempt A│──╮  ┌───────┐                               │
+│  └─────────┘  ├─▸│judge 1│───╮                           │
+│  ┌─────────┐  │  └───────┘   │                           │
+│  │attempt B│──╯              │   ┌─────┐  ┌──────┐       │
+│  └─────────┘                 ├──▸│final│─▸│winner│       │
+│  ┌─────────┐                 │   └─────┘  └──────┘       │
+│  │attempt C│──╮  ┌───────┐   │                           │
+│  └─────────┘  ├─▸│judge 2│───╯                           │
+│  ┌─────────┐  │  └───────┘                               │
+│  │attempt D│──╯                                          │
+│  └─────────┘                                             │
+│                                                          │
+└──────────────────────────────────────────────────────────┘
+```
+
+Best practices:
+- Use pairwise comparison when absolute scores are noisy or subjective.
+- Randomize or balance presentation order where possible to reduce order bias.
+- Keep the judge rubric short and require rationale tied to observable criteria.
+
+#### 6. Loop until done
+
+```text
+┌─ 6  Loop until done ─────────────────────────────────────┐
+│                                                          │
+│      yes, spawn another                                  │
+│     ╭────────────────╮                                   │
+│     ▾                │                                   │
+│  ┌─────┐      ┌─────────────┐  no   ┌────┐               │
+│  │agent│─────▸│new findings?│──────▸│done│               │
+│  └─────┘      └─────────────┘       └────┘               │
+│                                                          │
+└──────────────────────────────────────────────────────────┘
+```
+
+Best practices:
+- Define both success and escape conditions before the loop starts.
+- Keep a durable ledger of attempted work, findings, failures, and validation evidence.
+- Bound loops by iterations, budget, or convergence criteria so exhausting a bound produces an inspectable failure instead of letting the loop continue indefinitely.
+
+### Choosing a starter pattern
+
+- Pick **classify-and-act** when routing correctness matters more than breadth.
+- Pick **fan-out-and-synthesize** when the work divides cleanly into independent slices.
+- Pick **adversarial verification** when the main risk is a plausible but wrong answer.
+- Pick **generate-and-filter** when output quality depends on exploring a large option space.
+- Pick **tournament** when multiple whole-solution strategies should compete under one rubric.
+- Pick **loop until done** when the workflow should continue until evidence says it is finished, not until a preselected number of stages completes.
+
+Record the selected pattern in your spec or workflow README, then adapt the diagram to the stage graph. If the final design does not resemble any starter pattern, explain why in the workflow's design notes.
+
+## Running Workflows
+
+List or inspect unfamiliar workflows before running them. If required inputs are missing and cannot be inferred, ask for the missing values before launch:
+
+```ts
+workflow({ action: "list" })
+workflow({ action: "get", workflow: "deep-research-codebase" })
+workflow({ action: "inputs", workflow: "deep-research-codebase" })
+```
+
+The workflow tool action surface is:
+
+- discovery: `list`, `get`, `inputs`
+- execution: named `run`, plus direct one-off `task`, `tasks`, and `chain` modes
+- inspection: `status`, `stages`, `stage`, `transcript`
+- messaging and run control: `send`, `pause`, `interrupt`, `quit`, `resume`
+- rediscovery: `reload`
+
+From interactive chat, model-launched workflows run in the background so the parent chat stays available. Run `/workflow connect <run>` to see agents working and chat with and steer each stage. Named workflow launches already run in the background; direct `task`, `tasks`, and `chain` launches must pass top-level `async: true`, and their accepted raw/rendered results include the same actionable connect guidance. This rule applies only to launches, not inspection or control calls (`status`, `stages`, `stage`, `transcript`, `send`, `pause`, `resume`, `interrupt`, `quit`).
+
+A model may launch in the foreground only when the user explicitly requests it or foreground execution is technically required, and it must tell the user before launching.
+
+Run a named workflow with inputs:
+
+```ts
+workflow({
+  action: "run",
+  workflow: "deep-research-codebase",
+  inputs: { prompt: "map workflow runtime", max_concurrency: 4 },
+})
+```
+
+Slash equivalent:
+
+```text
+/workflow deep-research-codebase prompt="map workflow runtime" max_concurrency=4
+```
+
+<p align="center"><img src="images/workflow-command.png" alt="Running a Workflow Command" width="600" /></p>
+
+Input overrides are bare `key=value` tokens. Atomic parses values as JSON when possible, so `count=3`, `flag=true`, and `prompt="multi word value"` preserve useful types. A whole input object can also be passed as one JSON token. Runtime validation is strict: unknown input keys, missing required values, type mismatches, and invalid `select` choices fail before a named workflow run starts or before a child workflow starts.
+
+In the TUI, `/workflow <name>` opens an input picker when the workflow declares inputs and either no arguments were supplied or required inputs are missing. Supplied values seed the picker. Pass `--no-picker` to skip that interactive flow.
+
+In non-interactive (`-p`, `--print`, or `--mode json`) sessions, named workflow dispatch waits for the terminal run snapshot and skips pickers. Because human input is runtime-only and workflows no longer carry a declaration-time HIL marker, headless dispatch does not reject a workflow because its source contains `ctx.ui.*`.
+
+If you copy a HIL workflow example into a headless session, it can pass dispatch and then fail when execution reaches the prompt with an error such as `atomic-workflows: interactive ctx.ui.confirm is unavailable in headless (non-interactive) mode; run the workflow in interactive mode or remove the interactive prompt from this stage` (the primitive name varies, including `ctx.ui.custom`). Run those workflows interactively, or guard/remove runtime `ctx.ui.*` calls before using headless mode.
+
+<p align="center"><img src="images/workflow-input-picker.png" alt="Workflow Input Picker" width="600" /></p>
+
+## Workflow Commands
+
+```text
+/workflow list
+/workflow inputs <name>
+/workflow <name> --help
+/workflow <name> [key=value ...]
+/workflow connect [run-id]
+/workflow attach [run-id] [stage-id-or-name]
+/workflow pause [run-id] [stage-id-or-name]
+/workflow status [run-id]
+/workflow status --all
+/workflow interrupt <run-id|--all>
+/workflow quit <run-id|--all>
+/workflow resume <run-id> [stage-id-or-name] [message]
+/workflows [workflow-id-or-prefix]
+/workflow reload
+```
+
+Common controls:
+
+```text
+/workflow status                       # list retained active and terminal runs
+/workflow connect <run-id>             # graph viewer, including terminal runs
+/workflow attach <run-id> <stage>      # chat with a single stage
+/workflow interrupt <run-id>           # pause resumably
+/workflow resume <run-id> [stage] msg  # forward a steer message and resume
+/workflow quit <run-id>                # pause gracefully and keep the run resumable
+/workflows [run-id]                    # retained alias for /workflow resume (history picker)
+```
+
+Surface behavior:
+
+- **Graph vs. stage chat** - Use `connect` for the workflow graph. Use `attach` when you want a chat pane for a specific stage.
+- **Hierarchy chord** - `ctrl+x` is the workflow hierarchy chord: in an attached stage chat it means **return to graph**, and in the graph it means **return to main chat**. The workflow surface handles `ctrl+x` before configurable editor or tool actions, including while a composer draft, primitive prompt, custom question, stage switcher, or legacy prompt card owns input.
+- **Draft preservation** - Leaving a stage preserves unsent composer and prompt drafts and keeps pending custom questions unresolved so they reappear when you attach again.
+- **Reserved keys** - `ctrl+d` and `q` do not navigate workflow surfaces; `ctrl+d` keeps its ordinary editor or prompt behavior where applicable, and `q` remains printable in text-owning prompts. Existing `esc`, `ctrl+c`, and graph `h` close/hide controls are unchanged.
+- **Wheel and trackpad** - While the workflow graph is active, vertical wheel/trackpad gestures pan it up and down, and horizontal gestures pan wide graphs left and right when the terminal exposes horizontal wheel events; these gestures remain scoped to the graph instead of leaking into the main chat or terminal scrollback. Attached stage chats capture mouse/trackpad wheel events by default so scrolling stays inside the active stage transcript or prompt instead of falling through to terminal/main-chat scrollback.
+- **Subagent progress** - Live `subagent` tool calls in stage chats use the same single, parallel, and chain progress widgets as main chat, including after exiting and re-attaching to an in-flight stage; press Ctrl+O (the `app.tools.expand` binding) to expand live detail for every child, including current tool activity and artifact paths.
+- **Async statusline** - If an async/background subagent is running while the fullscreen workflow graph is open, the graph statusline mirrors the async summary so the background run remains visible; hide the graph with `h`, leave it with `ctrl+x`, or reconnect later to return to the full below-editor async widget.
+- **Copy mode** - Press `ctrl+t` inside an attached stage chat to toggle **copy mode**: copy mode disables workflow-chat mouse reporting so normal terminal/tmux text selection can work; press `ctrl+t` again to leave copy mode and restore transcript or prompt scrolling. Archived read-only stage transcripts expose the same footer and copy-mode status, so their text can also be selected and copied; `esc` closes the transcript and `ctrl+x` returns to the graph. While copy mode is on, wheel/trackpad gestures are handled by the terminal/tmux and may scroll terminal scrollback, so leave copy mode before using the wheel again.
+- **Run control** - Use `interrupt`, `pause`, and `resume` for resumable live work; `resume` on a non-paused run reopens the saved snapshot or overlay. Use `quit` to pause a live run gracefully while preserving it for `/workflow resume`.
+- **Rediscovery** - Use `/workflow reload` after adding, editing, installing, or removing workflow resources or package manifest workflow entries and you want Atomic to rediscover them in-process ([Reloading workflow resources](#reloading-workflow-resources)).
+- **Status listing** - `/workflow status` lists all retained active and terminal top-level runs by default; implementation-owned nested child runs are flattened into their parent workflow rather than listed separately. `/workflow status --all` is retained as a compatibility alias.
+
+`/workflows` is the retained-run history alias for `/workflow resume`: with no id it opens the same mixed resumable/completed picker, and with an id it resumes unfinished work or opens completed inspection. It is intentionally different from `/workflow list`, which lists installed workflow definitions. See [`/workflow resume` — cross-session resume selector](#workflow-resume--cross-session-resume-selector) for the full picker semantics.
+
+At the supported 40-column terminal minimum, attached stage chats use the compact `ctrl+x graph · ctrl+t …` footer. The TUI may truncate provider/model context to make room, but it keeps that context separate from the hierarchy hint so the controls stay readable.
+
+<p align="center"><img src="images/workflow-graph.png" alt="Workflow Graph Viewer" width="600" /></p>
+
+Human-in-the-loop prompts appear as awaiting-input nodes in the workflow graph, not as ordinary chat modals — see [Lifecycle Notices and Human Input](#lifecycle-notices-and-human-input) for how to find and answer them.
+
+## Monitor and Control Runs
+
+The workflow tool exposes lifecycle controls for non-interactive use:
+
+```ts
+workflow({ action: "status" })                                  // list every session run, in-flight first
+workflow({ action: "status", statusFilter: "running" })         // filter the run listing by status
+workflow({ action: "status", statusFilter: "awaiting_input" })  // runs with a pending human prompt
+workflow({ action: "status", format: "json" })                  // structured listing for programmatic use
+workflow({ action: "status", runId: "<id-or-prefix>" })         // full detail for one run
+
+workflow({ action: "stages", runId: "<id-or-prefix>", statusFilter: "all" })
+workflow({ action: "stage", runId: "<id-or-prefix>", stageId: "review" })
+// Prefer sessionFile/transcriptPath from stages/stage; quote the exact path, preserve Windows separators, then search/read small ranges.
+workflow({ action: "transcript", runId: "<id-or-prefix>", stageId: "review" })
+// Omit tail/limit for the default 5-entry preview; pass them for quick recent-context checks.
+workflow({ action: "transcript", runId: "<id-or-prefix>", stageId: "review", tail: 40 })
+workflow({ action: "transcript", runId: "<id-or-prefix>", stageId: "review", limit: 20, includeToolOutput: true })
+
+workflow({ action: "send", runId: "<id-or-prefix>", stageId: "review", text: "please focus on tests" })
+workflow({ action: "send", runId: "<id-or-prefix>", stageId: "approval", promptId: "prompt-1", response: true, delivery: "answer" })
+workflow({ action: "send", runId: "<id-or-prefix>", stageId: "review", message: "continue with tests", delivery: "resume" })
+
+workflow({ action: "pause", runId: "<id-or-prefix>" })
+workflow({ action: "pause", runId: "<id-or-prefix>", stageId: "review" })
+
+workflow({ action: "interrupt", runId: "<id-or-prefix>" })
+workflow({ action: "interrupt", all: true })
+
+workflow({ action: "resume", runId: "<id-or-prefix>" })
+workflow({ action: "resume", runId: "<id-or-prefix>", stageId: "review", message: "continue" })
+
+workflow({ action: "quit", runId: "<id-or-prefix>" })
+workflow({ action: "quit", all: true })
+
+workflow({ action: "reload", reason: "added team workflow" })
+```
+
+Control behavior:
+
+- `runId` accepts full run ids or unique prefixes for every lifecycle and inspection action, including `status`. The abbreviated IDs printed by status surfaces are valid inputs. Exact IDs take precedence; a prefix shared by multiple runs returns an ambiguity diagnostic with longer matching prefixes instead of selecting the first run. Status lists and run pickers show top-level user-launched workflows; nested child runs are implementation details of the expanded parent graph.
+- `status` without `runId` lists every top-level run in the session with a concise per-run summary: run id plus abbreviated prefix, workflow name, run status, started/ended timing with pause-adjusted elapsed time, currently active stages, and awaiting-input details (count plus the stage, prompt id, kind, and message for each pending human prompt). In-flight runs are listed first. The summaries carry the exact identifiers that `pause`/`resume`/`interrupt`/`quit`/`send` accept, so an orchestrating agent can list runs and act on them directly.
+- `statusFilter` narrows the `status` run listing: run statuses (`pending`, `running`, `paused`, `blocked`, `completed`, `failed`, `skipped`, `cancelled`, `killed`) match runs directly, `awaiting_input` selects runs with at least one stage awaiting input or pending human prompt, and `all` (the default) includes everything.
+- `format: "json"` on data-bearing inspection actions (`status`, `stages`, `stage`, `transcript`) returns the full structured result; the default text output for `status` is the concise per-run summary list.
+- `status` / `status <runId>` show terminal `ctx.exit(...)` statuses (`completed`, `skipped`, `cancelled`, or `blocked`) and the optional exit reason when one was supplied.
+- `stages` lists stage summaries, including flattened stages from nested `ctx.workflow(...)` imports and `sessionFile`/`transcriptPath` when a stage has a persisted session. Use `statusFilter: "all"` to include completed, failed, skipped, and pending stages.
+- `stage` returns details for one stage by stage id, unique prefix, or stage name, including nested child stages shown in the expanded graph and the persisted `sessionFile` when available. Abbreviated stage IDs printed in graph/control messages use this same unique-prefix resolver; collisions return an ambiguity diagnostic rather than selecting a stage.
+- `transcript` is reference-first with a small preview by default: it returns metadata, transcript paths, and up to 5 recent entries. For targeted lookup, quote the exact `sessionFile`/`transcriptPath` value without changing platform separators (preserve Windows backslashes), search it with `rg` or `grep`, then read only small surrounding ranges. Text results include JSON-escaped `sessionFileJson`/`transcriptPathJson` lines for copy-safe path literals. Pass explicit `tail` or `limit` to override the 5-entry preview; `tail` overrides `limit`; `includeToolOutput` includes captured snapshot tool output in snapshot transcript results.
+- `send` delivery modes are `auto`, `answer`, `prompt`, `steer`, `followUp`, and `resume`.
+  - Prompt answers can include `promptId` and can carry answer content in `response`, `text`, or `message`; structured UI prompts usually prefer `response`.
+  - Follow-up messaging to completed or failed stages reuses the retained `sessionFile` when available so the conversation resumes from the archived stage transcript instead of starting empty. If no session metadata was retained, Atomic refuses the follow-up rather than silently resetting.
+  - Explicit `delivery: "resume"` or `delivery: "steer"` against a completed post-mortem stage returns a structured `noop` with guidance to use `followUp` or `prompt`; it never appends the supplied text or mutates workflow execution.
+  - Arbitrary `ctx.ui.custom<T>` widget prompts require the interactive workflow graph and return a clear unsupported message when targeted through `send`.
+- `delivery: "auto"` first answers a pending prompt, then resumes paused work, then steers a streaming stage, then queues a follow-up.
+- `pause`, `interrupt`, and `quit` can target one top-level run or `all: true`; `stageId` cannot be combined with `all: true`. Stage-scoped `pause` and `interrupt` controls can target a visible nested child stage from the expanded graph; `quit` remains run-level. Atomic routes stage controls to the owning nested run internally.
+- `interrupt` is resumable: it pauses live work when pausable stages exist and keeps the run in live history/status.
+- `pause` is useful for pausing a live run or a single live stage without treating it as a destructive abort.
+- `resume` can target a stage with `stageId`; the target may be a stage id, unique prefix, or stage name. `message` is forwarded to paused work. For a live interrupted stage, Atomic automatically injects the continuation prompt described in [Pausing, quitting, and resuming](#pausing-quitting-and-resuming) after any non-empty resume-message answer—or immediately after a no-message resume—before normal readiness-gate completion when the stage has not already finalized, including when the resume-answer turn used `ask_user_question`.
+- `quit` gracefully pauses in-flight work, marks the run resumable, and leaves it available to `/workflow resume`.
+- `reload` refreshes discovered workflow resources in-process; the optional `reason` is echoed in the result.
+
+Use slash commands for graph connect and stage attach because those are interactive TUI surfaces. When a run needs user input or attention, tell the user instead of polling silently.
+
+### Pausing, quitting, and resuming
+
+Graceful quit is idempotent for an already-paused resumable run. If a run is waiting on `ctx.ui`, quit preserves its current DBOS prompt reservation. Answers cannot advance paused workflow code until explicit resume; checkpointing the answer releases exactly that reservation generation. Concurrent and nested prompts use composed scopes and independent DBOS reservation tokens.
+
+When a paused stage is resumed, whether or not the resume includes a message, Atomic first lets the stage answer any non-empty resume message and then (if the stage has not already finalized) injects `Continue where you left off. If you believe you are finished with your original task (or a redefined task if the user told you), stop.` into the same stage session before normal stage completion/readiness handling. This re-drives an interrupted no-message resume before result harvesting, keeps interrupted work moving without asking you to type a continuation prompt, and prevents stages that already finished their scoped work from overstepping.
+
+The same continuation applies to user messages queued into a live streaming stage. Steering a turn (Enter in an attached stage chat), queueing a follow-up (Ctrl+F), or using `workflow({ action: "send" })` with `steer`/`followUp` delivery arms the identical continuation prompt, which Atomic injects once when the interrupted turn ends — even if several messages were queued during that turn — so a steered stage returns to its original (or user-redefined) objective instead of stopping after answering the queued message.
+
+Messages delivered to an idle stage start a fresh user turn and receive no continuation nudge, and the injection is suppressed for aborted runs and finalized or fail-fast-skipped stages.
+
+When several paused stages resume together, Atomic settles every acknowledgement and then re-reads the actual stage/control state. A late rejection after its stage visibly starts counts as resumed and is not retried; genuinely paused failures remain available for a later resume. The run and durable root follow visible running work, while slash/tool output reports acknowledgement or durable-transition failures as partial progress instead of a no-op. If local resume succeeds but persisting the durable running transition fails, a later resume request retries reconciliation while the durable handle remains paused. A terminal run cannot be revived by a late acknowledgement.
+
+### Post-mortem chat vs. execution resume
+
+These are distinct operations. *Resuming workflow execution* (`/workflow resume`) is for paused, interrupted, recoverably failed, or unfinished durable work; it may replay checkpoints, continue an incomplete stage, and dispatch remaining DAG work. *Opening a post-mortem chat* reopens one terminal agent stage's retained conversation for follow-up only — it never resumes, retries, rewinds, or otherwise changes workflow execution.
+
+Any eligible terminal agent stage with a valid retained session opens as an interactive post-mortem chat regardless of how you reach it: same-process `task`/`tasks`/`chain` stages, completed-workflow inspection, generic `/workflow attach` / `/workflow connect`, restored/replayed durable snapshots after a restart, and `workflow({ action: "send" })`. Explicit `/workflow attach <root-run> <nested-stage>` targets are resolved through the expanded graph and routed to the child run that owns the stage while the overlay remains rooted on the requested graph; the resolved owner is preserved when sibling child workflows reuse the same local stage ID.
+
+When a nested stage is reopened after a restart or from another checkout, its session cwd comes from the durable root workflow (resolved workflow cwd first, then original invocation cwd) while stage-control ownership remains with the actual child run. Follow-up turns are appended in place to the stage's retained session (no separate fork), so the agent may still invoke its ordinary tools and cause side effects; only the workflow DAG, run/stage status, results, timings, checkpoints, and topology are immutable.
+
+Every host session replacement or shutdown invalidates post-mortem handles, including a session whose lazy reopen is still pending: if creation finishes after the boundary, Atomic disposes the newly created session and rejects the already-submitted prompt before it can execute. A stage stays a **read-only transcript** when it has no valid retained agent session — prompt/HIL and boundary/summary nodes, skipped nodes without a completed conversation, non-terminal handle-less stages (another process may still own the session), and missing/malformed/deleted session files.
+
+When a known stage cannot be reopened, the attached chat shows the complete `SESSION UNAVAILABLE` explanation down to the supported 40-column minimum instead of incorrectly labeling an invalid file as an archived transcript. Recoverably failed stages keep their execution-resume semantics and are not silently reopened as post-mortem chat.
+
+Completed stages also remain addressable by blocking `intercom.ask` calls from sibling workflow stages. If an ask reaches a completed target with a retained conversation, Atomic schedules one serialized post-mortem turn in that exact conversation; no manual `workflow send` follow-up is needed.
+
+The target sees the original ask, and its normal `intercom.reply` remains correlated to the originating child session and message ID. The parent chat or another session cannot satisfy the waiter. Late-message routing uses single-owner claiming: after the workflow post-mortem router claims a completed-stage ask and assigns its completion promise, later listeners preserve that claim, making bundled extension registration order irrelevant.
+
+This reopens only the conversation. The workflow DAG and terminal stage snapshot remain completed and are never resumed or re-dispatched. If the target run or stage was deleted, lacks a valid retained conversation, is non-resumable, or fails to reopen, the caller receives a bounded actionable `intercom.ask` tool error instead of waiting indefinitely.
+
+
+Workflow stage sessions and first-party subagent transcripts created inside them are classified as **internal** at creation and excluded from the standard `/resume`, `atomic -r`, `--continue`, and global history surfaces. Fork-context stages and subagents inherit the owning run/stage marker in their initial JSONL header, avoiding a briefly visible ordinary session. They remain resumable and inspectable through the workflow-specific commands and tool actions shown here (`/workflow resume`, `/workflow attach`, `workflow({ action: "status" | "stages" | "stage" | "resume" })`), which read the run/stage store and its `sessionFile` links directly.
+
+Passing a stage session's file path to `--session` still opens it explicitly. Classification requires exact `internal: true` plus complete run/stage metadata; malformed legacy markers and ordinary user forks remain in standard history. Legacy workflow sessions created before this marker behavior lack provable ownership and continue to appear until they age out.
+
+## Lifecycle Notices and Human Input
+
+Atomic emits deduplicated main-chat notices when top-level workflow runs complete, fail, or end blocked. Nested child workflow completion/failure is reflected inside the expanded parent graph instead of producing separate top-level completion cards. These terminal notices are queued into the active main chat as steering/context messages (`triggerTurn: true`, `deliverAs: "steer"`) so the model can react without the user manually polling status. Awaiting-input workflow states are tracked for dedupe/restore, but they do not enqueue main-chat connect cards or wake the model; prompt state remains visible through workflow status/connect surfaces.
+
+Configure lifecycle behavior with `workflowNotifications.enabled` (default `true`) and `workflowNotifications.notifyOn` (default `["completed", "failed", "blocked", "awaiting_input"]`).
+
+Human input is runtime-only: call `ctx.ui.input`, `ctx.ui.confirm`, `ctx.ui.select`, `ctx.ui.editor`, or `ctx.ui.custom<T>` when the workflow needs a decision. No builder-level declaration is required or supported.
+
+Human-in-the-loop prompts from `ctx.ui.input`, `ctx.ui.confirm`, `ctx.ui.select`, `ctx.ui.editor`, and `ctx.ui.custom<T>` appear as awaiting-input nodes in the workflow UI/graph viewer, not as ordinary chat modals. Workflow definitions do not declare HIL; runtime `ctx.ui.*` calls create prompt nodes. If the prompt lives inside an imported child workflow, it still appears in the same expanded parent graph so the user can focus and answer it without switching to a separate child status entry.
+
+Use `/workflow connect <run-id>` (or F2), then press Enter on the focused node or click a graph node to focus and open or attach it for local answers. Custom widget prompts mount inside the attached stage chat and must be completed interactively with the widget's `done(value)` callback.
+
+When a workflow needs human input, answer in the graph viewer or attached stage chat when possible:
+
+```text
+/workflow connect <run-id>
+/workflow attach <run-id> <stage-id-or-name>
+```
+
+Agents can answer primitive and structured pending prompts programmatically with `workflow({ action: "send", delivery: "answer", ... })`; use `promptId` when it is present in the stage details, and provide answer content with `response`, `text`, or `message`. Arbitrary custom TUI widget prompts intentionally refuse this path in iteration 1 because a generic `T` cannot be reconstructed safely from a non-TUI payload.
+
+`ctx.ui.custom<T>(factory, options?)` reuses Atomic's TUI component path: the factory receives the same real `(tui, theme, keybindings, done)` types as extension `ctx.ui.custom`, and the workflow resumes with the value passed to `done(value)`. Use `options.label` for a safe display-only graph/status label and `options.replayIdentity` when widget semantics can change without the callsite changing. Do not put secrets in labels or replay identities; only a hash of the identity is stored, and label text is not part of replay identity. Inline connected rendering is supported; `overlay: true` is rejected clearly because nested workflow graph overlays are not safely supported yet.
+
+Prompt answers are replayable only while the source run remains in the live in-memory store. `StageSnapshot.promptAnswerState` is snapshot-safe metadata for continuation: `available` means a matching live answer can be replayed, `unavailable` means the matching prompt node exists but its private answer was purged, and `ambiguous` means multiple matching prompt nodes exist so Atomic asks again. The raw answer lives in a private `PromptAnswerRecord` ledger, is never written to snapshots or persistence, and remains resident in memory until the answer is cleared, the run is removed, or the store is cleared.
+
+Prompt replay keys include the prompt kind, message text, select choices, input/editor initial value, custom prompt identity hash, and hashed author callsite, so changing any of those inputs may intentionally re-ask on continuation. An empty `ctx.ui.select(..., [])` has no answerable choices and throws before creating a prompt node. Arbitrary custom-widget answers cannot be supplied through `workflow send`; focus the `custom` awaiting-input node in the interactive graph instead.
+
+If the user answers a human-in-the-loop prompt in the workflow UI or stage UI broker, the stage receives the answer directly and the active main chat receives a display-only notice (`triggerTurn: false`, `excludeFromContext: true`) containing a concise answer summary. The notice is rendered for the user and persisted for audit, but it does not wake the model, enter LLM context, or authorize answering any other workflow prompt. Prompt answers sent by the main-chat `workflow` tool are suppressed from this notice because the tool result already informs the current turn.
+
+When an interactive, non-schema workflow stage calls `ask_user_question`, Atomic waits for the stage's assistant turn to finish and then brokers the deterministic readiness question **“Are you ready to move on to the next stage?”**. This includes typed or freeform questionnaire answers reported as `details.answers[].kind === "chat"`: the assistant first gives its normal conversational response, then the stage becomes `awaiting_input` with `inputRequest.kind: "readiness_gate"` in workflow status and graph surfaces.
+
+In this chat-answer flow, choosing the ready option completes the stage and releases dependent stages. Choosing the not-ready option keeps the stage open for a genuine stage-chat turn and brokers readiness again after that turn. A chat answer is never treated as an invisible stay decision.
+
+The readiness prompt can be answered in the attached stage UI or with `workflow({ action: "send", delivery: "answer", ... })`. Ordinary structured-option answers retain their existing readiness behavior. A schema-backed stage that has successfully finalized through `structured_output` is terminal and does not reopen this readiness gate.
+
+
+## Durable Workflows and Cross-Session Resume
+
+Atomic workflows use **DBOS/Postgres as their sole persistent workflow backend**. Atomic configures and launches DBOS lazily on the first workflow action, reuses that process-wide instance, and awaits readiness before workflow execution, resume, inspection, or deletion can access durable state. `DBOS_SYSTEM_DATABASE_URL` may select an existing database; DBOS initialization, query, and write failures fail the workflow action and never select another backend.
+
+**Zero-configuration local database.** Without `DBOS_SYSTEM_DATABASE_URL`, Atomic runs DBOS against its own embedded Postgres built from npm-distributed binaries — no Docker daemon or system Postgres install. The cluster lives under `~/.atomic/postgres/v18` on dedicated port `5439`; the first workflow action initializes it once and starts it with `pg_ctl` as a detached daemon that survives Atomic exiting, is shared by every concurrent Atomic session, and is never stopped by Atomic.
+
+When the embedded binaries are unavailable for the platform, Atomic falls back to DBOS's reusable `dbos-db` Docker container; if neither is usable, the workflow action fails with one actionable message: set `DBOS_SYSTEM_DATABASE_URL` to an existing Postgres.
+
+**Multiple concurrent Atomic sessions.** Every Atomic process launches DBOS with a unique executor id, and running root workflows carry owner/heartbeat metadata refreshed by ordinary ≤30-second stage-timing checkpoints. **Running workflows are never resume targets**: a running row with a fresh heartbeat is hidden from every session's picker and refused by direct `/workflow resume <id>` — resuming a workflow that is executing elsewhere would double-dispatch it. Once the heartbeat goes stale (about two minutes after a crash), the workflow surfaces as a red `crashed` row.
+
+When two sessions race to resume the same paused workflow, a durable first-writer-wins claim decides exactly one winner; the loser reconciles to the authoritative state and reports that the workflow changed while resume was pending.
+
+### How it works
+
+- **Only `ctx.*` blocks are checkpointed**: code outside `ctx.*` is not durable.
+- **Durable side effects**: Atomic flushes `ctx.tool` and `ctx.ui` writes before exposing completed results, so resume does not repeat an already-completed effect.
+- **Durable graph operations**: stage, task, chain, parallel, and child-workflow checkpoints include current topology, timing, model, output, and retained chat-session references. Completed inspection reconstructs the graph directly from DBOS.
+- **DBOS-only discovery**: `/workflow resume`, `/workflows`, completed inspection, deletion, and targeted lookup hydrate/query DBOS. Session JSONL remains only a chat transcript referenced by a current checkpoint; it is not a workflow catalog or discovery source.
+- **Current format only**: Atomic encodes and decodes one current DBOS format. Prior local files and older DBOS records are not read, converted, or cleaned up. Unsupported or malformed records are ignored as foreign data.
+- **Child side-effect scoping**: nested workflow effects are checkpointed under the durable root with stable child scopes.
+- **Cross-session safety**: per-process executor identity, owner/heartbeat liveness on running handles, and claim-guarded status transitions prevent double dispatch when several Atomic sessions share the database.
+
+**Privacy and retention.** DBOS persists workflow inputs, completed tool outputs, UI responses, stage outputs, and chat-session paths. Treat the configured database as sensitive. History does not automatically delete records by age or count; confirmed picker deletion removes inactive DBOS workflow state while preserving independent chat transcripts.
+
+**Resume after editing a workflow.** Replay identity combines the workflow id with stable content hashes and call order. Editing, inserting, or reordering `ctx.*` calls can intentionally invalidate matches. Finish or delete retained runs before deploying incompatible workflow changes.
+
+Durable `/workflow resume` preserves completed stage metadata, active-stage elapsed time, total run elapsed time, and graph topology. While an LM stage or task is active, repeated durable checkpoints refresh its accumulated pause-adjusted duration even when its session file does not change, and refresh the run's total accumulated elapsed time alongside it; graceful quit and recoverable failure additionally persist the exact run total at the boundary.
+
+Each new Atomic process that reopens the unfinished session mid-chat starts from the latest saved baseline and uses the same continuation prompt shown above, so repeated process-boundary resumes keep status, graph, stored, and lifecycle duration cumulative without double-counting pauses from earlier process segments — a resumed mid-running stage timer continues from its previously accumulated elapsed time instead of restarting at zero, and the total workflow duration shown in the main-chat dashboard and status surfaces reports prior-session elapsed plus current-session elapsed.
+
+Replayed `ctx.stage`, `ctx.task`, `ctx.chain`, `ctx.parallel`, and child-workflow checkpoints keep their original summaries, timing, session/model metadata, and parallel fanout parentage instead of appearing as freshly flattened replay nodes.
+
+### `ctx.tool` — durable cached tool execution
+
+The `ctx.tool(name, args, fn, options?)` primitive runs arbitrary TypeScript code and caches the result durably. On resume, if that ordinal tool call already completed (matched by call order plus content hash of `name` + `args`), the runtime returns the cached result without re-executing the function — ensuring completed side effects are not repeated while still allowing two intentional same-name/same-args calls in one workflow.
+
+```ts
+export default workflow({
+  name: "data-pipeline",
+  inputs: { source: Type.String() },
+  run: async (ctx) => {
+    // This side effect is cached durably. On resume, it will NOT re-execute.
+    const data = await ctx.tool(
+      "fetch-dataset",
+      { source: ctx.inputs.source },
+      async () => {
+        const res = await fetch(ctx.inputs.source);
+        return await res.text();
+      },
+      { retriesAllowed: true, maxAttempts: 3 },
+    );
+
+    // Subsequent stages use the cached result.
+    const analysis = await ctx.task("analyze", { prompt: `Analyze: ${data}` });
+    return { summary: analysis.text };
+  },
+});
+```
+
+### `/workflow resume` — cross-session resume selector
+
+The `/workflow resume` command mirrors `/resume` ergonomics and `/workflows` is its alias. With no id, it builds one newest-first picker from eligible live runs and current DBOS resumable/completed records. DBOS is the authoritative catalog; selected records are hydrated and revalidated before resume or inspection. Running workflows never appear: fresh-heartbeat rows are excluded in every session to prevent double dispatch, and stale ones surface as `crashed`.
+
+Rows carry semantic colors — completed green, paused yellow, failed/blocked/crashed red — and the open picker live-updates on local run changes plus a bounded cross-session poll, so state transitions appear (and freshly running workflows disappear) without reopening it.
+
+Ctrl+D deletes a highlighted inactive durable or completed row after confirmation. Deletion rechecks same-process activity and the authoritative DBOS status, refuses a `running` workflow, and leaves host and stage chat transcripts untouched. The history surface matches `/resume` retention semantics: eligible runs remain searchable regardless of age or count, with no automatic history garbage collection. The picker mounts before asynchronous catalog hydration completes and merges DBOS rows when ready.
+
+Only current-format DBOS records are selectable. Atomic hides unsupported or malformed records without reinterpreting them.
+
+Selecting a paused, failed, blocked, or crash-recovery target follows the existing resume path unchanged: Atomic re-dispatches the workflow with its cached inputs and the **original workflow id**, so previously completed `ctx.tool`, `ctx.ui`, stage/task/chain/parallel items, and child workflow boundaries replay from durable checkpoints rather than executing again. Selecting a completed target follows a separate open path.
+
+Atomic reconstructs a completed run/stage snapshot from authoritative checkpoints, remaps persisted source-stage parent references to the reconstructed stage ids in two passes, and opens the detail/chat overlay without calling the durable resume dispatcher or re-running workflow stages, tools, tasks, prompts, or workflow code.
+
+Completed detail state is read-only. A retained stage chat may be reopened for follow-up without resuming workflow execution or mutating its DBOS handle. Current checkpoints always include supported topology; foreign checkpoints are excluded rather than displayed with inferred edges.
+
+```text
+/workflow resume                          # Mixed picker: resumable + completed
+/workflow resume <workflow-id-or-prefix> # Resume unfinished work or open completed detail/chat
+/workflows                               # Alias for the same mixed picker
+/workflows <workflow-id-or-prefix>        # Alias for targeted resume/open
+```
+
+Explicit full IDs take precedence, while prefixes resolve across top-level live, resumable durable, and completed targets as one namespace. An exact loadable paused top-level live target resumes directly from in-session state without enumerating the durable completed-history catalog; this keeps explicit live resume responsive even when retained durable history is large and preserves live-over-durable precedence for duplicate IDs. Nested child runs remain excluded from this top-level target namespace even when addressed by an exact ID.
+
+Prefixes and other targets continue through the combined catalog so ambiguity and completed-inspection behavior remain unchanged. Ambiguous prefixes use the existing-style ambiguity diagnostic. A completed backend row with no checkpoints or no usable retained stage conversation is hidden from the picker; an explicit target reports that it is stale or missing required durable checkpoint/session data. A completed run remains inspectable when at least one stage has a usable transcript; missing, empty, directory, context-empty, or partially malformed transcript paths are omitted from stage chat attachment.
+
+Validation uses the final retained transcript for a repeated stage replay key, so an obsolete superseded checkpoint path does not hide an otherwise valid completed run. Reopening inspection refreshes a changed authoritative retained-chat handle. Session-cache-only rows are likewise hidden because the backend is authoritative. Cancelled, killed, non-resumable failed, and other terminal non-success states are never added. Normal `/resume`, `atomic -r`, and `--continue` behavior for internal workflow stage sessions is unchanged.
+
+### Cancellation, failure, and retry semantics
+
+| Scenario | Behavior |
+| --- | --- |
+| **Internally cancelled workflow** | Marked `cancelled` in durable state and excluded from `/workflow resume` discovery. Start a new workflow run if you intentionally want to retry cancelled work. |
+| **Stage failure (recoverable)** | Workflow marked `failed` or `blocked` and remains resumable by default. `/workflow resume <id>` continues from the last completed checkpoint unless durable metadata explicitly sets `resumable: false`. |
+| **Stage failure (non-recoverable)** | Workflow marked `failed` or `blocked` with `resumable: false`, so it is excluded from resume discovery. |
+| **Process crash** | Workflow remains `running` in durable state. On next session start, it appears in resume discovery when it has a durable checkpoint or pending prompt. Resume re-executes from the last completed checkpoint. |
+| **`ctx.tool` retry** | When `retriesAllowed: true`, the tool function is retried with exponential backoff. Cancellation is checked before each attempt and during retry backoff, so later attempts do not run after the workflow is cancelled. After exhausting retries, the error propagates and the workflow fails. |
+| **`ctx.ui` pending prompt** | If a UI prompt was not answered before interruption, resume leaves off on that prompt — the user must answer it to continue. |
+
+### Configuring DBOS/Postgres
+
+DBOS/Postgres durability requires no setup on supported local platforms. To use an existing Postgres database, set `DBOS_SYSTEM_DATABASE_URL` before starting Atomic; otherwise Atomic provisions embedded Postgres, with Docker as a platform fallback. The DBOS SDK ships with `@bastani/atomic`. If the SDK cannot load or Postgres cannot be reached or provisioned, Atomic fails the workflow action with an actionable diagnostic instead of falling back to the legacy per-workflow file store under `~/.atomic/workflow-durable`.
+
+```bash
+export DBOS_SYSTEM_DATABASE_URL="postgresql://user:password@localhost:5432/atomic_dbos_sys"
+```
+
+When `/workflow resume` lists or resumes a DBOS-backed workflow in a fresh process, Atomic first hydrates its in-memory replay mirror from DBOS. Atomic stores checkpoints as structured, versioned DBOS outputs containing the checkpoint kind, id, tool argument hash, UI prompt hash, stage replay key, completed output, and additive versioned stage-topology metadata when available, so replay can skip completed `ctx.tool`, `ctx.ui`, `ctx.stage`, `ctx.task`, `ctx.chain`, `ctx.parallel`, and `ctx.workflow` work without relying on prior in-process state and completed inspection can rebuild the original DAG.
+
+Atomic updates the in-memory replay mirror for awaited DBOS checkpoints only after DBOS accepts the write, and root metadata is mirrored as versioned DBOS records where the latest timestamp wins during hydration. Unmarked raw-output checkpoint records remain readable as generic stage checkpoints when their workflow has compatible current metadata; marked envelopes with unsupported envelope versions are ignored rather than decoded as raw output, while unsupported or malformed additive topology fields are ignored without dropping an otherwise valid stage envelope.
+
+Atomic does not use the legacy file backend under `~/.atomic/workflow-durable`; cross-session `/workflow resume` reads DBOS only.
+
+## Direct One-Off Runs
+
+Use direct workflow-native orchestration for one-off tracked work that does not need a reusable workflow file.
+
+Single tracked task:
+
+```ts
+workflow({
+  task: {
+    name: "review",
+    task: "Review this patch for API risks.",
+    context: "fresh",
+    output: "reviews/api.md",
+  },
+  async: true,
+  intercom: { delivery: "result" },
+})
+```
+
+Parallel fan-out:
+
+```ts
+workflow({
+  tasks: [
+    { name: "docs", task: "Review documentation gaps" },
+    { name: "risks", task: "Review operational risks" },
+  ],
+  concurrency: 2,
+  outputMode: "file-only",
+  async: true,
+})
+```
+
+Dependent chain:
+
+```ts
+workflow({
+  task: "Design the workflow SDK migration",
+  chain: [
+    { name: "research", task: "Research {task}" },
+    { name: "plan", task: "Plan from {previous}" },
+  ],
+  async: true,
+})
+```
+
+Mixed chain with a parallel review step:
+
+```ts
+workflow({
+  task: "map the release process",
+  chain: [
+    { name: "researcher", task: "Research {task}" },
+    {
+      parallel: [
+        { name: "risk-reviewer", task: "Review risks in {previous}" },
+        { name: "docs-reviewer", task: "Find documentation gaps in {previous}" },
+      ],
+      concurrency: 2,
+    },
+    { name: "planner", task: "Create a plan from {previous}" },
+  ],
+  async: true,
+  intercom: { delivery: "result" },
+})
+```
+
+Direct mode supports top-level/default options and per-task options such as `context`, `forkFromSessionFile`, `model`, `fallbackModels`, `thinkingLevel`, `contextWindow`, `tools`, `noTools`, `customTools`, `mcp`, `output`, `outputMode`, `reads`, `worktree`, `gitWorktreeDir`, `baseBranch`, `maxOutput`, `artifacts`, `sessionDir`, `cwd`, and `agentDir`. Direct chains also support `chainName`, `chainDir`, and `failFast`.
+
+### Direct-run grouping and Intercom options
+
+```typescript
+interface WorkflowToolArgs extends StageOptions {
+  // Named-workflow, inspection, messaging, task/chain, and output fields omitted here.
+  chainName?: string;
+  chainDir?: string;
+  concurrency?: number;
+  failFast?: boolean;
+  async?: boolean;
+  intercom?: {
+    enabled?: boolean;
+    delivery?: "off" | "notify" | "result" | "control-and-result";
+    parentSession?: string;
+    notifyOn?: Array<
+      "active_long_running" | "needs_attention" | "completed" | "failed"
+    >;
+  };
+}
+```
+
+The signature excerpt shows the grouping, scheduling, and Intercom fields; `WorkflowToolArgs` also carries the named-workflow, inspection, messaging, task/chain, and output fields documented throughout this guide. `chainName` and `chainDir` group direct-chain status and artifacts, while `concurrency` and `failFast` control direct fan-out. `async` launches independently; `intercom` controls whether and how notifications or results return to a parent session, which parent receives them, and which lifecycle events notify.
+
+For large fan-outs, prefer `outputMode: "file-only"` so the parent result contains compact file references instead of full output. Treat [intercom](/intercom) payloads from async direct runs as user-visible workflow output.
+
+Worktree isolation is an explicit runtime option, not a property inferred from task text. Natural-language instructions to create or use a worktree do not enable runner isolation, and `cwd` only selects the starting directory; a write-capable direct run without a worktree option executes in that checkout. Set `worktree: true` for runner-managed temporary per-task worktrees, or set `gitWorktreeDir` for a runner-managed reusable same-repository worktree. Invalid, empty, foreign-repository, or conflicting worktree requests fail with an actionable diagnostic rather than falling back to the invoking checkout.
+
+For independent task queues, prefer one run per item with its own reusable worktree instead of a monolithic chain rooted in the primary checkout.
+
+Worktree mechanics and validation rules are covered in [Task and Stage Options](#task-and-stage-options).
+
+## Workflow Locations
+
+Atomic discovers workflow definitions in this order:
+
+| Location | Scope | Notes |
+|----------|-------|-------|
+| `.atomic/extensions/workflow/config.json` | Project | `workflows.<name>.path`; project entries override global entries |
+| `.atomic/workflows/*.{ts,js,mjs,cjs}` | Project | Legacy `.pi/workflows/` is also checked |
+| `~/.atomic/agent/extensions/workflow/config.json` | Global | `workflows.<name>.path` for user-wide configured paths |
+| `~/.atomic/agent/workflows/*.{ts,js,mjs,cjs}` | Global | Legacy `~/.pi/agent/workflows/` is also checked |
+| Installed Atomic packages | Package | Uses package metadata or conventional `workflows/` directories |
+| Bundled workflows | Built-in | Shipped with `@bastani/workflows` |
+
+A workflow module may export one default workflow definition and/or named workflow definitions. Discovery checks the default export first, then named exports.
+
+Discovery validates every runtime export of a discovered workflow file as a workflow definition. Discovery rejects a named export that is not a workflow definition — a widget factory, shared constant, or utility function — with an `INVALID_DEFINITION` discovery diagnostic (`export is not an object`), even when the module also has a valid default export (the valid workflow still loads; the diagnostic flags the extra export as skipped). TypeScript erases type-only exports (`export type` / `export interface`) at runtime, so discovery never flags them.
+
+To co-locate reusable helpers with your workflows — for example a `ctx.ui.custom<T>` widget factory you want to import in tests without running the workflow — put them in a subdirectory and import them from the workflow file. Discovery scans only the top level of each workflow directory, so subdirectories such as `.atomic/workflows/lib/` are never treated as workflow modules:
+
+```text
+.atomic/workflows/
+  release-picker.ts      # only runtime export: workflow({...})
+  lib/
+    table-selector.ts    # widget factory + helpers; not scanned by discovery
+```
+
+```ts
+// .atomic/workflows/release-picker.ts
+import { workflow } from "@bastani/workflows";
+import { Type } from "typebox";
+import { tableSelectorFactory } from "./lib/table-selector.js";
+```
+
+```ts
+// .atomic/workflows/lib/table-selector.ts
+import type { WorkflowCustomUiFactory } from "@bastani/workflows";
+
+export const tableSelectorFactory: WorkflowCustomUiFactory<{ id: string; name: string }> = (
+  tui,
+  theme,
+  _keybindings,
+  done,
+) => ({
+  render: (width) => ["..."],
+  invalidate: () => {},
+  handleInput: (data) => {
+    /* ... done({ id, name }) on Enter ... */
+  },
+});
+```
+
+Atomic loads workflow files with [jiti](https://github.com/unjs/jiti), so TypeScript works without compilation.
+
+## Reloading workflow resources
+
+Run `/workflow reload` after adding, editing, renaming, or deleting workflow modules or changing workflow config. Reload rescans project and user conventional directories, legacy `.pi` locations, configured file/directory paths, and package resources without restarting Atomic. The workflow tool's `reload` action uses the same in-process path.
+
+Reload builds a complete replacement registry before publishing it. Concurrent requests are serialized and coalesced, stale discovery from an earlier session cannot overwrite newer state, and a fatal refresh failure retains the previous registry. Reload is safe while workflows are running: existing runs keep the definition and runtime snapshot they started with, while subsequent list/get/inputs/help/completion/invocation calls use the newly published registry.
+
+A successful rescan may still contain per-resource diagnostics. Both reload surfaces show `CONFIG_INVALID`, `IMPORT_FAILED`, `INVALID_DEFINITION`, `PATH_NOT_FOUND`, and duplicate-name diagnostics instead of reporting bare success while silently skipping a resource. Valid sibling workflows remain available. Fix the reported source/path and reload again; no process restart is required.
+
+## Workflow Configuration
+
+Configured workflow paths live in workflow extension config. Project config paths are relative to the project root. Global config paths are relative to `~/.atomic/agent`.
+
+Project config:
+
+```text
+.atomic/extensions/workflow/config.json
+```
+
+Global config:
+
+```text
+~/.atomic/agent/extensions/workflow/config.json
+```
+
+Example config:
+
+```json
+{
+  "workflows": {
+    "team": { "path": "./workflows/team.ts" },
+    "shared": { "path": "/shared/team/workflows" }
+  },
+  "defaultConcurrency": 4,
+  "maxDepth": 4,
+  "persistRuns": true,
+  "statusFile": false,
+  "resumeInFlight": "ask",
+  "workflowNotifications": {
+    "enabled": true,
+    "notifyOn": ["completed", "failed", "blocked", "awaiting_input"]
+  }
+}
+```
+
+Runtime config defaults:
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `defaultConcurrency` | `4` | Default concurrency for direct parallel/grouped execution |
+| `maxDepth` | `4` | Maximum workflow nesting depth |
+| `persistRuns` | `true` | Persist run metadata for status/resume/history |
+| `statusFile` | `false` | Write a derived status file; defaults under `.atomic/workflows/status.json` when enabled |
+| `resumeInFlight` | `"ask"` | Behavior when discovering resumable in-flight work |
+| `workflowNotifications.enabled` | `true` | Emit terminal workflow lifecycle notices into the active main chat |
+| `workflowNotifications.notifyOn` | `["completed", "failed", "blocked", "awaiting_input"]` | Lifecycle states to track; terminal `completed`/`failed`/`blocked` states create main-chat notices, while `awaiting_input` is tracked for dedupe/restore without waking the main agent |
+
+Invalid JSON or invalid shapes produce `CONFIG_INVALID` diagnostics. Missing config files are ignored.
+
+## Settings
+
+Settings can list package sources directly:
+
+```json
+{
+  "packages": [
+    "npm:my-atomic-workflows@1.0.0",
+    "git:github.com/user/team-workflows@v2",
+    "./tools/local-workflows"
+  ]
+}
+```
+
+Use object form to filter which workflows load from a package:
+
+```json
+{
+  "packages": [
+    {
+      "source": "npm:my-atomic-workflows",
+      "workflows": ["workflows/*.ts", "!workflows/experimental/**"]
+    }
+  ]
+}
+```
+
+`workflows` patterns follow package filtering rules:
+
+- Omit `workflows` to load every workflow allowed by the package manifest.
+- Use `[]` to load no workflows from that package.
+- Use `!pattern` to exclude matches.
+- Use `+path` to force-include an exact path.
+- Use `-path` to force-exclude an exact path.
+
+Run `atomic config` to enable or disable package resources interactively. Atomic saves workflow package filters as `workflows` patterns in settings.
+
+## Package Setup
+
+Atomic packages can ship workflows through package metadata or conventional directories. A package manifest can declare workflows next to extensions, skills, prompt templates, and themes:
+
+```json
+{
+  "name": "my-atomic-workflows",
+  "keywords": ["atomic-package", "pi-package"],
+  "atomic": {
+    "extensions": ["./src/index.ts"],
+    "workflows": ["./workflows"]
+  }
+}
+```
+
+Paths are relative to the package root and may use glob patterns. Include `atomic-package` for Atomic package discovery and `pi-package` for compatibility with existing package-gallery tooling.
+
+For new Atomic package examples, prefer `atomic.workflows` and `atomic.extensions`. `pi.workflows` and `pi.extensions` remain supported for compatibility with existing packages. Workflows can be declared with `atomic.workflows` or discovered from conventional `workflows/` / `workflow/` directories. Unlike other resource types, package workflows still fall back to conventional directories when a package manifest exists but omits the workflow key. App-level config prefers `atomicConfig` where available; legacy `piConfig` is still read as a shim.
+
+Convention directory example:
+
+```text
+my-atomic-workflows/
+  package.json
+  workflows/
+    release-plan.ts
+    review-loop.ts
+  src/
+    index.ts
+```
+
+Install packages globally or locally:
+
+```bash
+atomic install npm:my-atomic-workflows
+atomic install git:github.com/user/my-atomic-workflows
+atomic install ./local-workflow-package -l
+```
+
+By default, `atomic install` writes to global settings (`~/.atomic/agent/settings.json`). Use `-l` to write to project settings (`.atomic/settings.json`). A team can commit project settings to share the same workflow package set.
+
+To try a package for one run, use `--extension` or `-e`:
+
+```bash
+atomic -e npm:my-atomic-workflows
+atomic -e ./local-workflow-package
+```
+
+Workflow stage sessions inherit the same package and temporary `-e` resource discovery snapshot as the main chat. That means a workflow loaded from an external package or directory can start stages that see the package's extensions/tools, subagents and agent definitions, skills, prompt templates, themes, workflows, and trusted borrowed project-local resources without sharing the parent chat's resource-loader instance. Passing an explicit `resourceLoader` in stage options still opts that stage out of this inheritance.
+
+## Programmatic Usage
+
+`@bastani/workflows` is an Atomic package extension. It registers:
+
+- `/workflow <name> key=value ...` for interactive named runs
+- `/workflow connect|attach|pause|interrupt|quit|resume|status|inputs|reload` for live control, inspection, and rediscovery
+- the `workflow` tool for agent-initiated orchestration and direct one-off runs
+
+The signatures in this reference follow the externally shipped standalone authoring declaration in `packages/workflows/src/authoring.ts`. Atomic's internal runtime types may specialize opaque SDK values or add executor-only integration fields; those are not ordinary workflow-package authoring API.
+
+Workflow definition files must export definitions produced by `workflow({...})`. Keep non-workflow runtime helpers (widget factories, shared utilities) in a subdirectory the discovery scan ignores, such as `.atomic/workflows/lib/` — see [Workflow Locations](#workflow-locations). The former imperative object-form runner is not part of the public SDK, and authored workflow files cannot use `runWorkflow` as a runner from `@bastani/workflows`.
+
+Standalone TypeScript workflow packages type-check the SDK import without a hand-authored `.d.ts`, `declare module` shim, or `tsconfig` `paths` alias. The SDK types ship with `@bastani/atomic`, so a workflow package depends only on `@bastani/atomic` (plus a `typebox` peer):
+
+```ts
+import { workflow } from "@bastani/workflows";
+import { Type } from "typebox";
+
+export default workflow({
+  name: "map-workflow-sdk",
+  description: "Map the workflow SDK.",
+  inputs: {
+    prompt: Type.String({ default: "map workflow sdk" }),
+  },
+  outputs: {},
+  run: async (ctx) => {
+    await ctx.task("map", { prompt: ctx.inputs.prompt });
+    return {};
+  },
+});
+```
+
+Workflow SDK type resolution depends on the package's other imports:
+
+- A package that imports `@bastani/atomic` anywhere (for example, an extension shipped in the same package) automatically resolves the workflow SDK types. `@bastani/atomic`'s root declarations reference the ambient bridge, so no extra configuration is needed.
+- A pure workflow-only package — one that imports nothing but `@bastani/workflows` — adds a single opt-in so TypeScript loads the ambient bridge. Set it once for the project in `tsconfig.json`:
+
+  ```jsonc
+  {
+    "compilerOptions": {
+      "module": "NodeNext",
+      "moduleResolution": "NodeNext",
+      "types": ["@bastani/atomic/workflows/ambient"]
+    }
+  }
+  ```
+
+  or add a single reference directive at the top of one workflow file:
+
+  ```ts
+  /// <reference types="@bastani/atomic/workflows/ambient" />
+  ```
+
+Either form makes `import { workflow } from "@bastani/workflows"
+import { Type } from "typebox"` and the `@bastani/workflows/builtin/*` composition imports resolve under `tsc` (`moduleResolution: NodeNext`) with no hand-authored `.d.ts`, no `declare module` shim, and no `paths` alias. `@bastani/workflows` is not a separate npm package — its types ship with `@bastani/atomic` — so list both `@bastani/atomic` and `typebox` (workflow files import `Type` from `typebox`) in `peerDependencies`. Runtime discovery and loading via `atomic.workflows` are unchanged: Atomic's loader still supplies the SDK when workflow files execute.
+
+The `workflow` tool supports direct one-off `task`, `tasks`, and `chain` modes. Direct chains support `chainName` for status/artifact grouping and `chainDir` as a shared directory for relative reads, outputs, and worktree diffs.
+
+### `workflow(spec)`
+
+```typescript
+function workflow<
+  const TInputs extends WorkflowInputSchemaMap = {},
+  const TOutputs extends WorkflowOutputSchemaMap = WorkflowOutputSchemaMap,
+  TActualOutputs extends WorkflowOutputsFromSchemas<TOutputs> = WorkflowOutputsFromSchemas<TOutputs>,
+>(
+  spec: AuthoredWorkflowSpec<TInputs, TOutputs, TActualOutputs>,
+): AuthoredWorkflowDefinition<TInputs, TOutputs>;
+```
+
+Creates the frozen branded definition documented in [The `workflow()` Definition](#the-workflow-definition). Discovery accepts only definitions minted by this function.
+
+### `createRegistry(initial?)`
+
+```typescript
+function createRegistry<
+  TDefinitions extends readonly AnyWorkflowDefinition[] = readonly AnyWorkflowDefinition[],
+>(initial?: TDefinitions): WorkflowRegistry;
+
+interface WorkflowRegistry {
+  register<TInputs extends WorkflowInputValues, TOutputs extends WorkflowOutputValues, TRunInputs extends WorkflowInputValues = TInputs>(
+    definition: WorkflowDefinition<TInputs, TOutputs, TRunInputs>,
+  ): WorkflowRegistry;
+  merge(other: WorkflowRegistry): WorkflowRegistry;
+  get(name: string): AnyWorkflowDefinition | undefined;
+  has(name: string): boolean;
+  remove(name: string): WorkflowRegistry;
+  names(): string[];
+  all(): AnyWorkflowDefinition[];
+}
+```
+
+Creates an immutable-style registry keyed by normalized workflow name. `register`, `merge`, and `remove` return registries rather than mutating the current registry.
+
+```ts
+import { createRegistry, workflow } from "@bastani/workflows";
+import { Type } from "typebox";
+
+const alpha = workflow({
+  name: "alpha",
+  description: "",
+  inputs: {},
+  outputs: {
+    text: Type.String({ description: "Alpha task output text." }),
+  },
+  run: async (ctx) => {
+    const result = await ctx.task("alpha", { prompt: "Run alpha." });
+    return { text: result.text };
+  },
+});
+
+const registry = createRegistry().register(alpha);
+registry.names();
+registry.get("alpha");
+```
+
+### `run(definition, inputs, opts?)`
+
+```typescript
+type WorkflowRunInputArgument<TInputs extends WorkflowInputValues> =
+  [keyof TInputs] extends [never] ? Readonly<Record<string, never>> : TInputs;
+
+function run<
+  TInputs extends WorkflowInputValues,
+  TOutputs extends WorkflowOutputValues,
+  TRunInputs extends WorkflowInputValues = TInputs,
+>(
+  definition: WorkflowDefinition<TInputs, TOutputs, TRunInputs>,
+  inputs: Readonly<NoInfer<WorkflowRunInputArgument<TRunInputs>>>,
+  opts?: RunOpts,
+): Promise<RunResult<TOutputs>>;
+```
+
+Executes a compiled definition programmatically with validated inputs. Empty-input workflows accept an empty readonly record.
+
+### `RunOpts`
+
+```typescript
+interface RunOpts {
+  readonly adapters?: StageAdapters;
+  readonly cwd?: string;
+  readonly ui?: WorkflowUIAdapter;
+  readonly executionMode?: WorkflowExecutionMode;
+  readonly usePromptNodesForUi?: boolean;
+  readonly confirmStageReadiness?: (request: {
+    readonly runId: string;
+    readonly stageId: string;
+    readonly stageName: string;
+    readonly signal: AbortSignal;
+  }) => Promise<boolean>;
+  readonly store?: object;
+  readonly persistence?: WorkflowPersistencePort;
+  readonly mcp?: WorkflowMcpPort;
+  readonly cancellation?: CancellationRegistry;
+  readonly overlay?: WorkflowOverlayAdapter;
+  readonly signal?: AbortSignal;
+  readonly deferWorkflowStart?: boolean;
+  readonly config?: WorkflowRuntimeConfig;
+  readonly models?: WorkflowModelCatalogPort;
+  readonly registry?: WorkflowRegistry;
+  readonly depth?: number;
+  readonly stageControlRegistry?: object;
+  readonly runId?: string;
+  readonly continuation?: RunContinuationOpts;
+  readonly parentRun?: WorkflowParentRunLink;
+  readonly onRunStart?: (snapshot: RunSnapshot) => void;
+  readonly onStageStart?: (runId: string, snapshot: StageSnapshot) => void;
+  readonly onStageEnd?: (runId: string, snapshot: StageSnapshot) => unknown;
+  readonly onRunEnd?: (
+    runId: string,
+    status: RunStatus,
+    result?: WorkflowOutputValues,
+    error?: string,
+    exitReason?: string,
+  ) => void;
+}
+```
+
+Supplies runtime adapters, execution policy, persistence, MCP, cancellation, graph/store integration, continuation metadata, and lifecycle callbacks to `run(...)` and direct helpers. Every field is optional.
+
+The public authoring declaration intentionally excludes runtime-only executor fields such as `defaultSessionDir`, `gitWorktreeSetupCache`, `durableBackend`, `durableScope`, and `onStageSession`.
+
+### `runTask()` / `runChain()` / `runParallel()`
+
+```typescript
+function runTask(task: WorkflowDirectTaskItem, runOptions?: RunOpts): Promise<WorkflowDetails>;
+function runTask(task: WorkflowDirectTaskItem, options?: WorkflowDirectOptions, runOptions?: RunOpts): Promise<WorkflowDetails>;
+function runChain(steps: readonly WorkflowChainStep[], options?: WorkflowDirectOptions, runOptions?: RunOpts): Promise<WorkflowDetails>;
+function runParallel(tasks: readonly WorkflowDirectTaskItem[], options?: WorkflowDirectOptions, runOptions?: RunOpts): Promise<WorkflowDetails>;
+```
+
+Execute direct one-off shapes without a reusable definition. Their item and option fields match [Task and Stage Options](#task-and-stage-options), and they return [`WorkflowDetails`](#workflowdetails).
+
+### `resolveInputs(schema, provided)`
+
+```typescript
+function resolveInputs<TInputs extends WorkflowInputValues>(
+  schema: Readonly<Record<keyof TInputs & string, TSchema>>,
+  provided: Partial<TInputs>,
+): ResolvedInputs<TInputs>;
+```
+
+Applies schema defaults and validates the provided input record, returning typed resolved values. The function rejects invalid provided values.
+
+### `setupGitWorktree(options)`
+
+```typescript
+function setupGitWorktree(options: {
+  readonly gitWorktreeDir: string;
+  readonly baseBranch?: string;
+  readonly cwd: string;
+}): {
+  readonly worktreeRoot: string;
+  readonly cwd: string;
+  readonly repositoryRoot: string;
+  readonly created: boolean;
+};
+```
+
+Synchronously creates or validates a reusable worktree and remaps the cwd. It applies the same validation, symlink-preserving path handling, and cwd-preservation behavior as workflow stages.
+
+### `normalizeWorkflowName(name)` / `workflowNamesEqual(a, b)`
+
+```typescript
+function normalizeWorkflowName(name: string): string;
+function workflowNamesEqual(a: string, b: string): boolean;
+```
+
+Normalization trims and lowercases, converts whitespace and underscores to hyphens, removes other characters, collapses hyphens, and trims edge hyphens. Equality compares normalized names.
+
+### `GraphFrontierTracker`
+
+```typescript
+class GraphFrontierTracker {
+  onSpawn(stageId: string, stageName: string): string[];
+  currentParents(): string[];
+  replaceParents(stageId: string, parentIds: readonly string[]): void;
+  onSettle(stageId: string): void;
+  getNodes(): StageNode[];
+  getParents(stageId: string): string[];
+  reset(): void;
+}
+
+interface StageNode extends WorkflowSerializableObject {
+  readonly id: string;
+  readonly name: string;
+  readonly parentIds: readonly string[];
+}
+```
+
+Tracks inferred DAG parents from JavaScript execution order. It is a low-level engine utility for integrations that need the same frontier semantics as the workflow executor.
+
+### Execution policies
+
+```typescript
+const INTERACTIVE_WORKFLOW_POLICY: WorkflowExecutionPolicy = {
+  mode: "interactive",
+  allowHumanInput: true,
+  awaitTerminalRun: false,
+  allowInputPicker: true,
+};
+const NON_INTERACTIVE_WORKFLOW_POLICY: WorkflowExecutionPolicy = {
+  mode: "non_interactive",
+  allowHumanInput: false,
+  awaitTerminalRun: true,
+  allowInputPicker: false,
+};
+```
+
+The exported frozen policies define the standard interactive and headless behavior. Each constant satisfies `WorkflowExecutionPolicy`.
+
+### `createStore()` / `store`
+
+```typescript
+function createStore(): Store;
+const store: Store;
+
+interface Store {
+  runs(): readonly RunSnapshot[];
+  notices(): readonly WorkflowNotice[];
+  activeRunId(): string | null;
+  recordRunStart(run: RunSnapshot): void;
+  recordStageStart(runId: string, stage: StageSnapshot): void;
+  recordToolStart(runId: string, stageId: string, event: ToolEvent): void;
+  recordToolEnd(runId: string, stageId: string, event: ToolEvent): void;
+  recordStageEnd(runId: string, stage: StageSnapshot): void;
+  recordRunEnd(runId: string, status: RunStatus, result?: WorkflowOutputValues, error?: string): boolean;
+  removeRun(runId: string): boolean;
+  recordNotice(notice: WorkflowNotice): void;
+  ackNotice(id: string): boolean;
+}
+```
+
+`createStore()` returns an isolated workflow state store. `store` is the default singleton exported by the SDK authoring surface.
+
+This is the stable core exposed by the standalone authoring declaration. Atomic's runtime store also has graph, prompt, session, pause/resume, snapshot, and subscription methods used by embedded integrations; those richer runtime controls are not part of the lean workflow-package `Store` contract shown here.
+
+### `createCancellationRegistry()` / `cancellationRegistry`
+
+```typescript
+function createCancellationRegistry(): CancellationRegistry;
+const cancellationRegistry: CancellationRegistry;
+
+interface CancellationRegistry {
+  register(runId: string, controller: AbortController): void;
+  registerChild(runId: string, controller: AbortController): void;
+  abort(runId: string, reason?: unknown): boolean;
+  abortAll(reason?: unknown): number;
+  unregister(runId: string): void;
+  isAborted(runId: string): boolean;
+}
+```
+
+The factory creates an isolated registry; `cancellationRegistry` is the default singleton. Aborts signal registered controllers and children rather than killing processes.
+
+### `Static` / `TSchema`
+
+```typescript
+export type { Static, TSchema } from "typebox";
+```
+
+These TypeBox types are re-exported for authoring helpers. The runtime `Type` builder is not re-exported; import it from `typebox`.
+
+### `runWorkflow` (removed)
+
+```typescript
+/** @deprecated Always throws a migration error. */
+const runWorkflow: never;
+```
+
+This runtime migration stub exists only so old modules fail at the callsite with a clear error. Use `workflow({...})` for authoring and `run(...)` for programmatic execution.
+
+### Builtin workflow exports
+
+```typescript
+import {
+  deepResearchCodebase,
+  goal,
+  openClaudeDesign,
+  ralph,
+} from "@bastani/workflows/builtin";
+```
+
+Each builtin is a workflow definition. You can also import it from its individual module path: `@bastani/workflows/builtin/deep-research-codebase`, `/goal`, `/open-claude-design`, or `/ralph`. See [Compose with builtin workflows](#compose-with-builtin-workflows) for the import table and a parent workflow example.
+
+
+## Fast Inference for Workflow Stages
+
+Workflow stages can use faster, higher-priority inference on supported providers so multi-stage runs finish sooner. Codex fast mode currently provides this option.
+
+### Codex fast mode
+
+Use `/fast` to manage Codex fast mode separately for normal chat and workflow-stage sessions. The settings are `codexFastMode.chat` and `codexFastMode.workflow`; workflow stages use the workflow scope, not the chat scope.
+
+Fast mode is eligible only for supported `openai/*` and `openai-codex/*` providers. It does not apply to `github-copilot/*`, Azure OpenAI, OpenRouter, or custom OpenAI-compatible providers. When Atomic applies fast mode, workflow stage displays keep the raw model id and expose `fast` as a separate marker/stage metadata indicator.
+
+Enable workflow fast mode deliberately for broad workflows: parallel fan-out and fallback attempts can multiply priority-tier requests and cost.
+
+## Context Engineering
+
+A workflow is an information-flow system, not just a list of prompts. Most workflow failures come from missing, stale, oversized, or poorly-routed context. Design every stage boundary deliberately.
+
+### Locally Scoped Stage Prompts
+
+Stage prompts should define local contracts, not describe the full workflow runtime. Write prompts as if the stage could be executed independently from a fresh session with only the listed inputs. Include:
+
+- the stage's current objective and what is out of scope for this stage
+- the exact files, artifacts, child outputs, or user inputs it may use
+- the expected output format, or the schema it must return when the workflow item is schema-enabled
+- the checks, tools, or deterministic commands it should run when relevant
+- the success criteria that let this stage stop
+
+Avoid unrelated workflow internals such as reducer algorithms, future PR stages, sibling reviewer names, loop implementation details, or project-specific nicknames unless they are explicitly part of the current stage contract. If a term such as a gate name, ledger field, or workflow nickname is necessary, define it in the prompt before using it.
+
+Choose context mode deliberately. Use `context: "fork"` or `forkFromSessionFile` for coherent long-running implementation stages that need continuity from their own earlier work. Use `context: "fresh"` for unbiased reviewer, evaluator, and gate stages so they inspect the current files and explicit artifacts rather than inheriting the implementer's assumptions. When continuity is needed across fresh stages, pass it explicitly through files, declared outputs, and `reads`.
+
+### Context-Mode-Aware Prompt Text
+
+Context mode is an execution property configured with `context`/`forkFromSessionFile`; the model cannot act on context mode, so keep it out of prompt text:
+
+- **Never describe the stage's own context mode.** Sentences like "you are running in a fresh context window", "your context is clean/non-forked", or "this is a forked session" add tokens without changing behavior. State the concrete action, inputs, and success criteria instead.
+- **Fresh stages must not reference invisible context.** A fresh stage has no "previous conversation", cannot see sibling stages, and does not know the surrounding graph, so instructions like "compare against previous workflow reasoning" or "this runs in parallel with the locator pass" do not help and may confuse the model. Phrase the same intent stage-locally ("compare the working tree against the baseline branch"; "do your own scan; do not assume any other stage's output is available") and pass any state the stage needs through files, declared outputs, and `reads`.
+- **Forked continuation prompts send only the delta.** A forked stage already carries the role, contracts, guidance, and output format from its own earlier prompts, so repeating them uses more tokens and can make the two copies diverge. Send what changed since the fork point — new artifacts, updated state, the next action — plus a one-line pointer back ("the contracts and report format established earlier in this thread still apply unchanged") instead of re-injecting the full text.
+- **Keep one canonical copy of shared contracts.** When fresh and forked variants of a stage share guidance, render the full contract only in the prompt that first establishes it and reference it from continuations. If a continuation needs a contract restated (for example, after a schema change), that is a new contract version, not a repeat.
+
+The builtin `goal` and `ralph` workflows follow this pattern: their first worker/orchestrator prompts include the full contracts, while forked continuation turns send only the per-turn state (new receipts, the latest review artifacts, the rewritten research file) with a pointer back to the established guidance.
+
+### Context Fundamentals
+
+Treat context as a finite attention budget. Include only information needed for the current decision, place critical constraints near the beginning or end of prompts, and use progressive disclosure instead of loading every possible reference up front.
+
+Common context sources:
+
+- **System instructions:** persistent behavior and guardrails.
+- **User inputs:** workflow inputs and human-in-the-loop decisions.
+- **Retrieved documents:** files, search results, logs, API responses, and artifacts.
+- **Message history:** useful for continuity, but grows quickly in long-running stages.
+- **Tool outputs:** often the largest source of context bloat.
+
+For long workflows, assume effective model performance degrades before the advertised context limit. Keep high-signal summaries and artifact references close to the stage that needs them.
+
+### Context Degradation Patterns
+
+Watch for these failure modes in long or multi-stage workflows:
+
+| Pattern | Symptom | Mitigation |
+|---------|---------|------------|
+| Lost in the middle | Important constraints are ignored in long prompts | Repeat critical constraints near the end; shorten handoffs |
+| Context poisoning | Bad or obsolete information steers later stages | Validate sources, overwrite stale artifacts, cite evidence |
+| Distraction | Irrelevant context crowds out useful context | Pass only stage-specific files and summaries |
+| Confusion | Similar instructions or duplicate facts conflict | Consolidate instructions and name artifacts clearly |
+| Clash | User, system, or stage instructions disagree | Resolve conflicts before launching downstream stages |
+
+Use compaction, file references, and bounded loops before context fills with transcript noise. In attached workflow stage chat, manual compaction shows `Compacting context...`, threshold compaction shows `Auto-compacting...`, and overflow recovery shows `Context overflow detected. Auto-compacting...` in the same animated status row used for normal model work. A successful compaction leaves the normal expandable `✻ Context compacted` boundary in the transcript; the boundary is reconstructed from the durable session and has a typed live fallback if the refreshed session snapshot is temporarily unavailable.
+
+### Compression and Artifact Handoffs
+
+Optimize for tokens per completed task, not the smallest prompt. Aggressive compression can force later stages to rediscover information.
+
+A compressed handoff includes:
+
+- objective and current status
+- decisions already made
+- files, symbols, commands, and artifact paths with evidence
+- open questions and known risks
+- rejected alternatives when they matter
+- next action expected from the downstream stage
+
+Use `output`, `outputMode: "file-only"`, `reads`, and `chainDir` for large research bundles, logs, or reviewer outputs. Keep summaries compact and let downstream stages read full artifacts only when needed. In the downstream stage prompt, say `Read the file at ${artifactPath} before continuing.` Do not inject full session tails, all previous stage outputs, or every prior review round into later prompts by default; pass the latest relevant artifact paths and make older history discoverable from a ledger or index file.
+
+Substantial handoffs should travel through files or durable artifacts instead of hidden transcript assumptions. This keeps stage prompts small, makes review/audit possible, and lets later stages reread the authoritative material without depending on what a previous model summarized.
+
+```ts
+const researchPath = ".atomic/workflows/runs/context-demo/research.md";
+await ctx.task("researcher", {
+  task: "Map the subsystem and save the report.",
+  output: researchPath,
+  outputMode: "file-only",
+});
+
+const review = await ctx.task("reviewer", {
+  task: [
+    `Research artifact: ${researchPath}`,
+    `Read the file at ${researchPath} incrementally and inspect only the sections needed for this review.`,
+  ].join("\n"),
+  reads: [researchPath],
+});
+```
+
+### Multi-Agent and Parallel Patterns
+
+Use parallel stages to isolate context and separate independent work, not merely to assign role labels. Good parallel branches have distinct evidence-gathering or review angles:
+
+- locator / mapper: where relevant files and systems live
+- analyzer: how the current implementation works
+- pattern finder: how similar code is written elsewhere
+- external researcher: what upstream docs or APIs require
+- reviewer/evaluator: whether outputs satisfy the validation contract
+
+Have the parent workflow synthesize results rather than letting branches silently make conflicting decisions. If branches must agree, design an explicit consensus or adjudication stage.
+
+### Filesystem Context
+
+Use files when workflow context grows too large:
+
+```text
+.atomic/workflows/runs/<run-name>/
+  research.md
+  reviews/
+    correctness.md
+    docs.md
+  artifacts/
+    raw-log.txt
+    summary.json
+```
+
+Recommended patterns:
+
+- write large tool outputs to files and return concise references
+- store plans, state, and reviewer findings in structured markdown or JSON
+- pass artifact paths via `reads`; prompt agents with `Read the file at <path>...` rather than pasting artifacts into `{previous}`
+- for review loops, pass the latest review-round artifact first and let a ledger/index point to older rounds only when needed
+- give parallel branches separate output paths to avoid write conflicts
+- use `grep`, globbing, and line-range reads instead of loading entire logs
+- clean scratch files or keep them under run-specific directories
+
+### Evaluation and Quality Gates
+
+Build validation into the workflow instead of waiting for a final manual check. Useful gates include:
+
+- deterministic checks: tests, typechecks, linters, schema validation, command exit codes
+- rubric checks: completeness, correctness, evidence quality, risk coverage, user fit
+- reviewer stages: fresh-context reviewers that inspect artifacts and current files
+- LLM-as-judge stages: direct scoring, pairwise comparison, or rubric-based grading for subjective outputs
+
+Prefer schema-enabled workflow items for model review and gate decisions. Atomic passes the schema directly to the final-answer tool and captures the tool arguments; it no longer adds separate structured-output parsing, object-root restrictions, or sidecar validation. Object-shaped decision schemas with explicit booleans/enums, findings arrays, confidence, evidence fields, and error reporting are usually easiest to consume, but array or primitive schemas are valid when they fit the handoff. Avoid brittle regular-expression matching against free-form prose such as “looks good”, “approved”, or “PASS”.
+
+Use small dedicated model stages for adaptive gates when deterministic code alone cannot decide what to check. For example, a stage can read an artifact, inspect the repo, run a named tool or command, and then emit a structured decision by configuring `schema` on that workflow item. Keep that stage's prompt narrow: tell it the specific check to perform, the files/tools it may use, and the structured decision it must return.
+
+When using LLM judges, reduce bias by defining score anchors, asking for evidence, calibrating against examples, and keeping length/order effects in mind. Track pass rates and failures over time for reusable workflows.
+
+### Tools, MCP, Memory, and Hosted Execution
+
+Constrain each stage to the tools it needs. Too many tools increase ambiguity and token cost; too few tools force brittle workarounds. Tool descriptions should make inputs, side effects, and error handling clear.
+
+Use per-stage `mcp` allow/deny lists when a workflow needs external systems but some stages should remain read-only or isolated. Use memory or durable project knowledge only when cross-run continuity is required; otherwise prefer explicit inputs and artifacts.
+
+Hosted or remote agent workflows need additional design work: sandbox setup, dependency caching, auth boundaries, artifact transfer, concurrency limits, and multiplayer/session handoff behavior. Optimize startup before the user begins the run; do not make each stage rebuild its environment.
+
+### Task Fit and Project Design
+
+Before turning a process into a workflow, confirm that it suits automation:
+
+| Proceed when | Avoid or redesign when |
+|--------------|------------------------|
+| The task needs synthesis across sources | The task requires exact deterministic computation only |
+| The output is natural language or judgment with a rubric | The workflow must be perfectly deterministic every run |
+| Errors can be caught by review or validation gates | A single hallucination would be unacceptable |
+| Stages can be cached, retried, or inspected | Every step depends on unverified previous guesses |
+| A manual prototype works on representative inputs | The model lacks required context and cannot retrieve it |
+
+For complex workflows, structure the implementation as a pipeline: acquire context, prepare prompts/artifacts, process with LLM stages, parse or validate outputs, and render the final result.
+
 ## Migrating from the `defineWorkflow()` Builder API
 
-The chained builder API — `defineWorkflow(name).description(...).input(...).output(...).worktreeFromInputs(...).run(...).compile()` — was removed in [#1457](https://github.com/bastani-inc/atomic/pull/1457). The single `workflow({ name?, description, inputs, outputs, run })` object form is now the only authoring door. There is no shim and no deprecation period: workflow files that still call `defineWorkflow(...).compile()` fail discovery with a module-load error until they are migrated.
+[#1457](https://github.com/bastani-inc/atomic/pull/1457) removed the chained builder API — `defineWorkflow(name).description(...).input(...).output(...).worktreeFromInputs(...).run(...).compile()` — and made the single `workflow({ name?, description, inputs, outputs, run })` object form the only authoring API. There is no shim and no deprecation period: workflow files that still call `defineWorkflow(...).compile()` fail discovery with a module-load error until authors migrate them.
 
-This section is for workflow files written against the previous API. If you are authoring a new workflow, skip it and start from [Writing a Workflow](#writing-a-workflow).
+Use this section for workflow files that use the previous API. If you are authoring a new workflow, skip it and start from [Writing a Workflow](#writing-a-workflow).
 
 ### What changed
 
@@ -1811,7 +3508,7 @@ This section is for workflow files written against the previous API. If you are 
 | `.run(fn)` callback | `run: fn` |
 | `.compile()` terminal | delete — `workflow({ ... })` returns the definition |
 
-`ctx` and every primitive (`ctx.task`, `ctx.chain`, `ctx.parallel`, `ctx.stage`, `ctx.workflow`, `ctx.exit`, `ctx.ui`) are unchanged, so workflow **bodies do not need rewriting** — only the authoring wrapper changes.
+`ctx` and every primitive (`ctx.task`, `ctx.chain`, `ctx.parallel`, `ctx.stage`, `ctx.workflow`, `ctx.exit`, `ctx.ui`) are unchanged, so **you do not need to rewrite workflow bodies** — only the authoring wrapper changes.
 
 ### Full before / after
 
@@ -1883,402 +3580,21 @@ For each `.atomic/workflows/*.ts` (or workflow-package) file:
 4. Collect every `.input(key, schema)` into one `inputs: { key: schema, ... },` map.
 5. Collect every `.output(key, schema)` into one `outputs: { key: schema, ... },` map. If there were no `.output(...)` calls, add `outputs: {},` — it is now required.
 6. Move `.worktreeFromInputs(binding)` to a `worktreeFromInputs: binding,` property (same binding shape, unchanged).
-7. Move the `.run(fn)` callback to a `run: fn,` property; the body stays byte-for-byte the same.
+7. Move the `.run(fn)` callback to a `run: fn,` property; keep the body byte-for-byte identical.
 8. Delete the trailing `.compile()`, close the object with `})`, and keep `export default`.
 9. Run `/workflow reload` (or restart Atomic) and `/workflow list` to confirm the file loads. Because `ctx` and its primitives are unchanged, stage behavior, graph layout, resume/quit, and human-input prompts are unaffected.
 
 ### Gotchas
 
-- **`outputs` is required.** The old `.output(...)` calls were optional, and a workflow with none compiled fine. The new object form throws `workflow: outputs must be a schema map` when `outputs` is missing, so declare `outputs: {}` for outputless workflows.
+- **`outputs` is required.** The old `.output(...)` calls were optional, and a workflow without outputs compiled successfully. The new object form throws `workflow: outputs must be a schema map` when `outputs` is missing, so declare `outputs: {}` for outputless workflows.
 - **`Type` is no longer re-exported.** `import { Type } from "@bastani/workflows"` fails type-checking; import it from `typebox` instead. (`Static` and `TSchema` *types* are still re-exported from `@bastani/workflows`, so those imports do not need to change.)
 - **`.compile()` does not exist.** Leaving it produces a runtime `TypeError`; `workflow({ ... })` already returns the frozen, branded definition.
-- **`name` is derived from the filename when omitted.** `review-changes.ts` becomes the `review-changes` workflow, so an explicit `name` is only needed when it should differ from the basename.
-- **No hand-rolled definitions.** Objects carrying `__piWorkflow: true` that you construct by hand are rejected by discovery and by `ctx.workflow(...)`. Only definitions minted by `workflow({ ... })` are accepted.
+- **`name` is derived from the filename when omitted.** Discovery derives the name from the filename: `review-changes.ts` becomes `review-changes`, so an explicit `name` is only needed when it should differ from the basename.
+- **Do not construct definitions manually.** Discovery rejects hand-built objects carrying `__piWorkflow: true`, and `ctx.workflow(...)` rejects them too. Both accept only definitions minted by `workflow({ ... })`.
 - **The imperative `runWorkflow` runner is gone.** It is now a `never` placeholder that throws on access; use the exported `run(def, inputs)` helper or a registry for programmatic execution.
 - **Keep `outputs` inline for the strictest type checking.** The old builder enforced no-extra-output keys through a `NoExtraOutputs` generic on `.run(fn)`; the object form re-creates that check for inline `outputs` maps, but cannot recover output keys when a schema map is widened or built up before being passed to `workflow({ ... })`. Keep the `outputs` literal inline so the declared-key check stays exact.
 
 Everything else — stage primitives, `ctx.inputs` typing, runtime validation, DAG inference, MCP scoping, resume/quit, worktree binding, model fallback, and the `/workflow` tool contract — is unchanged.
-
-## Workflow Primitives
-
-Prefer high-level primitives because they create tracked graph nodes, provide consistent handoff semantics, and keep workflow definitions easier to read.
-
-| Need | Use |
-|------|-----|
-| One LLM/session task with workflow tracking | `ctx.task(name, options)` |
-| Dependent sequential tasks | `ctx.chain(steps, options?)` |
-| Independent concurrent branches | `ctx.parallel(steps, options?)` |
-| Reusable child workflow | Call `ctx.workflow(workflowDefinition, options?)` |
-| Human input during a workflow run | `ctx.ui.input/confirm/select/editor/custom` |
-| Pure deterministic computation, parsing, or file I/O | Plain TypeScript in `run` or helpers |
-| Fine-grained session control | `ctx.stage(name, options?)` |
-
-Use `previous` and `{previous}` for compact handoffs only. If no placeholder is present, the runtime appends context, so a large `previous` payload can silently bloat the next model prompt. Chain defaults are:
-
-- first missing task uses `{task}` from chain options or the root direct task
-- later missing tasks use `{previous}`
-- missing tasks in chain-parallel groups use `{previous}`
-
-For large handoffs, write artifacts to files, pass their paths with `reads`, and tell downstream stages to read those files incrementally. Put the instruction in the downstream prompt explicitly, e.g. `Read the file at ${artifactPath} and use only the sections needed for this stage.` Prefer `outputMode: "file-only"` when the parent only needs the artifact path.
-
-`ctx.parallel` snapshots the current graph frontier when the fan-out starts. Every branch in that call uses the same parent set, including branches dequeued later because of a limited `concurrency` value and branches that continue after an earlier sibling fails with `failFast: false`. Downstream stages then depend on all settled parallel branches instead of accidentally chaining queued siblings behind one another.
-
-### Fine-Grained Stages
-
-Use `ctx.stage(name, options?)` when `ctx.task` is too coarse and you need direct control over the underlying stage session. `StageContext` supports:
-
-- prompting and completion: `prompt(text, options?)`, `complete(text, options?)`
-- live input: `sendUserMessage(content, options?)`, `steer(text)`, `followUp(text)`, `subscribe(listener)`
-- session metadata: `sessionId`, `sessionFile`
-- model controls: `setModel`, `setThinkingLevel`, `cycleModel`, `cycleThinkingLevel`
-- state access: `agent`, `model`, `thinkingLevel`, `messages`, `isStreaming`
-- tree/context controls: `navigateTree(...)`, `compact(...)`, `abortCompaction()`
-- current operation abort: `abort()`
-
-## Task and Stage Options
-
-Common task/stage options include:
-
-- `prompt` or `task`
-- `previous` for small handoff context; use artifact paths plus `reads` for large outputs, logs, research bundles, or reviewer payloads
-- `context: "fresh" | "fork"`, `forkFromSessionFile`
-- `model`, `fallbackModels`, `thinkingLevel`, `scopedModels`, `modelRegistry` — `model` and each `fallbackModels` entry accept a `model_name:thinking_effort` reasoning suffix and an optional parenthesized context-window token such as `model (1m)` (see [Reasoning levels](#reasoning-levels) and [Context windows](#context-windows)); the standalone `thinkingLevel` is deprecated
-- `contextWindow`, `contextWindowStrict` — stage-wide context-window budget mapped to the SDK `createAgentSession` options of the same name (non-strict by default)
-- `tools`, `noTools`, `customTools`, `mcp: { allow?: string[], deny?: string[] }`
-- `schema` for a structured final answer from this workflow item
-- `output`, `outputMode`, `reads`, `worktree`, `gitWorktreeDir`, `baseBranch`, `maxOutput`, `artifacts`, `sessionDir`, `cwd`, `agentDir`
-- advanced host-supplied SDK seams: `authStorage`, `resourceLoader`, `sessionManager`, `settingsManager`, `sessionStartEvent`
-
-Workflow stages inherit the active host session directory only when the host is using a non-default session location. For example, headless runs launched with `atomic --mode json --session-dir <dir> -p '/workflow <name> ...'` write the main chat transcript and every stage transcript under `<dir>`; the same applies when the non-default directory comes from `ATOMIC_CODING_AGENT_SESSION_DIR` or settings. If no non-default host session directory is configured, stage sessions keep using Atomic's normal global session store. A per-stage `sessionDir` option always overrides the inherited host directory, including for forked stages (`context: "fork"`, `forkFromSessionFile`).
-
-`schema` is opt-in. When a `ctx.stage` call, `ctx.task` call, `ctx.chain` item, or `ctx.parallel` item includes a TypeBox schema or plain JSON Schema descriptor object, Atomic registers a schema-specific final-answer tool for that item only. The schema may describe object, array, or primitive final values; the captured value is the JSON value passed to the tool. The prompt result is the captured structured value for `ctx.stage(..., { schema }).prompt(...)`; task/chain/parallel results also include `result.structured` and keep `result.text` as formatted JSON for handoffs. Because the result contract is single-use, a schema-backed `StageContext` supports one `prompt()` call; create a new `ctx.stage(..., { schema })` for each additional structured prompt. If a turn finishes without calling `structured_output`, or the tool call fails schema validation, Atomic sends up to three corrective follow-up prompts that quote the concrete contract/validation error and remind the model to call `structured_output` instead of replying with plain JSON. If the item also uses an explicit `tools` allowlist, Atomic automatically adds the final-answer tool to that allowlist. Items without `schema` do not receive it from the normal tool registry.
-
-`subagent` is available as a default workflow-stage tool, with the same five-level nesting budget as main chat: a workflow stage can launch recursively delegated subagents until the shared depth guard reaches five delegated levels, then deeper calls are blocked. `tools` remains an allowlist across built-in tools and bundled extension tools; if you set `tools`, list every tool the stage should see. Explicitly listing tools such as `subagent`, `web_search`, `fetch_content`, or `intercom` exposes those tools to the stage, while `excludedTools` and `noTools: "all"` still win. The bundled subagent definitions from `@bastani/subagents` are available to the `subagent` tool in workflow stages; when a workflow is itself running inside a subagent child process, Atomic isolates stage resource discovery from the parent child-process flags so `subagent` remains available while workflow-stage nested-depth guards remain in force.
-
-Workflow stages use the same upstream-compatible `bash` tool as normal Atomic sessions. If `bash` is enabled for a stage, commands run through the configured shell with the stage process permissions; workflow options no longer include a command-level allow/deny field for shell text. Use `tools`/`noTools` to expose or hide shell access, prefer narrower custom tools for repeatable operations, and run workflows inside a container, VM, or other sandbox when command allowlisting or stronger isolation is required.
-
-`gitWorktreeDir` selects a reusable Git worktree root for `ctx.stage`, `ctx.task`, `ctx.chain`, and `ctx.parallel`. If the path is missing, Atomic creates it with `git worktree add --detach <path> <baseBranch>`; if it exists, it must be a same-repository worktree root located outside the invoking checkout. The invoking checkout itself, nested targets inside it, and missing targets whose symlinked parent resolves inside it are rejected before Git creates or reuses a worktree. The default stage cwd becomes the matching cwd inside the worktree and preserves the invoking repo-relative subdirectory. An explicit absolute `cwd` inside the invoking repository is remapped to the corresponding location inside the selected worktree; an absolute `cwd` already inside that worktree is preserved. Relative values resolve from the worktree cwd and cannot escape it. Any `cwd` that would escape either lexically or through a symlink fails before the stage session starts instead of silently running elsewhere. Runner-managed reusable-worktree relative direct output paths follow the effective worktree cwd and cannot traverse or follow symlinks outside the selected worktree. Temporary-worktree relative direct outputs are persisted under distinct per-task runner-owned temporary artifact directories before cleanup so returned artifacts remain readable, including with `outputMode: "file-only"`; they likewise cannot escape their output root, and Atomic rejects a pre-existing symlink or junction at the trusted artifact root. Explicit absolute outputs and nonblank explicit `chainDir` locations remain caller-selected, while blank `chainDir` values are treated as omitted. `gitWorktreeDir` is mutually exclusive with `worktree: true`: use `gitWorktreeDir` for named/reusable worktrees and `worktree: true` for temporary direct-mode worktrees that are cleaned up even when startup fails before the workflow callback. Temporary isolation defaults to the runner invocation cwd when a task cwd is omitted, and relative task cwd values resolve from that invocation cwd. Atomic caches reusable setup by canonical repository and target identity within a workflow run, independent of equivalent path spelling or `baseBranch`, and revalidates the selected checkout identity before reuse, retries one transient timeout from read-only Git repository probes, and reports the exact Git command, cwd, timeout, elapsed time, exit status/signal, and spawn error details when preflight fails. Worktrees provide checkout and cwd isolation, not an operating-system security sandbox; use a container, VM, or another OS-enforced boundary for untrusted code that can race or mutate arbitrary filesystem paths.
-
-To bind user inputs to a workflow-wide worktree default, set `worktreeFromInputs` in `workflow({...})`:
-
-```ts
-export default workflow({
-  name: "safe-implementation",
-  description: "",
-  inputs: {
-    task: Type.String(),
-    git_worktree_dir: Type.String({ default: "" }),
-    base_branch: Type.String({ default: "origin/main" }),
-  },
-  outputs: {
-    result: Type.String({ description: "Implementation result text." }),
-  },
-  worktreeFromInputs: { gitWorktreeDir: "git_worktree_dir", baseBranch: "base_branch" },
-  run: async (ctx) => {
-    const result = await ctx.task("implement", { task: String(ctx.inputs.task) });
-    return { result: result.text };
-  },
-});
-```
-
-For lower-level integrations, `@bastani/workflows` also exports `setupGitWorktree({ gitWorktreeDir, baseBranch, cwd })`, returning `{ worktreeRoot, cwd, repositoryRoot, created }` with the same validation, symlink-preserving path handling, and cwd-preservation behavior used by workflow stages.
-
-`fallbackModels` retries transient provider/model failures with the primary `model` first, then each fallback, then the current Atomic-selected model when available. It is for rate limits, quota/usage-limit exhaustion (provider messages such as `The usage limit has been reached` and codes such as `usage_limit_reached`/`insufficient_quota` classify as retryable rate-limit failures so the chain advances to a candidate provider/model with remaining headroom), auth/provider outages, unavailable models, network timeouts, generic transport errors such as `Connection error.` / `fetch failed`, and 5xx errors — not workflow-code errors, tool failures, validation failures, or cancellations.
-
-A candidate that is **request/context incompatible** with the current turn — for example an HTTP 400/413/422 bad/unprocessable/payload-too-large request, an unsupported tool or parameter, a context-length/context-window overflow, or a `too large` / `invalid_request` / `bad_request` error — also advances the chain to the next candidate rather than stopping. This ensures that if none of the configured candidates can serve the request, the workflow stage falls back to the currently selected user model instead of hard-failing. Refusals, content-filter/safety blocks, cancellations, and task failures still stop the chain and are never retried on another model.
-
-When a finished stage's session is reattached for a follow-up (for example a post-completion follow-up, or after the CLI is reloaded), the stage resumes on the model the session last settled on — the one that actually worked — instead of replaying the chain from the primary. If that model fails again with a transient/retryable error, the full chain is retried from the primary.
-
-### Reasoning levels
-
-Each `model` and `fallbackModels` entry accepts a `model_name:thinking_effort` suffix that sets the reasoning effort for that candidate (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`). The selected model's capability map still governs whether `xhigh` or `max` is available. The effort travels with the model string, so a single fallback chain can mix efforts — for example a high-effort primary that degrades to lower-effort, cheaper fallbacks:
-
-```ts
-await ctx.task("review", {
-  task: "Review the diff",
-  model: "anthropic/claude-sonnet-4:high",
-  fallbackModels: ["openai/gpt-5:medium", "anthropic/claude-haiku-4-5:off"],
-});
-```
-
-The standalone `thinkingLevel` stage option is deprecated. It still applies as a default to any candidate without a suffix, and when both are present the suffix wins, but new workflows should fold the effort into the model strings:
-
-```diff
--  model: "openai/gpt-5.5",
--  fallbackModels: ["anthropic/claude-opus-4-8"],
--  thinkingLevel: "high",
-+  model: "openai/gpt-5.5:high",
-+  fallbackModels: ["anthropic/claude-opus-4-8:high"],
-```
-
-This applies everywhere a stage accepts a model: direct `ctx.task`/`ctx.chain`/`ctx.parallel` options, `ctx.stage` options, builtin workflow stage definitions, and workflow parameters. `fallbackThinkingLevels` is an optional compatibility helper aligned by index to `fallbackModels`; it applies only to fallback entries that do not already carry a suffix. Each `WorkflowModelAttempt` reports the resolved model and the effective reasoning effort used for that attempt.
-
-### Context windows
-
-A `model`/`fallbackModels` entry may also request a context-window budget with a parenthesized size token in the model-name portion — placed *before or after* the optional `:reasoning` suffix so it never collides with the reasoning level. This mirrors GitHub Copilot's `Claude Opus 4.8 (1M context)` model-name convention:
-
-```ts
-await ctx.task("review", {
-  task: "Review the diff",
-  model: "anthropic/claude-fable-5:high",
-  // The copilot opus fallback runs at its largest advertised (long-context) window.
-  // Use (long) for a size-agnostic marker, or a rounded long-tier label like (1m).
-  fallbackModels: ["github-copilot/claude-opus-4.8 (long):xhigh", "anthropic/claude-opus-4-8:xhigh"],
-});
-```
-
-The token accepts the same compact sizes as the `--context-window` flag (`1m`, `1.1m`, `936k`, `400k`, or a raw token count), plus a generic `(long)` marker, and is resolved against that specific candidate model's advertised windows:
-
-- `(long)` — a size-agnostic long-context marker that selects the model's advertised long tier regardless of its exact size, so the same token works across models with different long tiers;
-- a request at or below the model's default window keeps the default;
-- a request above the default selects the long tier — an exact supported window is used as-is, otherwise the smallest supported window at or above the request is selected, rounding **up** so a rounded marker like `(1m)` or `(1.1m)` lands on the long tier even when it sits slightly above or below the marker size (e.g. `(1m)` selects claude-opus-4.8's 1M tier and gpt-5.5's 1.05M tier; `(1.1m)` matches gpt-5.5's rounded long-tier label);
-- when the model exposes no larger tier (or is unavailable), the request is dropped and the session keeps the model's default (short) window — a non-strict, automatic fallback.
-
-The budget applies only to the candidate that carries the token; other primary and fallback models in the same chain are unaffected. A parenthesized token that is not a valid size (for example `(preview)`) is left attached to the model id rather than being treated as a context window. Without the token, a tiered model **pins its natural default (short) window** in a workflow stage, so a persisted interactive long-context preference does not leak into workflow runs — use the `(1m)` token or the `contextWindow` stage option to opt into long context. For stage-wide selection you can instead set the `contextWindow` (and `contextWindowStrict`) stage option, which maps to the SDK `createAgentSession` options of the same name.
-
-## Programmatic Usage
-
-`@bastani/workflows` is an Atomic package extension. It registers:
-
-- `/workflow <name> key=value ...` for interactive named runs
-- `/workflow connect|attach|pause|interrupt|quit|resume|status|inputs|reload` for live control, inspection, and rediscovery
-- the `workflow` tool for agent-initiated orchestration and direct one-off runs
-Workflow definition files must export definitions produced by `workflow({...})`. Keep non-workflow runtime helpers (widget factories, shared utilities) in a subdirectory the discovery scan ignores, such as `.atomic/workflows/lib/` — see [Workflow Locations](#workflow-locations). The former imperative object-form runner is not part of the public SDK, and authored workflow files cannot import `runWorkflow` from `@bastani/workflows`.
-
-Standalone TypeScript workflow packages type-check the SDK import with no hand-authored `.d.ts`, no `declare module` shim, and no `tsconfig` `paths` alias. The SDK types ship with `@bastani/atomic`, so a workflow package depends only on `@bastani/atomic` (plus a `typebox` peer):
-
-```ts
-import { workflow } from "@bastani/workflows";
-import { Type } from "typebox";
-
-export default workflow({
-  name: "map-workflow-sdk",
-  description: "Map the workflow SDK.",
-  inputs: {
-    prompt: Type.String({ default: "map workflow sdk" }),
-  },
-  outputs: {},
-  run: async (ctx) => {
-    await ctx.task("map", { prompt: ctx.inputs.prompt });
-    return {};
-  },
-});
-```
-
-How those types resolve depends on what else the package imports:
-
-- A package that imports `@bastani/atomic` anywhere (for example, an extension shipped in the same package) picks the workflow SDK types up automatically. `@bastani/atomic`'s root declarations reference the ambient bridge, so no extra configuration is needed.
-- A pure workflow-only package — one that imports nothing but `@bastani/workflows` — adds a single opt-in so TypeScript loads the ambient bridge. Set it once for the project in `tsconfig.json`:
-
-  ```jsonc
-  {
-    "compilerOptions": {
-      "module": "NodeNext",
-      "moduleResolution": "NodeNext",
-      "types": ["@bastani/atomic/workflows/ambient"]
-    }
-  }
-  ```
-
-  or add a single reference directive at the top of one workflow file:
-
-  ```ts
-  /// <reference types="@bastani/atomic/workflows/ambient" />
-  ```
-
-Either form makes `import { workflow } from "@bastani/workflows"
-import { Type } from "typebox"` and the `@bastani/workflows/builtin/*` composition imports resolve under `tsc` (`moduleResolution: NodeNext`) with no hand-authored `.d.ts`, no `declare module` shim, and no `paths` alias. `@bastani/workflows` is not a separate npm package — its types ship with `@bastani/atomic` — so list both `@bastani/atomic` and `typebox` (workflow files import `Type` from `typebox`) in `peerDependencies`. Runtime discovery and loading via `atomic.workflows` are unchanged: Atomic's loader still supplies the SDK when workflow files execute.
-
-The `workflow` tool still supports direct one-off `task`, `tasks`, and `chain` modes. Direct chains support `chainName` for status/artifact grouping and `chainDir` as a shared directory for relative reads, outputs, and worktree diffs.
-
-Use `createRegistry()` when code needs to group definitions explicitly:
-
-```ts
-import { createRegistry, workflow } from "@bastani/workflows";
-import { Type } from "typebox";
-
-const alpha = workflow({
-  name: "alpha",
-  description: "",
-  inputs: {},
-  outputs: {
-    text: Type.String({ description: "Alpha task output text." }),
-  },
-  run: async (ctx) => {
-    const result = await ctx.task("alpha", { prompt: "Run alpha." });
-    return { text: result.text };
-  },
-});
-
-const registry = createRegistry().register(alpha);
-registry.names();
-registry.get("alpha");
-```
-
-## Context Engineering
-
-A workflow is an information-flow system, not just a list of prompts. Most workflow failures come from missing, stale, oversized, or poorly-routed context. Design every stage boundary deliberately.
-
-### Locally Scoped Stage Prompts
-
-Stage prompts should be local contracts, not miniature descriptions of the entire workflow runtime. Write prompts as if the stage could be executed independently from a fresh session with only the listed inputs. Include:
-
-- the stage's current objective and what is out of scope for this stage
-- the exact files, artifacts, child outputs, or user inputs it may use
-- the expected output format, or the schema it must return when the workflow item is schema-enabled
-- the checks, tools, or deterministic commands it should run when relevant
-- the success criteria that let this stage stop
-
-Avoid unrelated workflow internals such as reducer algorithms, future PR stages, sibling reviewer names, loop implementation details, or project-specific nicknames unless they are explicitly part of the current stage contract. If a term such as a gate name, ledger field, or workflow nickname is necessary, define it in the prompt before using it.
-
-Choose context mode deliberately. Use `context: "fork"` or `forkFromSessionFile` for coherent long-running implementation stages that need continuity from their own earlier work. Use `context: "fresh"` for unbiased reviewer, evaluator, and gate stages so they inspect the current files and explicit artifacts rather than inheriting the implementer's assumptions. When continuity is needed across fresh stages, pass it explicitly through files, declared outputs, and `reads`.
-
-### Context-Mode-Aware Prompt Text
-
-Context mode is an execution property configured with `context`/`forkFromSessionFile`; it is not something the model can act on, so keep it out of prompt text:
-
-- **Never describe the stage's own context mode.** Sentences like "you are running in a fresh context window", "your context is clean/non-forked", or "this is a forked session" add tokens without changing behavior. State the concrete action, inputs, and success criteria instead.
-- **Fresh stages must not reference invisible context.** A fresh stage has no "previous conversation", cannot see sibling stages, and does not know the surrounding graph, so instructions like "compare against previous workflow reasoning" or "this runs in parallel with the locator pass" are noise at best and confusing at worst. Phrase the same intent stage-locally ("compare the working tree against the baseline branch"; "do your own scan; do not assume any other stage's output is available") and pass any state the stage genuinely needs through files, declared outputs, and `reads`.
-- **Forked continuation prompts send only the delta.** A forked stage already carries the role, contracts, guidance, and output format from its own earlier prompts, so repeating them re-spends the tokens and invites drift between the two copies. Send what changed since the fork point — new artifacts, updated state, the next action — plus a one-line pointer back ("the contracts and report format established earlier in this thread still apply unchanged") instead of re-injecting the full text.
-- **Keep one canonical copy of shared contracts.** When fresh and forked variants of a stage share guidance, render the full contract only in the prompt that first establishes it and reference it from continuations. If a continuation genuinely needs a contract restated (for example, after a schema change), that is a new contract version, not a repeat.
-
-The builtin `goal` and `ralph` workflows follow this pattern: their first worker/orchestrator prompts carry the full contracts, while forked continuation turns send only the per-turn state (new receipts, the latest review artifacts, the rewritten research file) with a pointer back to the established guidance.
-
-### Context Fundamentals
-
-Treat context as a finite attention budget. Include only information needed for the current decision, place critical constraints near the beginning or end of prompts, and use progressive disclosure instead of loading every possible reference up front.
-
-Common context sources:
-
-- **System instructions:** persistent behavior and guardrails.
-- **User inputs:** workflow inputs and human-in-the-loop decisions.
-- **Retrieved documents:** files, search results, logs, API responses, and artifacts.
-- **Message history:** useful for continuity, but grows quickly in long-running stages.
-- **Tool outputs:** often the largest source of context bloat.
-
-For long workflows, assume effective model performance degrades before the advertised context limit. Keep high-signal summaries and artifact references close to the stage that needs them.
-
-### Context Degradation Patterns
-
-Watch for these failure modes in long or multi-stage workflows:
-
-| Pattern | Symptom | Mitigation |
-|---------|---------|------------|
-| Lost in the middle | Important constraints are ignored in long prompts | Repeat critical constraints near the end; shorten handoffs |
-| Context poisoning | Bad or obsolete information steers later stages | Validate sources, overwrite stale artifacts, cite evidence |
-| Distraction | Irrelevant context crowds out useful context | Pass only stage-specific files and summaries |
-| Confusion | Similar instructions or duplicate facts conflict | Consolidate instructions and name artifacts clearly |
-| Clash | User, system, or stage instructions disagree | Resolve conflicts before launching downstream stages |
-
-Use compaction, file references, and bounded loops before context fills with transcript noise. In attached workflow stage chat, manual compaction shows `Compacting context...`, threshold compaction shows `Auto-compacting...`, and overflow recovery shows `Context overflow detected. Auto-compacting...` in the same animated status row used for normal model work. A successful compaction leaves the normal expandable `✻ Context compacted` boundary in the transcript; the boundary is reconstructed from the durable session and has a typed live fallback if the refreshed session snapshot is temporarily unavailable.
-
-### Compression and Artifact Handoffs
-
-Optimize for tokens per completed task, not simply the smallest prompt. Aggressive compression can force later stages to rediscover information.
-
-A good compressed handoff includes:
-
-- objective and current status
-- decisions already made
-- files, symbols, commands, and artifact paths with evidence
-- open questions and known risks
-- rejected alternatives when they matter
-- next action expected from the downstream stage
-
-Use `output`, `outputMode: "file-only"`, `reads`, and `chainDir` for large research bundles, logs, or reviewer outputs. Keep summaries compact and let downstream stages read full artifacts only when needed. In the downstream stage prompt, explicitly say something like `Read the file at ${artifactPath} before continuing.` Do not inject full session tails, all previous stage outputs, or every prior review round into later prompts by default; pass the latest relevant artifact paths and make older history discoverable from a ledger or index file.
-
-Substantial handoffs should travel through files or durable artifacts instead of hidden transcript assumptions. This keeps stage prompts small, makes review/audit possible, and lets later stages reread the authoritative material without depending on what a previous model happened to summarize.
-
-```ts
-const researchPath = ".atomic/workflows/runs/context-demo/research.md";
-await ctx.task("researcher", {
-  task: "Map the subsystem and save the report.",
-  output: researchPath,
-  outputMode: "file-only",
-});
-
-const review = await ctx.task("reviewer", {
-  task: [
-    `Research artifact: ${researchPath}`,
-    `Read the file at ${researchPath} incrementally and inspect only the sections needed for this review.`,
-  ].join("\n"),
-  reads: [researchPath],
-});
-```
-
-### Multi-Agent and Parallel Patterns
-
-Use parallel stages for context isolation and independent work, not just for role labels. Good parallel branches have distinct evidence-gathering or review angles:
-
-- locator / mapper: where relevant files and systems live
-- analyzer: how the current implementation works
-- pattern finder: how similar code is written elsewhere
-- external researcher: what upstream docs or APIs require
-- reviewer/evaluator: whether outputs satisfy the validation contract
-
-Have the parent workflow synthesize results rather than letting branches silently make conflicting decisions. If branches must agree, design an explicit consensus or adjudication stage.
-
-### Filesystem Context
-
-Use files as the overflow layer for workflow context:
-
-```text
-.atomic/workflows/runs/<run-name>/
-  research.md
-  reviews/
-    correctness.md
-    docs.md
-  artifacts/
-    raw-log.txt
-    summary.json
-```
-
-Recommended patterns:
-
-- write large tool outputs to files and return concise references
-- store plans, state, and reviewer findings in structured markdown or JSON
-- pass artifact paths via `reads`; prompt agents with `Read the file at <path>...` rather than pasting artifacts into `{previous}`
-- for review loops, pass the latest review-round artifact first and let a ledger/index point to older rounds only when needed
-- give parallel branches separate output paths to avoid write conflicts
-- use `grep`, globbing, and line-range reads instead of loading entire logs
-- clean scratch files or keep them under run-specific directories
-
-### Evaluation and Quality Gates
-
-Build validation into the workflow instead of waiting for a final manual check. Useful gates include:
-
-- deterministic checks: tests, typechecks, linters, schema validation, command exit codes
-- rubric checks: completeness, correctness, evidence quality, risk coverage, user fit
-- reviewer stages: fresh-context reviewers that inspect artifacts and current files
-- LLM-as-judge stages: direct scoring, pairwise comparison, or rubric-based grading for subjective outputs
-
-Prefer schema-enabled workflow items for model review and gate decisions. Atomic passes the schema directly to the final-answer tool and captures the tool arguments; it no longer adds separate structured-output parsing, object-root restrictions, or sidecar validation. Object-shaped decision schemas with explicit booleans/enums, findings arrays, confidence, evidence fields, and error reporting are usually easiest to consume, but array or primitive schemas are valid when they fit the handoff. Avoid brittle regular-expression matching against free-form prose such as “looks good”, “approved”, or “PASS”.
-
-Use small dedicated model stages for adaptive gates when deterministic code alone cannot decide what to check. For example, a stage can read an artifact, inspect the repo, run a named tool or command, and then emit a structured decision by configuring `schema` on that workflow item. Keep that stage's prompt narrow: tell it the specific check to perform, the files/tools it may use, and the structured decision it must return.
-
-When using LLM judges, mitigate bias by defining score anchors, asking for evidence, calibrating against examples, and keeping length/order effects in mind. Track pass rates and failures over time for reusable workflows.
-
-### Tools, MCP, Memory, and Hosted Execution
-
-Constrain each stage to the tools it needs. Too many tools increase ambiguity and token cost; too few tools force brittle workarounds. Tool descriptions should make inputs, side effects, and error handling clear.
-
-Use per-stage `mcp` allow/deny lists when a workflow needs external systems but some stages should remain read-only or isolated. Use memory or durable project knowledge only when cross-run continuity is genuinely required; otherwise prefer explicit inputs and artifacts.
-
-Hosted or remote agent workflows need additional design work: sandbox setup, dependency caching, auth boundaries, artifact transfer, concurrency limits, and multiplayer/session handoff behavior. Optimize startup before the user begins the run; do not make each stage rebuild its environment.
-
-### Task Fit and Project Design
-
-Before turning a process into a workflow, validate that it is a good automation target:
-
-| Proceed when | Avoid or redesign when |
-|--------------|------------------------|
-| The task needs synthesis across sources | The task requires exact deterministic computation only |
-| The output is natural language or judgment with a rubric | The workflow must be perfectly deterministic every run |
-| Errors can be caught by review or validation gates | A single hallucination would be unacceptable |
-| Stages can be cached, retried, or inspected | Every step depends on unverified previous guesses |
-| A manual prototype works on representative inputs | The model lacks required context and cannot retrieve it |
-
-For complex workflows, structure the implementation as a pipeline: acquire context, prepare prompts/artifacts, process with LLM stages, parse or validate outputs, and render the final result.
 
 ## Design Checklist
 
@@ -2302,29 +3618,31 @@ Good workflows are information-flow systems, not just prompt sequences. Keep sta
 
 ## Common Mistakes
 
-- Do not fabricate workflow names; list first.
+- Do not invent workflow names; list first.
 - Do not guess input keys; inspect with `inputs` or `get` first.
 - Do not call `create`, `update`, or `delete` on the workflow tool; definitions are code-authored.
 - Do not use legacy workflow tool fields like `agent`, `stage`, or run-control `name`.
 - Do not pass strings such as `"goal"` or path objects to `ctx.workflow(...)`; import the workflow definition from `@bastani/workflows/builtin` or another TypeScript module first.
-- Do not rely on undeclared child outputs; returning a key that is not declared in `outputs` fails the run. Declare every child-workflow field you expose in `outputs` — including `result` — and return values matching those schemas from `run`.
+- Do not rely on undeclared child outputs; returning a key that is not declared in `outputs` fails the run. Declare every child-workflow field you expose in `outputs` — including `result` — and return values matching those schemas from `run` (see [Outputs](#outputs)).
 - Do not expect to select or rename child outputs at the call site; parent workflows receive the child's declared output contract as `child.outputs` after checking `child.exited === false`, and a partial declared-output map when `child.exited === true`.
 - Do not expect named workflow runs to block the chat turn; they are background tasks.
 - Use `interrupt` or `pause` when the user asks to pause specific live work resumably; use `quit` for a graceful run-level process boundary.
 - Keep stage names readable because they appear in workflow status and UI.
-- Do not ask a stage to reason from workflow or stage names that are only orchestration labels. Model stages see their local prompt/artifacts/tools; describe the action to perform and the evidence to use (`review the current code delta`, `create/update the review request`) instead of relying on labels such as `the create-PR workflow stage`, `this Goal run`, or `the Ralph reviewer`.
-- Do not write stage prompts that depend on hidden workflow-wide awareness; make each model stage locally scoped and self-described.
+- Do not ask a stage to reason from workflow or stage names that are only orchestration labels. Model stages see their local prompt/artifacts/tools; describe the action to perform and the evidence to use (`review the current code delta`, `create/update the review request`) instead of relying on labels such as `this Goal run` or `the Ralph reviewer` — see the prompt-vocabulary item in the [Design Checklist](#design-checklist).
+- Do not write stage prompts that depend on hidden workflow-wide awareness; make each model stage locally scoped and self-described ([Locally Scoped Stage Prompts](#locally-scoped-stage-prompts)).
 - Do not parse model gate decisions from ad-hoc prose with regular expressions; configure `schema` on a focused workflow item and consume `result.structured`.
 - Do not make reviewers fail an implementation gate solely because an authorized final action has not run yet. Represent that remainder as a post-approval next action (for example `finalActionRemaining` / `nextAction`) and let the final stage perform it.
 - Return compact structured decisions and save large artifacts to files; artifact handoffs should still use files when the next stage does not need the whole payload in context.
 
+These mistakes cover workflow tool usage and authoring. For run-prompt anti-patterns, see the [Anti-patterns](#anti-patterns) table in [Workflow Best Practices](#workflow-best-practices).
+
 ## Workflow Best Practices
 
-This is the playbook I use to get consistently better results from coding agents and workflow systems.
+This playbook helps coding agents and workflow systems produce better results.
 
-The core idea is simple: do not treat an agent like a magic box. Treat it like a capable engineering partner that needs a clear objective, tight scope, explicit validation, and occasional steering.
+Treat an agent as a capable engineering partner that needs a clear objective, tight scope, explicit validation, and occasional steering.
 
-Most weak agent runs fail for predictable reasons: the goal is vague, the scope is too broad, validation is missing, or the agent keeps following the wrong signal. This playbook is about avoiding those failure modes.
+Most weak agent runs fail for predictable reasons: the goal is vague, the scope is too broad, validation is missing, or the agent keeps following the wrong signal. This playbook addresses these failure modes.
 
 The examples below are synthetic and intentionally generic. Replace placeholders like `[component]`, `[test command]`, and `[workflow]` with your own project details.
 
@@ -2332,30 +3650,30 @@ The examples below are synthetic and intentionally generic. Replace placeholders
 
 ### The core loop
 
-The workflow pattern I rely on most often is:
+The core workflow pattern is:
 
 ```text
 Objective -> Scope -> Done criteria -> Run -> Inspect -> Steer -> Validate -> Summarize
 ```
 
-In practice, that means:
+Use this sequence:
 
 1. Define the end state.
 2. Constrain the blast radius.
 3. State what counts as done.
-4. Let the agent or workflow work.
+4. Run the agent or workflow.
 5. Inspect status before reading details.
 6. Steer only when the run is off track, blocked, or missing criteria.
 7. Require evidence before accepting the result.
 8. Ask for a summary, handoff, or next-step plan.
 
-A good workflow prompt does not just say what to try. It says what success looks like.
+A good workflow prompt states both the task and its success criteria.
 
 ---
 
 ### Prompt anatomy
 
-A strong workflow prompt usually has these parts:
+A strong workflow prompt usually includes:
 
 #### Objective
 
@@ -2415,7 +3733,7 @@ If this requires changing `[public API/security behavior/data migration]`, stop 
 
 #### 1. Start with the end state
 
-I try to describe what should be true at the end, not just what the agent should investigate.
+Describe what should be true at the end, not just what the agent should investigate.
 
 Bad:
 
@@ -2431,7 +3749,7 @@ Fix the login redirect regression. Done means users who sign in from `[page]` re
 
 #### 2. Keep scope tight
 
-Agents are often tempted to clean up nearby code. Sometimes that is useful, but most workflow runs should be bounded.
+Agents often expand into nearby cleanup, which can help, but most workflow runs should stay bounded.
 
 Use phrases like:
 
@@ -2442,9 +3760,9 @@ Use phrases like:
 
 #### 3. Separate implementation from validation
 
-A change is not done because the agent says it is done. It is done when the relevant evidence supports it.
+Relevant evidence, not the agent's claim, determines whether a change is done.
 
-That evidence can be:
+Evidence can include:
 
 - a targeted test,
 - a broader regression test,
@@ -2455,7 +3773,7 @@ That evidence can be:
 
 #### 4. Prefer evidence over speculation
 
-When something fails, I steer the agent back to the observable signal: the error, failing test, log line, user behavior, or broken contract.
+When something fails, steer the agent back to the observable signal: the error, failing test, log line, user behavior, or broken contract.
 
 ```text
 Treat the failing assertion as the source of truth. Do not guess from nearby code alone.
@@ -2463,23 +3781,23 @@ Treat the failing assertion as the source of truth. Do not guess from nearby cod
 
 #### 5. Use staged thinking
 
-For ambiguous work, I usually separate the flow into stages:
+For ambiguous work, separate the flow into stages:
 
 ```text
 Investigate -> identify root cause -> propose fix -> implement -> validate -> summarize
 ```
 
-If the cause is not clear, I do not want the agent making broad changes just to see what happens.
+If the cause is not clear, do not let the agent make broad, speculative changes.
 
 #### 6. Steer, do not micromanage
 
 The best steering messages are short and corrective. They add constraints, redirect attention, or provide a decision.
 
-You usually do not need to rewrite the whole prompt. You need to say what changed.
+Usually, state only what changed instead of rewriting the whole prompt.
 
 #### 7. Treat failed validation as the next task
 
-A failed test is not a footnote. It becomes the next objective.
+A failed test becomes the next objective.
 
 ```text
 Validation failed on `[command]`. Treat that as the source of truth. Fix the root cause only, rerun the failing check, then report the result.
@@ -2487,11 +3805,11 @@ Validation failed on `[command]`. Treat that as the source of truth. Fix the roo
 
 #### 8. Interrupt stale or wrong work
 
-If a run is solving the wrong problem, based on outdated assumptions, or duplicating another run, stop it. Letting it continue usually creates more cleanup later.
+If a run is solving the wrong problem, based on outdated assumptions, or duplicating another run, stop it. Continuing usually creates more cleanup.
 
 #### 9. Inspect at the right level
 
-For long-running workflows, I do not start by reading every log. I check:
+For long-running workflows, do not start by reading every log. Check:
 
 1. overall status,
 2. current stage,
@@ -2500,7 +3818,7 @@ For long-running workflows, I do not start by reading every log. I check:
 
 #### 10. Ask for synthesis before handoff
 
-Before switching from investigation to implementation, or from implementation to review, I often ask for a concise synthesis:
+Before switching from investigation to implementation, or from implementation to review, ask for a concise synthesis:
 
 ```text
 Summarize root cause, proposed fix, files involved, validation plan, and remaining risks.
@@ -2536,7 +3854,7 @@ Implement `[feature]` in `[component]`. Only touch files directly needed for thi
 Fix the failing `[test suite]` regression. Treat the failure output as the source of truth. Do not refactor unrelated code. Done means the failing test passes and no nearby tests regress.
 ```
 
-**Why it works:** It anchors the run to observable evidence instead of speculation.
+**Why it works:** It keeps the run focused on observable evidence instead of speculation.
 
 **Validation:** Reproduce the failure, fix the root cause, rerun the failing check, then run a nearby or broader check.
 
@@ -2568,7 +3886,7 @@ Validate `[workflow/tool]` after the change. Run a minimal smoke case, confirm r
 If blocked, ask before changing public API behavior. Otherwise proceed with the smallest compatible fix.
 ```
 
-**Why it works:** The agent keeps moving where it can, but does not guess on high-impact decisions.
+**Why it works:** The agent continues work that does not require the decision but does not guess about high-impact choices.
 
 **Validation:** Confirm the decision is reflected in the final behavior and summary.
 
@@ -2588,9 +3906,19 @@ Prepare a `[release kind]` release for `[version]`. Do not publish unless valida
 
 **Validation:** Require changelog review, tests, build/package checks, and a clear publish/no-publish decision.
 
-**Atomic repository `publish-release` reconciliation.** The repository-local release workflow captures one release PR by URL, number, base ref, head ref, and exact head SHA before inspecting required checks. It never calls `gh ... --watch`, sleeps, polls, scans workflow history exhaustively, or dispatches another workflow. Instead, each mutable gate performs one current-state observation. Pending PR checks or an active/not-yet-observable publish action produce a resumable blocked result; resume the workflow after GitHub advances the external state. If an administrator or another actor merges the PR between observations, the deterministic gate accepts the advanced state only when the same captured PR remains on the expected refs and SHA and every required result matches the `statusCheckRollup` returned atomically with that SHA. Workflow-qualified Actions reruns are correlated by check name plus workflow identity. When `gh pr checks` leaves workflow empty—for external statuses and GitHub App checks—the exact passing name/link evidence infers whether linked required results are a `StatusContext` or `CheckRun`; linked reruns group by that kind plus name across URL changes. Linkless rows inspect both same-name `StatusContext` and empty-workflow `CheckRun` attempts, accepting one or both kinds when all candidates pass while blocking any pending/failure and excluding nonempty-workflow Actions. Duplicate required-check aliases may reuse the same exact passing rollup result. GitHub must also report a semantically valid RFC3339 `mergedAt`, a full merge commit OID, and the remote release branch retained at the captured SHA. `CLOSED`, stale or substituted identity/refs/SHA, failing required checks, malformed merge evidence, and missing or moved retained branches are rejected.
+**Atomic repository `publish-release` reconciliation.** The repository-local release workflow captures one release PR by URL, number, base ref, head ref, and exact head SHA before inspecting required checks. It never calls `gh ... --watch`, sleeps, polls, scans workflow history exhaustively, or dispatches another workflow. Instead, each mutable gate performs one current-state observation. Pending PR checks or an active/not-yet-observable publish action produce a resumable blocked result; resume the workflow after GitHub advances the external state.
 
-When exact evidence proves the PR is already `MERGED`, `publish-release` skips the merge command. The normal `OPEN` path uses an explicit selector plus `--match-head-commit`; both paths re-query required checks after the merge stage before final `MERGED` acceptance. Immutable evidence uses durable `ctx.tool` checkpoints, while mutable PR/check/branch/publish evidence refreshes on resume. The existing `base_ref` input remains supported as a short branch name and defaults to `main`; it selects the PR target, merge/readiness evidence, synchronized branch, and `cut-release.ts --base <base_ref>` argument. Prior tags are reused only when their required release-base trailers match the requested workstream and `verified merge → tag parent → current base` ancestry; new tags require the exact current base parent. `cut-release.ts` resolves the exact remote branch and records canonical `Release-base-ref: refs/heads/<base_ref>` plus exact `Release-base-sha` trailers on the release commit. Missing trailers are rejected without a legacy fallback. Pushing the tag is the sole publish signal: GitHub's native `create` event starts `publish.yml`, which must exist on the protected default branch. The publisher verifies the pinned workflow source and event tag/SHA, permits `refs/heads/main` by default and non-main bases only through exact comma-separated `RELEASE_BASE_REFS` repository-variable entries, fetches that exact branch into a fixed local remote-tracking ref, proves the recorded SHA equals the sole release parent and remains contained in the current remote branch, and verifies deterministic integrity against the fetched ref. It never uses a tag-sourced privileged workflow, branch-containment inference to choose a base, workflow dispatch, history scan, wait, sleep, or polling loop. Final verification observes the matching `Publish <version>` run once and requires its protected `Verify release integrity` job log to name the exact verified tag SHA.
+If an administrator or another actor merges the PR between observations, the deterministic gate accepts the advanced state only when the same captured PR remains on the expected refs and SHA and every required result matches the `statusCheckRollup` returned atomically with that SHA. Workflow-qualified Actions reruns are correlated by check name plus workflow identity. When `gh pr checks` leaves workflow empty—for external statuses and GitHub App checks—the exact passing name/link evidence infers whether linked required results are a `StatusContext` or `CheckRun`; linked reruns group by that kind plus name across URL changes.
+
+Linkless rows inspect both same-name `StatusContext` and empty-workflow `CheckRun` attempts, accepting one or both kinds when all candidates pass while blocking any pending/failure and excluding nonempty-workflow Actions. Duplicate required-check aliases may reuse the same exact passing rollup result. GitHub must also report a semantically valid RFC3339 `mergedAt`, a full merge commit OID, and the remote release branch retained at the captured SHA. `CLOSED`, stale or substituted identity/refs/SHA, failing required checks, malformed merge evidence, and missing or moved retained branches are rejected.
+
+When exact evidence proves the PR is already `MERGED`, `publish-release` skips the merge command. The normal `OPEN` path uses an explicit selector plus `--match-head-commit`; both paths re-query required checks after the merge stage before final `MERGED` acceptance. Immutable evidence uses durable `ctx.tool` checkpoints, while mutable PR/check/branch/publish evidence refreshes on resume. The existing `base_ref` input remains supported as a short branch name and defaults to `main`; it selects the PR target, merge/readiness evidence, synchronized branch, and `cut-release.ts --base <base_ref>` argument.
+
+Prior tags are reused only when their required release-base trailers match the requested workstream and `verified merge → tag parent → current base` ancestry; new tags require the exact current base parent. `cut-release.ts` resolves the exact remote branch and records canonical `Release-base-ref: refs/heads/<base_ref>` plus exact `Release-base-sha` trailers on the release commit. Missing trailers are rejected without a legacy fallback. Pushing the tag is the sole publish signal: GitHub's native `create` event starts `publish.yml`, which must exist on the protected default branch.
+
+The publisher verifies the pinned workflow source and event tag/SHA, permits `refs/heads/main` by default and non-main bases only through exact comma-separated `RELEASE_BASE_REFS` repository-variable entries, fetches that exact branch into a fixed local remote-tracking ref, proves the recorded SHA equals the sole release parent and remains contained in the current remote branch, and verifies deterministic integrity against the fetched ref. It never uses a tag-sourced privileged workflow, branch-containment inference to choose a base, workflow dispatch, history scan, wait, sleep, or polling loop.
+
+Final verification observes the matching `Publish <version>` run once and requires its protected `Verify release integrity` job log to name the exact verified tag SHA.
 
 ---
 
@@ -2604,7 +3932,7 @@ When exact evidence proves the PR is already `MERGED`, `publish-release` skips t
 Show the current stage and blocker. If implementation is complete, summarize validation status and remaining risks.
 ```
 
-**Why it works:** It avoids both blind trust and excessive log-reading.
+**Why it works:** It verifies the run without reading unnecessary logs.
 
 **Validation:** Inspect status first, then stages, then only the relevant details.
 
@@ -2644,7 +3972,7 @@ Narrow this to `[specific behavior]` in `[component]`. Do not refactor unrelated
 
 #### Add missing done criteria
 
-**Signal:** The agent has a plan, but no clear finish line.
+**Signal:** The agent has a plan, but no clear completion criteria.
 
 **Steer:**
 
@@ -2712,7 +4040,7 @@ Validation failed on `[command]`. Treat that as the source of truth. Fix the roo
 Synthesize the current findings into: root cause, proposed fix, files likely involved, validation plan, and remaining risks.
 ```
 
-**Why:** Converts exploration into a usable plan.
+**Why:** Turns findings into a usable plan.
 
 ---
 
@@ -2933,6 +4261,8 @@ Synthesize findings first: root cause, affected path, proposed fix, and validati
 
 ### Anti-patterns
 
+These anti-patterns target run prompts; [Common Mistakes](#common-mistakes) covers workflow tool and authoring mistakes.
+
 | Anti-pattern | Better approach |
 | --- | --- |
 | `Fix this.` | `Fix [specific failure]; done means [test command] passes.` |
@@ -2970,4 +4300,4 @@ Before accepting a workflow result, ask:
 - [ ] What still might be risky?
 - [ ] Is anything blocked or unresolved?
 
-The better the prompt defines the game, the better the agent can play it.
+Clearer prompts help agents produce better results.


### PR DESCRIPTION
## Summary

Improve the workflow documentation for engineers using Atomic workflows for the first time, and add a dedicated user-facing Intercom guide. The workflow page now follows the same progressive, API-reference structure as the extensions guide while preserving detailed runtime behavior and links.

## Changes

- Reorder the workflow guide from orientation and authoring fundamentals through operation, configuration, and advanced reference material
- Keep the workflow Table of Contents focused on top-level sections
- Document the complete public workflow authoring surface, including `workflow()`, `WorkflowContext`, `StageContext`, task/stage options, result contracts, and programmatic exports
- Break dense prose into short sections and tighten wording without removing technical details
- Preserve and incorporate the latest `main` documentation for completed-stage Intercom asks, readiness gates, and post-mortem message admission
- Add a dedicated Intercom page covering session messaging, tool actions, attachments, supervisor escalation, workflow/subagent notifications, configuration, and broker behavior
- Add Intercom to the documentation navigation and cross-link it from workflow, subagent, and usage documentation

## Validation

- `bun run docs:check` — 33 documentation pages validated
- `bun run lint`
- `bun run check:file-length`
- `bun test test/unit/execution-routing-guidance.test.ts test/unit/release-docs-workflow.test.ts` — 32 passed
- Full `bun run test:unit` through commit and push hooks
- `git diff --check`

## Notes

Documentation-only change; no runtime behavior or public API is modified.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the user-facing docs for workflows and Intercom. The main changes are:

- Added a dedicated Intercom guide for session messaging, attachments, supervisor escalation, notifications, configuration, and broker behavior.
- Added Intercom to the docs navigation and cross-linked it from subagent, workflow, and usage docs.
- Reorganized the workflow guide into a progressive authoring and API-reference structure.
- Expanded workflow documentation for authoring surfaces, runtime behavior, result contracts, and programmatic usage.

<h3>Confidence Score: 5/5</h3>

This documentation-only PR is safe to merge.

The changes are limited to Markdown documentation and docs navigation. The added navigation entry and cross-links are consistent with the reviewed docs structure. No blocking issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The docs validation command completed successfully and produced the docs-check log with timestamps, output, and exit code 0.
- The PR's workflow docs unit tests passed, as shown in the workflow-docs-unit log.
- The whitespace validation check completed successfully according to the git-diff-check log.

<a href="https://app.greptile.com/trex/runs/14969364/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/docs/docs.json | Adds the new Intercom guide to the Customization navigation without changing other navigation structure. |
| packages/coding-agent/docs/intercom.md | Adds a dedicated user-facing Intercom guide covering session messaging, subagent escalation, workflow notifications, configuration, broker behavior, and limitations. |
| packages/coding-agent/docs/subagents.md | Cross-links foreground supervisor coordination and related docs to the new Intercom page. |
| packages/coding-agent/docs/usage.md | Updates environment-variable and bundled-extension prose to link readers to the Intercom guide. |
| packages/coding-agent/docs/workflows.md | Reorganizes the workflow guide into progressive authoring and reference sections while preserving workflow behavior details and adding Intercom notification guidance. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant DocsNav as docs.json navigation
participant WorkflowDocs as workflows.md
participant IntercomDocs as intercom.md
participant SubagentDocs as subagents.md
participant UsageDocs as usage.md

User->>DocsNav: Opens Customization docs
DocsNav-->>User: Shows Intercom alongside subagents and workflows
User->>IntercomDocs: Reads cross-session messaging guide
IntercomDocs-->>WorkflowDocs: Links async workflow notifications
IntercomDocs-->>SubagentDocs: Links supervisor escalation and result delivery
UsageDocs-->>IntercomDocs: Links config/env-var details
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant DocsNav as docs.json navigation
participant WorkflowDocs as workflows.md
participant IntercomDocs as intercom.md
participant SubagentDocs as subagents.md
participant UsageDocs as usage.md

User->>DocsNav: Opens Customization docs
DocsNav-->>User: Shows Intercom alongside subagents and workflows
User->>IntercomDocs: Reads cross-session messaging guide
IntercomDocs-->>WorkflowDocs: Links async workflow notifications
IntercomDocs-->>SubagentDocs: Links supervisor escalation and result delivery
UsageDocs-->>IntercomDocs: Links config/env-var details
```

</a>

<sub>Reviews (1): Last reviewed commit: ["docs: improve workflow and intercom guid..."](https://github.com/bastani-inc/atomic/commit/9c36949da12975b32712e187a64c2392e1312374) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45359072)</sub>

<!-- /greptile_comment -->