### PR TITLE
fix(workflows): retain direct run startup failures

### DIFF
--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -2574,6 +2574,8 @@ workflow({
 
 Direct mode supports top-level/default options and per-task options such as `context`, `forkFromSessionFile`, `model`, `fallbackModels`, `thinkingLevel`, `contextWindow`, `tools`, `noTools`, `customTools`, `mcp`, `output`, `outputMode`, `reads`, `worktree`, `gitWorktreeDir`, `baseBranch`, `maxOutput`, `artifacts`, `sessionDir`, `cwd`, and `agentDir`. Direct chains also support `chainName`, `chainDir`, and `failFast`.
 
+Every async direct launch that returns `status: "accepted"` is registered in the run store before control returns. The run therefore appears immediately in `workflow({ action: "status" })`, `/workflow status`, and the workflow graph, and remains inspectable through its terminal state. Model validation, task expansion, and temporary-worktree preparation run inside that registered lifecycle; if any of them fails before the first stage starts, Atomic retains a terminal `failed` snapshot with the concrete error and emits the ordinary failed lifecycle notice to the invoking chat. Foreground direct helpers use the same retained lifecycle rather than returning an untracked startup error.
+
 ### Direct-run grouping and Intercom options
 
 ```typescript

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 
 ### Fixed
+- Fixed accepted direct one-off `task`, `tasks`, and `chain` runs disappearing when model validation, task expansion, or worktree preparation failed before the first stage. Direct runs are now registered before startup work, remain visible in status and graph surfaces for their full lifecycle, retain terminal failed snapshots with the concrete startup error, and emit the normal failure notice to the invoking chat. Stage-less named workflow body failures such as a throwing `ctx.tool()` are likewise retained as failed rather than misclassified as killed.
 - Fixed busy workflow stages deadlocking when a foreground subagent waited on Intercom or blocking `contact_supervisor`. Exact foreground-owner detach now completes before the request enters the stage generation boundary, owner loss before commit falls back to normal open-stage admission, and parallel foreground groups release aggregate supervision while retaining every child's lifecycle and result recovery. Native workflow messaging and terminal close semantics remain unchanged.
 - Fixed Ctrl+O (`app.tools.expand`) being consumed without expanding tool and workflow-node detail in attached workflow stage chats under Atomic's isolated interactive engine. Repeated expand/collapse toggles now match main chat across active and completed runs, single/parallel/chain views, and narrow terminals while prompts, custom questions, and unrelated keybindings retain input ownership.
 

--- a/packages/workflows/src/engine/run.ts
+++ b/packages/workflows/src/engine/run.ts
@@ -30,6 +30,7 @@ import {
   finalizeKilled,
   finalizeKilledByFailure,
   recordActiveBlockedFailure,
+  normalizeStageLessFailureMetadata,
   reconcileTerminalRunResult,
   selectRunFailureDisposition,
 } from "../runs/foreground/executor-lifecycle.js";
@@ -441,12 +442,12 @@ export async function run<
     }
 
     const failure = classifyExecutorFailure(err);
-    const metadata = selectRunFailureDisposition({
+    const metadata = normalizeStageLessFailureMetadata(selectRunFailureDisposition({
       outerFailure: failure,
       thrownError: err,
       stages: runSnapshot.stages,
       classifyFailure: classifyExecutorFailure,
-    });
+    }), runSnapshot.stages.length);
 
     if (metadata.failureDisposition === "terminal_killed") {
       for (const failedStageId of metadata.failedStageIds) scheduler.blockKnownNonTerminalDescendants(failedStageId);

--- a/packages/workflows/src/extension/runtime-direct.ts
+++ b/packages/workflows/src/extension/runtime-direct.ts
@@ -65,23 +65,6 @@ export function directMode(args: WorkflowToolArgs): WorkflowDetails["mode"] {
   return "single";
 }
 
-export function directModelRequests(args: WorkflowToolArgs): Array<{ readonly model?: WorkflowDirectTaskItem["model"]; readonly fallbackModels?: readonly string[] }> {
-  const options = directOptions(args);
-  const withFallbackDefault = (item: WorkflowDirectTaskItem) => ({
-    model: item.model ?? options.model,
-    fallbackModels: item.fallbackModels ?? options.fallbackModels,
-  });
-  if (args.task !== undefined && typeof args.task === "object") return [withFallbackDefault(args.task)];
-  if (Array.isArray(args.tasks)) return args.tasks.map(withFallbackDefault);
-  if (Array.isArray(args.chain)) {
-    return args.chain.flatMap((step) =>
-      "parallel" in step
-        ? step.parallel.map(withFallbackDefault)
-        : [withFallbackDefault(step)],
-    );
-  }
-  return [];
-}
 
 export function directProgressTotal(args: WorkflowToolArgs): number {
   const countTask = (task: WorkflowDirectTaskItem): number => task.count ?? 1;

--- a/packages/workflows/src/extension/runtime.ts
+++ b/packages/workflows/src/extension/runtime.ts
@@ -38,13 +38,12 @@ import {
   type WorkflowIntercomDelivery,
   type WorkflowResultIntercomPort,
 } from "../intercom/result-intercom.js";
-import { validateWorkflowModels } from "../runs/shared/model-fallback.js";
 import { workflowConnectGuidance } from "../runs/background/runner.js";
 import { launchDetachedUntilStartup, workflowStartupFailureMessage } from "../runs/background/startup-admission.js";
 import type { JobTracker } from "../runs/background/job-tracker.js";
 import { classifyWorkflowFailure } from "../shared/workflow-failures.js";
 import { getDurableBackend, initializeDurableBackend } from "../durable/factory.js";
-import { directMode, directModelRequests, directOptions, directProgressTotal } from "./runtime-direct.js";
+import { directMode, directOptions, directProgressTotal } from "./runtime-direct.js";
 import {
   createDurableResumeRuntime,
   type DurableResumeRuntime,
@@ -400,22 +399,6 @@ export function createExtensionRuntime(opts: ExtensionRuntimeOpts = {}): Extensi
     const mode = directMode(args);
     const delivery = effectiveIntercomDelivery(args, mode);
     const parentSession = intercomParentSession(args);
-    let warnings: readonly string[] = [];
-    try {
-      warnings = await validateWorkflowModels({
-        requests: directModelRequests(args),
-        catalog: models,
-      });
-    } catch (error: unknown) {
-      return withIntercomSummary({
-        mode,
-        action: "run",
-        runId,
-        status: "failed",
-        progress: { completed: 0, total: directProgressTotal(args) },
-        error: classifyWorkflowFailure(error).userMessage,
-      }, delivery, parentSession);
-    }
     const background = runDirectForeground(args, runId, policy);
     void background.then(
       (details) => {
@@ -440,7 +423,6 @@ export function createExtensionRuntime(opts: ExtensionRuntimeOpts = {}): Extensi
       status: "accepted",
       progress: { completed: 0, total: directProgressTotal(args) },
       message: workflowConnectGuidance(runId),
-      ...(warnings.length > 0 ? { warnings: [...warnings] } : {}),
     }, delivery, parentSession);
   }
 

--- a/packages/workflows/src/runs/foreground/executor-direct-helpers.ts
+++ b/packages/workflows/src/runs/foreground/executor-direct-helpers.ts
@@ -15,7 +15,6 @@ import type {
   WorkflowTaskStep,
 } from "../../shared/types.js";
 import { stampWorkflowDefinition } from "../../authoring/workflow.js";
-import { classifyWorkflowFailure } from "../../shared/workflow-failures.js";
 import { buildModelCandidatesFromCatalog, validateWorkflowModels, workflowModelId } from "../shared/model-fallback.js";
 import {
   cleanupWorktrees,
@@ -376,28 +375,6 @@ export function isRunOpts(value: WorkflowDirectOptions | RunOpts | undefined): v
 }
 
 
-function directFailureMessage(error: unknown): string {
-  return classifyWorkflowFailure(error).userMessage;
-}
-
-export function failedDirectDetails(
-  mode: WorkflowDetails["mode"],
-  runId: string,
-  total: number,
-  error: unknown,
-  options: WorkflowDirectOptions = {},
-): WorkflowDetails {
-  return {
-    mode,
-    action: "run",
-    runId,
-    status: "failed",
-    ...(options.context !== undefined ? { context: options.context } : {}),
-    results: [],
-    progress: { completed: 0, total },
-    error: directFailureMessage(error),
-  };
-}
 
 export function workflowDetailsFromRun(
   mode: WorkflowDetails["mode"],

--- a/packages/workflows/src/runs/foreground/executor-direct.ts
+++ b/packages/workflows/src/runs/foreground/executor-direct.ts
@@ -19,7 +19,6 @@ import {
   directModelRequestsFromChain,
   directRunId,
   expandedParallelTasks,
-  failedDirectDetails,
   isRunOpts,
   prepareDirectWorktrees,
   validateDirectModels,
@@ -52,18 +51,15 @@ export async function runTask(
   const options = isRunOpts(optionsOrRunOptions) ? {} : optionsOrRunOptions;
   const runOptions = isRunOpts(optionsOrRunOptions) ? optionsOrRunOptions : maybeRunOptions;
   const runId = directRunId(runOptions);
-  const taskWithDefaults = directTaskWithDefaults(task, options);
-  let validationWarnings: readonly string[] = [];
-  try {
-    validationWarnings = await validateDirectModels([taskWithDefaults], runOptions);
-  } catch (err) {
-    return failedDirectDetails("single", runId, 1, err, options);
-  }
   const workflowInvocationCwd = runOptions.cwd ?? process.cwd();
-  const prepared = prepareDirectWorktrees([taskWithDefaults], options, runId, "single", workflowInvocationCwd);
-  const preparedTask = prepared.tasks[0]!;
   const gitWorktreeSetupCache = createGitWorktreeSetupCache();
+  let validationWarnings: readonly string[] = [];
+  let prepared: ReturnType<typeof prepareDirectWorktrees> | undefined;
   const direct = defineDirectWorkflow("direct-task", async (ctx) => {
+    const taskWithDefaults = directTaskWithDefaults(task, options);
+    validationWarnings = await validateDirectModels([taskWithDefaults], runOptions);
+    prepared = prepareDirectWorktrees([taskWithDefaults], options, runId, "single", workflowInvocationCwd);
+    const preparedTask = prepared.tasks[0]!;
     const rawResult = await ctx.task(preparedTask.name, directTaskToStep(preparedTask));
     const { result, artifact } = await writeDirectOutput(
       preparedTask, rawResult, workflowInvocationCwd, prepared.outputIsolations?.[0], gitWorktreeSetupCache,
@@ -86,7 +82,7 @@ export async function runTask(
     try {
       gitWorktreeSetupCache.dispose();
     } finally {
-      cleanupPreparedWorktrees(prepared);
+      if (prepared !== undefined) cleanupPreparedWorktrees(prepared);
     }
   }
   const results = (runResult.result?.["results"] ?? []) as WorkflowTaskResult[];
@@ -98,19 +94,16 @@ export async function runParallel(
   options: WorkflowDirectOptions = {},
   runOptions: RunOpts = {},
 ): Promise<WorkflowDetails> {
-  const tasksWithDefaults = tasks.map((task) => directTaskWithDefaults(task, options));
-  const expanded = expandedParallelTasks(tasksWithDefaults);
   const runId = directRunId(runOptions);
-  let validationWarnings: readonly string[] = [];
-  try {
-    validationWarnings = await validateDirectModels(expanded, runOptions);
-  } catch (err) {
-    return failedDirectDetails("parallel", runId, expanded.length, err, options);
-  }
   const workflowInvocationCwd = runOptions.cwd ?? process.cwd();
-  const prepared = prepareDirectWorktrees(expanded, options, runId, "parallel", workflowInvocationCwd);
   const gitWorktreeSetupCache = createGitWorktreeSetupCache();
+  let validationWarnings: readonly string[] = [];
+  let prepared: ReturnType<typeof prepareDirectWorktrees> | undefined;
   const direct = defineDirectWorkflow("direct-parallel", async (ctx) => {
+    const tasksWithDefaults = tasks.map((task) => directTaskWithDefaults(task, options));
+    const expanded = expandedParallelTasks(tasksWithDefaults);
+    validationWarnings = await validateDirectModels(expanded, runOptions);
+    prepared = prepareDirectWorktrees(expanded, options, runId, "parallel", workflowInvocationCwd);
     const steps = prepared.tasks.map((task) => directTaskToStep(task));
     const rawResults = await ctx.parallel(steps, {
       task: options.task,
@@ -119,7 +112,7 @@ export async function runParallel(
     });
     const persisted = await Promise.all(
       rawResults.map((result, index) => writeDirectOutput(
-        prepared.tasks[index]!, result, workflowInvocationCwd, prepared.outputIsolations?.[index], gitWorktreeSetupCache,
+        prepared!.tasks[index]!, result, workflowInvocationCwd, prepared!.outputIsolations?.[index], gitWorktreeSetupCache,
       )),
     );
     const results = persisted.map((item) => item.result);
@@ -142,7 +135,7 @@ export async function runParallel(
     try {
       gitWorktreeSetupCache.dispose();
     } finally {
-      cleanupPreparedWorktrees(prepared);
+      if (prepared !== undefined) cleanupPreparedWorktrees(prepared);
     }
   }
   const results = (runResult.result?.["results"] ?? []) as WorkflowTaskResult[];
@@ -240,17 +233,13 @@ export async function runChain(
 ): Promise<WorkflowDetails> {
   const runId = directRunId(runOptions);
   let validationWarnings: readonly string[] = [];
-  try {
+  const workflowInvocationCwd = runOptions.cwd ?? process.cwd();
+  const gitWorktreeSetupCache = createGitWorktreeSetupCache();
+  const direct = defineDirectWorkflow("direct-chain", async (ctx) => {
     validationWarnings = await validateWorkflowModels({
       requests: directModelRequestsFromChain(chain, options),
       catalog: runOptions.models,
     });
-  } catch (err) {
-    return failedDirectDetails("chain", runId, chain.length, err, options);
-  }
-  const workflowInvocationCwd = runOptions.cwd ?? process.cwd();
-  const gitWorktreeSetupCache = createGitWorktreeSetupCache();
-  const direct = defineDirectWorkflow("direct-chain", async (ctx) => {
     const results: WorkflowTaskResult[] = [];
     const artifacts: WorkflowArtifact[] = [];
     let prior: WorkflowTaskResult | readonly WorkflowTaskResult[] | undefined;

--- a/packages/workflows/src/runs/foreground/executor-lifecycle.ts
+++ b/packages/workflows/src/runs/foreground/executor-lifecycle.ts
@@ -135,7 +135,7 @@ export function runFailureMetadata(
   };
 }
 
-interface SelectedRunFailureMetadata extends RunFailureMetadata {
+export interface SelectedRunFailureMetadata extends RunFailureMetadata {
   readonly failedStageIds: readonly string[];
 }
 
@@ -335,6 +335,17 @@ export function selectRunFailureDisposition(input: {
   }
 
   return selectedMetadata(runFailureMetadata(input.outerFailure, input.stages), failedStageIds);
+}
+
+/** Stage-less non-cancellation errors are startup failures, not killed runs. */
+export function normalizeStageLessFailureMetadata(
+  metadata: SelectedRunFailureMetadata,
+  stageCount: number,
+): SelectedRunFailureMetadata {
+  if (metadata.failureDisposition !== "terminal_killed" || metadata.failureKind === "cancelled" || stageCount > 0) {
+    return metadata;
+  }
+  return { ...metadata, failureDisposition: "terminal_failed" };
 }
 
 export function stageReplayFields(stage: StageSnapshot): Partial<Pick<StageSnapshot, "replayKey" | "replayedFromStageId" | "replayed">> {

--- a/test/unit/executor-direct-sdk-helpers.test.ts
+++ b/test/unit/executor-direct-sdk-helpers.test.ts
@@ -212,6 +212,7 @@ describe("direct SDK helpers", () => {
             mkdtempSync(join(tmpdir(), "atomic-workflow-invalid-model-")),
             "out.txt",
         );
+        const store = createStore();
         const details = await runTask(
             {
                 name: "scout",
@@ -238,7 +239,7 @@ describe("direct SDK helpers", () => {
                         },
                     },
                 },
-                store: createStore(),
+                store,
             },
         );
 
@@ -246,6 +247,11 @@ describe("direct SDK helpers", () => {
         assert.equal(details.error, WORKFLOW_UNKNOWN_MODEL_MESSAGE);
         assert.equal(creates, 0);
         assert.throws(() => readFileSync(output, "utf8"));
+        const snapshot = store.runs().find((run) => run.id === details.runId);
+        assert.equal(snapshot?.status, "failed");
+        assert.equal(snapshot?.error, WORKFLOW_UNKNOWN_MODEL_MESSAGE);
+        assert.deepEqual(snapshot?.stages, []);
+        assert.notEqual(snapshot?.endedAt, undefined);
     });
 
     test("runTask direct options expose context and sessionDir", async () => {

--- a/test/unit/runtime-02.test.ts
+++ b/test/unit/runtime-02.test.ts
@@ -230,7 +230,7 @@ describe("runtime.runDirect — workflow intercom", () => {
         }
     });
 
-    test("async direct invalid fallback models fail before background spawn", async () => {
+    test("async direct invalid models are accepted, retained, and fail with the real error", async () => {
         const activeStore = createStore();
         const runtime = createExtensionRuntime({
             store: activeStore,
@@ -246,7 +246,7 @@ describe("runtime.runDirect — workflow intercom", () => {
             },
         });
 
-        const result = await runtime.runDirect({
+        const accepted = await runtime.runDirect({
             async: true,
             task: {
                 name: "solo",
@@ -257,9 +257,46 @@ describe("runtime.runDirect — workflow intercom", () => {
             },
         });
 
-        assert.equal(result.status, "failed");
-        assert.equal(result.error, WORKFLOW_UNKNOWN_MODEL_MESSAGE);
-        assert.equal(activeStore.runs().length, 0);
+        assert.equal(accepted.status, "accepted");
+        assert.ok(accepted.runId);
+        await waitForRunEnded(activeStore, accepted.runId);
+        const failed = activeStore.runs().find((run) => run.id === accepted.runId);
+        assert.equal(failed?.status, "failed");
+        assert.equal(failed.error, WORKFLOW_UNKNOWN_MODEL_MESSAGE);
+        assert.deepEqual(failed.stages, []);
+        assert.notEqual(failed.endedAt, undefined);
+    });
+
+    test("async direct parallel and chain startup failures remain visible", async () => {
+        const activeStore = createStore();
+        const runtime = createExtensionRuntime({
+            store: activeStore,
+            adapters: noopAdapters,
+            models: {
+                listModels: async () => [{ provider: "openai", id: "known", fullId: "openai/known" }],
+            },
+        });
+        const launches = [
+            {
+                expected: /count must be a positive integer/,
+                args: { async: true, tasks: [{ name: "bad-count", task: "inspect", count: 0 }] },
+            },
+            {
+                expected: new RegExp(WORKFLOW_UNKNOWN_MODEL_MESSAGE),
+                args: { async: true, chain: [{ name: "bad-model", task: "inspect", model: "missing-model" }] },
+            },
+        ];
+
+        for (const launch of launches) {
+            const accepted = await runtime.runDirect(launch.args);
+            assert.equal(accepted.status, "accepted");
+            assert.ok(accepted.runId);
+            await waitForRunEnded(activeStore, accepted.runId);
+            const failed = activeStore.runs().find((run) => run.id === accepted.runId);
+            assert.equal(failed?.status, "failed");
+            assert.match(failed?.error ?? "", launch.expected);
+            assert.deepEqual(failed?.stages, []);
+        }
     });
 
     test("non-interactive async direct single task awaits a terminal completed result", async () => {

--- a/test/unit/slash-dispatch-tool-reload-resume.ts
+++ b/test/unit/slash-dispatch-tool-reload-resume.ts
@@ -369,7 +369,7 @@ describe("tool run-control actions", () => {
         assert.equal(r.runId, runId);
     });
 
-    test.serial("runtime runDirect classifies direct pre-run model auth failures", async () => {
+    test.serial("runtime runDirect retains direct startup model auth failures", async () => {
         const runtime = createExtensionRuntime({
             registry: createRegistry([]),
             models: {
@@ -379,13 +379,17 @@ describe("tool run-control actions", () => {
             },
         });
 
-        const result = await runtime.runDirect({
+        const accepted = await runtime.runDirect({
             task: { name: "scout", task: "inspect repo", model: "openai/gpt" },
             async: true,
         });
 
-        assert.equal(result.status, "failed");
-        assert.equal(result.error, WORKFLOW_INVALID_PROVIDER_CREDENTIALS_MESSAGE);
+        assert.equal(accepted.status, "accepted");
+        assert.ok(accepted.runId);
+        await waitForToolRunEnded(accepted.runId);
+        const failed = store.runs().find((run) => run.id === accepted.runId);
+        assert.equal(failed?.status, "failed");
+        assert.equal(failed?.error, WORKFLOW_INVALID_PROVIDER_CREDENTIALS_MESSAGE);
     });
 
     test.serial("makeExecuteWorkflowTool resume rejects ambiguous stage prefixes", async () => {

--- a/test/unit/workflow-named-background-lifecycle-e2e.test.ts
+++ b/test/unit/workflow-named-background-lifecycle-e2e.test.ts
@@ -76,6 +76,11 @@ export default workflow({
     if (outcome === "exit_blocked") {
       return ctx.exit({ status: "blocked", reason: "approval required" });
     }
+    if (outcome === "tool_failure") {
+      await ctx.tool("failing-tool", {}, async () => {
+        throw new Error("named tool startup exploded");
+      });
+    }
     await ctx.stage("worker").prompt(outcome === "recoverable_auth" ? "throw-auth" : "finish");
     if (outcome === "completed") return {};
     if (outcome === "needs_human_empty") return { status: "needs_human" };
@@ -282,6 +287,71 @@ describe("named background workflow lifecycle notifications", () => {
       assert.equal(store.runs().some((run) => run.id === result.details.runId), false);
       assert.equal(durableBackend.getWorkflow(result.details.runId), undefined);
       assert.equal(harness.entries.some((entry) => entry.type === "workflow.stage.start"), false);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  test.serial("retains direct startup failures and sends the real error to the invoking chat", async () => {
+    const harness = await createHarness();
+    try {
+      const accepted = await harness.tool.execute(
+        "call-direct-startup-failure",
+        {
+          async: true,
+          task: {
+            name: "direct-startup-failure",
+            task: "never starts",
+            worktree: true,
+            gitWorktreeDir: "reused-worktree",
+          },
+        },
+        undefined,
+        undefined,
+        { hasUI: true } as never,
+      );
+
+      assert.equal(accepted.details.status, "accepted");
+      const runId = accepted.details.runId;
+      assert.ok(runId);
+      const deadline = Date.now() + 1000;
+      while (store.runs().find((run) => run.id === runId)?.endedAt === undefined && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      const snapshot = store.runs().find((run) => run.id === runId);
+      assert.equal(snapshot?.status, "failed");
+      assert.match(snapshot?.error ?? "", /worktree and gitWorktreeDir are mutually exclusive/);
+      assert.deepEqual(snapshot?.stages, []);
+      const status = await harness.tool.execute(
+        "call-direct-startup-status",
+        { action: "status" },
+        undefined,
+        undefined,
+        { hasUI: true } as never,
+      );
+      assert.equal(status.details.action, "status");
+      assert.equal(status.details.runs.some((run) => run.runId === runId && run.status === "failed"), true);
+      assert.equal(status.details.snapshots.some((run) => run.id === runId && run.error === snapshot?.error), true);
+      const notices = noticesFor(harness, runId);
+      assert.equal(notices.length, 1);
+      assert.equal(notices[0]?.details?.kind, "failed");
+      assert.match(notices[0]?.content ?? "", /worktree and gitWorktreeDir are mutually exclusive/);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  test.serial("records a named ctx.tool startup throw as failed with a lifecycle notice", async () => {
+    const harness = await createHarness();
+    try {
+      const snapshot = await runNamed(harness, "tool_failure");
+      assert.equal(snapshot.status, "failed");
+      assert.match(snapshot.error ?? "", /named tool startup exploded/);
+      assert.deepEqual(snapshot.stages, []);
+      const notices = noticesFor(harness, snapshot.id);
+      assert.equal(notices.length, 1);
+      assert.equal(notices[0]?.details?.kind, "failed");
+      assert.match(notices[0]?.content ?? "", /named tool startup exploded/);
     } finally {
       await harness.cleanup();
     }


### PR DESCRIPTION
## Summary

Fix direct one-off workflow runs that could be accepted and then disappear when startup work failed before the run was registered. Direct task, parallel, and chain runs now enter the retained workflow lifecycle before validation or worktree preparation, so status/UI surfaces and lifecycle notices remain accurate.

## Root cause

Direct-run model validation, task expansion, and worktree preparation could execute before `run()` registered a snapshot. Synchronous startup failures therefore returned or rejected through paths that never wrote to the run store. Separately, stage-less workflow-body failures were classified as killed rather than failed.

## Changes

- Move direct single, parallel, and chain startup work inside the registered workflow definition.
- Remove untracked async validation/failure-return paths.
- Normalize stage-less, non-cancellation startup errors to terminal `failed` runs while preserving genuine cancellation behavior.
- Add regression coverage for async and foreground startup failures, status retention, lifecycle notices, and throwing named `ctx.tool()` calls.
- Document the retained direct-run lifecycle and add an Unreleased changelog entry.

## Validation

- Focused affected suites: 206 passed, 0 failed (worker focused subset: 32 passed)
- `CLAUDECODE=1 bun run test:unit`: 3895 passed, 0 failed
- `bun run typecheck`: passed
- `bun run lint`: passed
- `bun run check:file-length`: passed
- Coding-agent build and docs-link validation: passed
- `git diff --check`: passed
- Real Atomic session: successful async direct `worktree:true` run completed; deliberate startup failure remained visible as failed and emitted the concrete failure notice

## Notes

Three independent reviewers approved the patch. One reviewer noted a non-blocking follow-up: stage-less startup failures currently retain `resumable: true` metadata even though direct stage-less failures cannot be resumed; this does not affect the visibility/failure-lifecycle contract fixed here.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps direct one-off workflow startup failures visible after a run is accepted. The main changes are:

- Moves direct task, parallel, and chain startup work inside the registered workflow lifecycle.
- Records stage-less startup errors as terminal `failed` runs while preserving cancellation behavior.
- Removes untracked async validation failure paths from direct runtime launch.
- Adds tests for retained failed snapshots, status visibility, lifecycle notices, and named `ctx.tool()` startup throws.
- Updates the direct-run docs and workflows changelog.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changes are narrowly scoped to direct workflow startup lifecycle handling, preserve cancellation semantics, and include tests for the affected direct-run paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The direct run of the lifecycle focus test was executed for the lifecycle-focused-02-after path, as reflected by the proof log.
- The proof log documents the exact command, working directory, timestamp, Bun test summary, and exit code used in the run to validate the focused subset.
- Validation shows that the focused passing subset satisfied the objective, so no adjacent lifecycle subset was run.

<a href="https://app.greptile.com/trex/runs/15037020/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/workflows/src/extension/runtime.ts | Changes async direct launches to return accepted immediately and rely on the foreground run lifecycle for validation failures and notices. |
| packages/workflows/src/runs/foreground/executor-direct.ts | Moves direct task, parallel, and chain startup validation/worktree preparation inside stamped workflow definitions with guarded cleanup. |
| packages/workflows/src/engine/run.ts | Normalizes stage-less non-cancellation executor failures to terminal failed runs before recording lifecycle state. |
| packages/workflows/src/runs/foreground/executor-lifecycle.ts | Adds exported metadata normalization for stage-less startup errors while preserving genuine cancellation as killed. |
| test/unit/runtime-02.test.ts | Updates async direct startup-failure tests to assert accepted launches become retained failed runs across single, parallel, and chain modes. |
| test/unit/workflow-named-background-lifecycle-e2e.test.ts | Adds end-to-end coverage for retained direct startup failures, lifecycle notices, status visibility, and named ctx.tool startup throws. |
| packages/coding-agent/docs/workflows.md | Documents the retained lifecycle for accepted async direct launches and startup-failure visibility. |
| packages/workflows/CHANGELOG.md | Adds an Unreleased fixed entry for retained direct-run startup failures. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Caller as Direct run caller
  participant Runtime as Extension runtime
  participant Executor as Direct foreground executor
  participant Engine as run() lifecycle
  participant Store as Run store
  participant Intercom as Lifecycle notice

  Caller->>Runtime: runDirect(async task/tasks/chain)
  Runtime->>Executor: runDirectForeground(runId)
  Runtime-->>Caller: accepted + runId
  Executor->>Engine: run(stamped direct workflow, runId)
  Engine->>Store: record run start
  Engine->>Executor: execute workflow body
  Executor->>Executor: validate models / expand tasks / prepare worktrees
  alt startup succeeds
    Executor->>Engine: create ctx.task/parallel/chain stages
    Engine->>Store: record completed/terminal result
  else startup fails before any stage
    Executor-->>Engine: throw concrete startup error
    Engine->>Engine: normalize stage-less non-cancel failure
    Engine->>Store: record terminal failed snapshot
    Engine->>Intercom: emit failed lifecycle notice
  end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Caller as Direct run caller
  participant Runtime as Extension runtime
  participant Executor as Direct foreground executor
  participant Engine as run() lifecycle
  participant Store as Run store
  participant Intercom as Lifecycle notice

  Caller->>Runtime: runDirect(async task/tasks/chain)
  Runtime->>Executor: runDirectForeground(runId)
  Runtime-->>Caller: accepted + runId
  Executor->>Engine: run(stamped direct workflow, runId)
  Engine->>Store: record run start
  Engine->>Executor: execute workflow body
  Executor->>Executor: validate models / expand tasks / prepare worktrees
  alt startup succeeds
    Executor->>Engine: create ctx.task/parallel/chain stages
    Engine->>Store: record completed/terminal result
  else startup fails before any stage
    Executor-->>Engine: throw concrete startup error
    Engine->>Engine: normalize stage-less non-cancel failure
    Engine->>Store: record terminal failed snapshot
    Engine->>Intercom: emit failed lifecycle notice
  end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(workflows): retain direct run startu..."](https://github.com/bastani-inc/atomic/commit/819c0b655f83b52fdd62e615627361cf816aa0ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45496182)</sub>

<!-- /greptile_comment -->