### PR TITLE
ci: use Blacksmith checkout for all publish jobs

### DIFF
--- a/.atomic/workflows/publish-release.ts
+++ b/.atomic/workflows/publish-release.ts
@@ -269,7 +269,7 @@ export default workflow({
     }
 
     const publish = await inspectGate("publish action", (attempt) => [
-      `Inspect the automatically triggered protected Publish ${release.version} GitHub Actions run exactly once (attempt ${attempt}).`,
+      `Inspect the automatically triggered Publish ${release.version} GitHub Actions run exactly once (attempt ${attempt}).`,
       facts,
       `Expected release SHA: ${released.release_sha}`,
       "Use gh run list/view without --watch and select the push-event publish.yml run for the exact tag and release SHA.",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,7 +86,7 @@ jobs:
           - { runner: blacksmith-4vcpu-ubuntu-2404, platform: win32, arch: x64, target: x86_64-pc-windows-msvc }
           - { runner: blacksmith-4vcpu-ubuntu-2404, platform: win32, arch: arm64, target: aarch64-pc-windows-msvc }
     steps:
-      - uses: actions/checkout@v4
+      - uses: useblacksmith/checkout@v1
         with:
           ref: ${{ env.SOURCE_REF }}
           persist-credentials: false
@@ -163,7 +163,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: useblacksmith/checkout@v1
         with:
           ref: ${{ env.SOURCE_REF }}
           persist-credentials: false
@@ -204,7 +204,7 @@ jobs:
     runs-on: blacksmith-4vcpu-windows-2025
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: useblacksmith/checkout@v1
         with:
           ref: ${{ env.SOURCE_REF }}
           persist-credentials: false
@@ -249,7 +249,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: useblacksmith/checkout@v1
         with:
           ref: ${{ env.SOURCE_REF }}
           persist-credentials: false


### PR DESCRIPTION
## Summary
- All checkout steps in `publish.yml` now use `useblacksmith/checkout@v1` (sticky-disk git mirror; documented safe fallback to a standard clone) — no per-runner conditionals, per maintainer preference.
- Removed the leftover "protected" wording from the `publish-release` Atomic workflow's inspect prompt (a remnant of the deleted signal/publisher architecture).

## Validation
- YAML parse valid
- `bun test test/ci test/unit/publish-release-workflow.test.ts` — 24 pass, 0 fail

🤖 Generated with Claude Fable 5

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the publish release flow and CI checkout action. The main changes are:

- Switches remaining `publish.yml` checkout steps to `useblacksmith/checkout@v1`.
- Keeps publish jobs on the existing pinned `SOURCE_REF` checkout behavior.
- Removes obsolete `protected` wording from the `publish-release` workflow inspect prompt.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are narrow CI/release workflow updates and preserve the existing release integrity and pinned checkout flow.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the publish workflow validation to exercise the code path and generate a traceable proof log.
- T-Rex reviewed the proof log to confirm the exact commands, working directory, Bun version, YAML parse output, test output, and exit codes were captured.
- T-Rex verified that dependencies were already present and that no bun install --frozen-lockfile step was required.

<a href="https://app.greptile.com/trex/runs/15041835/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish.yml | Updates downstream publish job checkout steps to use `useblacksmith/checkout@v1` with no correctness issues found. |
| .atomic/workflows/publish-release.ts | Removes obsolete wording from the publish-run inspection prompt without changing workflow control flow. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Tag as Release tag push
participant Publish as publish.yml
participant Checkout as useblacksmith/checkout@v1
participant Jobs as Native/smoke/build jobs
participant Workflow as publish-release workflow

Tag->>Publish: "Trigger Publish <version>"
Publish->>Checkout: Verify tag checkout
Publish->>Jobs: Fan out downstream publish jobs
Jobs->>Checkout: Checkout env.SOURCE_REF via Blacksmith checkout
Checkout-->>Jobs: Working tree at verified source ref
Workflow->>Publish: Inspect matching push-event run
Publish-->>Workflow: Report completion evidence
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Tag as Release tag push
participant Publish as publish.yml
participant Checkout as useblacksmith/checkout@v1
participant Jobs as Native/smoke/build jobs
participant Workflow as publish-release workflow

Tag->>Publish: "Trigger Publish <version>"
Publish->>Checkout: Verify tag checkout
Publish->>Jobs: Fan out downstream publish jobs
Jobs->>Checkout: Checkout env.SOURCE_REF via Blacksmith checkout
Checkout-->>Jobs: Working tree at verified source ref
Workflow->>Publish: Inspect matching push-event run
Publish-->>Workflow: Report completion evidence
```

</a>

<sub>Reviews (1): Last reviewed commit: ["ci: use Blacksmith checkout for all publ..."](https://github.com/bastani-inc/atomic/commit/f04b42142eb53e1c1a51a99b98cae67048c6eef9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45537938)</sub>

<!-- /greptile_comment -->