### PR TITLE
fix(tests): guard fixtures against hook git env pollution

### DIFF
--- a/packages/coding-agent/test/git-update.test.ts
+++ b/packages/coding-agent/test/git-update.test.ts
@@ -13,12 +13,16 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { DefaultPackageManager } from "../src/core/package-manager.ts";
 import { SettingsManager } from "../src/core/settings-manager.ts";
+import { createGitEnvironment } from "../src/utils/git-env.ts";
 
-// Helper to run git commands in a directory
+// Helper to run git commands in a directory. Scrub repository-local Git env so
+// runs under commit/push hooks (GIT_DIR, GIT_WORK_TREE, GIT_INDEX_FILE) cannot
+// redirect fixture git commands at the invoking repository.
 function git(args: string[], cwd: string): string {
 	const result = spawnSync("git", args, {
 		cwd,
 		encoding: "utf-8",
+		env: createGitEnvironment(),
 	});
 	if (result.status !== 0) {
 		throw new Error(`Command failed: git ${args.join(" ")}\n${result.stderr}`);

--- a/test/unit/git-env-pollution-guard.test.ts
+++ b/test/unit/git-env-pollution-guard.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, test } from "bun:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createGitEnvironment } from "../../packages/coding-agent/src/utils/git-env.js";
+import { runGitChecked } from "../../packages/workflows/src/runs/shared/worktree-git.js";
+
+/**
+ * Regression guard for the 2026-07-20 core.worktree pollution incident.
+ *
+ * Git hooks export repository-local environment variables, and a nested
+ * `git init` run with `GIT_DIR=<foreign .git>` and `GIT_WORK_TREE=<cwd>`
+ * persists `core.worktree=<cwd>` into the foreign repository's config —
+ * silently redirecting that checkout. This is documented git behavior, not
+ * a git bug; the invariant under test is OURS: every repository git-spawning
+ * helper must scrub hook-inherited repository-local env before spawning.
+ */
+
+let sentinelRepo: string;
+let sentinelConfigBefore: string;
+let fixtureDir: string;
+const savedEnv = new Map<string, string | undefined>();
+
+beforeEach(() => {
+	sentinelRepo = mkdtempSync(join(tmpdir(), "atomic-git-env-sentinel-"));
+	fixtureDir = mkdtempSync(join(tmpdir(), "atomic-git-env-fixture-"));
+	const init = spawnSync("git", ["init", "--quiet", "--initial-branch=main"], {
+		cwd: sentinelRepo,
+		env: createGitEnvironment(),
+	});
+	assert.equal(init.status, 0, init.stderr?.toString());
+	sentinelConfigBefore = readFileSync(join(sentinelRepo, ".git", "config"), "utf-8");
+
+	// Hook-style env aimed at the sentinel; GIT_WORK_TREE matches the nested
+	// command's cwd — the exact combination that persists core.worktree.
+	for (const key of ["GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE"]) {
+		savedEnv.set(key, process.env[key]);
+	}
+	process.env.GIT_DIR = join(sentinelRepo, ".git");
+	process.env.GIT_WORK_TREE = fixtureDir;
+	process.env.GIT_INDEX_FILE = join(sentinelRepo, ".git", "index");
+});
+
+afterEach(() => {
+	for (const [key, value] of savedEnv) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+	savedEnv.clear();
+	rmSync(sentinelRepo, { recursive: true, force: true });
+	rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+test("repository git helpers stay scrubbed under hook env and cannot touch the hook repository", () => {
+	runGitChecked(fixtureDir, ["init", "--quiet", "--initial-branch=main"]);
+	runGitChecked(fixtureDir, ["config", "--local", "user.email", "fixture@example.com"]);
+	const after = readFileSync(join(sentinelRepo, ".git", "config"), "utf-8");
+	assert.ok(!after.includes("worktree"), `sentinel config gained a worktree entry:\n${after}`);
+	assert.equal(after, sentinelConfigBefore, "sentinel repository config must be byte-identical");
+});


### PR DESCRIPTION
## Summary
Closes out the 2026-07-20 `core.worktree` pollution incident (TODO-0cea93d6):

- **`packages/coding-agent/test/git-update.test.ts`** — its `git()` helper spawned git with inherited env; under commit/push hooks, repository-local Git variables (`GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`) redirect fixture commands at the invoking repository. Now scrubbed via `createGitEnvironment()`.
- **New `test/unit/git-env-pollution-guard.test.ts`** — one focused regression guard. The empirically-identified vector: `git init` with `GIT_DIR=<foreign .git>` and `GIT_WORK_TREE=<cwd>` persists `core.worktree=<cwd>` into the foreign config (documented git behavior; exactly what silently redirected the primary checkout during the #1896 PR-stage hook run). The guard runs the repository's git-spawning helper under that hostile hook env against a sentinel repo and asserts the sentinel's config stays byte-identical. It pins OUR scrubbing invariant, not git's behavior.

## Validation
- Guard + git-update + git-env + worktree-git tests: all pass
- `bun run typecheck`, `bun run lint`, `bun run check:file-length` — clean

🤖 Generated with Claude Fable 5

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens git-related tests against hook-inherited Git environment pollution. The main changes are:

- Scrubs repository-local Git environment variables in the `git-update` test helper.
- Adds a Bun regression test for the `core.worktree` pollution scenario.
- Verifies the workflows git helper leaves a foreign sentinel repository config unchanged under hostile hook-style env.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are narrowly scoped to test helpers and regression coverage, and they follow the repository's existing Bun test and createGitEnvironment patterns.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The primary scrub run completed with 14 pass, 0 fail, and EXIT\_CODE 0 as shown in the proof.
- The related-suite scrub run completed with 22 pass, 0 fail, and EXIT\_CODE 0 as shown in the proof.
- Both runs captured the exact commands, working directories, and Bun outputs in the provided logs.
- Two log artifacts were created to store these results for review.

<a href="https://app.greptile.com/trex/runs/15042433/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/test/git-update.test.ts | Updated the test-local git helper to scrub repository-local Git environment variables before spawning fixture git commands. |
| test/unit/git-env-pollution-guard.test.ts | Added a Bun regression test that simulates hook-inherited Git env pollution and verifies `runGitChecked` leaves a sentinel repository config unchanged. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant HookEnv as Hook-inherited env
participant Fixture as Test fixture cwd
participant Helper as Repository git helper
participant Git as git subprocess
participant Sentinel as Sentinel repo config

HookEnv->>Helper: GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE
Helper->>Helper: createGitEnvironment() scrubs local Git vars
Helper->>Git: spawn git in fixture cwd with scrubbed env
Git->>Fixture: init/config fixture repository
Git--xSentinel: no inherited env points at sentinel
Sentinel-->>Helper: config remains byte-identical
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant HookEnv as Hook-inherited env
participant Fixture as Test fixture cwd
participant Helper as Repository git helper
participant Git as git subprocess
participant Sentinel as Sentinel repo config

HookEnv->>Helper: GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE
Helper->>Helper: createGitEnvironment() scrubs local Git vars
Helper->>Git: spawn git in fixture cwd with scrubbed env
Git->>Fixture: init/config fixture repository
Git--xSentinel: no inherited env points at sentinel
Sentinel-->>Helper: config remains byte-identical
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(tests): guard fixtures against hook ..."](https://github.com/bastani-inc/atomic/commit/9a11f86f08ff1168b9264c3f34b61e5871df114f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45539238)</sub>

<!-- /greptile_comment -->