### PR TITLE
fix(release): pack payload dirs as local paths and watch release gates to completion

### DIFF
--- a/.atomic/workflows/publish-release.ts
+++ b/.atomic/workflows/publish-release.ts
@@ -50,9 +50,6 @@ type Gate = Static<typeof gateSchema>;
 type Base = Static<typeof baseSchema>;
 type Release = Static<typeof releaseSchema>;
 
-const reinspectChoice = "Reinspect after external state changes";
-const stopChoice = "Stop this release";
-
 function releaseFacts(release: ValidatedRelease, baseRef: string): string {
   return [
     `Release kind: ${release.kind}`,
@@ -62,7 +59,7 @@ function releaseFacts(release: ValidatedRelease, baseRef: string): string {
     "The release base is versionless: package manifests, lockfiles, Cargo files, and generated version files remain at 0.0.0.",
     "Only scripts/cut-release.ts may stamp the real version on the detached Release commit after the changelog PR merges.",
     "Pushing the version tag directly starts publish.yml. Do not dispatch a duplicate normal publication run.",
-    "Use Bun for development commands. Do not watch, sleep, poll, force-push, force a tag, rerun publication during a normal release, or launch a duplicate release workflow.",
+    "Use Bun for development commands. Do not force-push, force a tag, rerun publication during a normal release, or launch a duplicate release workflow.",
   ].join("\n");
 }
 
@@ -154,30 +151,22 @@ export default workflow({
 
     const inspectGate = async (
       label: "required CI" | "publish action",
-      prompt: (attempt: number) => string,
-      attempt = 1,
+      prompt: string,
     ): Promise<Gate> => {
-      const result = await ctx.task(`inspect-${label.replaceAll(" ", "-")}-${attempt}`, {
+      const stageName = `watch-${label.replaceAll(" ", "-")}`;
+      const result = await ctx.task(stageName, {
         context: "fresh",
         schema: gateSchema,
-        prompt: prompt(attempt),
+        prompt,
       });
       const outcome = result.structured as Gate;
       if (outcome.status === "passed") return outcome;
-
-      const choice = await ctx.ui.select(
-        [
-          `${label} is ${outcome.status}.`,
-          outcome.summary,
-          outcome.status === "pending"
-            ? "After GitHub advances, continue this same workflow run and reinspect."
-            : "Fix the external failure or stop. The workflow will not repair or bypass it silently.",
-          "Choose the next action:",
-        ].join("\n\n"),
-        [reinspectChoice, stopChoice] as const,
+      return stop(
+        stageName,
+        outcome.status === "pending"
+          ? `${label} did not reach a terminal state within the watch window: ${outcome.summary}`
+          : outcome.summary,
       );
-      if (choice === stopChoice) return stop(`inspect-${label.replaceAll(" ", "-")}`, outcome.summary);
-      return inspectGate(label, prompt, attempt + 1);
     };
 
     const prepareResult = await ctx.task("prepare-changelog-branch", {
@@ -220,14 +209,16 @@ export default workflow({
       return stop("validate-commit-push-open-pr", pullRequest.summary);
     }
 
-    const ci = await inspectGate("required CI", (attempt) => [
-      `Inspect required checks exactly once for ${pullRequest.pr_url} (attempt ${attempt}).`,
+    const ci = await inspectGate("required CI", [
+      `Watch required checks for ${pullRequest.pr_url} until they reach a terminal state.`,
       facts,
       `Expected PR number: ${pullRequest.pr_number}`,
       `Expected PR head SHA: ${pullRequest.head_sha}`,
       "Use current gh pr view/checks data. Require the same PR, base, head branch, exact head SHA, and a non-empty required-check set.",
-      "Return passed only when every required check passed. Return pending for queued/in-progress/missing-yet checks. Return failed for failed checks, identity drift, malformed evidence, or command/auth failure.",
-      "Do not merge, rerun, watch, sleep, poll, tag, or publish. Include an evidence_url when available.",
+      "Wait for completion instead of returning early: re-check with gh pr checks/view roughly every 30 seconds, for up to 45 minutes.",
+      "If the PR becomes merged while waiting (for example an admin merge), treat that as passed and cite the merge as evidence.",
+      "Return passed only when every required check passed or the PR is merged. Return failed for failed checks, identity drift, malformed evidence, or command/auth failure. Return pending only if the watch window expires without a terminal state.",
+      "Do not merge, rerun checks, tag, or publish. Include an evidence_url when available.",
     ].join("\n\n"));
 
     const mergeResult = await ctx.task("merge-exact-head-and-sync-base", {
@@ -268,14 +259,14 @@ export default workflow({
       return stop("cut-and-push-release-tag", released.summary);
     }
 
-    const publish = await inspectGate("publish action", (attempt) => [
-      `Inspect the automatically triggered Publish ${release.version} GitHub Actions run exactly once (attempt ${attempt}).`,
+    const publish = await inspectGate("publish action", [
+      `Watch the automatically triggered Publish ${release.version} GitHub Actions run until it completes.`,
       facts,
       `Expected release SHA: ${released.release_sha}`,
-      "Use gh run list/view without --watch and select the push-event publish.yml run for the exact tag and release SHA.",
-      "Require repository bastani-inc/atomic, the exact publish workflow path, matching tag, SHA, and push event. Return pending when the exact run is absent, queued, or active. Return failed for identity mismatch, command/auth failure, or a completed non-success conclusion.",
-      "Return passed only when the exact publish action completed successfully. Include its URL as evidence_url.",
-      "Do not dispatch, rerun, watch, sleep, poll, tag, publish packages, or create a GitHub Release manually.",
+      "Use gh run list/view and select the push-event publish.yml run for the exact tag and release SHA. Require repository bastani-inc/atomic, the exact publish workflow path, matching tag, SHA, and push event.",
+      "Wait for completion instead of returning early: re-check roughly every 30 seconds, for up to 60 minutes; the run may take a few minutes to appear after the tag push.",
+      "Return passed only when the exact publish action completed successfully; include its URL as evidence_url. Return failed for identity mismatch, command/auth failure, or a completed non-success conclusion. Return pending only if the watch window expires without a terminal state.",
+      "Do not dispatch, rerun, tag, publish packages, or create a GitHub Release manually.",
     ].join("\n\n"));
 
     const summary = [

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -308,7 +308,7 @@ jobs:
           awk -v ver="$VERSION" 'BEGIN { found=0 } /^## \[/ { if (found) exit; if ($0 ~ "^## \\[" ver "\\]") { found=1; next } } found { print }' packages/coding-agent/CHANGELOG.md > release-assets/RELEASE_NOTES.md
           test -s release-assets/RELEASE_NOTES.md || echo "Release $VERSION" > release-assets/RELEASE_NOTES.md
           (cd release-assets && sha256sum atomic-*.tar.gz atomic-*.zip > SHA256SUMS)
-          for dir in packages/natives/npm/* packages/natives packages/coding-agent; do npm pack "$dir" --pack-destination npm-packages; done
+          for dir in packages/natives/npm/* packages/natives packages/coding-agent; do npm pack "./$dir" --pack-destination npm-packages; done
           test "$(find npm-packages -name '*.tgz' -type f | wc -l | tr -d ' ')" = 8
           bun -e '
             const expected = new Set(["@bastani/atomic-natives-darwin-arm64","@bastani/atomic-natives-darwin-x64","@bastani/atomic-natives-linux-arm64-gnu","@bastani/atomic-natives-linux-x64-gnu","@bastani/atomic-natives-win32-arm64-msvc","@bastani/atomic-natives-win32-x64-msvc"]);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,10 +140,10 @@ If a user asks to publish a release or prerelease, route the request through the
 3. For non-main bases, require the branch to be protected with the repository's required CI checks before using it as the selected release base.
 4. Launch one `publish-release` workflow run with `target_version`, `release_kind`, and `base_ref`. Do not duplicate its Git, PR, tag, or publishing actions inline.
 5. The workflow creates `[release|prerelease]/<version>` from the selected base, updates relevant changelogs without bumping package versions, validates and commits the changes, pushes the branch, and opens the PR.
-6. It inspects required CI once. Pending or failed checks pause at a human choice to reinspect the same run or stop; the workflow never watches, sleeps, or polls.
+6. It watches required CI until every required check reaches a terminal state, treating an admin merge of the PR as approval to proceed; check failures or an expired watch window stop the run with evidence.
 7. After checks pass, it merges the exact verified PR head, switches to the selected base, and fast-forwards from `origin/<base_ref>`.
 8. It runs `bun run scripts/cut-release.ts <version> --base <base_ref> --push --yes`, which stamps only the detached release commit and pushes the tag. That tag push automatically starts `publish.yml`; the workflow does not manually dispatch normal publication.
-9. It inspects the matching `Publish <version>` action once. Pending or failed publishing pauses at the same reinspect-or-stop gate; success returns a concise release summary.
+9. It watches the matching `Publish <version>` action until it completes. Failure or an expired watch window stops the run with evidence; success returns a concise release summary.
 
 ## Docs
 

--- a/test/unit/publish-release-workflow.test.ts
+++ b/test/unit/publish-release-workflow.test.ts
@@ -104,13 +104,14 @@ test("workflow preserves versionless bases and inspects direct tag publication",
   assert.doesNotMatch(source, /gh workflow run|workflow_dispatch|environment:\s*npm-publish/u);
 });
 
-test("pending and failed external gates pause for a same-run human decision", () => {
+test("external gates watch to a terminal state and stop the run instead of prompting humans", () => {
   const source = workflowSource();
-  assert.match(source, /await ctx\.ui\.select/u);
-  assert.match(source, /Reinspect after external state changes/u);
-  assert.match(source, /Stop this release/u);
-  assert.match(source, /continue this same workflow run and reinspect/u);
-  assert.match(source, /return inspectGate\(label, prompt, attempt \+ 1\)/u);
+  assert.doesNotMatch(source, /await ctx\.ui\.select|Reinspect after external state changes|Stop this release/u);
+  assert.match(source, /until they reach a terminal state/u);
+  assert.match(source, /re-check with gh pr checks\/view roughly every 30 seconds/u);
+  assert.match(source, /admin merge/u);
+  assert.match(source, /Watch the automatically triggered Publish \$\{release\.version\} GitHub Actions run until it completes/u);
+  assert.match(source, /did not reach a terminal state within the watch window/u);
 });
 
 test("workflow contains no executable wait, polling, watch, or manual publisher dispatch", () => {


### PR DESCRIPTION
## Summary

Two fixes discovered while recovering the failed `Publish 0.9.10-alpha.1` run ([failed job](https://github.com/bastani-inc/atomic/actions/runs/29718937847/job/88278286364)):

### 1. `publish.yml`: npm pack parsed `packages/natives` as GitHub shorthand

The Build release payload job runs `npm pack` over payload directories. npm parses the bare two-segment spec `packages/natives` (and `packages/coding-agent`) as GitHub shorthand (`github:packages/natives`) and attempts `git ls-remote ssh://git@github.com/packages/natives.git`, failing with `Permission denied (publickey)`. Prefixing each target with `./` forces local-path resolution.

### 2. `publish-release` workflow: watch gates instead of human reinspect loops

The CI and publish-action gates previously inspected external state exactly once and paused at a human reinspect-or-stop prompt whenever anything was pending. The gate stages now instruct the agent to watch until a terminal state (re-checking ~every 30s, bounded watch windows):

- **required CI**: passes when all required checks pass, or when the PR is completed by an admin merge; failures and expired watch windows stop the run with evidence.
- **publish action**: passes when the exact push-event `Publish <version>` run completes successfully.

AGENTS.md release-request steps 6/9 and the publish-release unit tests are updated to match.

## Test plan

- [x] `bun test test/unit/publish-release-workflow.test.ts` (8 pass)
- [x] Full pre-commit hooks (lint, file-length, unit tests) green on both commits
- [x] Workflow resources reload cleanly (13 workflows, generation 2)
- [ ] After merge: dispatch `publish.yml` with `tag: 0.9.10-alpha.1` to validate the payload fix on the existing tag

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the release automation flow and payload packaging. The main changes are:

- Release gates now watch required CI and publish runs until a terminal state.
- Pending gate timeouts now stop the workflow with evidence instead of prompting for human reinspection.
- `npm pack` payload directories are prefixed with `./` so they resolve as local paths.
- `AGENTS.md` and unit tests now match the new release-gate behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are narrow release-automation fixes, align with the documented versionless release pipeline, and include matching unit-test and agent-instruction updates. No blocking correctness or security issues were found in the changed paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the publish-release workflow test and confirmed it completed with 8 passing tests, 0 failures, and EXIT\_CODE 0.
- Ran the natives package dry-run packaging and confirmed it produced the package @bastani/atomic-natives@0.0.0 with EXIT\_CODE 0.
- Ran the coding-agent package dry-run packaging and confirmed it produced the package @bastani/atomic@0.0.0 with EXIT\_CODE 0.

<a href="https://app.greptile.com/trex/runs/15050670/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .atomic/workflows/publish-release.ts | Replaces human reinspect prompts with bounded gate-watching task prompts for required CI and publish action completion. |
| .github/workflows/publish.yml | Prefixes npm pack payload directories with local-path specifiers so package directories are not parsed as GitHub shorthand. |
| AGENTS.md | Updates release-request instructions to describe the new watch-to-terminal-state gates. |
| test/unit/publish-release-workflow.test.ts | Updates unit assertions to cover the removal of human prompts and the new bounded watch guidance. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Maintainer
  participant Workflow as publish-release workflow
  participant PR as Release PR / required CI
  participant Tag as cut-release tag push
  participant Publish as publish.yml run

  Maintainer->>Workflow: Launch release request
  Workflow->>PR: Create changelog PR and record head SHA
  loop Up to CI watch window
    Workflow->>PR: Re-check required checks / merge state
    PR-->>Workflow: passed, failed, pending, or merged
  end
  Workflow->>Tag: Merge verified PR, cut and push release tag
  Tag->>Publish: "Trigger push-event Publish <version>"
  loop Up to publish watch window
    Workflow->>Publish: Re-check exact tag/SHA workflow run
    Publish-->>Workflow: success, failure, active, or absent
  end
  Workflow-->>Maintainer: Completed summary or blocked evidence
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Maintainer
  participant Workflow as publish-release workflow
  participant PR as Release PR / required CI
  participant Tag as cut-release tag push
  participant Publish as publish.yml run

  Maintainer->>Workflow: Launch release request
  Workflow->>PR: Create changelog PR and record head SHA
  loop Up to CI watch window
    Workflow->>PR: Re-check required checks / merge state
    PR-->>Workflow: passed, failed, pending, or merged
  end
  Workflow->>Tag: Merge verified PR, cut and push release tag
  Tag->>Publish: "Trigger push-event Publish <version>"
  loop Up to publish watch window
    Workflow->>Publish: Re-check exact tag/SHA workflow run
    Publish-->>Workflow: success, failure, active, or absent
  end
  Workflow-->>Maintainer: Completed summary or blocked evidence
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore(workflows): watch release gates to..."](https://github.com/bastani-inc/atomic/commit/5011c8abf71950c99962517e642b55d5f7e51902) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45557117)</sub>

<!-- /greptile_comment -->