### PR TITLE
docs: explain turning skills into workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ See [Terminal setup](./packages/coding-agent/docs/terminal-setup.md), [Security]
 
 </details>
 
+### Bring your skill stack
+
+Already have agent skills? Bring them into Atomic by pointing Atomic at their existing directories or placing them in its project or user skill locations. Atomic implements the Agent Skills standard, and configured Claude Code or Codex skill directories can be used without rewriting them. See [Skills](./packages/coding-agent/docs/skills.md#using-skills-from-other-harnesses).
+
+When a skill captures a repeatable process, ask Atomic to author it as a durable workflow. Atomic inspects the skill and writes reviewable TypeScript using the [workflow guide](./packages/coding-agent/docs/workflows.md) and its examples.
+
+```text
+Inspect the existing skill `<skill-name-or-path>`—including its SKILL.md, scripts, references, and assets—and consult Atomic’s workflow docs and runnable TypeScript examples; then author a reusable TypeScript `workflow({...})` that preserves the skill’s intent while turning its repeatable process into durable multi-stage execution with precise typed inputs and declared outputs, artifact-backed handoffs for substantial context, explicit validation gates, and bounded retries or stop conditions where appropriate; add and run representative tests or smoke cases for the applicable success, validation-failure, and retry/stop paths, reload and verify workflow discovery, and ask me only questions whose answers materially change the design—otherwise state sensible assumptions and proceed.
+```
+
 ### Migrating from another coding agent
 
 Atomic publishes an agent-readable **[`llms.txt`](https://docs.bastani.ai/llms.txt)**. Ask your current coding agent to:


### PR DESCRIPTION
## Summary

Help existing Agent Skills users bring their current stack into Atomic and turn repeatable skills into durable, reviewable workflows.

## Changes

- Add a **Bring your skill stack** subsection to the README's Get started guide.
- Explain direct reuse of configured Claude Code and Codex skill directories.
- Provide a copy-paste prompt for authoring, testing, reloading, and validating a reusable Atomic workflow from an existing skill.

## Notes

- Documentation-only change; no runtime behavior changes.
- Commit and pre-push hooks passed, including lint, file-length checks, and the full unit test suite.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds README guidance for bringing existing skill setups into Atomic. The main changes are:

- A new `Bring your skill stack` subsection in the Get started guide.
- Guidance for reusing Claude Code and Codex skill directories with Atomic.
- A copy-paste prompt for turning repeatable skills into durable TypeScript workflows.

<h3>Confidence Score: 5/5</h3>

Safe to merge as a documentation-only change.

The README addition matches the existing skills and workflows documentation, and the referenced anchors are present.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Saved the verification script used for README link checks.
- Executed the link/anchor validation using the verification script and completed with exit code 0.
- Ran the lint check with Bun and completed with exit code 0.

<a href="https://app.greptile.com/trex/runs/15135691/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Adds user-facing guidance for reusing existing skill directories and converting repeatable skills into workflows. |

<sub>Reviews (1): Last reviewed commit: ["docs: explain turning skills into workfl..."](https://github.com/bastani-inc/atomic/commit/c04e03d4a2012ab16d80e03430fe3dc90a163f09) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45732330)</sub>

<!-- /greptile_comment -->