### PR TITLE
fix(evals): allow Kimi/Moonshot and ZAI providers in Pier adapter

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -193,3 +193,5 @@ uv run pier run \
 The Atomic Pier adapter reads `OPENROUTER_API_KEY` from the Pier process environment and passes it into the sandbox for Atomic. If your launcher does not inherit shell exports, pass it explicitly with `--agent-env OPENROUTER_API_KEY=...` instead.
 
 The Pier network allowlist automatically includes `openrouter.ai` when the model provider is `openrouter`. To use a custom OpenRouter-compatible endpoint, pass it with `--agent-env OPENROUTER_BASE_URL=...`.
+
+Kimi/Moonshot and ZAI are supported both as top-level `--model` providers and as nested workflow/subagent model assignments: the adapter forwards `KIMI_API_KEY`, `MOONSHOT_API_KEY`, `ZAI_API_KEY`, and `ZAI_CODING_CN_API_KEY` from the Pier process environment into the sandbox (alongside every other supported provider credential), and the restricted-egress allowlist includes their pi-ai base-URL domains (`api.kimi.com`, `api.moonshot.ai`, `api.moonshot.cn`, `api.z.ai`, `open.bigmodel.cn`). A stored `kimi-coding` entry in the local Atomic `auth.json` is copied into the sandbox like any other subscription credential.

--- a/evals/atomic_pier.py
+++ b/evals/atomic_pier.py
@@ -88,11 +88,18 @@ class Atomic(BaseInstalledAgent):
         # repos/datasets (code lookup in restricted egress). Re-enable
         # alongside the _PROVIDER_DOMAINS entry if HF inference is needed.
         # "huggingface": ("HF_TOKEN",),
+        # Kimi/Moonshot and ZAI env keys mirror pi-ai's provider registry
+        # (getApiKeyEnvVars in @earendil-works/pi-ai env-api-keys).
+        "kimi-coding": ("KIMI_API_KEY",),
         "mistral": ("MISTRAL_API_KEY",),
+        "moonshotai": ("MOONSHOT_API_KEY",),
+        "moonshotai-cn": ("MOONSHOT_API_KEY",),
         "openai": ("OPENAI_API_KEY",),
         "openai-codex": (),
         "openrouter": ("OPENROUTER_API_KEY",),
         "xai": ("XAI_API_KEY",),
+        "zai": ("ZAI_API_KEY",),
+        "zai-coding-cn": ("ZAI_CODING_CN_API_KEY",),
     }
     _PROVIDER_AUTH_ENV_KEYS: dict[str, tuple[str, ...]] = {
         "amazon-bedrock": ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"),
@@ -105,10 +112,15 @@ class Atomic(BaseInstalledAgent):
             "GOOGLE_API_KEY",
         ),
         "groq": ("GROQ_API_KEY",),
+        "kimi-coding": ("KIMI_API_KEY",),
         "mistral": ("MISTRAL_API_KEY",),
+        "moonshotai": ("MOONSHOT_API_KEY",),
+        "moonshotai-cn": ("MOONSHOT_API_KEY",),
         "openai": ("OPENAI_API_KEY",),
         "openrouter": ("OPENROUTER_API_KEY",),
         "xai": ("XAI_API_KEY",),
+        "zai": ("ZAI_API_KEY",),
+        "zai-coding-cn": ("ZAI_CODING_CN_API_KEY",),
     }
     _BASE_URL_ENV_KEYS: tuple[str, ...] = (
         "ANTHROPIC_BASE_URL",
@@ -145,11 +157,22 @@ class Atomic(BaseInstalledAgent):
         "google": (".googleapis.com",),
         "groq": ("api.groq.com",),
         # "huggingface": ("huggingface.co",),  # disabled: unused provider
+        # Kimi/Moonshot and ZAI domains come from pi-ai's provider base URLs:
+        # kimi-coding -> https://api.kimi.com/coding
+        # moonshotai -> https://api.moonshot.ai/v1
+        # moonshotai-cn -> https://api.moonshot.cn/v1
+        # zai -> https://api.z.ai/api/coding/paas/v4
+        # zai-coding-cn -> https://open.bigmodel.cn/api/coding/paas/v4
+        "kimi-coding": ("api.kimi.com",),
         "mistral": ("api.mistral.ai",),
+        "moonshotai": ("api.moonshot.ai",),
+        "moonshotai-cn": ("api.moonshot.cn",),
         "openai": ("api.openai.com",),
         "openai-codex": ("chatgpt.com", "auth.openai.com"),
         "openrouter": ("openrouter.ai",),
         "xai": ("api.x.ai",),
+        "zai": ("api.z.ai",),
+        "zai-coding-cn": ("open.bigmodel.cn",),
     }
 
     CLI_FLAGS: ClassVar[list[CliFlag]] = [
@@ -466,15 +489,20 @@ class Atomic(BaseInstalledAgent):
             requested_provider,
             requested_model,
         )
+        # Forward credentials for every Atomic-supported provider, not just the
+        # top-level Pier --model provider: nested workflow/subagent model
+        # assignments can select other providers (e.g. kimi-coding under an
+        # openai-codex-led run), and the network allowlist already admits all
+        # provider domains for the same reason. Forwarding everything also keeps
+        # _provision_subscription_auth's env-credential shadowing consistent —
+        # any host env credential that suppresses a copied auth.json entry is
+        # guaranteed to be present inside the container as its replacement.
         env = {
             key: value
-            for key in (
-                *self._PROVIDER_ENV_KEYS.get(provider, ()),
-                *(
-                    ("OPENROUTER_API_KEY",)
-                    if requested_provider in {"anthropic", self._OPENAI_CODEX_PROVIDER}
-                    else ()
-                ),
+            for key in dict.fromkeys(
+                env_key
+                for env_keys in self._PROVIDER_ENV_KEYS.values()
+                for env_key in env_keys
             )
             if (value := self._get_env(key))
         }


### PR DESCRIPTION
## Summary

The Pier restricted-egress allowlist in `evals/atomic_pier.py` intentionally unions every Atomic-supported provider domain so nested workflow/subagent model assignments can reach providers other than the top-level `--model` provider — but Kimi/Moonshot and ZAI were missing entirely. Their calls failed as generic SDK connection errors inside eval containers, and runs silently fell back to Codex.

## Changes

- Add `kimi-coding`, `moonshotai`, `moonshotai-cn`, `zai`, and `zai-coding-cn` to `_PROVIDER_ENV_KEYS`, `_PROVIDER_AUTH_ENV_KEYS`, and `_PROVIDER_DOMAINS`, mirroring pi-ai's provider registry (`@earendil-works/pi-ai@0.80.10`):
  | Provider | Env key | Domain (from pi-ai base URL) |
  |---|---|---|
  | `kimi-coding` | `KIMI_API_KEY` | `api.kimi.com` |
  | `moonshotai` | `MOONSHOT_API_KEY` | `api.moonshot.ai` |
  | `moonshotai-cn` | `MOONSHOT_API_KEY` | `api.moonshot.cn` |
  | `zai` | `ZAI_API_KEY` | `api.z.ai` |
  | `zai-coding-cn` | `ZAI_CODING_CN_API_KEY` | `open.bigmodel.cn` |
- Forward credentials for **every** supported provider into the sandbox instead of only the selected provider's keys. This fixes `KIMI_API_KEY` never reaching Codex-led eval containers, and makes `_provision_subscription_auth`'s env-credential shadowing self-consistent: a host env credential that suppresses a copied `auth.json` entry is now guaranteed to be present inside the container as its replacement (previously non-primary Anthropic env credentials could suppress copied OAuth without replacing it).
- Document Kimi/ZAI support in `evals/README.md`.

## Notes

Verified with restricted-egress (`allow_internet = false`) docker runs of a dummy hello-world task via `pier run --agent-import-path atomic_pier:Atomic` (atomic 0.9.10):

- `kimi-coding/kimi-for-coding` — completed through the squid egress proxy; generated proxy allowlist contains all five new domains.
- `anthropic/claude-opus-4-8` — 8 successful assistant turns via copied OAuth, **no 429/rate-limit/overloaded errors**, no Codex fallback.
- `openai-codex/gpt-5.6-sol` (`thinking=xhigh`) — completed normally.

Validation: `uv run basedpyright atomic_pier.py` (0 errors), pier tests `test_network_allowlists.py` + `test_filtered_egress_env.py` (15 passed), plus repo pre-commit hooks (lint, file-length, full unit suite).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Pier eval adapter to support more Atomic providers in restricted-egress runs. The main changes are:

- Adds Kimi/Moonshot and ZAI provider env keys to the Pier adapter.
- Adds the matching Kimi/Moonshot and ZAI API domains to the restricted-egress allowlist.
- Forwards credentials for all supported providers into the sandbox so nested workflow and subagent model assignments can use non-primary providers.
- Documents Kimi/Moonshot and ZAI support in `evals/README.md`.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are localized to provider maps, allowlist domains, sandbox env assembly, and matching docs. Existing OpenRouter forwarding remains covered through the unified provider-key iteration. No correctness or security issues were identified in the changed paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex executed the general-contract-validation-proof to validate the contract behavior for the atomic pier provider.
- The harness log shows the test run completed with RESULT=PASS and lists the extracted allowlist domains, forwarded env keys, and shadowed auth behavior.
- The harness source file atomic\_pier\_provider\_harness.py, which contains the import stubs and assertions used to exercise the changed code paths, was reviewed.
- A blocker was observed in the uv run due to missing Pier package metadata, as captured in the blocker log.

<a href="https://app.greptile.com/trex/runs/15187445/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| evals/atomic_pier.py | Adds Kimi/Moonshot and ZAI provider env keys/domains and forwards all supported provider credentials into Pier sandboxes. |
| evals/README.md | Documents Kimi/Moonshot and ZAI support and credential forwarding behavior for Pier evals. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Pier as Pier run
  participant Adapter as Atomic Pier adapter
  participant Env as Host environment
  participant Auth as Local auth.json
  participant Sandbox as Eval sandbox
  participant Provider as Provider APIs

  Pier->>Adapter: run with provider/model
  Adapter->>Adapter: select provider/model and build all-provider allowlist
  Adapter->>Env: read supported provider credentials
  Adapter->>Auth: load subscription credentials
  Adapter->>Sandbox: forward env credentials and provision non-shadowed auth.json
  Sandbox->>Provider: Atomic top-level or nested model calls through allowed domains
  Provider-->>Sandbox: model responses
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Pier as Pier run
  participant Adapter as Atomic Pier adapter
  participant Env as Host environment
  participant Auth as Local auth.json
  participant Sandbox as Eval sandbox
  participant Provider as Provider APIs

  Pier->>Adapter: run with provider/model
  Adapter->>Adapter: select provider/model and build all-provider allowlist
  Adapter->>Env: read supported provider credentials
  Adapter->>Auth: load subscription credentials
  Adapter->>Sandbox: forward env credentials and provision non-shadowed auth.json
  Sandbox->>Provider: Atomic top-level or nested model calls through allowed domains
  Provider-->>Sandbox: model responses
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): allow Kimi/Moonshot and ZAI ..."](https://github.com/bastani-inc/atomic/commit/df771178701b34b340c48529aa41a4b170cd2ec1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45830388)</sub>

<!-- /greptile_comment -->