### PR TITLE
fix(auth): guide recovery from invalidated Codex tokens

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Added actionable `/logout` and `/login` recovery guidance when OpenAI Codex invalidates or revokes a locally unexpired OAuth token, and prevented an earlier WebSocket-to-SSE transport diagnostic from making the definitive authentication rejection retryable ([#1922](https://github.com/bastani-inc/atomic/issues/1922)).
+
 ## [0.9.10] - 2026-07-20
 
 ### Breaking Changes

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -27,6 +27,8 @@ Use `/logout` to clear credentials. Tokens are stored in `~/.atomic/agent/auth.j
 - Requires ChatGPT Plus or Pro subscription
 - Officially endorsed by OpenAI: [Codex for OSS](https://developers.openai.com/community/codex-for-oss)
 
+If the Codex backend reports that an OAuth/auth token was invalidated or revoked, retry the request once in case the rejection is transient. If it persists, run `/logout` and select **OpenAI ChatGPT Plus/Pro**, then run `/login`, authenticate that subscription again, and retry the request. Atomic displays these recovery steps with the provider error; it does not automatically delete the stored credential or repeatedly retry a definitive authentication rejection.
+
 ### Codex Fast Mode
 
 Run `/fast` in interactive mode to enable OpenAI priority service tier separately for normal chat and workflow-stage sessions. The command is shown only when the current model scope includes a supported `openai/*` or `openai-codex/*` model. Workflow stages use the workflow setting, not the chat setting. When enabled for the active supported model, the UI appends `fast` after the model name in the chat footer and workflow stage model labels. Fast mode intentionally does not apply to `github-copilot/*`, Azure OpenAI, OpenRouter, or custom OpenAI-compatible providers. Use workflow fast mode deliberately because parallel workflow fan-out can multiply priority-tier usage.

--- a/packages/coding-agent/src/core/agent-session-events.ts
+++ b/packages/coding-agent/src/core/agent-session-events.ts
@@ -2,6 +2,7 @@ import { disposeSessionAsyncJobManager } from "./async/session-manager.js";
 import type { AgentEvent, AgentMessage } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage, Message, TextContent } from "@earendil-works/pi-ai/compat";
 import { cleanupSessionResources } from "@earendil-works/pi-ai/compat";
+import { formatCodexProviderError } from "./codex-errors.ts";
 import { formatCopilotProviderError } from "./copilot-errors.ts";
 import type { AgentSessionInternalSurface as AgentSession } from "./agent-session-methods.ts";
 import { customMessageExcludesContext, isSingleGenericAbortTextContent, replacementAbortContent, type AgentSessionEvent, type AgentSessionEventListener } from "./agent-session-types.ts";
@@ -240,9 +241,9 @@ export function _applyProviderErrorGuidance(this: AgentSession, event: AgentEven
 	const assistantMessage = event.message as AssistantMessage;
 	if (assistantMessage.stopReason !== "error" || !assistantMessage.errorMessage) return;
 
-	assistantMessage.errorMessage = formatCopilotProviderError(
+	assistantMessage.errorMessage = formatCodexProviderError(
 		assistantMessage.provider,
-		assistantMessage.errorMessage,
+		formatCopilotProviderError(assistantMessage.provider, assistantMessage.errorMessage),
 	);
 }
 

--- a/packages/coding-agent/src/core/agent-session-retry.ts
+++ b/packages/coding-agent/src/core/agent-session-retry.ts
@@ -3,6 +3,7 @@ import type { Api, AssistantMessage, Model } from "@earendil-works/pi-ai/compat"
 import { clampThinkingLevel, isContextOverflow, modelsAreEqual } from "@earendil-works/pi-ai/compat";
 import { sleep } from "../utils/sleep.ts";
 import { DEFAULT_THINKING_LEVEL } from "./defaults.ts";
+import { isCodexTokenInvalidationError } from "./codex-errors.ts";
 import { isCopilotGeminiModel } from "./copilot-gemini-payload-sanitizer.ts";
 import { normalizeToolArgumentsForModel } from "./copilot-gemini-tool-arguments.ts";
 import type { AgentSessionInternalSurface as AgentSession } from "./agent-session-methods.ts";
@@ -87,6 +88,12 @@ export function _isRetryableError(this: AgentSession, message: AssistantMessage)
 	// Context overflow is handled by compaction, not retry
 	const contextWindow = this.model?.contextWindow ?? 0;
 	if (isContextOverflow(message, contextWindow)) return false;
+
+	// A definitive Codex authentication rejection is terminal. It takes
+	// precedence over transport diagnostics recorded during WebSocket-to-SSE
+	// fallback so those earlier diagnostics cannot trigger a pointless retry.
+	const provider = message.provider || this.model?.provider;
+	if (provider && isCodexTokenInvalidationError(provider, message.errorMessage)) return false;
 
 	if (hasProviderTransportDiagnostic(message) || hasProviderModelUnavailableDiagnostic(message)) return true;
 	if (!message.errorMessage) return false;

--- a/packages/coding-agent/src/core/codex-errors.ts
+++ b/packages/coding-agent/src/core/codex-errors.ts
@@ -1,0 +1,14 @@
+const CODEX_INVALIDATED_TOKEN_PATTERN = /\binvalidated\s+(?:oauth|auth)\s+token\b|\btoken_revoked\b/i;
+const CODEX_RECOVERY_GUIDANCE =
+	"This Codex session may no longer be valid. Retry the request once in case the rejection is transient. If it persists, run `/logout` and select OpenAI ChatGPT Plus/Pro. Then run `/login`, authenticate OpenAI ChatGPT Plus/Pro again, and retry the request.";
+
+export function isCodexTokenInvalidationError(provider: string, errorMessage: string | undefined): boolean {
+	return provider === "openai-codex" && errorMessage !== undefined && CODEX_INVALIDATED_TOKEN_PATTERN.test(errorMessage);
+}
+
+export function formatCodexProviderError(provider: string, errorMessage: string): string {
+	if (!isCodexTokenInvalidationError(provider, errorMessage) || errorMessage.includes(CODEX_RECOVERY_GUIDANCE)) {
+		return errorMessage;
+	}
+	return `${errorMessage}\n\n${CODEX_RECOVERY_GUIDANCE}`;
+}

--- a/test/unit/codex-oauth-recovery.test.ts
+++ b/test/unit/codex-oauth-recovery.test.ts
@@ -1,0 +1,99 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import type { AssistantMessage } from "@earendil-works/pi-ai/compat";
+import { formatCodexProviderError } from "../../packages/coding-agent/src/core/codex-errors.js";
+import {
+  _applyProviderErrorGuidance,
+  _createRetryPromiseForAgentEnd,
+} from "../../packages/coding-agent/src/core/agent-session-events.js";
+import { _isRetryableError } from "../../packages/coding-agent/src/core/agent-session-retry.js";
+
+const GUIDANCE =
+  "This Codex session may no longer be valid. Retry the request once in case the rejection is transient. If it persists, run `/logout` and select OpenAI ChatGPT Plus/Pro. Then run `/login`, authenticate OpenAI ChatGPT Plus/Pro again, and retry the request.";
+
+function errorMessage(errorMessage: string, diagnostics?: object[]): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [],
+    provider: "openai-codex",
+    model: "gpt-5.5",
+    api: "openai-codex-responses",
+    stopReason: "error",
+    errorMessage,
+    diagnostics,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    timestamp: Date.now(),
+  } as AssistantMessage;
+}
+
+const session = { model: { provider: "openai-codex", contextWindow: 200_000 } };
+
+test("Codex invalidated OAuth errors include actionable reauthentication guidance", () => {
+  const original = "Codex error: invalidated oauth token (request id: redacted)";
+  assert.equal(formatCodexProviderError("openai-codex", original), `${original}\n\n${GUIDANCE}`);
+});
+
+test("Codex invalidated auth and token_revoked wording receive the same guidance", () => {
+  for (const original of ["Codex error: invalidated auth token", "Codex error: token_revoked"]) {
+    assert.equal(formatCodexProviderError("openai-codex", original), `${original}\n\n${GUIDANCE}`);
+  }
+});
+
+test("Codex recovery guidance preserves unrelated errors and is idempotent", () => {
+  assert.equal(formatCodexProviderError("openai-codex", "Codex error: usage limit"), "Codex error: usage limit");
+  assert.equal(formatCodexProviderError("openai", "invalidated oauth token"), "invalidated oauth token");
+
+  const guided = formatCodexProviderError("openai-codex", "Codex error: token_revoked");
+  assert.equal(formatCodexProviderError("openai-codex", guided), guided);
+});
+
+test("definitive Codex token invalidation overrides an earlier transport diagnostic", () => {
+  const diagnostic = {
+    type: "provider_transport_failure",
+    timestamp: Date.now(),
+    error: { message: "WebSocket error; falling back to SSE", status: 404 },
+  };
+
+  for (const wording of ["invalidated oauth token", "invalidated auth token", "token_revoked"]) {
+    const message = errorMessage(`Codex error: ${wording}`, [diagnostic]);
+    assert.equal(_isRetryableError.call(session as never, message), false, wording);
+  }
+});
+
+test("transport diagnostics remain retryable for other Codex errors", () => {
+  const message = errorMessage("Codex error: request failed", [
+    { type: "provider_transport_failure", error: { message: "WebSocket error" } },
+  ]);
+  assert.equal(_isRetryableError.call(session as never, message), true);
+});
+
+test("main-chat event handling renders guidance and does not open a retry lifecycle", () => {
+  const message = errorMessage("Codex error: invalidated oauth token", [
+    { type: "provider_transport_failure", error: { message: "WebSocket error" } },
+  ]);
+  const event = { type: "message_end", message } as const;
+  const retrySession = {
+    model: session.model,
+    _retryPromise: undefined as Promise<void> | undefined,
+    _retryResolve: undefined as (() => void) | undefined,
+    _fallbackModels: [],
+    settingsManager: { getRetrySettings: () => ({ enabled: true }) },
+    _findLastAssistantInMessages: () => message,
+    _isRetryableError,
+    _isEmptyCompletion: () => false,
+    _isSafetyRefusal: () => false,
+  };
+
+  _createRetryPromiseForAgentEnd.call(retrySession as never, { type: "agent_end", messages: [message] });
+  assert.equal(retrySession._retryPromise, undefined);
+
+  _applyProviderErrorGuidance.call(retrySession as never, event as never);
+  assert.equal(message.errorMessage, `Codex error: invalidated oauth token\n\n${GUIDANCE}`);
+});


### PR DESCRIPTION
## Summary

Improve recovery guidance when OpenAI Codex invalidates or revokes an OAuth token that Atomic still considers locally valid. Atomic now keeps the provider error visible, explains how to reauthenticate with `/logout` and `/login`, and treats the definitive authentication rejection as terminal even after WebSocket-to-SSE fallback diagnostics.

## Changes

- Detect the Codex `invalidated oauth token`, `invalidated auth token`, and `token_revoked` error variants.
- Append idempotent, actionable recovery guidance without deleting stored credentials automatically.
- Prevent earlier transport fallback diagnostics from making a definitive token rejection retryable.
- Add `bun:test` coverage for guidance formatting, provider scoping, wording variants, retry precedence, and the main-chat retry lifecycle.
- Document the behavior in the provider guide and coding-agent changelog.

## Validation

- `bun run typecheck`
- `AGENT=1 bun run test:unit` — 3861 passed, 0 failed in the uncontended worker run; commit and push hooks also passed the unit suite
- `bun run check:file-length`
- `bun run --cwd packages/coding-agent build`
- Real source-launched CLI validation in tmux using `openai-codex/gpt-5.5`, including read/bash tool smoke checks, a dummy workflow, and a controlled invalidated-token backend scenario
- Controlled backend recorded one WebSocket attempt and one SSE rejection, confirming no transport-driven retry

Fixes #1922

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds recovery guidance when OpenAI Codex invalidates a locally valid OAuth token, and prevents the auto-retry mechanism from firing on what is a definitive authentication rejection.

- **`codex-errors.ts` (new)**: Pure module with a regex matching three Codex token-invalidation wordings, an unexported guidance constant, and two functions — `isCodexTokenInvalidationError` for detection and `formatCodexProviderError` for idempotent guidance appending.
- **`agent-session-retry.ts`**: Early-exit guard inserted in `_isRetryableError` *before* the transport-diagnostic check, ensuring a WS→SSE fallback diagnostic recorded during the same request cannot promote the terminal auth rejection to a retryable state.
- **`agent-session-events.ts`**: `_applyProviderErrorGuidance` now chains `formatCodexProviderError` around the existing `formatCopilotProviderError` call; the two providers are mutually exclusive so there is no interference.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the logic is correct, well-tested, and the change is narrowly scoped to the Codex provider path.

The implementation is clean and the tests cover the key scenarios. The only noteworthy gap is that CODEX_RECOVERY_GUIDANCE is unexported, so the test file maintains a duplicate copy of the exact wording — a future wording update would require two edits.

No files require special attention; test/unit/codex-oauth-recovery.test.ts has a minor maintenance concern with the hardcoded GUIDANCE constant but no correctness risk.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/src/core/codex-errors.ts | New module: defines the token-invalidation regex, unexported guidance constant, and two clean pure functions for detection and formatting. No logic issues. |
| packages/coding-agent/src/core/agent-session-events.ts | Chains formatCodexProviderError around the existing formatCopilotProviderError call. Providers are mutually exclusive so there is no interference between the two formatters. |
| packages/coding-agent/src/core/agent-session-retry.ts | Inserts the Codex token-invalidation terminal guard before the transport-diagnostic check, correctly preventing a WebSocket→SSE fallback diagnostic from making a definitive auth rejection retryable. |
| test/unit/codex-oauth-recovery.test.ts | Good coverage of formatting, scoping, idempotency, retry precedence, and the lifecycle test; GUIDANCE constant is duplicated from the unexported source constant, creating a two-place update requirement if the wording changes. |
| packages/coding-agent/docs/providers.md | Adds a short paragraph documenting the invalidated-token recovery procedure, consistent with the guidance text in codex-errors.ts. |
| packages/coding-agent/CHANGELOG.md | Adds a Fixed entry under [Unreleased] following the changelog format specified in AGENTS.md; references the correct issue number. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Codex as Codex Backend
    participant Agent as Agent Core
    participant HAE as _handleAgentEvent
    participant PAE as _processAgentEvent
    participant IRE as _isRetryableError
    participant APG as _applyProviderErrorGuidance
    participant UI as UI / Listeners

    Codex->>Agent: 401 "invalidated oauth token"
    Agent->>HAE: emit(message_end)
    HAE->>PAE: queue _processAgentEvent(message_end)
    Agent->>HAE: emit(agent_end)
    HAE->>HAE: _createRetryPromiseForAgentEnd (sync)
    HAE->>IRE: _isRetryableError(lastAssistant)
    IRE-->>HAE: isCodexTokenInvalidationError → true → return false
    Note over HAE: No _retryPromise created
    HAE->>PAE: queue _processAgentEvent(agent_end)

    PAE->>APG: _applyProviderErrorGuidance(message_end)
    APG-->>PAE: "errorMessage += CODEX_RECOVERY_GUIDANCE"
    PAE->>UI: emit(message_end with guidance)
    PAE->>PAE: persist message

    PAE->>IRE: _isRetryableError(msg) at agent_end
    IRE-->>PAE: false (terminal auth rejection)
    PAE->>UI: No auto_retry_start event
    Note over UI: User sees error + /logout /login instructions
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Codex as Codex Backend
    participant Agent as Agent Core
    participant HAE as _handleAgentEvent
    participant PAE as _processAgentEvent
    participant IRE as _isRetryableError
    participant APG as _applyProviderErrorGuidance
    participant UI as UI / Listeners

    Codex->>Agent: 401 "invalidated oauth token"
    Agent->>HAE: emit(message_end)
    HAE->>PAE: queue _processAgentEvent(message_end)
    Agent->>HAE: emit(agent_end)
    HAE->>HAE: _createRetryPromiseForAgentEnd (sync)
    HAE->>IRE: _isRetryableError(lastAssistant)
    IRE-->>HAE: isCodexTokenInvalidationError → true → return false
    Note over HAE: No _retryPromise created
    HAE->>PAE: queue _processAgentEvent(agent_end)

    PAE->>APG: _applyProviderErrorGuidance(message_end)
    APG-->>PAE: "errorMessage += CODEX_RECOVERY_GUIDANCE"
    PAE->>UI: emit(message_end with guidance)
    PAE->>PAE: persist message

    PAE->>IRE: _isRetryableError(msg) at agent_end
    IRE-->>PAE: false (terminal auth rejection)
    PAE->>UI: No auto_retry_start event
    Note over UI: User sees error + /logout /login instructions
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/coding-agent/src/core/codex-errors.ts:2-3
Consider exporting `CODEX_RECOVERY_GUIDANCE` so the test file can import it directly instead of maintaining a hardcoded copy. Right now `GUIDANCE` in the test and `CODEX_RECOVERY_GUIDANCE` in the source are identical, but if the wording changes (e.g., a command rename), two spots need to be kept in sync. Exporting the constant makes that a one-edit change and removes any ambiguity about which string is authoritative.

```suggestion
export const CODEX_RECOVERY_GUIDANCE =
	"This Codex session may no longer be valid. Retry the request once in case the rejection is transient. If it persists, run `/logout` and select OpenAI ChatGPT Plus/Pro. Then run `/login`, authenticate OpenAI ChatGPT Plus/Pro again, and retry the request.";
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): guide recovery from invalidat..."](https://github.com/bastani-inc/atomic/commit/4c827063c515aadd8ef81c94bd53e338f19b1915) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45832209)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->