### PR TITLE
fix(workflows): DBOS durability under root and without Postgres

### DIFF
--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -2427,11 +2427,13 @@ The readiness prompt can be answered in the attached stage UI or with `workflow(
 
 ## Durable Workflows and Cross-Session Resume
 
-Atomic workflows use **DBOS/Postgres as their sole persistent workflow backend**. Atomic configures and launches DBOS lazily on the first workflow action, reuses that process-wide instance, and awaits readiness before workflow execution, resume, inspection, or deletion can access durable state. `DBOS_SYSTEM_DATABASE_URL` may select an existing database; DBOS initialization, query, and write failures fail the workflow action and never select another backend.
+Atomic workflows use **DBOS/Postgres as their sole persistent workflow backend**. Atomic configures and launches DBOS lazily on the first workflow action, reuses that process-wide instance, and awaits readiness before workflow execution, resume, inspection, or deletion can access durable state. `DBOS_SYSTEM_DATABASE_URL` may select an existing database; DBOS query and write failures fail the workflow action and never select another backend.
 
 **Zero-configuration local database.** Without `DBOS_SYSTEM_DATABASE_URL`, Atomic runs DBOS against its own embedded Postgres built from npm-distributed binaries — no Docker daemon or system Postgres install. The cluster lives under `~/.atomic/postgres/v18` on dedicated port `5439`; the first workflow action initializes it once and starts it with `pg_ctl` as a detached daemon that survives Atomic exiting, is shared by every concurrent Atomic session, and is never stopped by Atomic.
 
-When the embedded binaries are unavailable for the platform, Atomic falls back to DBOS's reusable `dbos-db` Docker container; if neither is usable, the workflow action fails with one actionable message: set `DBOS_SYSTEM_DATABASE_URL` to an existing Postgres.
+**Running as root (Linux).** PostgreSQL refuses to run as UID 0, so a root Atomic process (containers, CI sandboxes, eval harnesses) resolves an unprivileged system account (`postgres`, `nobody`, or `daemon`), keeps the cluster under `/var/lib/atomic-postgres` instead (a root home directory is untraversable for that account), and runs every Postgres command with dropped privileges. When the embedded binaries themselves sit under an untraversable prefix (for example a root-owned `~/.nvm` global install), Atomic copies the Postgres runtime into the cluster directory once and reuses it.
+
+When the embedded binaries are unavailable for the platform, Atomic falls back to DBOS's reusable `dbos-db` Docker container. If no durable backend can be provisioned at all, workflows **degrade to a process-local in-memory backend with a loud warning** instead of refusing to run: the run executes normally, but its state does not survive the process and `/workflow resume` after exit has nothing to restore. Set `DBOS_SYSTEM_DATABASE_URL` to an existing Postgres to restore durability.
 
 **Multiple concurrent Atomic sessions.** Every Atomic process launches DBOS with a unique executor id, and running root workflows carry owner/heartbeat metadata refreshed by ordinary ≤30-second stage-timing checkpoints. **Running workflows are never resume targets**: a running row with a fresh heartbeat is hidden from every session's picker and refused by direct `/workflow resume <id>` — resuming a workflow that is executing elsewhere would double-dispatch it. Once the heartbeat goes stale (about two minutes after a crash), the workflow surfaces as a red `crashed` row.
 
@@ -2526,7 +2528,7 @@ Validation uses the final retained transcript for a repeated stage replay key, s
 
 ### Configuring DBOS/Postgres
 
-DBOS/Postgres durability requires no setup on supported local platforms. To use an existing Postgres database, set `DBOS_SYSTEM_DATABASE_URL` before starting Atomic; otherwise Atomic provisions embedded Postgres, with Docker as a platform fallback. The DBOS SDK ships with `@bastani/atomic`. If the SDK cannot load or Postgres cannot be reached or provisioned, Atomic fails the workflow action with an actionable diagnostic instead of falling back to the legacy per-workflow file store under `~/.atomic/workflow-durable`.
+DBOS/Postgres durability requires no setup on supported local platforms. To use an existing Postgres database, set `DBOS_SYSTEM_DATABASE_URL` before starting Atomic; otherwise Atomic provisions embedded Postgres (with drop-privilege support when running as root on Linux), with Docker as a platform fallback. The DBOS SDK ships with `@bastani/atomic`. If no durable backend can be provisioned, workflows run on a process-local in-memory backend with a loud non-durable warning — never on the legacy per-workflow file store under `~/.atomic/workflow-durable` — and cross-process resume is unavailable until Postgres provisioning is fixed.
 
 ```bash
 export DBOS_SYSTEM_DATABASE_URL="postgresql://user:password@localhost:5432/atomic_dbos_sys"

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Embedded DBOS Postgres now works when Atomic runs as root on Linux (containers, CI sandboxes, eval harnesses): PostgreSQL refuses UID 0, so Atomic resolves an unprivileged system account (`postgres`, `nobody`, or `daemon`), keeps the cluster under `/var/lib/atomic-postgres` (a root home directory is untraversable for that account), and runs `initdb`/`pg_ctl` with dropped privileges. When the embedded binaries sit under an untraversable prefix (for example a root-owned `~/.nvm` global install), the Postgres runtime is copied into the cluster directory once and reused.
+
+### Changed
+
+- When no durable backend can be provisioned at all (no `DBOS_SYSTEM_DATABASE_URL`, embedded Postgres unavailable, and no Docker), workflows now degrade to a process-local in-memory backend with a loud non-durable warning instead of failing every workflow action. Degraded runs execute normally but do not survive the process, so `/workflow resume` after exit has nothing to restore; DBOS query and write failures on a provisioned backend still fail the workflow action.
+
+### Fixed
+
+- Fixed session teardown crashing the process (exit code 1) after DBOS durability provisioning had failed: `shutdownDbos` re-awaited the memoized rejected configuration promise and rethrew the original provisioning error out of session dispose and the `beforeExit` hook, turning otherwise-successful `--print` runs into nonzero exits (surfacing as `NonZeroAgentExitCodeError` in eval harnesses). Shutdown is now a no-op for a backend that never reached readiness, and genuine teardown failures are logged instead of thrown.
+
 ## [0.9.10] - 2026-07-20
 
 ### Breaking Changes

--- a/packages/workflows/src/durable/backend.ts
+++ b/packages/workflows/src/durable/backend.ts
@@ -37,7 +37,7 @@ export type DurableInactiveDeleteResult =
   | { readonly ok: true }
   | { readonly ok: false; readonly reason: "not_found" | "running" };
 
-/** DBOS is the sole persistent implementation. In-memory is an explicit test seam. */
+/** DBOS is the sole persistent implementation. In-memory is a test seam and the non-durable last-resort fallback. */
 export interface DurableWorkflowBackend {
   /** Whether state survives the current process. */
   readonly persistent: boolean;
@@ -156,7 +156,7 @@ function checkpointKey(c: DurableCheckpoint): string {
   return `${c.kind}:${c.checkpointId}`;
 }
 
-/** Process-local current-interface backend for explicit test injection. */
+/** Process-local backend: explicit test injection and the loud non-durable fallback when DBOS cannot be provisioned. */
 export class InMemoryDurableBackend implements DurableWorkflowBackend {
   public readonly persistent: boolean = false;
   private readonly workflows = new Map<string, InMemoryWorkflowRecord>();

--- a/packages/workflows/src/durable/dbos-embedded-postgres-root.ts
+++ b/packages/workflows/src/durable/dbos-embedded-postgres-root.ts
@@ -1,0 +1,173 @@
+/**
+ * Root-execution support for the embedded DBOS Postgres.
+ *
+ * PostgreSQL categorically refuses to run `initdb`/`postgres` as UID 0, so a
+ * root Atomic process (common in containers, CI sandboxes, and eval harnesses)
+ * cannot provision the embedded cluster directly. On Linux we instead resolve
+ * an unprivileged system account, keep the cluster under a root-safe base
+ * directory (`/root` is mode 0700 and untraversable by that account), and run
+ * every Postgres command with dropped privileges.
+ *
+ * Privilege dropping is strategy-probed at runtime: Node honors the child
+ * process `uid`/`gid` spawn options, but Bun currently ignores them, so we
+ * verify the drop actually happens (`id -u` must report the owner) and fall
+ * back to `setpriv`, `runuser`, or `su` wrappers when it does not.
+ *
+ * The embedded binaries themselves may also live under an untraversable
+ * prefix (for example a root-owned `~/.nvm` global install), so the caller can
+ * probe them as the unprivileged owner and fall back to a one-time copy into
+ * the cluster base directory.
+ */
+
+import { cpSync, existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { runLocalCommand, type LocalCommandResult } from "./local-command.js";
+
+export interface EmbeddedPostgresOwner {
+  readonly uid: number;
+  readonly gid: number;
+  readonly name: string;
+}
+
+export interface EmbeddedPostgresRunContext {
+  /** Directory that holds the cluster, log file, and setup locks. */
+  readonly baseDir: string;
+  /** Present only when commands must drop privileges (Linux root). */
+  readonly owner?: EmbeddedPostgresOwner;
+  /** Runs a command as the owner; identity pass-through when no owner. */
+  readonly runAsOwner: LocalCommandRunner;
+}
+
+export interface EmbeddedPostgresBinaryPaths {
+  readonly pg_ctl: string;
+  readonly initdb: string;
+}
+
+export type LocalCommandRunner = (
+  command: string,
+  args: readonly string[],
+  options?: { readonly uid?: number; readonly gid?: number },
+) => Promise<LocalCommandResult>;
+
+/** Root-safe cluster location: system path, traversable by system accounts. */
+export const ROOT_EMBEDDED_BASE_DIR = "/var/lib/atomic-postgres";
+
+/** Unprivileged accounts tried in order; `postgres` wins when present. */
+const OWNER_CANDIDATES = ["postgres", "nobody", "daemon"] as const;
+
+export function defaultEmbeddedBaseDir(): string {
+  return join(homedir(), ".atomic", "postgres");
+}
+
+/**
+ * Resolve where and as whom the embedded cluster should run. Non-root (and
+ * every non-Linux platform) keeps the historical home-directory layout. Linux
+ * root without a resolvable unprivileged account, or without any working
+ * privilege-drop mechanism, also falls through to the default context so
+ * PostgreSQL's own root refusal surfaces with full detail.
+ */
+export async function resolveEmbeddedRunContext(
+  runner: LocalCommandRunner = runLocalCommand,
+  euid: number | undefined = process.getuid?.(),
+  platform: NodeJS.Platform = process.platform,
+): Promise<EmbeddedPostgresRunContext> {
+  if (platform !== "linux" || euid !== 0) {
+    return { baseDir: defaultEmbeddedBaseDir(), runAsOwner: runner };
+  }
+  for (const name of OWNER_CANDIDATES) {
+    const owner = await lookupOwner(runner, name);
+    if (owner === undefined) continue;
+    const runAsOwner = await resolvePrivilegeDrop(runner, owner);
+    if (runAsOwner === undefined) continue;
+    return { baseDir: ROOT_EMBEDDED_BASE_DIR, owner, runAsOwner };
+  }
+  return { baseDir: defaultEmbeddedBaseDir(), runAsOwner: runner };
+}
+
+/**
+ * Return a runner that verifiably executes commands as the owner, or
+ * `undefined` when no drop mechanism works. Each strategy is validated by
+ * running `id -u` through it and requiring the owner's uid on stdout — the
+ * spawn `uid`/`gid` options in particular are silently ignored by Bun.
+ */
+export async function resolvePrivilegeDrop(
+  runner: LocalCommandRunner,
+  owner: EmbeddedPostgresOwner,
+): Promise<LocalCommandRunner | undefined> {
+  const strategies: readonly LocalCommandRunner[] = [
+    (command, args) => runner(command, args, { uid: owner.uid, gid: owner.gid }),
+    (command, args) => runner("setpriv", [
+      `--reuid=${owner.uid}`, `--regid=${owner.gid}`, "--clear-groups", "--", command, ...args,
+    ]),
+    (command, args) => runner("runuser", ["-u", owner.name, "--", command, ...args]),
+    (command, args) => runner("su", ["-s", "/bin/sh", "-c", shellCommand(command, args), owner.name]),
+  ];
+  for (const strategy of strategies) {
+    const probe = await strategy("id", ["-u"]).catch(() => undefined);
+    if (probe !== undefined && probe.exitCode === 0 && probe.stdout.trim() === String(owner.uid)) {
+      return strategy;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Ensure the embedded binaries are executable by the drop-privilege owner.
+ * Probes `initdb --version` as the owner; on failure (typically an
+ * untraversable ancestor such as `/root`) copies the package's `native` tree
+ * into the cluster base directory once and reuses it afterwards.
+ */
+export async function prepareBinariesForOwner(
+  binaries: EmbeddedPostgresBinaryPaths,
+  context: EmbeddedPostgresRunContext,
+  runner: LocalCommandRunner = runLocalCommand,
+): Promise<EmbeddedPostgresBinaryPaths> {
+  const owner = context.owner;
+  if (owner === undefined) return binaries;
+
+  const probe = await context.runAsOwner(binaries.initdb, ["--version"]).catch(() => undefined);
+  if (probe !== undefined && probe.exitCode === 0) return binaries;
+
+  // `<packageRoot>/native/bin/initdb` → copy the whole `native` tree so the
+  // binaries keep their relative `../lib` runtime library references.
+  const nativeDir = dirname(dirname(binaries.initdb));
+  const copiedNativeDir = join(context.baseDir, "pg-runtime", "native");
+  const copied: EmbeddedPostgresBinaryPaths = {
+    pg_ctl: join(copiedNativeDir, "bin", "pg_ctl"),
+    initdb: join(copiedNativeDir, "bin", "initdb"),
+  };
+  if (!existsSync(copied.initdb)) {
+    cpSync(nativeDir, copiedNativeDir, { recursive: true });
+  }
+  const chown = await runner("chown", ["-R", `${owner.uid}:${owner.gid}`, join(context.baseDir, "pg-runtime")]);
+  if (chown.exitCode !== 0) {
+    throw new Error(
+      `Could not hand the copied embedded Postgres runtime to ${owner.name}: ${chown.stderr.trim() || chown.stdout.trim() || `exit ${chown.exitCode}`}`,
+    );
+  }
+  return copied;
+}
+
+async function lookupOwner(runner: LocalCommandRunner, name: string): Promise<EmbeddedPostgresOwner | undefined> {
+  const uid = await lookupId(runner, ["-u", name]);
+  const gid = await lookupId(runner, ["-g", name]);
+  if (uid === undefined || gid === undefined || uid === 0) return undefined;
+  return { uid, gid, name };
+}
+
+async function lookupId(runner: LocalCommandRunner, args: readonly string[]): Promise<number | undefined> {
+  try {
+    const result = await runner("id", args);
+    if (result.exitCode !== 0) return undefined;
+    const value = Number.parseInt(result.stdout.trim(), 10);
+    return Number.isInteger(value) && value > 0 ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Single-quote a command line for `su -c`; arguments never embed user input. */
+function shellCommand(command: string, args: readonly string[]): string {
+  return [command, ...args].map((part) => `'${part.replaceAll("'", "'\\''")}'`).join(" ");
+}

--- a/packages/workflows/src/durable/dbos-embedded-postgres.ts
+++ b/packages/workflows/src/durable/dbos-embedded-postgres.ts
@@ -10,12 +10,23 @@
  * is started with `pg_ctl`, which daemonizes the server into its own session:
  * it survives Atomic exiting and is shared by every concurrent Atomic session.
  * Atomic never stops it.
+ *
+ * PostgreSQL refuses to run as UID 0, so a root Atomic process (containers,
+ * CI sandboxes, eval harnesses) resolves an unprivileged system account, keeps
+ * the cluster under `/var/lib/atomic-postgres` instead (a root home directory
+ * is untraversable for that account), and runs every Postgres command with
+ * dropped privileges. See dbos-embedded-postgres-root.ts.
  */
 
-import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
-import { homedir, tmpdir } from "node:os";
+import { chmodSync, chownSync, copyFileSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join, relative } from "node:path";
-import { commandFailureDetail, delay, runLocalCommand, tcpReachable } from "./local-command.js";
+import {
+  prepareBinariesForOwner,
+  resolveEmbeddedRunContext,
+  type EmbeddedPostgresRunContext,
+} from "./dbos-embedded-postgres-root.js";
+import { commandFailureDetail, delay, tcpReachable } from "./local-command.js";
 
 const EMBEDDED_HOST = "127.0.0.1";
 const EMBEDDED_PORT = 5439;
@@ -47,17 +58,20 @@ export function ensureEmbeddedDbosPostgres(): Promise<void> {
 
 async function ensure(): Promise<void> {
   if (await tcpReachable(EMBEDDED_HOST, EMBEDDED_PORT)) return;
-  const binaries = await loadEmbeddedPostgresBinaries();
-  hydrateBinaryLibraryLinks(binaries.pg_ctl);
-  const root = join(homedir(), ".atomic", "postgres");
+  const loaded = await loadEmbeddedPostgresBinaries();
+  hydrateBinaryLibraryLinks(loaded.pg_ctl);
+  const context = await resolveEmbeddedRunContext();
+  const root = context.baseDir;
   const dataDir = join(root, `v${EMBEDDED_PG_MAJOR}`);
   const logFile = join(root, `v${EMBEDDED_PG_MAJOR}.log`);
   mkdirSync(root, { recursive: true, mode: 0o700 });
+  if (context.owner !== undefined) chownSync(root, context.owner.uid, context.owner.gid);
+  const binaries = await prepareBinariesForOwner(loaded, context);
 
   await withSetupLock(join(root, `v${EMBEDDED_PG_MAJOR}.setup-lock`), async () => {
     if (await tcpReachable(EMBEDDED_HOST, EMBEDDED_PORT)) return;
-    if (!existsSync(join(dataDir, "PG_VERSION"))) await initializeCluster(binaries.initdb, dataDir);
-    await startCluster(binaries.pg_ctl, dataDir, logFile);
+    if (!existsSync(join(dataDir, "PG_VERSION"))) await initializeCluster(binaries.initdb, dataDir, context);
+    await startCluster(binaries.pg_ctl, dataDir, logFile, context);
   });
 
   for (let attempt = 0; attempt < READY_ATTEMPTS; attempt += 1) {
@@ -67,11 +81,16 @@ async function ensure(): Promise<void> {
   throw new Error(`Embedded Postgres started but never accepted connections on ${EMBEDDED_HOST}:${EMBEDDED_PORT}; see ${logFile}.`);
 }
 
-async function initializeCluster(initdb: string, dataDir: string): Promise<void> {
+async function initializeCluster(
+  initdb: string,
+  dataDir: string,
+  context: EmbeddedPostgresRunContext,
+): Promise<void> {
   const passwordFile = join(tmpdir(), `atomic-pg-pw-${process.pid}-${crypto.randomUUID().slice(0, 8)}`);
   writeFileSync(passwordFile, `${EMBEDDED_PASSWORD}\n`, { mode: 0o600 });
   try {
-    const result = await runLocalCommand(initdb, [
+    if (context.owner !== undefined) chownSync(passwordFile, context.owner.uid, context.owner.gid);
+    const result = await context.runAsOwner(initdb, [
       "-D", dataDir,
       "-U", EMBEDDED_USER,
       "-A", "password",
@@ -87,8 +106,13 @@ async function initializeCluster(initdb: string, dataDir: string): Promise<void>
   }
 }
 
-async function startCluster(pgCtl: string, dataDir: string, logFile: string): Promise<void> {
-  const result = await runLocalCommand(pgCtl, [
+async function startCluster(
+  pgCtl: string,
+  dataDir: string,
+  logFile: string,
+  context: EmbeddedPostgresRunContext,
+): Promise<void> {
+  const result = await context.runAsOwner(pgCtl, [
     "-D", dataDir,
     "-l", logFile,
     "-o", `-p ${EMBEDDED_PORT} -c listen_addresses=${EMBEDDED_HOST}`,

--- a/packages/workflows/src/durable/dbos-lifecycle.ts
+++ b/packages/workflows/src/durable/dbos-lifecycle.ts
@@ -119,10 +119,16 @@ export function getReadyDbosBackendSync(): DbosDurableBackend | undefined {
 
 export async function shutdownDbos(): Promise<void> {
   if (shutdownPromise !== undefined) return await shutdownPromise;
-  if (configured === undefined) return;
+  const configuredPromise = configured;
+  if (configuredPromise === undefined) return;
   shutdownPromise = (async () => {
-    const durability = await configured;
-    if (launchPromise !== undefined) await launchPromise;
+    // A backend that never reached "ready" has nothing to flush or stop.
+    // `configured`/`launchPromise` memoize rejections, so re-awaiting them
+    // unguarded would rethrow the original provisioning failure out of every
+    // session dispose — crashing otherwise-successful runs at process exit.
+    const durability = await configuredPromise.catch(() => undefined);
+    if (durability === undefined) return;
+    if (launchPromise !== undefined) await launchPromise.catch(() => undefined);
     if (state !== "ready") return;
     state = "shutting_down";
     await durability.backend.flush();

--- a/packages/workflows/src/durable/factory.ts
+++ b/packages/workflows/src/durable/factory.ts
@@ -1,4 +1,4 @@
-/** DBOS-only durable backend factory and internal test injection seam. */
+/** DBOS-first durable backend factory with a non-durable last-resort fallback. */
 
 import { InMemoryDurableBackend, type DurableWorkflowBackend } from "./backend.js";
 import {
@@ -9,8 +9,9 @@ import {
 
 let injectedBackend: DurableWorkflowBackend | undefined;
 let initializedBackend: DurableWorkflowBackend | undefined;
+let initializing: Promise<DurableWorkflowBackend> | undefined;
 
-/** Return the injected test backend or the process-wide ready DBOS backend. */
+/** Return the injected test backend or the process-wide initialized backend. */
 export function getDurableBackend(): DurableWorkflowBackend {
   const backend = injectedBackend ?? initializedBackend ?? getReadyDbosBackendSync();
   if (backend === undefined) throw new DbosNotReadyError();
@@ -20,7 +21,10 @@ export function getDurableBackend(): DurableWorkflowBackend {
 /** Internal injection seam. Production initialization uses DBOS. */
 export function setDurableBackend(backend: DurableWorkflowBackend | undefined): void {
   injectedBackend = backend;
-  if (backend === undefined) initializedBackend = undefined;
+  if (backend === undefined) {
+    initializedBackend = undefined;
+    initializing = undefined;
+  }
 }
 
 /** Create an isolated current-interface backend for tests only. */
@@ -28,9 +32,34 @@ export function createInMemoryTestBackend(): InMemoryDurableBackend {
   return new InMemoryDurableBackend();
 }
 
-/** Configure, register, launch, and install the mandatory DBOS backend. */
+/**
+ * Configure, register, launch, and install the DBOS backend.
+ *
+ * When no durable backend can be provisioned (no `DBOS_SYSTEM_DATABASE_URL`,
+ * embedded Postgres unavailable — e.g. running as root without an
+ * unprivileged account — and no Docker), workflows degrade to a process-local
+ * in-memory backend with a loud warning instead of refusing to run at all.
+ * Non-durable runs execute normally but do not survive the process:
+ * `/workflow resume` after exit has nothing to restore.
+ */
 export async function initializeDurableBackend(): Promise<DurableWorkflowBackend> {
   if (injectedBackend !== undefined) return injectedBackend;
-  initializedBackend ??= await getReadyDbosBackend();
-  return initializedBackend;
+  if (initializedBackend !== undefined) return initializedBackend;
+  initializing ??= getReadyDbosBackend()
+    .catch((error: unknown) => degradeToNonDurableBackend(error))
+    .then((backend) => {
+      initializedBackend = backend;
+      return backend;
+    });
+  return await initializing;
+}
+
+function degradeToNonDurableBackend(error: unknown): DurableWorkflowBackend {
+  const detail = error instanceof Error ? error.message : String(error);
+  console.error(
+    "atomic-workflows: durable backend unavailable — continuing NON-DURABLY with an in-memory backend. "
+    + "Workflow runs will execute, but their state will not survive this process and `/workflow resume` "
+    + `after exit will not work. Restore durability by fixing Postgres provisioning: ${detail}`,
+  );
+  return new InMemoryDurableBackend();
 }

--- a/packages/workflows/src/durable/local-command.ts
+++ b/packages/workflows/src/durable/local-command.ts
@@ -11,16 +11,25 @@ export interface LocalCommandResult {
 
 const OUTPUT_LIMIT_BYTES = 16_384;
 
+export interface LocalCommandOptions {
+  readonly env?: Readonly<Record<string, string>>;
+  /** POSIX drop-privilege identity for the spawned process (root only). */
+  readonly uid?: number;
+  readonly gid?: number;
+}
+
 export function runLocalCommand(
   command: string,
   args: readonly string[],
-  env?: Readonly<Record<string, string>>,
+  options?: LocalCommandOptions,
 ): Promise<LocalCommandResult> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, [...args], {
       stdio: ["ignore", "pipe", "pipe"],
       windowsHide: true,
-      ...(env !== undefined ? { env: { ...process.env, ...env } } : {}),
+      ...(options?.env !== undefined ? { env: { ...process.env, ...options.env } } : {}),
+      ...(options?.uid !== undefined ? { uid: options.uid } : {}),
+      ...(options?.gid !== undefined ? { gid: options.gid } : {}),
     });
     let stdout = "";
     let stderr = "";

--- a/packages/workflows/src/extension/extension-lifecycle.ts
+++ b/packages/workflows/src/extension/extension-lifecycle.ts
@@ -16,10 +16,22 @@ import { shutdownDbos } from "../durable/dbos-lifecycle.js";
 
 let processShutdownInstalled = false;
 
+/**
+ * Session dispose and process exit must never crash on durability teardown:
+ * a genuine flush/stop failure is diagnostic, not fatal, and an unhandled
+ * rejection here turns an otherwise-successful run into a nonzero exit.
+ */
+function shutdownDbosQuietly(): Promise<void> {
+  return shutdownDbos().catch((error: unknown) => {
+    const detail = error instanceof Error ? error.message : String(error);
+    console.error(`atomic-workflows: DBOS durability shutdown failed: ${detail}`);
+  });
+}
+
 function installDbosProcessShutdown(): void {
   if (processShutdownInstalled) return;
   processShutdownInstalled = true;
-  process.once("beforeExit", () => shutdownDbos());
+  process.once("beforeExit", () => void shutdownDbosQuietly());
 }
 
 export interface WorkflowLifecycleRegistrationDeps {
@@ -123,6 +135,6 @@ export function registerWorkflowLifecycleHandlers(
     deps.storeWidgetRef.current = null;
     runtimeState.resetWorkflowDiscoveryForSession();
     runtimeState.setNotificationsActive(false);
-    await shutdownDbos();
+    await shutdownDbosQuietly();
   });
 }

--- a/test/unit/durable-dbos-lifecycle.test.ts
+++ b/test/unit/durable-dbos-lifecycle.test.ts
@@ -119,4 +119,30 @@ describe("mandatory DBOS lifecycle", () => {
     assert.equal(events.at(-1), "shutdown");
     assert.equal(events.filter((event) => event === "shutdown").length, 1);
   });
+
+  test.serial("shutdown after a configuration failure resolves without rethrowing", async () => {
+    resetDbosLifecycleForTests(async () => {
+      throw new Error("initdb: error: cannot be run as root");
+    });
+
+    await assert.rejects(getReadyDbosBackend(), DbosDurabilityError);
+    // Session dispose calls shutdownDbos unconditionally; a backend that never
+    // reached "ready" must make this a no-op instead of rethrowing the
+    // memoized provisioning failure out of process exit.
+    await shutdownDbos();
+    await shutdownDbos();
+    assert.equal(dbosLifecycleState(), "failed");
+  });
+
+  test.serial("shutdown after a launch failure resolves without rethrowing", async () => {
+    const events: string[] = [];
+    resetDbosLifecycleForTests(async () => configured(events, async () => {
+      throw new Error("postgres unavailable");
+    }));
+
+    await assert.rejects(getReadyDbosBackend(), DbosDurabilityError);
+    await shutdownDbos();
+    assert.equal(events.filter((event) => event === "shutdown").length, 0);
+    assert.equal(dbosLifecycleState(), "failed");
+  });
 });

--- a/test/unit/durable-embedded-postgres-root.test.ts
+++ b/test/unit/durable-embedded-postgres-root.test.ts
@@ -1,0 +1,222 @@
+import { describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  defaultEmbeddedBaseDir,
+  prepareBinariesForOwner,
+  resolveEmbeddedRunContext,
+  resolvePrivilegeDrop,
+  ROOT_EMBEDDED_BASE_DIR,
+  type EmbeddedPostgresRunContext,
+  type LocalCommandRunner,
+} from "../../packages/workflows/src/durable/dbos-embedded-postgres-root.js";
+
+interface FakeCall {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly uid?: number;
+}
+
+function fakeRunner(
+  respond: (command: string, args: readonly string[], uid?: number) => { exitCode: number; stdout?: string },
+  calls: FakeCall[] = [],
+): LocalCommandRunner {
+  return async (command, args, options) => {
+    calls.push({ command, args, uid: options?.uid });
+    const result = respond(command, args, options?.uid);
+    return { exitCode: result.exitCode, stdout: result.stdout ?? "", stderr: "" };
+  };
+}
+
+const noCommands: LocalCommandRunner = async () => {
+  throw new Error("no command expected");
+};
+
+/** Answers account lookups and honors the spawn-uid drop like a Node runtime. */
+function nodeLikeRunner(accounts: Record<string, number>, calls: FakeCall[] = []): LocalCommandRunner {
+  return fakeRunner((command, args, uid) => {
+    if (command === "id" && args.length === 2 && args[1] !== undefined) {
+      const id = accounts[args[1]];
+      return id === undefined ? { exitCode: 1 } : { exitCode: 0, stdout: `${id}\n` };
+    }
+    if (command === "id" && args[0] === "-u") {
+      return { exitCode: 0, stdout: `${uid ?? 0}\n` }; // spawn uid honored
+    }
+    return { exitCode: 1 };
+  }, calls);
+}
+
+describe("embedded Postgres root run context", () => {
+  test("non-root keeps the home-directory base and pass-through runner", async () => {
+    const context = await resolveEmbeddedRunContext(noCommands, 1000, "linux");
+    assert.equal(context.baseDir, defaultEmbeddedBaseDir());
+    assert.equal(context.owner, undefined);
+  });
+
+  test("non-Linux root keeps the default context", async () => {
+    for (const platform of ["darwin", "win32"] as const) {
+      const context = await resolveEmbeddedRunContext(noCommands, 0, platform);
+      assert.equal(context.baseDir, defaultEmbeddedBaseDir());
+      assert.equal(context.owner, undefined);
+    }
+  });
+
+  test("Linux root resolves the first unprivileged candidate account", async () => {
+    const context = await resolveEmbeddedRunContext(nodeLikeRunner({ postgres: 70 }), 0, "linux");
+    assert.equal(context.baseDir, ROOT_EMBEDDED_BASE_DIR);
+    assert.deepEqual(context.owner, { uid: 70, gid: 70, name: "postgres" });
+  });
+
+  test("Linux root falls back through candidates and rejects uid 0", async () => {
+    const context = await resolveEmbeddedRunContext(
+      nodeLikeRunner({ postgres: 0, nobody: 65534 }),
+      0,
+      "linux",
+    );
+    assert.deepEqual(context.owner, { uid: 65534, gid: 65534, name: "nobody" });
+  });
+
+  test("Linux root without any unprivileged account keeps the default context", async () => {
+    const context = await resolveEmbeddedRunContext(fakeRunner(() => ({ exitCode: 1 })), 0, "linux");
+    assert.equal(context.baseDir, defaultEmbeddedBaseDir());
+    assert.equal(context.owner, undefined);
+  });
+
+  test("Linux root without any working privilege drop keeps the default context", async () => {
+    // Accounts resolve, but every drop strategy still reports uid 0.
+    const runner = fakeRunner((command, args) => {
+      if (command === "id" && args.length === 2) return { exitCode: 0, stdout: "65534\n" };
+      if (args.includes("-u") || args.includes("id -u") || args.some((a) => a.includes("id"))) {
+        return { exitCode: 0, stdout: "0\n" };
+      }
+      return { exitCode: 0, stdout: "0\n" };
+    });
+    const context = await resolveEmbeddedRunContext(runner, 0, "linux");
+    assert.equal(context.baseDir, defaultEmbeddedBaseDir());
+    assert.equal(context.owner, undefined);
+  });
+});
+
+describe("privilege drop strategy probing", () => {
+  const owner = { uid: 65534, gid: 65534, name: "nobody" } as const;
+
+  test("prefers the spawn uid/gid options when the runtime honors them", async () => {
+    const calls: FakeCall[] = [];
+    const drop = await resolvePrivilegeDrop(nodeLikeRunner({}, calls), owner);
+    assert.ok(drop);
+    const result = await drop("echo", ["hi"]);
+    assert.equal(result.exitCode, 1); // fake runner: non-id commands fail, but…
+    const last = calls.at(-1)!;
+    assert.equal(last.command, "echo"); // …the command ran directly with uid set
+    assert.equal(last.uid, owner.uid);
+  });
+
+  test("falls back to setpriv when spawn uid/gid is silently ignored (Bun)", async () => {
+    const calls: FakeCall[] = [];
+    const runner = fakeRunner((command, args, uid) => {
+      if (command === "id" && uid !== undefined) return { exitCode: 0, stdout: "0\n" }; // Bun: drop ignored
+      if (command === "setpriv") {
+        assert.deepEqual(args.slice(0, 3), ["--reuid=65534", "--regid=65534", "--clear-groups"]);
+        return { exitCode: 0, stdout: "65534\n" };
+      }
+      return { exitCode: 1 };
+    }, calls);
+
+    const drop = await resolvePrivilegeDrop(runner, owner);
+    assert.ok(drop);
+    await drop("initdb", ["-D", "/data"]);
+    const last = calls.at(-1)!;
+    assert.equal(last.command, "setpriv");
+    assert.deepEqual(last.args.slice(-3), ["initdb", "-D", "/data"]);
+  });
+
+  test("falls back to runuser and then su, and reports failure when nothing drops", async () => {
+    const suRunner = fakeRunner((command) => (
+      command === "su" ? { exitCode: 0, stdout: "65534\n" } : { exitCode: 0, stdout: "0\n" }
+    ));
+    const suDrop = await resolvePrivilegeDrop(suRunner, owner);
+    assert.ok(suDrop);
+
+    const nothingWorks = fakeRunner(() => ({ exitCode: 0, stdout: "0\n" }));
+    assert.equal(await resolvePrivilegeDrop(nothingWorks, owner), undefined);
+  });
+});
+
+describe("embedded Postgres binaries under a drop-privilege owner", () => {
+  function contextWith(baseDir: string, runAsOwner: LocalCommandRunner): EmbeddedPostgresRunContext {
+    return { baseDir, owner: { uid: 65534, gid: 65534, name: "nobody" }, runAsOwner };
+  }
+
+  test("no owner returns the loaded binaries untouched", async () => {
+    const binaries = { pg_ctl: "/pkg/native/bin/pg_ctl", initdb: "/pkg/native/bin/initdb" };
+    const context: EmbeddedPostgresRunContext = { baseDir: "/anywhere", runAsOwner: noCommands };
+    assert.equal(await prepareBinariesForOwner(binaries, context, noCommands), binaries);
+  });
+
+  test("owner-accessible binaries are used in place", async () => {
+    const calls: FakeCall[] = [];
+    const binaries = { pg_ctl: "/pkg/native/bin/pg_ctl", initdb: "/pkg/native/bin/initdb" };
+    const result = await prepareBinariesForOwner(
+      binaries,
+      contextWith("/var/lib/atomic-postgres", fakeRunner(() => ({ exitCode: 0, stdout: "initdb 18.0" }), calls)),
+      noCommands,
+    );
+    assert.equal(result, binaries);
+    assert.deepEqual(calls, [{ command: "/pkg/native/bin/initdb", args: ["--version"], uid: undefined }]);
+  });
+
+  test("inaccessible binaries are copied into the base dir and chowned to the owner", async () => {
+    const scratch = mkdtempSync(join(tmpdir(), "atomic-pg-root-test-"));
+    try {
+      const packageNative = join(scratch, "pkg", "native");
+      mkdirSync(join(packageNative, "bin"), { recursive: true });
+      mkdirSync(join(packageNative, "lib"), { recursive: true });
+      writeFileSync(join(packageNative, "bin", "initdb"), "#!/bin/sh\n", { mode: 0o755 });
+      writeFileSync(join(packageNative, "bin", "pg_ctl"), "#!/bin/sh\n", { mode: 0o755 });
+      writeFileSync(join(packageNative, "lib", "libpq.so"), "lib");
+      const baseDir = join(scratch, "cluster");
+      mkdirSync(baseDir, { recursive: true });
+
+      const rootCalls: FakeCall[] = [];
+      const result = await prepareBinariesForOwner(
+        { pg_ctl: join(packageNative, "bin", "pg_ctl"), initdb: join(packageNative, "bin", "initdb") },
+        contextWith(baseDir, fakeRunner(() => ({ exitCode: 126 }))), // probe: permission denied
+        fakeRunner(() => ({ exitCode: 0 }), rootCalls),
+      );
+
+      assert.equal(result.initdb, join(baseDir, "pg-runtime", "native", "bin", "initdb"));
+      assert.equal(result.pg_ctl, join(baseDir, "pg-runtime", "native", "bin", "pg_ctl"));
+      assert.ok(existsSync(result.initdb));
+      assert.ok(existsSync(join(baseDir, "pg-runtime", "native", "lib", "libpq.so")));
+      const chown = rootCalls.find((call) => call.command === "chown");
+      assert.deepEqual(chown?.args, ["-R", "65534:65534", join(baseDir, "pg-runtime")]);
+    } finally {
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+
+  test("a failed chown handoff surfaces an actionable error", async () => {
+    const scratch = mkdtempSync(join(tmpdir(), "atomic-pg-root-test-"));
+    try {
+      const packageNative = join(scratch, "pkg", "native");
+      mkdirSync(join(packageNative, "bin"), { recursive: true });
+      writeFileSync(join(packageNative, "bin", "initdb"), "#!/bin/sh\n", { mode: 0o755 });
+      writeFileSync(join(packageNative, "bin", "pg_ctl"), "#!/bin/sh\n", { mode: 0o755 });
+      const baseDir = join(scratch, "cluster");
+      mkdirSync(baseDir, { recursive: true });
+
+      await assert.rejects(
+        prepareBinariesForOwner(
+          { pg_ctl: join(packageNative, "bin", "pg_ctl"), initdb: join(packageNative, "bin", "initdb") },
+          contextWith(baseDir, fakeRunner(() => ({ exitCode: 126 }))),
+          fakeRunner(() => ({ exitCode: 1 })),
+        ),
+        /Could not hand the copied embedded Postgres runtime to nobody/,
+      );
+    } finally {
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/unit/durable-factory-degradation.test.ts
+++ b/test/unit/durable-factory-degradation.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, spyOn, test } from "bun:test";
+import assert from "node:assert/strict";
+import { InMemoryDurableBackend } from "../../packages/workflows/src/durable/backend.js";
+import { resetDbosLifecycleForTests } from "../../packages/workflows/src/durable/dbos-lifecycle.js";
+import {
+  getDurableBackend,
+  initializeDurableBackend,
+  setDurableBackend,
+} from "../../packages/workflows/src/durable/factory.js";
+
+afterEach(() => {
+  setDurableBackend(undefined);
+  resetDbosLifecycleForTests();
+});
+
+describe("durable factory non-durable degradation", () => {
+  test.serial("falls back to one in-memory backend with a loud warning when DBOS cannot be provisioned", async () => {
+    setDurableBackend(undefined); // clear the preload-injected test backend
+    resetDbosLifecycleForTests(async () => {
+      throw new Error("initdb: error: cannot be run as root");
+    });
+    const warnings: string[] = [];
+    const consoleSpy = spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    });
+    try {
+      const [first, second] = await Promise.all([
+        initializeDurableBackend(),
+        initializeDurableBackend(),
+      ]);
+
+      assert.ok(first instanceof InMemoryDurableBackend);
+      assert.equal(first.persistent, false);
+      // Concurrent initialization must converge on a single fallback backend.
+      assert.equal(second, first);
+      assert.equal(await initializeDurableBackend(), first);
+      // The sync accessor serves the degraded backend after initialization.
+      assert.equal(getDurableBackend(), first);
+
+      const degradationWarnings = warnings.filter((message) => message.includes("NON-DURABLY"));
+      assert.equal(degradationWarnings.length, 1);
+      assert.match(degradationWarnings[0]!, /cannot be run as root/);
+      assert.match(degradationWarnings[0]!, /\/workflow resume/);
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  test.serial("a provisionable DBOS backend is preferred and produces no degradation warning", async () => {
+    const warnings: string[] = [];
+    setDurableBackend(undefined); // clear the preload-injected test backend
+    const consoleSpy = spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    });
+    try {
+      const backend = await initializeDurableBackendWithFakeDbos();
+      assert.equal(backend.persistent, true);
+      assert.equal(warnings.filter((message) => message.includes("NON-DURABLY")).length, 0);
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+});
+
+async function initializeDurableBackendWithFakeDbos() {
+  const { DbosDurableBackend } = await import("../../packages/workflows/src/durable/dbos-backend.js");
+  const sdk = {
+    launch: async () => {},
+    shutdown: async () => {},
+    startWorkflow: async () => {},
+    retrieveWorkflow: async () => undefined,
+    cancelWorkflow: async () => {},
+    resumeWorkflow: async () => {},
+    listAllWorkflows: async () => [],
+    listStepRecords: async () => [],
+    recordStepOutput: async () => {},
+    deleteWorkflowData: async () => {},
+  };
+  resetDbosLifecycleForTests(async () => ({
+    backend: new DbosDurableBackend(sdk),
+    launch: async () => {},
+    shutdown: async () => {},
+  }));
+  return await initializeDurableBackend();
+}


### PR DESCRIPTION
## Summary

Three related workflow-durability fixes discovered while validating Atomic in eval sandboxes (root containers, no Docker, no external Postgres). Together they take that environment from *every workflow action fails + the process crashes at exit* to *workflows run (durably where possible, loudly non-durable otherwise) and exit cleanly*.

## Changes

### 1. `shutdownDbos` no longer crashes dispose after failed provisioning (Fixed)
`shutdownDbos()` re-awaited the memoized **rejected** configure/launch promises, rethrowing the original provisioning error out of `session_shutdown` and the `beforeExit` hook — an unhandled rejection that turned fully-successful `--print` runs into exit code 1 (observed as Pier `NonZeroAgentExitCodeError`). Shutdown is now a no-op for a backend that never reached readiness, and the extension logs genuine teardown failures instead of throwing out of dispose (`shutdownDbosQuietly`).

### 2. Embedded Postgres works as root on Linux (Added)
PostgreSQL refuses UID 0, so a root Atomic process previously could never provision the embedded cluster. Now (`dbos-embedded-postgres-root.ts`):
- resolves an unprivileged system account (`postgres` → `nobody` → `daemon`),
- keeps the cluster under `/var/lib/atomic-postgres` (a root home dir is untraversable for that account),
- runs `initdb`/`pg_ctl` with **verifiably** dropped privileges — strategies are probed with `id -u` at runtime: spawn `uid`/`gid` first (honored by Node, **silently ignored by Bun**), then `setpriv`, `runuser`, `su`,
- copies the Postgres runtime into the cluster dir once when the binaries sit under an untraversable prefix (e.g. root-owned `~/.nvm` global install).

No behavior change for non-root or non-Linux.

### 3. Graceful non-durable degradation (Changed)
When no durable backend is obtainable at all, `initializeDurableBackend()` now degrades to a process-local in-memory backend with a loud warning (state doesn't survive the process; `/workflow resume` after exit has nothing to restore) instead of failing every workflow action. Query/write failures on a provisioned backend still fail the action.

Docs (`packages/coding-agent/docs/workflows.md`) and `packages/workflows/CHANGELOG.md` updated.

## Notes

**End-to-end proof (root Linux container, Bun runtime — worst case):** cluster initialized under `/var/lib/atomic-postgres` owned by `nobody:nogroup` via the `setpriv` fallback and accepted connections on 5439. Since `initdb` categorically refuses root, a running server is conclusive.

**Validation:** `bun run typecheck`, `bun run lint`, `bun run check:file-length`, full unit suite (3872 pass, includes 17 new tests: shutdown no-throw after config/launch failure, run-context + privilege-drop strategy resolution, binary copy handoff and chown failure surface, degradation warning/memoization/preference for real DBOS).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves DBOS workflow durability behavior in root and no-Postgres environments. The main changes are:

- Adds Linux-root support for embedded DBOS Postgres using an unprivileged system account.
- Moves root-owned embedded Postgres clusters under `/var/lib/atomic-postgres`.
- Adds verified privilege-drop fallback paths for Postgres commands.
- Falls back to a loud process-local in-memory backend when no durable backend can be provisioned.
- Makes DBOS shutdown safe after configuration or launch failures.
- Updates workflow docs, changelog entries, and unit tests for the new durability paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changes are scoped to DBOS durability provisioning and teardown, and the new root and fallback paths have focused unit coverage.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The durable tests were executed with Bun 1.3.10 across three requested files, reporting 21 tests passed, 0 failed, across 3 files, with EXIT\_CODE: 0.
- The TypeScript typecheck step was run via bun run typecheck (tsc --noEmit) and completed with EXIT\_CODE: 0.

<a href="https://app.greptile.com/trex/runs/15192594/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/workflows/src/durable/dbos-embedded-postgres-root.ts | Adds Linux-root run-context resolution, verified privilege-drop strategies, and runtime-copy handoff for embedded Postgres. |
| packages/workflows/src/durable/dbos-embedded-postgres.ts | Integrates root-safe base directory ownership, owner-executed init/start commands, and owner-accessible binary preparation. |
| packages/workflows/src/durable/dbos-lifecycle.ts | Makes DBOS shutdown a no-op after failed configure or launch promises instead of rethrowing memoized provisioning failures. |
| packages/workflows/src/durable/factory.ts | Memoizes initialization and degrades to one process-local in-memory backend when DBOS cannot be provisioned. |
| packages/workflows/src/extension/extension-lifecycle.ts | Wraps DBOS shutdown during session and process teardown so teardown errors are logged rather than thrown. |
| test/unit/durable-embedded-postgres-root.test.ts | Covers root run-context selection, privilege-drop fallback ordering, binary-copy handoff, and chown failure reporting. |
| test/unit/durable-factory-degradation.test.ts | Covers non-durable fallback memoization, warning emission, sync accessor behavior, and preference for a real DBOS backend. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Workflow as Workflow action
participant Factory as initializeDurableBackend
participant DBOS as DBOS lifecycle
participant Embedded as Embedded Postgres
participant Root as Root run context
participant Memory as InMemory backend

Workflow->>Factory: Request durable backend
Factory->>DBOS: getReadyDbosBackend
DBOS->>Embedded: Resolve or provision local Postgres
Embedded->>Root: Resolve owner and privilege drop when Linux root
Root-->>Embedded: Base dir, owner runner, prepared binaries
Embedded-->>DBOS: Reachable Postgres URL
DBOS-->>Factory: Ready persistent backend
Factory-->>Workflow: DBOS backend
alt Provisioning fails
    DBOS-->>Factory: Durability error
    Factory->>Memory: Create process local backend
    Factory-->>Workflow: Non persistent fallback with warning
end
Workflow->>DBOS: Session or process shutdown
DBOS-->>Workflow: No op if never ready, otherwise flush and shutdown
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Workflow as Workflow action
participant Factory as initializeDurableBackend
participant DBOS as DBOS lifecycle
participant Embedded as Embedded Postgres
participant Root as Root run context
participant Memory as InMemory backend

Workflow->>Factory: Request durable backend
Factory->>DBOS: getReadyDbosBackend
DBOS->>Embedded: Resolve or provision local Postgres
Embedded->>Root: Resolve owner and privilege drop when Linux root
Root-->>Embedded: Base dir, owner runner, prepared binaries
Embedded-->>DBOS: Reachable Postgres URL
DBOS-->>Factory: Ready persistent backend
Factory-->>Workflow: DBOS backend
alt Provisioning fails
    DBOS-->>Factory: Durability error
    Factory->>Memory: Create process local backend
    Factory-->>Workflow: Non persistent fallback with warning
end
Workflow->>DBOS: Session or process shutdown
DBOS-->>Workflow: No op if never ready, otherwise flush and shutdown
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(workflows): DBOS durability under ro..."](https://github.com/bastani-inc/atomic/commit/8b5d540ee5ba54af9e4c8ba24ddffdf1a911869d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45839978)</sub>

<!-- /greptile_comment -->