### PR TITLE
docs(changelog): prepare 0.9.11-alpha.1 prerelease notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.11-alpha.1] - 2026-07-20
+
 ### Changed
 
 - Clarified the bundled `deep-research-codebase` discovery guidance so agents reserve the heavy workflow for tasks requiring comprehensive whole-repository context ([#1925](https://github.com/bastani-inc/atomic/issues/1925)).

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.11-alpha.1] - 2026-07-20
+
+### Changed
+
+- Published a synchronized Atomic 0.9.11-alpha.1 prerelease for the Cursor provider package; no functional Cursor provider changes were made after 0.9.9.
+
 ## [0.9.10] - 2026-07-20
 
 ### Changed

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.11-alpha.1] - 2026-07-20
+
+### Changed
+
+- Published a synchronized Atomic 0.9.11-alpha.1 prerelease for the intercom extension; no functional intercom changes were made after 0.9.10.
+
 ## [0.9.10] - 2026-07-20
 
 ### Added

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.11-alpha.1] - 2026-07-20
+
+### Changed
+
+- Published a synchronized Atomic 0.9.11-alpha.1 prerelease for the MCP extension; no functional MCP changes were made after 0.9.10.
+
 ## [0.9.10] - 2026-07-20
 
 ### Added

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.11-alpha.1] - 2026-07-20
+
+### Changed
+
+- Published a synchronized Atomic 0.9.11-alpha.1 prerelease for the native transport package; no native transport changes were made after 0.9.9.
+
 ## [0.9.10] - 2026-07-20
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.11-alpha.1] - 2026-07-20
+
+### Changed
+
+- Published a synchronized Atomic 0.9.11-alpha.1 prerelease for the subagents extension; no functional subagent changes were made after 0.9.10.
+
 ## [0.9.10] - 2026-07-20
 
 ### Added

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.11-alpha.1] - 2026-07-20
+
+### Changed
+
+- Published a synchronized Atomic 0.9.11-alpha.1 prerelease for the web-access extension; no functional web-access changes were made after 0.9.10.
+
 ## [0.9.10] - 2026-07-20
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.11-alpha.1] - 2026-07-20
+
 ### Added
 
 - Embedded DBOS Postgres now works when Atomic runs as root on Linux (containers, CI sandboxes, eval harnesses): PostgreSQL refuses UID 0, so Atomic resolves an unprivileged system account (`postgres`, `nobody`, or `daemon`), keeps the cluster under `/var/lib/atomic-postgres` (a root home directory is untraversable for that account), and runs `initdb`/`pg_ctl` with dropped privileges. When the embedded binaries sit under an untraversable prefix (for example a root-owned `~/.nvm` global install), the Postgres runtime is copied into the cluster directory once and reused.


### PR DESCRIPTION
## Summary

Prepares the changelog-only release-notes branch for the **0.9.11-alpha.1** prerelease cut from `main`.

- Adds `## [0.9.11-alpha.1] - 2026-07-20` sections to all eight package changelogs (`coding-agent`, `cursor`, `intercom`, `mcp`, `natives`, `subagents`, `web-access`, `workflows`).
- Changelog-only diff: no version stamping — all package manifests, `bun.lock`, Cargo manifests/lock, and generated native version checks remain at the `0.0.0` placeholder per the versionless release-base flow.
- After this PR merges, `scripts/cut-release.ts 0.9.11-alpha.1 --base main --push` stamps the detached Release commit and the tag push starts `publish.yml`.

## Validation

- `bun run typecheck` ✅
- `bun run check:file-length` ✅
- prek hooks on commit (lint, file-length, unit tests) ✅

🤖 Generated with Claude Fable 5

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares the package changelogs for the `0.9.11-alpha.1` prerelease. The main changes are:

- Added `0.9.11-alpha.1` sections to all eight package changelogs.
- Kept the release-base flow versionless by avoiding manifest, lockfile, and generated version changes.
- Documented synchronized prerelease notes for packages without functional changes.

<h3>Confidence Score: 5/5</h3>

This changelog-only PR is safe to merge with minimal risk.

The diff only adds prerelease changelog sections and does not alter source code, manifests, locks, or generated version checks.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated TypeScript typecheck for the changelog validation workflow completed successfully.
- Validated the file-length check over 2330 tracked files completed with no issues.
- Validated the changelog section validation found the required 0.9.11-alpha.1 entry in all eight changed changelogs.

<a href="https://app.greptile.com/trex/runs/15197368/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/CHANGELOG.md | Adds the `0.9.11-alpha.1` prerelease section around existing coding-agent release notes without code changes. |
| packages/cursor/CHANGELOG.md | Adds a synchronized `0.9.11-alpha.1` Cursor prerelease note documenting no functional changes. |
| packages/intercom/CHANGELOG.md | Adds a synchronized `0.9.11-alpha.1` intercom prerelease note documenting no functional changes. |
| packages/mcp/CHANGELOG.md | Adds a synchronized `0.9.11-alpha.1` MCP prerelease note documenting no functional changes. |
| packages/natives/CHANGELOG.md | Adds a synchronized `0.9.11-alpha.1` native transport prerelease note documenting no functional changes. |
| packages/subagents/CHANGELOG.md | Adds a synchronized `0.9.11-alpha.1` subagents prerelease note documenting no functional changes. |
| packages/web-access/CHANGELOG.md | Adds a synchronized `0.9.11-alpha.1` web-access prerelease note documenting no functional changes. |
| packages/workflows/CHANGELOG.md | Adds the `0.9.11-alpha.1` prerelease section around existing workflows release notes without code changes. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Maintainer
  participant Changelogs as Package CHANGELOG.md files
  participant Main as main release base
  participant Cut as scripts/cut-release.ts
  participant Publish as publish.yml

  Maintainer->>Changelogs: Add 0.9.11-alpha.1 prerelease notes
  Changelogs->>Main: Merge changelog-only release branch
  Main->>Cut: Run cut-release 0.9.11-alpha.1 --base main --push
  Cut->>Cut: Stamp detached Release commit and tag
  Cut->>Publish: Push tag triggers publication workflow
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Maintainer
  participant Changelogs as Package CHANGELOG.md files
  participant Main as main release base
  participant Cut as scripts/cut-release.ts
  participant Publish as publish.yml

  Maintainer->>Changelogs: Add 0.9.11-alpha.1 prerelease notes
  Changelogs->>Main: Merge changelog-only release branch
  Main->>Cut: Run cut-release 0.9.11-alpha.1 --base main --push
  Cut->>Cut: Stamp detached Release commit and tag
  Cut->>Publish: Push tag triggers publication workflow
```

</a>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.11-alpha.1 ..."](https://github.com/bastani-inc/atomic/commit/95533cf836edc2e7210a2fcda9d834f6e191a70f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45849755)</sub>

<!-- /greptile_comment -->