### PR TITLE
docs(changelog): prepare 0.9.11-alpha.2 prerelease notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.11-alpha.2] - 2026-07-21
+
 ### Added
 
 - Added Qwen Token Plan and Qwen Token Plan China to Atomic's built-in provider defaults and credential guidance, inherited from `pi-ai` 0.81.1 ([#6858](https://github.com/earendil-works/pi/pull/6858)).

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.11-alpha.2] - 2026-07-21
+
 ### Fixed
 
 - Fixed fresh-process workflow resume and completed-run inspection losing nested child-workflow and parallel stage hierarchy. DBOS stage checkpoints now retain owning-run and boundary topology, replay restores source parentage and child runs, graceful quit persists exact sub-30-second stage timing, completed runs persist and display accumulated run duration, and project-local workflows reloaded during a chat are rediscovered from their original invocation directory. The `/workflow resume` and `/workflows` picker rows also no longer display the redundant `N prompts` segment.


### PR DESCRIPTION
## Summary

Prepare release notes for the **0.9.11-alpha.2** prerelease (base: `main`).

- Move the `[Unreleased]` entries in `packages/coding-agent/CHANGELOG.md` under a new `[0.9.11-alpha.2] - 2026-07-21` section
- Move the `[Unreleased]` entries in `packages/workflows/CHANGELOG.md` under a new `[0.9.11-alpha.2] - 2026-07-21` section

Changelog-only diff; all package manifests, lockfiles, Cargo files, and generated version files remain at the versionless `0.0.0` placeholder. Version stamping happens only on the detached `Release 0.9.11-alpha.2` commit produced by `scripts/cut-release.ts` after this PR merges.

## Validation

- `bun run typecheck` / `bun run lint` — pass
- `bun run check:file-length` — pass
- `bun run test:unit` — 3915 pass (via pre-commit hooks)
- Verified every `packages/*/package.json`, root `Cargo.toml`, `Cargo.lock`, and `@bastani/atomic-natives` pin remain at `0.0.0`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares the `0.9.11-alpha.2` prerelease notes. The main changes are:

- Adds dated `0.9.11-alpha.2` sections to the coding-agent and workflows changelogs.
- Moves the current `Unreleased` entries under those prerelease sections.
- Leaves package version stamping out of this changelog-only release-base change.

<h3>Confidence Score: 5/5</h3>

This changelog-only PR is safe to merge with minimal risk.

The changes only add dated prerelease headings and move existing changelog entries under them. The release-base flow stays versionless, with no package manifest or lockfile changes in this PR.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the generated validation script to validate changelog\_versions-02 and produced a scoped proof log.
- Verified the typecheck step completed successfully as part of the validation workflow.
- Reviewed the produced scoped proof log and the changelog excerpts, confirming that the associated exit codes were 0.

<a href="https://app.greptile.com/trex/runs/15309064/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/CHANGELOG.md | Moves current coding-agent release notes from `Unreleased` into the new `0.9.11-alpha.2` prerelease section. |
| packages/workflows/CHANGELOG.md | Moves current workflows release note from `Unreleased` into the new `0.9.11-alpha.2` prerelease section. |

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.11-alpha.2 ..."](https://github.com/bastani-inc/atomic/commit/8f706541be5ddfdcbc023e84d854ccc16c4be25f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46085867)</sub>

<!-- /greptile_comment -->