### PR TITLE
fix(subagents): notify parent when detached foreground children exit

### DIFF
--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed foreground subagent runs that detached for intercom coordination completing silently. When a foreground single, chain, or parallel child detaches (for example after asking its supervisor a question) and later exits, the parent session now receives a "Detached subagent task" completion/failure/paused notice through the same deduplicated, turn-triggering delivery pipeline used for background completion notifications, including per-child `(n/m)` attribution for parallel groups. Previously the detached child's final result was only recorded in remembered run state, so the orchestrating session had to poll `subagent status` to discover that a detached run had finished.
+
 ## [0.9.11-alpha.1] - 2026-07-20
 
 ### Changed

--- a/packages/subagents/src/runs/background/notify.ts
+++ b/packages/subagents/src/runs/background/notify.ts
@@ -44,6 +44,7 @@ interface SubagentResult {
 	results?: ChainStepResult[];
 	taskIndex?: number;
 	totalTasks?: number;
+	noticeLabel?: string;
 }
 
 interface TerminalPreludeMessage {
@@ -194,8 +195,9 @@ export default function registerSubagentNotify(pi: ExtensionAPI): () => void {
 					: undefined;
 
 		const displaySummary = summary.trim() ? summary : "(no output)";
+		const noticeLabel = typeof result.noticeLabel === "string" && result.noticeLabel.trim() ? result.noticeLabel.trim() : "Background task";
 		const content = [
-			`Background task ${status}: **${agent}**${taskInfo}`,
+			`${noticeLabel} ${status}: **${agent}**${taskInfo}`,
 			"",
 			displaySummary,
 			sessionLine ? "" : undefined,

--- a/packages/subagents/src/runs/foreground/subagent-executor-chain.ts
+++ b/packages/subagents/src/runs/foreground/subagent-executor-chain.ts
@@ -7,7 +7,7 @@ import { resolveSubagentDepthPolicy } from "../../shared/types.ts";
 import type { ChainStep } from "../../shared/settings.ts";
 import type { ExecutionContextData, ResolvedExecutorDeps } from "./subagent-executor-types.ts";
 import { wrapChainTasksForFork } from "./subagent-executor-input.ts";
-import { createForegroundControlNotifier, maybeBuildForegroundIntercomReceipt, rememberForegroundRun, replaceForegroundRunChild } from "./subagent-executor-status.ts";
+import { createForegroundControlNotifier, maybeBuildForegroundIntercomReceipt, notifyDetachedForegroundChildExit, rememberForegroundRun, replaceForegroundRunChild } from "./subagent-executor-status.ts";
 
 export async function runChainPath(data: ExecutionContextData, deps: ResolvedExecutorDeps): Promise<import("../../shared/types.ts").SubagentToolResult> {
 	const {
@@ -64,7 +64,10 @@ export async function runChainPath(data: ExecutionContextData, deps: ResolvedExe
 		worktreeSetupHook: deps.config.worktreeSetupHook,
 		worktreeSetupHookTimeoutMs: deps.config.worktreeSetupHookTimeoutMs,
 		runSync: deps.runtime.runSync,
-		onDetachedExit: (index, result) => replaceForegroundRunChild(deps.state, runId, index, result),
+		onDetachedExit: (index, result) => {
+			replaceForegroundRunChild(deps.state, runId, index, result);
+			notifyDetachedForegroundChildExit({ pi: deps.pi, runId, mode: "chain", index, result });
+		},
 	});
 
 	const chainDetails = chainResult.details ? compactForegroundDetails({ ...chainResult.details, runId }) : undefined;

--- a/packages/subagents/src/runs/foreground/subagent-executor-parallel.ts
+++ b/packages/subagents/src/runs/foreground/subagent-executor-parallel.ts
@@ -43,7 +43,7 @@ import {
 	findDuplicateParallelOutputPath,
 	resolveParallelTaskCwd,
 } from "./subagent-executor-worktree.ts";
-import { createForegroundControlNotifier, maybeBuildForegroundIntercomReceipt, rememberForegroundRun, replaceForegroundRunChild } from "./subagent-executor-status.ts";
+import { createForegroundControlNotifier, maybeBuildForegroundIntercomReceipt, notifyDetachedForegroundChildExit, rememberForegroundRun, replaceForegroundRunChild } from "./subagent-executor-status.ts";
 import { createDetachedCleanupBarrier } from "./detached-cleanup-barrier.ts";
 
 export async function runParallelPath(data: ExecutionContextData, deps: ResolvedExecutorDeps): Promise<SubagentToolResult> {
@@ -171,6 +171,7 @@ export async function runParallelPath(data: ExecutionContextData, deps: Resolved
 			onDetachedExit: (index, result) => {
 				try {
 					replaceForegroundRunChild(deps.state, runId, index, result);
+					notifyDetachedForegroundChildExit({ pi: deps.pi, runId, mode: "parallel", index, totalTasks: tasks.length, result });
 				} finally {
 					detachedCleanup.recover(index);
 				}

--- a/packages/subagents/src/runs/foreground/subagent-executor-single.ts
+++ b/packages/subagents/src/runs/foreground/subagent-executor-single.ts
@@ -30,7 +30,7 @@ import {
 	type SubagentToolResult,
 } from "../../shared/types.ts";
 import type { ExecutionContextData, ResolvedExecutorDeps } from "./subagent-executor-types.ts";
-import { createForegroundControlNotifier, maybeBuildForegroundIntercomReceipt, rememberForegroundRun, replaceForegroundRunChild } from "./subagent-executor-status.ts";
+import { createForegroundControlNotifier, maybeBuildForegroundIntercomReceipt, notifyDetachedForegroundChildExit, rememberForegroundRun, replaceForegroundRunChild } from "./subagent-executor-status.ts";
 
 function formatFailedSingleRunOutput(result: SingleResult, displayOutput: string): string {
 	const error = result.error || "Failed";
@@ -191,7 +191,10 @@ export async function runSinglePath(data: ExecutionContextData, deps: ResolvedEx
 			nestedRoute: foregroundControl?.nestedRoute,
 			onDetachedExit: (result) => {
 				cleanupTransientProgress(progressDir, artifactConfig.enabled);
-				if (result) replaceForegroundRunChild(deps.state, runId, 0, result);
+				if (result) {
+					replaceForegroundRunChild(deps.state, runId, 0, result);
+					notifyDetachedForegroundChildExit({ pi: deps.pi, runId, mode: "single", index: 0, result });
+				}
 			},
 			index: 0,
 			modelOverride,

--- a/packages/subagents/src/runs/foreground/subagent-executor-status.ts
+++ b/packages/subagents/src/runs/foreground/subagent-executor-status.ts
@@ -10,6 +10,7 @@ import {
 } from "../../intercom/result-intercom.ts";
 import { formatNestedRunStatusLines } from "../shared/nested-render.ts";
 import { formatControlIntercomMessage, formatControlNoticeMessage, shouldNotifyControlEvent } from "../shared/subagent-control.ts";
+import { deliverLocalCompletionNotification } from "../background/completion-notification.ts";
 import { updateForegroundNestedProjection } from "../shared/nested-events.ts";
 import {
 	SUBAGENT_CONTROL_EVENT,
@@ -213,6 +214,39 @@ function resultSummaryForIntercom(result: SingleResult): string {
 		return output ? `${result.error}\n\nOutput:\n${output}` : result.error;
 	}
 	return output || result.error || "(no output)";
+}
+
+/**
+ * Deliver a completion notice to the parent session for a foreground child
+ * that detached for intercom coordination and later exited. Foreground runs
+ * normally return their results inline in the tool result, but a detached
+ * child outlives that tool call, so without this the parent never learns the
+ * child finished (see run history: detached parallel runs completed silently).
+ * Reuses the async completion pipeline (dedupe, ordering barrier, triggerTurn).
+ */
+export function notifyDetachedForegroundChildExit(input: {
+	pi: ExtensionAPI;
+	runId: string;
+	mode: SubagentRunMode;
+	index: number;
+	totalTasks?: number;
+	result: SingleResult;
+}): void {
+	const { pi, runId, index, result } = input;
+	void deliverLocalCompletionNotification(pi.events, {
+		id: runId,
+		runId,
+		agent: result.agent,
+		success: result.exitCode === 0 && !result.interrupted && !result.error,
+		summary: resultSummaryForIntercom(result),
+		exitCode: result.exitCode,
+		...(result.interrupted ? { state: "paused" } : {}),
+		timestamp: Date.now(),
+		...(result.progressSummary?.durationMs !== undefined ? { durationMs: result.progressSummary.durationMs } : {}),
+		...(result.sessionFile ? { sessionFile: result.sessionFile } : {}),
+		...(input.totalTasks !== undefined && input.totalTasks > 1 ? { taskIndex: index, totalTasks: input.totalTasks } : {}),
+		noticeLabel: "Detached subagent task",
+	}, `foreground-detach-${runId}-${index}`);
 }
 
 async function emitForegroundResultIntercom(input: {

--- a/test/unit/subagents-detached-foreground-notify.test.ts
+++ b/test/unit/subagents-detached-foreground-notify.test.ts
@@ -1,0 +1,121 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import registerSubagentNotify from "../../packages/subagents/src/runs/background/notify.js";
+import { notifyDetachedForegroundChildExit } from "../../packages/subagents/src/runs/foreground/subagent-executor-status.js";
+import type { SingleResult } from "../../packages/subagents/src/shared/types.js";
+
+function createHarness() {
+	const listeners = new Map<string, Set<(data: unknown) => void>>();
+	const sent: { customType: string; content: string }[] = [];
+	const pi = {
+		events: {
+			on(event: string, handler: (data: unknown) => void) {
+				const set = listeners.get(event) ?? new Set();
+				set.add(handler);
+				listeners.set(event, set);
+				return () => set.delete(handler);
+			},
+			emit(event: string, payload: unknown) {
+				for (const handler of listeners.get(event) ?? []) handler(payload);
+			},
+		},
+		sendMessage(message: { customType: string; content: string }) {
+			sent.push(message);
+		},
+	};
+	return { pi, sent };
+}
+
+function makeResult(overrides: Partial<SingleResult> = {}): SingleResult {
+	return {
+		agent: "codebase-analyzer",
+		task: "audit",
+		exitCode: 0,
+		usage: {} as SingleResult["usage"],
+		finalOutput: "Findings report content",
+		sessionFile: "/tmp/sessions/child-0.jsonl",
+		...overrides,
+	};
+}
+
+test("detached foreground child exit delivers a completion notice to the parent session", () => {
+	const harness = createHarness();
+	const unregister = registerSubagentNotify(harness.pi as never);
+
+	notifyDetachedForegroundChildExit({
+		pi: harness.pi as never,
+		runId: "run-detach-1",
+		mode: "parallel",
+		index: 1,
+		totalTasks: 4,
+		result: makeResult(),
+	});
+
+	assert.equal(harness.sent.length, 1, "one notification is delivered");
+	const message = harness.sent[0]!;
+	assert.equal(message.customType, "subagent-notify");
+	assert.match(message.content, /^Detached subagent task completed: \*\*codebase-analyzer\*\* \(2\/4\)/);
+	assert.match(message.content, /Findings report content/);
+	assert.match(message.content, /Session file: \/tmp\/sessions\/child-0\.jsonl/);
+	unregister();
+});
+
+test("detached foreground completion notices dedupe per run and child index", () => {
+	const harness = createHarness();
+	const unregister = registerSubagentNotify(harness.pi as never);
+	const input = {
+		pi: harness.pi as never,
+		runId: "run-detach-2",
+		mode: "single" as const,
+		index: 0,
+		result: makeResult(),
+	};
+
+	notifyDetachedForegroundChildExit(input);
+	notifyDetachedForegroundChildExit(input);
+	assert.equal(harness.sent.length, 1, "duplicate child exits deliver a single notice");
+
+	notifyDetachedForegroundChildExit({ ...input, runId: "run-detach-3" });
+	assert.equal(harness.sent.length, 2, "a different run still notifies");
+	unregister();
+});
+
+test("failed and interrupted detached children report failed/paused status", () => {
+	const harness = createHarness();
+	const unregister = registerSubagentNotify(harness.pi as never);
+
+	notifyDetachedForegroundChildExit({
+		pi: harness.pi as never,
+		runId: "run-detach-4",
+		mode: "chain",
+		index: 0,
+		result: makeResult({ exitCode: 1, error: "boom" }),
+	});
+	assert.match(harness.sent[0]!.content, /^Detached subagent task failed: \*\*codebase-analyzer\*\*/);
+	assert.match(harness.sent[0]!.content, /boom/);
+
+	notifyDetachedForegroundChildExit({
+		pi: harness.pi as never,
+		runId: "run-detach-5",
+		mode: "single",
+		index: 0,
+		result: makeResult({ interrupted: true }),
+	});
+	assert.match(harness.sent[1]!.content, /^Detached subagent task paused: \*\*codebase-analyzer\*\*/);
+	unregister();
+});
+
+test("async background notifications keep their original heading", () => {
+	const harness = createHarness();
+	const unregister = registerSubagentNotify(harness.pi as never);
+	harness.pi.events.emit("subagent:async-complete", {
+		id: "async-run",
+		agent: "worker",
+		success: true,
+		summary: "done",
+		timestamp: Date.now(),
+	});
+	assert.equal(harness.sent.length, 1);
+	assert.match(harness.sent[0]!.content, /^Background task completed: \*\*worker\*\*/);
+	unregister();
+});


### PR DESCRIPTION
## Problem

Foreground subagent runs (single, chain, and parallel) that **detach for intercom coordination** — e.g. a child asks its supervisor a question via `contact_supervisor` — return their tool result early with *"…detached for intercom coordination. Reply to the supervisor request first. After the child exits, start a fresh follow-up if needed."*

When the detached child later exited, its final result was only written into remembered foreground run state (`replaceForegroundRunChild`). **The orchestrating session was never notified**, so the parent had to manually poll `subagent status` to discover that a detached run had finished. Observed in a real session: a 4-child parallel `codebase-analyzer` fan-out detached, all children completed, and the parent sat idle with no completion signal.

## Fix

Detached child exits now deliver a completion notice through the same pipeline used for async/background completion notifications (`deliverLocalCompletionNotification` → `SUBAGENT_ASYNC_COMPLETE_EVENT` → `registerSubagentNotify`), which provides dedupe, terminal ordering barriers, and `triggerTurn` delivery for free:

- **`subagent-executor-status.ts`**: new `notifyDetachedForegroundChildExit()` builds the completion envelope from the child's final `SingleResult` (status completed/failed/paused, summary, session file, duration, `(n/m)` task attribution for parallel groups) with a stable `foreground-detach-<runId>-<index>` notification id.
- **Call sites**: wired into all three foreground `onDetachedExit` seams — parallel (`subagent-executor-parallel.ts`), single (`subagent-executor-single.ts`), and chain (`subagent-executor-chain.ts`, covering sequential/parallel/dynamic chain steps).
- **`notify.ts`**: new optional `noticeLabel` envelope field so these render as **"Detached subagent task completed: …"** while background notices keep their original "Background task…" heading.

## Testing

- `test/unit/subagents-detached-foreground-notify.test.ts` (new): delivery to parent session, per-run/per-child dedupe, failed/paused status mapping, parallel `(n/m)` attribution, and unchanged background heading.
- `bun run typecheck` clean; subagents unit slice green (3918 pass; the one failure is the pre-existing `pi-0.81.1-artifacts` dist-artifact check in fresh worktrees, unrelated).
- Real tmux E2E validation in **both main chat and a dummy workflow** — evidence in PR comment below.

Assistant-model: Claude Fable 5

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR sends completion notices when detached foreground subagents finish. The main changes are:

- Adds a detached foreground completion envelope using the async notification pipeline.
- Wires single, chain, and parallel foreground detached exits into notification delivery.
- Adds a custom notice label so detached foreground notices render separately from background task notices.
- Adds unit tests for delivery, dedupe, status labels, parallel attribution, and unchanged background headings.

<h3>Confidence Score: 4/5</h3>

This PR is close, but one ordering-barrier bug should be fixed before merging.

The main notification path is covered, but detached parallel or chain children beyond index `0` can be ordered against the wrong child session.

`packages/subagents/src/runs/foreground/subagent-executor-status.ts` and `packages/subagents/src/runs/background/notify.ts`.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced an issue where detached foreground completion orders occurred against the wrong child by running a focused Bun test that registers subagent notify and calls notifyDetachedForegroundChildExit for run-order-123 with index 1 of 3, showing the second child attribution as Detached subagent task completed: Worker Agent (2/3).
- Observed that the SUBAGENT\_TERMINAL\_ORDERING\_BARRIER\_EVENT payload lacked the actual index-1 target and that sourceSessionTargets pointed to the index-0 value, confirming the barrier wiring mismatch.
- Verified broader test results by confirming the primary new unit test passes, TypeScript type checks pass, and the subagents notification intercom slice tests report 20 pass / 0 fail with exit code 0.
- Reviewed the artifacts from both proofs to corroborate reproduction steps and overall test health, including the reproduction artifacts and the test-suite logs.

<a href="https://app.greptile.com/trex/runs/15335708/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/subagents/CHANGELOG.md | Adds an Unreleased bug-fix note for detached foreground completion notifications. |
| packages/subagents/src/runs/background/notify.ts | Adds a customizable notification label while preserving the background default heading. |
| packages/subagents/src/runs/foreground/subagent-executor-chain.ts | Wires detached chain child exits into foreground state replacement and the async notification path. |
| packages/subagents/src/runs/foreground/subagent-executor-parallel.ts | Wires detached parallel child exits into notification delivery, but relies on a payload that loses the child index for ordering barriers. |
| packages/subagents/src/runs/foreground/subagent-executor-single.ts | Wires detached single child exits into state replacement and notification delivery after progress cleanup. |
| packages/subagents/src/runs/foreground/subagent-executor-status.ts | Adds detached foreground completion envelope creation; the envelope omits the actual child intercom target, causing ordering barriers to use index 0 for non-first children. |
| test/unit/subagents-detached-foreground-notify.test.ts | Covers delivery, dedupe, status labels, parallel attribution, and unchanged background headings, but not barrier target selection. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Child as Detached foreground child
  participant Foreground as Foreground executor
  participant Status as notifyDetachedForegroundChildExit
  participant Async as deliverLocalCompletionNotification
  participant Notify as registerSubagentNotify
  participant Parent as Parent session

  Child-->>Foreground: exits with final SingleResult
  Foreground->>Foreground: replaceForegroundRunChild(runId, index, result)
  Foreground->>Status: notifyDetachedForegroundChildExit(runId, index, result)
  Status->>Async: emit SUBAGENT_ASYNC_COMPLETE_EVENT
  Async->>Notify: completion envelope + notificationId
  Notify->>Notify: dedupe and terminal ordering barrier
  Notify->>Parent: send subagent-notify with triggerTurn
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Child as Detached foreground child
  participant Foreground as Foreground executor
  participant Status as notifyDetachedForegroundChildExit
  participant Async as deliverLocalCompletionNotification
  participant Notify as registerSubagentNotify
  participant Parent as Parent session

  Child-->>Foreground: exits with final SingleResult
  Foreground->>Foreground: replaceForegroundRunChild(runId, index, result)
  Foreground->>Status: notifyDetachedForegroundChildExit(runId, index, result)
  Status->>Async: emit SUBAGENT_ASYNC_COMPLETE_EVENT
  Async->>Notify: completion envelope + notificationId
  Notify->>Notify: dedupe and terminal ordering barrier
  Notify->>Parent: send subagent-notify with triggerTurn
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/subagents/src/runs/foreground/subagent-executor-status.ts:236-249
**Preserve child ordering target**
For detached parallel or chain children with `index > 0`, this payload only carries the index as display metadata. `notify.ts` then has no child result or intercom target and falls back to `resolveSubagentIntercomTarget(runId, agent, 0)`, so the terminal ordering barrier waits on child 1 while the completion notice is for child `index + 1`. Buffered messages from the actual child can arrive after the completion notice.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(subagents): notify parent when detac..."](https://github.com/bastani-inc/atomic/commit/05f9ed9927221c3d0ee45f1d20b7becf19be7d04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46139629)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/bastani-inc/github/bastani-inc/atomic/-/custom-context?memory=6b6bc6e3-dafb-4fa7-9d98-538aac70844a))

<!-- /greptile_comment -->