### PR TITLE
fix(coding-agent): let a single ctrl+c dismiss /login popups

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a single Ctrl+C not dismissing the `/login` popups (auth-method selector, provider selector, and login dialogs), even though Escape worked and the on-screen hint promised `esc/ctrl+c cancel`. The global Ctrl+C clear/exit handler consumed the key before the focused popup could see it, so the first press silently cleared the hidden editor and a second press within the double-press window exited the entire CLI. The global handler now defers whenever an inline popup owns input (and its overlay/custom-UI guards are evaluated live instead of once at startup), so Ctrl+C reaches the focused component and cancels exactly like Escape while editor clearing and double-press exit continue to work when the editor has focus.
+
 ## [0.9.11-alpha.2] - 2026-07-21
 
 ### Added

--- a/packages/coding-agent/src/modes/interactive/interactive-global-clear.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-global-clear.ts
@@ -1,7 +1,15 @@
 interface GlobalClearInputOptions {
 	matchesClear(data: string): boolean;
-	hasOverlay: boolean;
-	blockingInlineCustomUiActive: boolean;
+	hasOverlay(): boolean;
+	blockingInlineCustomUiActive(): boolean;
+	/**
+	 * True when the chat editor is the component that currently owns input.
+	 * Inline popups (login selectors/dialogs, settings, model selector, …) are
+	 * mounted in place of the editor and take focus; while one is active the
+	 * global clear handler must defer so the focused component can treat
+	 * Ctrl+C as cancel (`tui.select.cancel` binds escape and ctrl+c).
+	 */
+	editorOwnsInput(): boolean;
 	onClear(): void;
 	requestRender(): void;
 }
@@ -12,7 +20,8 @@ export function routeGlobalClearInput(
 	options: GlobalClearInputOptions,
 ): { consume: true } | undefined {
 	if (!options.matchesClear(data)) return undefined;
-	if (options.hasOverlay || options.blockingInlineCustomUiActive) return undefined;
+	if (options.hasOverlay() || options.blockingInlineCustomUiActive()) return undefined;
+	if (!options.editorOwnsInput()) return undefined;
 	options.onClear();
 	options.requestRender();
 	return { consume: true };

--- a/packages/coding-agent/src/modes/interactive/interactive-input-handling.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-input-handling.ts
@@ -46,8 +46,9 @@ InteractiveModeBase.prototype.runUserPromptTurn = async function(this: Interacti
 InteractiveModeBase.prototype.setupKeyHandlers = function(this: InteractiveModeBase): void {
     this.ui.addInputListener((data) => routeGlobalClearInput(data, {
       matchesClear: (candidate) => this.keybindings.matches(candidate, "app.clear"),
-      hasOverlay: this.ui.hasOverlay(),
-      blockingInlineCustomUiActive: this.blockingInlineCustomUiDepth > 0,
+      hasOverlay: () => this.ui.hasOverlay(),
+      blockingInlineCustomUiActive: () => this.blockingInlineCustomUiDepth > 0,
+      editorOwnsInput: () => this.editorContainer.children.includes(this.editor),
       onClear: () => this.handleCtrlC(),
       requestRender: () => this.ui.requestRender(),
     }));

--- a/test/unit/interactive-engine-input-form.test.ts
+++ b/test/unit/interactive-engine-input-form.test.ts
@@ -151,8 +151,9 @@ describe("host-native input form", () => {
 		formTui.setFocus(component);
 		formTui.addInputListener((data) => routeGlobalClearInput(data, {
 			matchesClear: (candidate) => keybindings.matches(candidate, "app.clear"),
-			hasOverlay: false,
-			blockingInlineCustomUiActive: true,
+			hasOverlay: () => false,
+			blockingInlineCustomUiActive: () => true,
+			editorOwnsInput: () => true,
 			onClear: () => { globalClears += 1; },
 			requestRender: () => {},
 		}));
@@ -169,8 +170,9 @@ describe("host-native input form", () => {
 		});
 		editorTui.addInputListener((data) => routeGlobalClearInput(data, {
 			matchesClear: (candidate) => keybindings.matches(candidate, "app.clear"),
-			hasOverlay: false,
-			blockingInlineCustomUiActive: false,
+			hasOverlay: () => false,
+			blockingInlineCustomUiActive: () => false,
+			editorOwnsInput: () => true,
 			onClear: () => { globalClears += 1; },
 			requestRender: () => {},
 		}));

--- a/test/unit/interactive-login-ctrlc-dismiss.test.ts
+++ b/test/unit/interactive-login-ctrlc-dismiss.test.ts
@@ -1,0 +1,103 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import { getKeybindings, Key, type KeyId, parseKey, setKeybindings } from "@earendil-works/pi-tui";
+import { KeybindingsManager } from "../../packages/coding-agent/src/core/keybindings.ts";
+import { routeGlobalClearInput } from "../../packages/coding-agent/src/modes/interactive/interactive-global-clear.ts";
+import { ExtensionSelectorComponent } from "../../packages/coding-agent/src/modes/interactive/components/extension-selector.ts";
+
+/**
+ * pi-tui exposes key parsing (raw bytes -> KeyId) but no encoder, so tests
+ * define the raw terminal sequences once and validate them against pi-tui's
+ * own parser instead of trusting hardcoded bytes.
+ */
+function rawKeyData(sequence: string, keyId: KeyId): string {
+	assert.equal(parseKey(sequence), keyId, `fixture must encode ${keyId}`);
+	return sequence;
+}
+
+const CTRL_C = rawKeyData("\u0003", Key.ctrl("c"));
+const ESCAPE = rawKeyData("\u001b", Key.escape);
+
+function makeOptions(overrides: Partial<{
+	hasOverlay: boolean;
+	blockingInlineCustomUiActive: boolean;
+	editorOwnsInput: boolean;
+}> = {}) {
+	const keybindings = new KeybindingsManager();
+	const state = { clears: 0 };
+	const options = {
+		matchesClear: (candidate: string) => keybindings.matches(candidate, "app.clear"),
+		hasOverlay: () => overrides.hasOverlay ?? false,
+		blockingInlineCustomUiActive: () => overrides.blockingInlineCustomUiActive ?? false,
+		editorOwnsInput: () => overrides.editorOwnsInput ?? true,
+		onClear: () => { state.clears += 1; },
+		requestRender: () => {},
+	};
+	return { options, state };
+}
+
+test("global clear consumes ctrl+c only while the editor owns input", () => {
+	const editorOwned = makeOptions({ editorOwnsInput: true });
+	assert.deepEqual(routeGlobalClearInput(CTRL_C, editorOwned.options), { consume: true });
+	assert.equal(editorOwned.state.clears, 1);
+
+	const popupOwned = makeOptions({ editorOwnsInput: false });
+	assert.equal(routeGlobalClearInput(CTRL_C, popupOwned.options), undefined);
+	assert.equal(popupOwned.state.clears, 0, "ctrl+c must reach the focused popup instead of the global clear handler");
+});
+
+test("global clear guards are evaluated live, not at registration time", () => {
+	let overlay = false;
+	let editorOwns = true;
+	const keybindings = new KeybindingsManager();
+	let clears = 0;
+	const options = {
+		matchesClear: (candidate: string) => keybindings.matches(candidate, "app.clear"),
+		hasOverlay: () => overlay,
+		blockingInlineCustomUiActive: () => false,
+		editorOwnsInput: () => editorOwns,
+		onClear: () => { clears += 1; },
+		requestRender: () => {},
+	};
+
+	assert.deepEqual(routeGlobalClearInput(CTRL_C, options), { consume: true });
+	assert.equal(clears, 1);
+
+	editorOwns = false; // a /login popup replaced the editor
+	assert.equal(routeGlobalClearInput(CTRL_C, options), undefined);
+	assert.equal(clears, 1);
+
+	editorOwns = true;
+	overlay = true; // a real TUI overlay is on screen
+	assert.equal(routeGlobalClearInput(CTRL_C, options), undefined);
+	assert.equal(clears, 1);
+});
+
+test("a single ctrl+c cancels the login auth-method selector once input reaches it", () => {
+	const previous = getKeybindings();
+	setKeybindings(new KeybindingsManager());
+	try {
+		let cancelled = 0;
+		const selector = new ExtensionSelectorComponent(
+			"Select authentication method:",
+			["Use a subscription", "Use an API key"],
+			() => {},
+			() => { cancelled += 1; },
+		);
+		// With the fix, the deferred global handler lets the focused selector
+		// receive the raw ctrl+c byte; tui.select.cancel binds escape AND ctrl+c.
+		selector.handleInput(CTRL_C);
+		assert.equal(cancelled, 1, "ctrl+c must cancel the selector exactly like escape");
+
+		const viaEscape = new ExtensionSelectorComponent(
+			"Select authentication method:",
+			["Use a subscription", "Use an API key"],
+			() => {},
+			() => { cancelled += 1; },
+		);
+		viaEscape.handleInput(ESCAPE);
+		assert.equal(cancelled, 2);
+	} finally {
+		setKeybindings(previous);
+	}
+});


### PR DESCRIPTION
## Problem

A single **Ctrl+C did not dismiss the `/login` popups** (auth-method selector, provider selector, login dialogs), even though Escape worked and the popup hint itself advertises `esc/ctrl+c cancel`. Worse, because the first press was silently consumed, a second press within the 500ms double-press window **exited the entire CLI** from inside the popup.

## Root cause

`setupKeyHandlers` registers a global TUI input listener (`routeGlobalClearInput`) so Ctrl+C can clear the editor and double-press-exit the CLI. Two defects:

1. The popups opened by `/login` are mounted **inline** in the editor container via `showSelector()` — they are not pi-tui overlays, so the listener's `hasOverlay` guard never applied and the listener consumed Ctrl+C before the focused popup could see it.
2. The `hasOverlay` / `blockingInlineCustomUiActive` guards were evaluated **once at registration time** (`hasOverlay: this.ui.hasOverlay()`), not per keypress — permanently stale `false`/`false`.

The focused components were always ready to handle the key: pi-tui's `tui.select.cancel` binds `["escape", "ctrl+c"]`.

## Fix

`interactive-global-clear.ts` options are now live callbacks, plus a new `editorOwnsInput()` guard (`editorContainer.children.includes(editor)`, using pi-tui's public `Container.children`). The global handler defers whenever an inline popup owns input, letting the focused component cancel on Ctrl+C exactly like Escape. Editor clearing and double-press exit are unchanged when the editor has focus.

## Testing

- `test/unit/interactive-login-ctrlc-dismiss.test.ts` (new): consume-only-when-editor-owns-input, live (not registration-time) guard evaluation, and selector cancellation on Ctrl+C == Escape — key fixtures validated against pi-tui's `parseKey`/`Key` primitives rather than trusted hardcoded bytes.
- Updated `interactive-engine-input-form.test.ts` callers to the live-callback signature.
- `bun run typecheck` clean; full `test:unit` green via the pre-commit hook.
- Real tmux E2E on `bun packages/coding-agent/src/cli.ts` — evidence in PR comment.

Assistant-model: Claude Fable 5

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Ctrl+C handling for inline `/login` popups in the interactive CLI. The main changes are:

- Live evaluation of global clear guards on each keypress.
- A new editor ownership check before consuming Ctrl+C globally.
- Updated routing so inline selectors and dialogs receive Ctrl+C as cancel.
- Unit tests for editor-owned clearing, popup cancellation, and input-form listener ordering.
- A changelog entry for the user-facing login popup fix.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped to input routing, preserves the editor clear path, defers correctly for inline and overlay UI, and includes targeted tests for the regression and listener-order behavior.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the focused login Ctrl+C tests with Bun and captured a test run showing 14 pass, 0 fail, and EXIT\_CODE: 0.
- T-Rex executed the typecheck step for the login Ctrl+C flow using tsc --noEmit and verified EXIT\_CODE: 0.
- T-Rex observed and documented the Ctrl+C behavior, including Ctrl+C reaching focused popups instead of global clear, live guard re-evaluation after editor ownership changes, and Ctrl+C cancelling the login auth-method selector exactly like Escape.

<a href="https://app.greptile.com/trex/runs/15338014/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/CHANGELOG.md | Adds an Unreleased user-facing fixed entry for the Ctrl+C login popup cancellation behavior. |
| packages/coding-agent/src/modes/interactive/interactive-global-clear.ts | Converts global clear guards to live callbacks and defers clear handling unless the editor currently owns input. |
| packages/coding-agent/src/modes/interactive/interactive-input-handling.ts | Passes live TUI/custom-UI guard callbacks and an editor-container ownership check into the global clear router. |
| test/unit/interactive-engine-input-form.test.ts | Updates input-form tests to the new live-callback global clear interface while preserving focused inline form behavior coverage. |
| test/unit/interactive-login-ctrlc-dismiss.test.ts | Adds focused unit coverage for editor-owned Ctrl+C clearing, live guard evaluation, and selector cancellation parity with Escape. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant User
  participant TUI
  participant GlobalClear as routeGlobalClearInput
  participant EditorContainer
  participant Focused as Focused component
  User->>TUI: Ctrl+C
  TUI->>GlobalClear: input listener(data)
  GlobalClear->>GlobalClear: matches app.clear?
  GlobalClear->>GlobalClear: hasOverlay() / blockingInlineCustomUiActive()?
  GlobalClear->>EditorContainer: editorOwnsInput()
  alt editor is mounted
    GlobalClear->>Focused: consume before focus dispatch
    GlobalClear->>Focused: handleCtrlC clears/exits per existing logic
  else inline popup owns input
    GlobalClear-->>TUI: undefined (do not consume)
    TUI->>Focused: deliver Ctrl+C
    Focused->>Focused: tui.select.cancel / dialog cancel
  end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant User
  participant TUI
  participant GlobalClear as routeGlobalClearInput
  participant EditorContainer
  participant Focused as Focused component
  User->>TUI: Ctrl+C
  TUI->>GlobalClear: input listener(data)
  GlobalClear->>GlobalClear: matches app.clear?
  GlobalClear->>GlobalClear: hasOverlay() / blockingInlineCustomUiActive()?
  GlobalClear->>EditorContainer: editorOwnsInput()
  alt editor is mounted
    GlobalClear->>Focused: consume before focus dispatch
    GlobalClear->>Focused: handleCtrlC clears/exits per existing logic
  else inline popup owns input
    GlobalClear-->>TUI: undefined (do not consume)
    TUI->>Focused: deliver Ctrl+C
    Focused->>Focused: tui.select.cancel / dialog cancel
  end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(coding-agent): let a single ctrl+c d..."](https://github.com/bastani-inc/atomic/commit/8a2fe336e9baf183d40069adba5e255b1cde6146) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46144405)</sub>

<!-- /greptile_comment -->