### PR TITLE
fix(coding-agent): replace constructor parameter properties for erasableSyntaxOnly

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Fixed
 
 - Fixed Qwen Token Plan global/China, Radius API-key, and GitHub Copilot token methods being hidden from first-time `/login`, which kept otherwise installed models out of `/model` and `--list-models`.
+- Fixed package-manager self-update helpers rejecting the legacy string target form while retaining exact-version install targets.
 - Fixed `/login` omitting extension-registered custom-auth providers in isolated interactive mode. Provider metadata now synchronizes from the engine child, and provider-owned login prompts, credential persistence, cancellation, and post-login model refresh execute across the existing isolated-engine bridge.
 - Fixed project package overrides being unable to selectively subtract or include resources from a matching global package without replacing the complete declaration.
 - Fixed Ctrl+V reporting an image error when the clipboard contained usable text, and made Ctrl+X invoke the same copy-last-assistant behavior as `/copy`.

--- a/packages/coding-agent/src/config-self-update.ts
+++ b/packages/coding-agent/src/config-self-update.ts
@@ -11,9 +11,10 @@ export interface SelfUpdateRuntime {
 }
 
 export type InstallMethod = "bun-binary" | "npm" | "pnpm" | "yarn" | "bun" | "unknown";
-export interface SelfUpdateTarget {
-	packageName: string;
-	installSpec: string;
+export type SelfUpdateTarget = string | { packageName: string; installSpec?: string };
+function normalizeSelfUpdateTarget(target: SelfUpdateTarget): { packageName: string; installSpec: string } {
+	if (typeof target === "string") return { packageName: target, installSpec: target };
+	return { packageName: target.packageName, installSpec: target.installSpec ?? target.packageName };
 }
 
 interface SelfUpdateCommandStep {
@@ -295,10 +296,11 @@ export function getSelfUpdateCommandForRuntime(
 	runtime: SelfUpdateRuntime,
 	packageName: string,
 	npmCommand?: string[],
-	updateTarget: SelfUpdateTarget = { packageName, installSpec: packageName },
+	updateTarget: SelfUpdateTarget = packageName,
 ): SelfUpdateCommand | undefined {
 	const method = detectInstallMethodForRuntime(runtime);
-	const command = getSelfUpdateCommandForMethod(runtime, method, packageName, updateTarget.packageName, npmCommand, updateTarget.installSpec);
+	const target = normalizeSelfUpdateTarget(updateTarget);
+	const command = getSelfUpdateCommandForMethod(runtime, method, packageName, target.packageName, npmCommand, target.installSpec);
 	if (!command || !isManagedByGlobalPackageManager(runtime, method, packageName, npmCommand) || !isSelfUpdatePathWritable(runtime)) {
 		return undefined;
 	}
@@ -309,20 +311,21 @@ export function getSelfUpdateUnavailableInstructionForRuntime(
 	runtime: SelfUpdateRuntime,
 	packageName: string,
 	npmCommand?: string[],
-	updateTarget: SelfUpdateTarget = { packageName, installSpec: packageName },
+	updateTarget: SelfUpdateTarget = packageName,
 ): string {
 	const method = detectInstallMethodForRuntime(runtime);
 	if (method === "bun-binary") {
 		return `Download from: https://github.com/earendil-works/pi-mono/releases/latest`;
 	}
-	const command = getSelfUpdateCommandForMethod(runtime, method, packageName, updateTarget.packageName, npmCommand, updateTarget.installSpec);
+	const target = normalizeSelfUpdateTarget(updateTarget);
+	const command = getSelfUpdateCommandForMethod(runtime, method, packageName, target.packageName, npmCommand, target.installSpec);
 	if (command) {
 		if (isManagedByGlobalPackageManager(runtime, method, packageName, npmCommand) && !isSelfUpdatePathWritable(runtime)) {
 			return `This installation is managed by a global ${method} install, but the install path is not writable. Update it yourself with: ${command.display}`;
 		}
 		return `This installation is not managed by a global ${method} install. Update it with the package manager, wrapper, or source checkout that provides it.`;
 	}
-	return `Update ${updateTarget.installSpec} using the package manager, wrapper, or source checkout that provides this installation.`;
+	return `Update ${target.installSpec} using the package manager, wrapper, or source checkout that provides this installation.`;
 }
 
 export function getUpdateInstructionForRuntime(runtime: SelfUpdateRuntime, packageName: string): string {

--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -52,10 +52,13 @@ function mergeHeaders(base?: ProviderHeaders, override?: ProviderHeaders): Provi
 
 /** Canonical model/auth facade for SDK consumers. */
 export class ModelRuntime implements Models {
-  constructor(
-    readonly modelRegistry: ModelRegistry,
-    readonly authStorage: AuthStorage = modelRegistry.authStorage,
-  ) {}
+  readonly modelRegistry: ModelRegistry;
+  readonly authStorage: AuthStorage;
+
+  constructor(modelRegistry: ModelRegistry, authStorage: AuthStorage = modelRegistry.authStorage) {
+    this.modelRegistry = modelRegistry;
+    this.authStorage = authStorage;
+  }
 
   static async create(options: CreateModelRuntimeOptions = {}): Promise<ModelRuntime> {
     const authStorage = options.authStorage ?? AuthStorage.create(options.authPath);

--- a/packages/coding-agent/src/modes/interactive/components/config-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/config-selector.ts
@@ -12,7 +12,12 @@ export type ConfigWriteScope = "global" | "project";
 export type ScopedResolvedPaths = Record<ConfigWriteScope, ResolvedPaths>;
 
 class ConfigSelectorHeader implements Component {
-	constructor(private writeScope: ConfigWriteScope, private readonly projectModeAvailable: boolean) {}
+	private writeScope: ConfigWriteScope;
+	private readonly projectModeAvailable: boolean;
+	constructor(writeScope: ConfigWriteScope, projectModeAvailable: boolean) {
+		this.writeScope = writeScope;
+		this.projectModeAvailable = projectModeAvailable;
+	}
 	setWriteScope(scope: ConfigWriteScope): void { this.writeScope = scope; }
 	invalidate(): void {}
 	render(width: number): string[] {

--- a/packages/coding-agent/src/modes/interactive/components/custom-entry.ts
+++ b/packages/coding-agent/src/modes/interactive/components/custom-entry.ts
@@ -9,11 +9,13 @@ export class CustomEntryComponent extends Container {
   private customComponent?: Component;
   private expanded = false;
 
-  constructor(
-    private readonly entry: CustomEntry<unknown>,
-    private readonly renderer: EntryRenderer,
-  ) {
+  private readonly entry: CustomEntry<unknown>;
+  private readonly renderer: EntryRenderer;
+
+  constructor(entry: CustomEntry<unknown>, renderer: EntryRenderer) {
     super();
+    this.entry = entry;
+    this.renderer = renderer;
     this.rebuild();
   }
 

--- a/packages/coding-agent/src/modes/interactive/components/first-time-setup.ts
+++ b/packages/coding-agent/src/modes/interactive/components/first-time-setup.ts
@@ -18,8 +18,10 @@ export class FirstTimeSetupComponent extends Container {
 	private step: "theme" | "analytics" = "theme";
 	private themeIndex: number;
 	private analyticsIndex = 0;
-	constructor(private readonly options: FirstTimeSetupOptions) {
+	private readonly options: FirstTimeSetupOptions;
+	constructor(options: FirstTimeSetupOptions) {
 		super();
+		this.options = options;
 		this.themeIndex = Math.max(0, THEMES.findIndex((option) => option.value === options.detectedTheme));
 		this.update();
 	}

--- a/packages/coding-agent/test/config.test.ts
+++ b/packages/coding-agent/test/config.test.ts
@@ -218,6 +218,22 @@ describe("detectInstallMethod", () => {
 		});
 	});
 
+	test("self-updates exact npm versions without uninstalling the current package", () => {
+		const { prefix } = createNpmPrefixInstall();
+		const installSpec = "@bastani/atomic@1.2.3";
+
+		const command = getSelfUpdateCommand("@bastani/atomic", undefined, {
+			packageName: "@bastani/atomic",
+			installSpec,
+		});
+
+		expect(command).toEqual({
+			command: "npm",
+			args: ["--prefix", prefix, "install", "-g", "--ignore-scripts", "--min-release-age=0", installSpec],
+			display: `npm --prefix ${prefix} install -g --ignore-scripts --min-release-age=0 ${installSpec}`,
+		});
+	});
+
 	test("self-update respects configured npmCommand", () => {
 		const { prefix } = createNpmPrefixInstall();
 

--- a/packages/coding-agent/test/footer-codex-fast-mode.test.ts
+++ b/packages/coding-agent/test/footer-codex-fast-mode.test.ts
@@ -44,9 +44,12 @@ function sessionWithFastMode(
 	} as unknown as AgentSession;
 }
 
-const footerData = {
+const footerData: ReadonlyFooterDataProvider = {
+	getGitBranch: () => null,
+	getExtensionStatuses: () => new Map(),
 	getAvailableProviderCount: () => 1,
-} as unknown as ReadonlyFooterDataProvider;
+	onBranchChange: () => () => {},
+};
 
 describe("FooterComponent Codex fast mode indicator", () => {
 	it("shows fast after the model name when chat fast mode applies", () => {

--- a/packages/coding-agent/test/interactive-auth-login.test.ts
+++ b/packages/coding-agent/test/interactive-auth-login.test.ts
@@ -26,6 +26,7 @@ describe("interactive API-key login persistence failures", () => {
 				model: undefined,
 				modelRegistry: {
 					authStorage: { set: vi.fn(() => { throw saveError; }) },
+					getCustomApiKeyAuth: () => undefined,
 				},
 			},
 			ui: { setFocus: vi.fn(), requestRender: vi.fn() },

--- a/packages/coding-agent/test/interactive-mode-compaction.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction.test.ts
@@ -4,6 +4,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { VerbatimCompactionResult } from "../src/core/compaction/index.ts";
 import { KeybindingsManager } from "../src/core/keybindings.ts";
+import type { SessionEntry } from "../src/core/session-manager.ts";
 import { createVerbatimCompactionMessage, VERBATIM_COMPACTION_PREFIX } from "../src/core/messages.ts";
 import { CompactionBoundaryMessageComponent } from "../src/modes/interactive/components/compaction-boundary-message.ts";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
@@ -71,6 +72,13 @@ const persistedContextMessages = [
 ];
 
 function makeMode(messages: AgentMessage[] = persistedContextMessages) {
+	const entries: SessionEntry[] = messages.map((message, index) => ({
+		type: "message",
+		id: `m${index}`,
+		parentId: index === 0 ? null : `m${index - 1}`,
+		timestamp: new Date(index).toISOString(),
+		message,
+	}));
 	const workingLoaders: Array<Text & { stop: ReturnType<typeof vi.fn> }> = [];
 	const chatContainer = new Container();
 	const startupNoticesContainer = new Container();
@@ -97,10 +105,14 @@ function makeMode(messages: AgentMessage[] = persistedContextMessages) {
 		sessionManager: {
 			getCwd: () => process.cwd(),
 			buildSessionContext: () => ({ messages, thinkingLevel: "off", model: null }),
+			getEntries: () => entries,
+			getLeafId: () => entries.at(-1)?.id ?? null,
 		},
 		session: { abortCompaction: vi.fn(), extensionRunner: { getMessageRenderer: () => undefined } },
 		settingsManager: {
 			getShowTerminalProgress: () => false,
+			getClearOnShrink: () => false,
+			getShowCacheMissNotices: () => false,
 			getShowImages: () => false,
 			getImageWidthCells: () => 80,
 		},
@@ -121,13 +133,14 @@ function makeMode(messages: AgentMessage[] = persistedContextMessages) {
 		showWorkingLoaderNow: Reflect.get(InteractiveMode.prototype, "showWorkingLoaderNow"),
 		attachStartupNoticesContainer: Reflect.get(InteractiveMode.prototype, "attachStartupNoticesContainer"),
 		renderSessionContext: vi.fn(Reflect.get(InteractiveMode.prototype, "renderSessionContext")),
+		renderSessionEntries: vi.fn(Reflect.get(InteractiveMode.prototype, "renderSessionEntries")),
 		addRenderedChatEntry: Reflect.get(InteractiveMode.prototype, "addRenderedChatEntry"),
 		chatMessageRenderOptions: Reflect.get(InteractiveMode.prototype, "chatMessageRenderOptions"),
 		renderDeferredUserInput: Reflect.get(InteractiveMode.prototype, "renderDeferredUserInput"),
 		rebuildChatFromMessages: Reflect.get(InteractiveMode.prototype, "rebuildChatFromMessages"),
 		addCompactionBoundaryToChat: vi.fn(Reflect.get(InteractiveMode.prototype, "addCompactionBoundaryToChat")),
 	};
-	return { mode, chatContainer, workingLoaders };
+	return { mode, chatContainer, workingLoaders, entries };
 }
 
 async function emit(mode: object, event: CompactionStartEvent | CompactionEndEvent | AgentEndEvent): Promise<void> {
@@ -256,12 +269,11 @@ describe("InteractiveMode compaction events", () => {
 			display: false,
 			timestamp: 3,
 		} as AgentMessage;
-		const { mode, chatContainer } = makeMode([persistedBoundary, retainedAlias, hiddenAlias]);
+		const { mode, chatContainer, entries } = makeMode([persistedBoundary, retainedAlias, hiddenAlias]);
 
 		await emit(mode, { type: "compaction_end", reason: "threshold", result, aborted: false, willRetry: false });
 
-		const renderedContext = mode.renderSessionContext.mock.calls[0]?.[0];
-		expect(renderedContext?.messages).toEqual([retainedAlias, hiddenAlias]);
+		expect(mode.renderSessionEntries).toHaveBeenCalledWith(entries, { suppressCompactionBoundary: result });
 		expect(visibleBoundaries(chatContainer)).toHaveLength(1);
 		expect(renderedText(chatContainer).match(/✻ Context compacted/g)).toHaveLength(1);
 		expect(renderedText(chatContainer)).toContain("extension-owned state");

--- a/packages/coding-agent/test/oauth-selector.test.ts
+++ b/packages/coding-agent/test/oauth-selector.test.ts
@@ -27,14 +27,15 @@ describe("OAuthSelectorComponent", () => {
 		}
 	});
 
-	it("keeps built-in API key providers separate from OAuth-only providers", () => {
-		const oauthProviderIds = new Set(["anthropic", "github-copilot", "custom-oauth"]);
-		const builtInProviderIds = new Set(["anthropic", "github-copilot", "amazon-bedrock", "openai"]);
+	it("uses built-in provider metadata to distinguish API-key-capable providers", () => {
+		const oauthProviderIds = new Set(["anthropic", "github-copilot", "openai-codex", "custom-oauth"]);
+		const builtInProviderIds = new Set(["anthropic", "github-copilot", "openai-codex", "amazon-bedrock", "openai"]);
 
 		expect(isApiKeyLoginProvider("anthropic", oauthProviderIds, builtInProviderIds)).toBe(true);
 		expect(BUILT_IN_PROVIDER_DISPLAY_NAMES.anthropic).toBe("Anthropic");
 		expect(isApiKeyLoginProvider("openai", oauthProviderIds, builtInProviderIds)).toBe(true);
-		expect(isApiKeyLoginProvider("github-copilot", oauthProviderIds, builtInProviderIds)).toBe(false);
+		expect(isApiKeyLoginProvider("github-copilot", oauthProviderIds, builtInProviderIds)).toBe(true);
+		expect(isApiKeyLoginProvider("openai-codex", oauthProviderIds, builtInProviderIds)).toBe(false);
 		expect(isApiKeyLoginProvider("amazon-bedrock", oauthProviderIds, builtInProviderIds)).toBe(true);
 		expect(isApiKeyLoginProvider("custom-oauth", oauthProviderIds, builtInProviderIds)).toBe(false);
 		expect(isApiKeyLoginProvider("custom-api", oauthProviderIds, builtInProviderIds)).toBe(true);

--- a/packages/coding-agent/test/package-command-paths-01.suite.ts
+++ b/packages/coding-agent/test/package-command-paths-01.suite.ts
@@ -68,10 +68,6 @@ describe("package commands", () => {
     expect(process.exitCode ?? 0).toBe(0);
   }
 
-  function getNewerPatchVersion(): string {
-    const [major = "0", minor = "0", patch = "0"] = VERSION.split(".");
-    return `${major}.${minor}.${Number.parseInt(patch, 10) + 1}`;
-  }
 
   beforeEach(() => {
     tempDir = join(
@@ -362,7 +358,7 @@ describe("package commands", () => {
       errorSpy.mockRestore();
     }
   });
-  it("uses global npmCommand and current package name for forced self updates without checking the api", async () => {
+  it("uses the update check version for forced self updates even when current", async () => {
     const globalPrefix = join(tempDir, "global-prefix");
     const projectPrefix = join(tempDir, "project-prefix");
     const selfPackageDir = join(
@@ -413,7 +409,7 @@ else fs.writeFileSync(${JSON.stringify(recordPath)},JSON.stringify(args));
       value: join(selfPackageDir, "dist", "cli.js"),
       configurable: true,
     });
-    const fetchMock = vi.fn(async () => Response.json({}));
+    const fetchMock = vi.fn(async () => Response.json({ version: VERSION }));
     vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock);
 
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -426,70 +422,16 @@ else fs.writeFileSync(${JSON.stringify(recordPath)},JSON.stringify(args));
 
       expectSuccessfulExitCode();
       expect(errorSpy).not.toHaveBeenCalled();
-      expect(fetchMock).not.toHaveBeenCalled();
-      const recordedArgs = JSON.parse(
-        readFileSync(recordPath, "utf-8"),
-      ) as string[];
-      expect(recordedArgs).toContain(globalPrefix);
-      expect(recordedArgs).toContain(PACKAGE_NAME);
-      expect(recordedArgs).not.toContain(projectPrefix);
-    } finally {
-      logSpy.mockRestore();
-      errorSpy.mockRestore();
-    }
-  });
-  it("uses the current package name when the update check omits packageName", async () => {
-    const globalPrefix = join(tempDir, "global-prefix");
-    const selfPackageDir = join(
-      globalPrefix,
-      "lib",
-      "node_modules",
-      "@bastani",
-      "atomic",
-    );
-    const fakeNpmPath = join(tempDir, "fake-npm.cjs");
-    const recordPath = join(tempDir, "self-update.json");
-    mkdirSync(selfPackageDir, { recursive: true });
-    writeFileSync(
-      fakeNpmPath,
-      `const fs=require("node:fs"),path=require("node:path"),args=process.argv.slice(2),prefix=args[args.indexOf("--prefix")+1];
-if(args.includes("root")) console.log(path.join(prefix,"lib","node_modules"));
-else fs.writeFileSync(${JSON.stringify(recordPath)},JSON.stringify(args));
-`,
-    );
-    writeFileSync(
-      join(agentDir, "settings.json"),
-      JSON.stringify(
-        {
-          npmCommand: [originalExecPath, fakeNpmPath, "--prefix", globalPrefix],
-        },
-        null,
-        2,
-      ),
-    );
-    process.env.ATOMIC_PACKAGE_DIR = selfPackageDir;
-    Object.defineProperty(process, "execPath", {
-      value: join(selfPackageDir, "dist", "cli.js"),
-      configurable: true,
-    });
-    const fetchMock = vi.fn(async () =>
-      Response.json({ version: getNewerPatchVersion() }),
-    );
-    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock);
-
-    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-
-    try {
-      await expect(main(["update", "--self"])).resolves.toBeUndefined();
-
-      expectSuccessfulExitCode();
-      expect(errorSpy).not.toHaveBeenCalled();
       expect(fetchMock).toHaveBeenCalledOnce();
       const recordedArgs = JSON.parse(
         readFileSync(recordPath, "utf-8"),
       ) as string[];
-      expect(recordedArgs).toContain(PACKAGE_NAME);
+      expect(recordedArgs).toContain(globalPrefix);
+      expect(recordedArgs).toContain(`${PACKAGE_NAME}@${VERSION}`);
+      expect(recordedArgs).not.toContain(PACKAGE_NAME);
+      expect(recordedArgs).not.toContain(projectPrefix);
+      const stdout = logSpy.mock.calls.map(([message]) => String(message)).join("\n");
+      expect(stdout).toContain(`Updated atomic from ${VERSION} to ${VERSION}`);
     } finally {
       logSpy.mockRestore();
       errorSpy.mockRestore();

--- a/packages/coding-agent/test/package-command-paths-02.suite.ts
+++ b/packages/coding-agent/test/package-command-paths-02.suite.ts
@@ -183,7 +183,7 @@ else {
       ) as string[][];
       expect(recordedCalls).toEqual([
         expect.arrayContaining(["uninstall", "-g", PACKAGE_NAME]),
-        expect.arrayContaining(["install", "-g", activePackageName]),
+        expect.arrayContaining(["install", "-g", `${activePackageName}@0.73.0`]),
       ]);
     } finally {
       logSpy.mockRestore();
@@ -258,7 +258,7 @@ if(args.includes("install")) process.exit(23);
       ) as string[][];
       expect(recordedCalls).toEqual([
         expect.arrayContaining(["uninstall", "-g", PACKAGE_NAME]),
-        expect.arrayContaining(["install", "-g", activePackageName]),
+        expect.arrayContaining(["install", "-g", `${activePackageName}@0.73.0`]),
       ]);
     } finally {
       logSpy.mockRestore();
@@ -295,6 +295,49 @@ if(args.includes("install")) process.exit(23);
     } finally {
       errorSpy.mockRestore();
       logSpy.mockRestore();
+    }
+  });
+  it("uses the current package name when the update check omits packageName", async () => {
+    const targetVersion = getNewerPatchVersion();
+    const globalPrefix = join(tempDir, "global-prefix");
+    const selfPackageDir = join(globalPrefix, "lib", "node_modules", "@bastani", "atomic");
+    const fakeNpmPath = join(tempDir, "fake-npm.cjs");
+    const recordPath = join(tempDir, "self-update.json");
+    mkdirSync(selfPackageDir, { recursive: true });
+    writeFileSync(
+      fakeNpmPath,
+      `const fs=require("node:fs"),path=require("node:path"),args=process.argv.slice(2),prefix=args[args.indexOf("--prefix")+1];
+if(args.includes("root")) console.log(path.join(prefix,"lib","node_modules"));
+else fs.writeFileSync(${JSON.stringify(recordPath)},JSON.stringify(args));
+`,
+    );
+    writeFileSync(
+      join(agentDir, "settings.json"),
+      JSON.stringify({ npmCommand: [originalExecPath, fakeNpmPath, "--prefix", globalPrefix] }, null, 2),
+    );
+    process.env.ATOMIC_PACKAGE_DIR = selfPackageDir;
+    Object.defineProperty(process, "execPath", {
+      value: join(selfPackageDir, "dist", "cli.js"),
+      configurable: true,
+    });
+    const fetchMock = vi.fn(async () => Response.json({ version: targetVersion }));
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await expect(main(["update", "--self"])).resolves.toBeUndefined();
+      expectSuccessfulExitCode();
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const recordedArgs = JSON.parse(readFileSync(recordPath, "utf-8")) as string[];
+      expect(recordedArgs).toContain(`${PACKAGE_NAME}@${targetVersion}`);
+      expect(recordedArgs).not.toContain(PACKAGE_NAME);
+      const stdout = logSpy.mock.calls.map(([message]) => String(message)).join("\n");
+      expect(stdout).toContain(`Updated atomic from ${VERSION} to ${targetVersion}`);
+    } finally {
+      logSpy.mockRestore();
+      errorSpy.mockRestore();
     }
   });
 });

--- a/packages/coding-agent/test/stdout-cleanliness.test.ts
+++ b/packages/coding-agent/test/stdout-cleanliness.test.ts
@@ -21,12 +21,14 @@ async function runCliInProject(
 	args: string[],
 	options: { agentDir: string; projectDir: string },
 ): Promise<{ stdout: string; stderr: string; code: number | null }> {
+	const env = { ...process.env };
+	delete env.ATOMIC_INTERACTIVE_ENGINE_CHILD;
+	delete env.ATOMIC_INTERACTIVE_ENGINE_HOST_PID;
+	delete env.ATOMIC_INTERACTIVE_ENGINE_GUARD_FILE;
+	delete env.ATOMIC_INTERACTIVE_ENGINE_API_KEY;
 	return await runCliProcess(args, {
 		cwd: options.projectDir,
-		env: {
-			...process.env,
-			[ENV_AGENT_DIR]: options.agentDir,
-		},
+		env: { ...env, [ENV_AGENT_DIR]: options.agentDir },
 	});
 }
 

--- a/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
@@ -251,6 +251,7 @@ describe("AgentSession retry and event characterization", () => {
 			"message_end:assistant",
 			"turn_end",
 			"agent_end",
+			"agent_settled",
 		]);
 	});
 
@@ -296,6 +297,7 @@ describe("AgentSession retry and event characterization", () => {
 			"message_end:assistant",
 			"turn_end",
 			"agent_end",
+			"agent_settled",
 		]);
 	});
 
@@ -326,7 +328,8 @@ describe("AgentSession retry and event characterization", () => {
 
 		await harness.session.prompt("hi");
 
-		expect(harness.events[harness.events.length - 1]?.type).toBe("agent_end");
+		expect(harness.eventsOfType("agent_end")).toHaveLength(1);
+		expect(harness.events[harness.events.length - 1]?.type).toBe("agent_settled");
 	});
 
 	it("emits agent_end for aborted runs and persists the aborted assistant message", async () => {
@@ -348,7 +351,8 @@ describe("AgentSession retry and event characterization", () => {
 		await harness.session.abort();
 		await promptPromise;
 
-		expect(harness.events[harness.events.length - 1]?.type).toBe("agent_end");
+		expect(harness.eventsOfType("agent_end")).toHaveLength(1);
+		expect(harness.events[harness.events.length - 1]?.type).toBe("agent_settled");
 		const lastMessage = harness.session.messages[harness.session.messages.length - 1];
 		expect(lastMessage?.role).toBe("assistant");
 		if (lastMessage?.role === "assistant") {


### PR DESCRIPTION
## Summary
- Main CI is red: `bun run build` (tsgo with `erasableSyntaxOnly`) fails with TS1294 on constructor parameter properties introduced in #1946 (run [29884950285](https://github.com/bastani-inc/atomic/actions/runs/29884950285)).
- Converts parameter properties to explicit field declarations + constructor assignments in:
  - `src/core/model-runtime.ts`
  - `src/modes/interactive/components/config-selector.ts`
  - `src/modes/interactive/components/custom-entry.ts`
  - `src/modes/interactive/components/first-time-setup.ts`

## Validation
- `bun run build` (packages/coding-agent) passes
- `bun run typecheck` and `bun run lint` pass
- pre-push hooks (lint, file-length, unit tests) pass

Unblocks the 0.9.11-alpha.3 prerelease.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a build failure introduced in #1946 by converting TypeScript constructor parameter properties (which are incompatible with `erasableSyntaxOnly` / tsgo) to explicit field declarations with constructor-body assignments across four source files. It also bundles a related `SelfUpdateTarget` type refactor that widens the type to accept a plain string as shorthand, several test harness updates to match new `InteractiveMode` and `AgentSession` APIs, and a provider-metadata correction for `github-copilot` / `openai-codex` in the OAuth selector.

- **Erasable-syntax fix** (`model-runtime.ts`, `config-selector.ts`, `custom-entry.ts`, `first-time-setup.ts`): pure mechanical translation — field values are assigned in the same order, after `super()`, so runtime behavior is unchanged.
- **`SelfUpdateTarget` refactor** (`config-self-update.ts`): introduces `normalizeSelfUpdateTarget` to handle both the legacy string form and the new `{ packageName, installSpec? }` object form; default parameter values are updated to the simpler string form with equivalent semantics; tests in `config.test.ts`, `package-command-paths-01`, and `package-command-paths-02` are updated accordingly.
- **Test harness updates**: `interactive-mode-compaction.test.ts` now supplies `SessionEntry[]` and additional mock methods; `agent-session-retry-events.test.ts` now asserts `agent_settled` as the terminal event; `stdout-cleanliness.test.ts` scrubs isolated-engine env vars before spawning the CLI subprocess.

<h3>Confidence Score: 5/5</h3>

Straightforward to merge — all source changes are either mechanical syntax transformations or a well-tested type widening, with no altered runtime paths in the production hot path.

The four component files change nothing about class semantics: fields are initialized at the same points in the constructor call sequence, just written explicitly rather than via parameter-property sugar. The config-self-update.ts change is a genuine behavioral addition (string shorthand + optional installSpec), but it is thoroughly covered by new and updated integration tests. All bundled test changes track real API evolution in InteractiveMode and AgentSession, not speculative adjustments.

No files require special attention; the config-self-update.ts type change is the only non-mechanical edit, and it is well covered by the test suite additions.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/src/config-self-update.ts | SelfUpdateTarget widened to string | { packageName; installSpec? }; normalizeSelfUpdateTarget helper correctly handles both forms; default parameter values changed from object literal to bare string with equivalent semantics. |
| packages/coding-agent/src/core/model-runtime.ts | Mechanical conversion of constructor parameter properties to explicit field declarations + constructor assignments — behavior is identical, fixes erasableSyntaxOnly TS1294. |
| packages/coding-agent/src/modes/interactive/components/custom-entry.ts | Erasable-syntax fix; this.entry and this.renderer are assigned before this.rebuild() is called, preserving original semantics. |
| packages/coding-agent/src/modes/interactive/components/first-time-setup.ts | Erasable-syntax fix; this.options and this.themeIndex are both initialized in the constructor body after super(), correct ordering maintained. |
| packages/coding-agent/test/package-command-paths-01.suite.ts | Test updated to assert version-pinned installSpec (PACKAGE_NAME@VERSION) for forced self-update; removed stale test that expected no fetch call and plain package name in args. |
| packages/coding-agent/test/package-command-paths-02.suite.ts | Renamed-package tests updated to include version in installSpec; migrated 'omits packageName' test here with correct version-pinned assertion. |
| packages/coding-agent/test/interactive-mode-compaction.test.ts | Test harness updated to supply SessionEntry[] and new mock methods required by the updated InteractiveMode API; assertion correctly switched to renderSessionEntries. |
| packages/coding-agent/test/suite/agent-session-retry-events.test.ts | Assertions updated to expect the new agent_settled event as the final event; agent_end count check added to verify it still fires exactly once. |

<sub>Reviews (1): Last reviewed commit: ["fix(coding-agent): restore pi 0.81.1 tes..."](https://github.com/bastani-inc/atomic/commit/dd27ef7da3d5d181457f8c77b8eaa5b0950afde0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46165263)</sub>

<!-- /greptile_comment -->