### PR TITLE
fix(coding-agent): support -- end-of-options terminator for positional prompts (#1950)

### DIFF
--- a/evals/atomic_harbor.py
+++ b/evals/atomic_harbor.py
@@ -376,7 +376,7 @@ class Atomic(BaseInstalledAgent):
                 f"atomic --print --mode json --session-dir {session_dir} "
                 f"{model_args}"
                 f"{cli_flags}"
-                f"{escaped_instruction} "
+                f"-- {escaped_instruction} "
                 "2>&1 </dev/null | grep -v '\"type\":\"message_update\"' | "
                 f"stdbuf -oL tee /logs/agent/{self._OUTPUT_FILENAME}; status=$?; "
                 "exit $status"

--- a/evals/atomic_pier.py
+++ b/evals/atomic_pier.py
@@ -536,7 +536,7 @@ class Atomic(BaseInstalledAgent):
             f"atomic --print --mode json --session-dir {session_dir} "
             f"--provider {shlex.quote(provider)} --model {shlex.quote(model)} "
             f"{cli_flags}"
-            f"{shlex.quote(instruction)} "
+            f"-- {shlex.quote(instruction)} "
             "2>&1 </dev/null | grep -v '\"type\":\"message_update\"' | "
             f"stdbuf -oL tee {output_file}; status=$?; "
             "exit $status"

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed positional prompts beginning with `-`, `--`, or `@` being parsed as options or file arguments by supporting the conventional `--` end-of-options terminator ([#1950](https://github.com/bastani-inc/atomic/issues/1950)).
+
 ## [0.9.11-alpha.3] - 2026-07-21
 
 ### Added

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -130,6 +130,12 @@ Treat exported and shared sessions as sensitive: transcripts can contain source 
 atomic [options] [@files...] [messages...]
 ```
 
+Use `--` to end option parsing when positional prompt text begins with `-`, `--`, or `@`. Every argument after the terminator is treated as literal message text rather than an option or file argument:
+
+```bash
+atomic --print -- "- leading-dash prompt"
+```
+
 ### Package Commands
 
 ```bash

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -71,6 +71,19 @@ export function isValidThinkingLevel(level: string): level is ThinkingLevel {
 	return VALID_THINKING_LEVELS.includes(level as ThinkingLevel);
 }
 
+/**
+ * Insert forced option arguments (e.g. a dedicated entry point's `--mode rpc`)
+ * immediately before the first `--` end-of-options terminator, or append them
+ * when no terminator is present. Keeps the forced options parsed as options
+ * (never literal message text) while preserving last-option-wins semantics,
+ * since caller options can only appear before the terminator.
+ */
+export function insertForcedOptionsBeforeTerminator(args: string[], forced: string[]): string[] {
+	const terminatorIndex = args.indexOf("--");
+	const insertAt = terminatorIndex === -1 ? args.length : terminatorIndex;
+	return [...args.slice(0, insertAt), ...forced, ...args.slice(insertAt)];
+}
+
 export function parseArgs(args: string[]): Args {
 	const result: Args = {
 		messages: [],

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -82,6 +82,11 @@ export function parseArgs(args: string[]): Args {
 	for (let i = 0; i < args.length; i++) {
 		const arg = args[i];
 
+		if (arg === "--") {
+			result.messages.push(...args.slice(i + 1));
+			break;
+		}
+
 		if (arg === "--help" || arg === "-h") {
 			result.help = true;
 		} else if (arg === "--version" || arg === "-v") {

--- a/packages/coding-agent/src/rpc-entry.ts
+++ b/packages/coding-agent/src/rpc-entry.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { insertForcedOptionsBeforeTerminator } from "./cli/args.ts";
 import { APP_NAME } from "./config.ts";
 import { configureHttpDispatcher } from "./core/http-dispatcher.ts";
 import { main } from "./main.ts";
@@ -10,5 +11,8 @@ process.emitWarning = (() => {}) as typeof process.emitWarning;
 configureHttpDispatcher();
 
 // rpc-entry is the dedicated RPC entry point, so --mode rpc must always win
-// over any --mode the caller passes (the last --mode in the args wins).
-main([...process.argv.slice(2), "--mode", "rpc"]);
+// over any --mode the caller passes (the last --mode in the args wins). The
+// forced flags are inserted before any `--` end-of-options terminator so they
+// are still parsed as options rather than literal message text; caller --mode
+// flags can only appear before the terminator, so last-wins is preserved.
+main(insertForcedOptionsBeforeTerminator(process.argv.slice(2), ["--mode", "rpc"]));

--- a/packages/coding-agent/test/args-end-of-options.test.ts
+++ b/packages/coding-agent/test/args-end-of-options.test.ts
@@ -1,0 +1,53 @@
+import { describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import { parseArgs } from "../src/cli/args.ts";
+
+describe("parseArgs -- end-of-options terminator", () => {
+	test("preserves a prompt beginning with a single hyphen", () => {
+		const prompt = "- leading-dash prompt";
+		const result = parseArgs(["--", prompt]);
+
+		assert.deepStrictEqual(result.messages, [prompt]);
+		assert.deepStrictEqual(result.fileArgs, []);
+		assert.strictEqual(result.unknownFlags.size, 0);
+		assert.deepStrictEqual(result.diagnostics, []);
+	});
+
+	test("preserves a prompt beginning with two hyphens", () => {
+		const prompt = "--leading-double-dash prompt";
+		const result = parseArgs(["--", prompt]);
+
+		assert.deepStrictEqual(result.messages, [prompt]);
+		assert.strictEqual(result.unknownFlags.size, 0);
+		assert.deepStrictEqual(result.diagnostics, []);
+	});
+
+	test("preserves a prompt beginning with @ as message text", () => {
+		const prompt = "@literal-file-looking prompt";
+		const result = parseArgs(["--", prompt]);
+
+		assert.deepStrictEqual(result.messages, [prompt]);
+		assert.deepStrictEqual(result.fileArgs, []);
+	});
+
+	test("consumes the terminator, parses preceding options, and preserves every following argument", () => {
+		const result = parseArgs([
+			"--print",
+			"--mode",
+			"json",
+			"--",
+			"first",
+			"--provider",
+			"@context.md",
+			"first",
+		]);
+
+		assert.strictEqual(result.print, true);
+		assert.strictEqual(result.mode, "json");
+		assert.strictEqual(result.provider, undefined);
+		assert.deepStrictEqual(result.messages, ["first", "--provider", "@context.md", "first"]);
+		assert.deepStrictEqual(result.fileArgs, []);
+		assert.strictEqual(result.unknownFlags.size, 0);
+		assert.deepStrictEqual(result.diagnostics, []);
+	});
+});

--- a/packages/coding-agent/test/args-end-of-options.test.ts
+++ b/packages/coding-agent/test/args-end-of-options.test.ts
@@ -1,33 +1,32 @@
-import { describe, test } from "bun:test";
-import assert from "node:assert/strict";
-import { parseArgs } from "../src/cli/args.ts";
+import { describe, expect, test } from "vitest";
+import { insertForcedOptionsBeforeTerminator, parseArgs } from "../src/cli/args.ts";
 
 describe("parseArgs -- end-of-options terminator", () => {
 	test("preserves a prompt beginning with a single hyphen", () => {
 		const prompt = "- leading-dash prompt";
 		const result = parseArgs(["--", prompt]);
 
-		assert.deepStrictEqual(result.messages, [prompt]);
-		assert.deepStrictEqual(result.fileArgs, []);
-		assert.strictEqual(result.unknownFlags.size, 0);
-		assert.deepStrictEqual(result.diagnostics, []);
+		expect(result.messages).toEqual([prompt]);
+		expect(result.fileArgs).toEqual([]);
+		expect(result.unknownFlags.size).toBe(0);
+		expect(result.diagnostics).toEqual([]);
 	});
 
 	test("preserves a prompt beginning with two hyphens", () => {
 		const prompt = "--leading-double-dash prompt";
 		const result = parseArgs(["--", prompt]);
 
-		assert.deepStrictEqual(result.messages, [prompt]);
-		assert.strictEqual(result.unknownFlags.size, 0);
-		assert.deepStrictEqual(result.diagnostics, []);
+		expect(result.messages).toEqual([prompt]);
+		expect(result.unknownFlags.size).toBe(0);
+		expect(result.diagnostics).toEqual([]);
 	});
 
 	test("preserves a prompt beginning with @ as message text", () => {
 		const prompt = "@literal-file-looking prompt";
 		const result = parseArgs(["--", prompt]);
 
-		assert.deepStrictEqual(result.messages, [prompt]);
-		assert.deepStrictEqual(result.fileArgs, []);
+		expect(result.messages).toEqual([prompt]);
+		expect(result.fileArgs).toEqual([]);
 	});
 
 	test("consumes the terminator, parses preceding options, and preserves every following argument", () => {
@@ -42,12 +41,44 @@ describe("parseArgs -- end-of-options terminator", () => {
 			"first",
 		]);
 
-		assert.strictEqual(result.print, true);
-		assert.strictEqual(result.mode, "json");
-		assert.strictEqual(result.provider, undefined);
-		assert.deepStrictEqual(result.messages, ["first", "--provider", "@context.md", "first"]);
-		assert.deepStrictEqual(result.fileArgs, []);
-		assert.strictEqual(result.unknownFlags.size, 0);
-		assert.deepStrictEqual(result.diagnostics, []);
+		expect(result.print).toBe(true);
+		expect(result.mode).toBe("json");
+		expect(result.provider).toBeUndefined();
+		expect(result.messages).toEqual(["first", "--provider", "@context.md", "first"]);
+		expect(result.fileArgs).toEqual([]);
+		expect(result.unknownFlags.size).toBe(0);
+		expect(result.diagnostics).toEqual([]);
+	});
+});
+
+describe("insertForcedOptionsBeforeTerminator", () => {
+	test("appends forced options when no terminator is present", () => {
+		const args = insertForcedOptionsBeforeTerminator(["--print", "hello"], ["--mode", "rpc"]);
+
+		expect(args).toEqual(["--print", "hello", "--mode", "rpc"]);
+		expect(parseArgs(args).mode).toBe("rpc");
+	});
+
+	test("inserts forced options before the terminator so they still parse as options", () => {
+		const args = insertForcedOptionsBeforeTerminator(
+			["--print", "--", "- leading-dash prompt"],
+			["--mode", "rpc"],
+		);
+
+		expect(args).toEqual(["--print", "--mode", "rpc", "--", "- leading-dash prompt"]);
+		const result = parseArgs(args);
+		expect(result.mode).toBe("rpc");
+		expect(result.messages).toEqual(["- leading-dash prompt"]);
+	});
+
+	test("forced --mode still wins over a caller --mode before the terminator", () => {
+		const args = insertForcedOptionsBeforeTerminator(
+			["--mode", "json", "--", "--mode json as message"],
+			["--mode", "rpc"],
+		);
+
+		const result = parseArgs(args);
+		expect(result.mode).toBe("rpc");
+		expect(result.messages).toEqual(["--mode json as message"]);
 	});
 });

--- a/packages/coding-agent/test/rpc-entry.test.ts
+++ b/packages/coding-agent/test/rpc-entry.test.ts
@@ -9,8 +9,16 @@ describe("rpc-entry env marker and forced RPC mode", () => {
 		expect(RPC_ENTRY_SOURCE).toContain("APP_NAME.toUpperCase()");
 	});
 
-	it("forces --mode rpc as the last argument so it cannot be overridden", () => {
-		// The main() call should append --mode rpc at the end so the last --mode wins.
-		expect(RPC_ENTRY_SOURCE).toMatch(/main\(\[\.\.\.process\.argv\.slice\(2\),\s*"--mode",\s*"rpc"\]\)/);
+	it("forces --mode rpc via terminator-aware insertion so it cannot be overridden", () => {
+		// The forced --mode rpc must be inserted before any `--` end-of-options
+		// terminator (never appended blindly after caller argv, where a caller
+		// `--` would demote it to literal message text). Caller --mode flags can
+		// only appear before the terminator, so last-option-wins is preserved.
+		expect(RPC_ENTRY_SOURCE).toMatch(
+			/main\(\s*insertForcedOptionsBeforeTerminator\(\s*process\.argv\.slice\(2\),\s*\["--mode",\s*"rpc"\]\s*\)\s*\)/,
+		);
+		expect(RPC_ENTRY_SOURCE).toContain(
+			'import { insertForcedOptionsBeforeTerminator } from "./cli/args.ts";',
+		);
 	});
 });


### PR DESCRIPTION
## Summary

Adds conventional `--` end-of-options handling so Atomic accepts positional prompts beginning with `-`, `--`, or `@` as literal message text. This fixes the CLI reproduction in #1950 and protects evaluation adapters from interpreting instructions as options.

## Changes

- consume `--` before generic option handling and preserve every following argument as a positional message
- add parser regressions for single-hyphen, double-hyphen, and `@`-prefixed prompts, including options parsed before the terminator
- delimit Pier and Harbor evaluation instructions with `--`
- document the CLI behavior and add an Unreleased changelog entry

## Validation

- `bun run typecheck`
- `bun run lint`
- parser tests: 80 passed
- `bun run test:unit`: 3967 passed
- `bun run check:file-length`
- documentation link validation
- Python adapter compilation
- pre-commit/pre-push hooks
- real CLI before/after reproduction in detached tmux (evidence posted as a PR comment)

Fixes #1950

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds end-of-options handling for positional prompts and preserves forced RPC mode.
- Treats every argument following `--` as literal message text.
- Inserts the dedicated entry point’s forced `--mode rpc` before the terminator.
- Updates evaluation adapters, regression tests, CLI documentation, and the changelog.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The CLI after-run reached the model execution stage with the literal arguments preserved and exited with code 1 due to a permitted provider-credential failure after parsing.
- The RPC after-run completed credential-free with exit code 0, proving terminator-aware forced RPC mode through the actual entrypoint.
- The artifacts collectively capture the executed command, the working directory, the captured output, and the exit code for inspection.

<a href="https://app.greptile.com/trex/runs/15437822/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/src/cli/args.ts | Adds terminator parsing and a helper that positions forced options before the first terminator. |
| packages/coding-agent/src/rpc-entry.ts | Uses terminator-aware insertion so the dedicated entry point continues to force RPC mode. |
| packages/coding-agent/test/args-end-of-options.test.ts | Covers literal hyphen- and at-prefixed prompts, preceding options, and forced-option placement. |
| packages/coding-agent/test/rpc-entry.test.ts | Updates the source-level regression assertion to match the terminator-aware RPC invocation. |
| evals/atomic_harbor.py | Delimits evaluation instructions with the end-of-options marker. |
| evals/atomic_pier.py | Delimits evaluation instructions with the end-of-options marker. |

<sub>Reviews (3): Last reviewed commit: ["test(coding-agent): update rpc-entry for..."](https://github.com/bastani-inc/atomic/commit/1ee52bb69d4d120270d7555984ce5c5983956670) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46333397)</sub>

<!-- /greptile_comment -->