### PR TITLE
fix(evals): guard NVM initialization like Pier installed agents (#1951)

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -2,6 +2,17 @@
 
 Utilities and adapters for running Atomic against evaluation suites such as Deep SWE through Pier.
 
+## Tests
+
+Run the eval bootstrap and adapter regression tests from this directory:
+
+```bash
+uv run pytest
+```
+
+The shell-level bootstrap tests execute the generated NVM setup command with
+isolated fake NVM installations, so they do not modify the host Node setup.
+
 ## Run Pier with Atomic
 
 Run commands from this `evals/` directory. Choose one provider configuration below, then pass `atomic_pier:Atomic` as the agent import path.

--- a/evals/atomic_harbor.py
+++ b/evals/atomic_harbor.py
@@ -15,8 +15,8 @@ from harbor.environments.base import BaseEnvironment
 from harbor.models.agent.context import AgentContext
 from prerequisites import (
     agent_install_command,
+    atomic_runtime_environment_command,
     root_install_command,
-    runtime_environment_command,
 )
 
 
@@ -103,7 +103,7 @@ class Atomic(BaseInstalledAgent):
 
     @override
     def get_version_command(self) -> str | None:
-        return f"{runtime_environment_command()}; . ~/.nvm/nvm.sh; atomic --version"
+        return f"{atomic_runtime_environment_command()}; atomic --version"
 
     @override
     def parse_version(self, stdout: str) -> str:
@@ -371,8 +371,7 @@ class Atomic(BaseInstalledAgent):
                 f"rm -rf {session_dir} {log_session_dir} && mkdir -p {session_dir} && "
                 f"{self._agent_state_setup_command()}"
                 f"{self._session_sync_trap_command(session_dir, log_session_dir)}"
-                f"{runtime_environment_command()} && "
-                f". ~/.nvm/nvm.sh && "
+                f"{atomic_runtime_environment_command()} && "
                 f"atomic --print --mode json --session-dir {session_dir} "
                 f"{model_args}"
                 f"{cli_flags}"

--- a/evals/atomic_pier.py
+++ b/evals/atomic_pier.py
@@ -38,8 +38,8 @@ from pier.utils.trajectory_utils import (
 )
 from prerequisites import (
     agent_install_command,
+    atomic_runtime_environment_command,
     root_install_command,
-    runtime_environment_command,
 )
 
 
@@ -236,11 +236,7 @@ class Atomic(BaseInstalledAgent):
 
     @override
     def get_version_command(self) -> str | None:
-        return (
-            f"{runtime_environment_command()}; "
-            "if [ -s ~/.nvm/nvm.sh ]; then . ~/.nvm/nvm.sh; fi; "
-            "atomic --version"
-        )
+        return f"{atomic_runtime_environment_command()}; atomic --version"
 
     @override
     def parse_version(self, stdout: str) -> str:
@@ -531,8 +527,7 @@ class Atomic(BaseInstalledAgent):
             f"{self._agent_state_setup_command()}"
             f"{self._session_sync_trap_command(session_dir, log_session_dir)}"
             f"{copilot_config_command}"
-            f"{runtime_environment_command()} && "
-            "if [ -s ~/.nvm/nvm.sh ]; then . ~/.nvm/nvm.sh; fi && "
+            f"{atomic_runtime_environment_command()} && "
             f"atomic --print --mode json --session-dir {session_dir} "
             f"--provider {shlex.quote(provider)} --model {shlex.quote(model)} "
             f"{cli_flags}"

--- a/evals/prerequisites.py
+++ b/evals/prerequisites.py
@@ -53,6 +53,17 @@ def _validate_version_spec(version_spec: str) -> None:
         raise ValueError(f"Unsafe Atomic npm version specifier: {version_spec!r}")
 
 
+def atomic_runtime_environment_command() -> str:
+    """Load eval environment and NVM without trusting nvm.sh's exit status."""
+    return (
+        'export PATH="$HOME/.local/bin:$PATH"; '
+        'if [ -f "$HOME/.atomic-eval-env" ]; then . "$HOME/.atomic-eval-env"; fi; '
+        'if [ -s "$HOME/.nvm/nvm.sh" ]; then . "$HOME/.nvm/nvm.sh" || true; fi; '
+        "command -v nvm >/dev/null 2>&1 || command -v atomic >/dev/null 2>&1 || "
+        "{ echo 'Error: neither NVM nor Atomic is available' >&2; exit 1; }"
+    )
+
+
 def runtime_environment_command() -> str:
     """Load installer-persisted environment in non-login eval runtime shells."""
     return (
@@ -61,10 +72,9 @@ def runtime_environment_command() -> str:
     )
 
 
-def agent_install_command(version_spec: str) -> str:
-    """Install Atomic and playwright-cli, then configure Chromium."""
-    _validate_version_spec(version_spec)
-    node_setup = (
+def _node_setup_command() -> str:
+    """Configure distribution Node on Alpine or NVM-managed Node elsewhere."""
+    return (
         "if command -v apk >/dev/null 2>&1; then "
         "node -e 'if (+process.versions.node.split(`.`)[0] < 18) process.exit(1)' || "
         "{ echo 'Error: Alpine nodejs must be Node.js 18 or newer' >&2; exit 1; }; "
@@ -72,10 +82,16 @@ def agent_install_command(version_spec: str) -> str:
         'else export NVM_DIR="$HOME/.nvm"; '
         'if [ ! -s "$NVM_DIR/nvm.sh" ]; then '
         "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash; fi; "
-        '. "$NVM_DIR/nvm.sh"; '
+        '. "$NVM_DIR/nvm.sh" || true; '
         "command -v nvm >/dev/null 2>&1 || { echo 'Error: NVM failed to load' >&2; exit 1; }; "
         "nvm install 22; nvm alias default 22; fi"
     )
+
+
+def agent_install_command(version_spec: str) -> str:
+    """Install Atomic and playwright-cli, then configure Chromium."""
+    _validate_version_spec(version_spec)
+    node_setup = _node_setup_command()
     browser_setup = (
         'env_tmp="$HOME/.atomic-eval-env.tmp"; '
         "printf '%s\\n' 'export PLAYWRIGHT_MCP_BROWSER=chromium' "

--- a/evals/pyproject.toml
+++ b/evals/pyproject.toml
@@ -14,4 +14,9 @@ datacurve-pier = { path = "vendor/pier", editable = true }
 [dependency-groups]
 dev = [
     "basedpyright>=1.39.9",
+    "pytest>=8.4.2",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/evals/tests/test_prerequisites.py
+++ b/evals/tests/test_prerequisites.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from prerequisites import (
+    _node_setup_command,
+    agent_install_command,
+    atomic_runtime_environment_command,
+)
+
+
+def _write_executable(path: Path, contents: str) -> None:
+    path.write_text(contents, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _run_node_setup(tmp_path: Path, nvm_sh: str | None) -> subprocess.CompletedProcess[str]:
+    home = tmp_path / "home"
+    nvm_dir = home / ".nvm"
+    fake_bin = tmp_path / "bin"
+    nvm_dir.mkdir(parents=True)
+    fake_bin.mkdir()
+    if nvm_sh is not None:
+        (nvm_dir / "nvm.sh").write_text(nvm_sh, encoding="utf-8")
+    _write_executable(
+        fake_bin / "curl",
+        "#!/bin/bash\nprintf 'curl unexpectedly invoked\\n' >&2\nexit 97\n",
+    )
+    env = {
+        "HOME": str(home),
+        "NVM_LOG": str(tmp_path / "nvm.log"),
+        "PATH": f"{fake_bin}:/usr/bin:/bin",
+    }
+    return subprocess.run(
+        ["/bin/bash", "-c", f"set -euo pipefail; {_node_setup_command()}"],
+        capture_output=True,
+        check=False,
+        env=env,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize("source_status", [0, 3])
+def test_existing_nvm_source_can_succeed_or_return_nonzero(
+    tmp_path: Path, source_status: int
+) -> None:
+    result = _run_node_setup(
+        tmp_path,
+        "nvm() { printf '%s\\n' \"$*\" >> \"$NVM_LOG\"; }\n"
+        f"return {source_status}\n",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "nvm.log").read_text(encoding="utf-8") == (
+        "install 22\nalias default 22\n"
+    )
+    assert "curl unexpectedly invoked" not in result.stderr
+
+
+def test_nonzero_nvm_source_without_nvm_fails_clearly(tmp_path: Path) -> None:
+    result = _run_node_setup(tmp_path, "return 3\n")
+
+    assert result.returncode == 1
+    assert result.stderr == "Error: NVM failed to load\n"
+
+
+def test_failed_nvm_download_is_not_swallowed(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    fake_bin = tmp_path / "bin"
+    home.mkdir()
+    fake_bin.mkdir()
+    _write_executable(fake_bin / "curl", "#!/bin/bash\nexit 23\n")
+
+    result = subprocess.run(
+        ["/bin/bash", "-c", f"set -euo pipefail; {_node_setup_command()}"],
+        capture_output=True,
+        check=False,
+        env={"HOME": str(home), "PATH": f"{fake_bin}:/usr/bin:/bin"},
+        text=True,
+    )
+
+    assert result.returncode == 23
+    assert "Error: NVM failed to load" not in result.stderr
+
+
+def test_generated_install_command_keeps_non_alpine_and_alpine_guards() -> None:
+    command = agent_install_command("@latest")
+
+    assert 'if [ ! -s "$NVM_DIR/nvm.sh" ]; then' in command
+    assert '. "$NVM_DIR/nvm.sh" || true' in command
+    assert "nvm install 22; nvm alias default 22" in command
+    assert "Alpine nodejs must be Node.js 18 or newer" in command
+    assert 'npm config set prefix "$HOME/.local"' in command
+
+
+@pytest.mark.parametrize(
+    "unsafe_spec",
+    ["latest", "@", "@latest; touch /tmp/pwned", "@latest $(false)", "@two words"],
+)
+def test_unsafe_version_spec_is_rejected(unsafe_spec: str) -> None:
+    with pytest.raises(ValueError, match="Unsafe Atomic npm version specifier"):
+        agent_install_command(unsafe_spec)
+
+
+def test_runtime_source_nonzero_still_launches_atomic(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    nvm_dir = home / ".nvm"
+    nvm_dir.mkdir(parents=True)
+    (nvm_dir / "nvm.sh").write_text(
+        "nvm() { :; }\natomic() { printf 'atomic launched\\n'; }\nreturn 3\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            "/bin/bash",
+            "-c",
+            f"set -euo pipefail; {atomic_runtime_environment_command()}; atomic --version",
+        ],
+        capture_output=True,
+        check=False,
+        env={"HOME": str(home), "PATH": "/usr/bin:/bin"},
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "atomic launched\n"
+
+
+def test_runtime_fails_when_neither_nvm_nor_atomic_is_available(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+
+    result = subprocess.run(
+        ["/bin/bash", "-c", atomic_runtime_environment_command()],
+        capture_output=True,
+        check=False,
+        env={"HOME": str(home), "PATH": "/usr/bin:/bin"},
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert result.stderr == "Error: neither NVM nor Atomic is available\n"
+
+
+def test_pier_and_harbor_use_shared_bootstrap_and_runtime_guard() -> None:
+    evals_dir = Path(__file__).parents[1]
+    for adapter_name in ("atomic_pier.py", "atomic_harbor.py"):
+        source = (evals_dir / adapter_name).read_text(encoding="utf-8")
+        assert "agent_install_command(version_spec)" in source
+        assert source.count("atomic_runtime_environment_command()") == 2
+        assert ". ~/.nvm/nvm.sh" not in source

--- a/evals/tests/test_prerequisites.py
+++ b/evals/tests/test_prerequisites.py
@@ -151,5 +151,10 @@ def test_pier_and_harbor_use_shared_bootstrap_and_runtime_guard() -> None:
     for adapter_name in ("atomic_pier.py", "atomic_harbor.py"):
         source = (evals_dir / adapter_name).read_text(encoding="utf-8")
         assert "agent_install_command(version_spec)" in source
-        assert source.count("atomic_runtime_environment_command()") == 2
+        # Both the version-detection path and the runtime-launch path must use
+        # the shared guarded environment loader. Assert the key call sites are
+        # present rather than an exact count so additional safe call sites do
+        # not break this test.
+        assert "{atomic_runtime_environment_command()}; atomic --version" in source
+        assert "{atomic_runtime_environment_command()} && " in source
         assert ". ~/.nvm/nvm.sh" not in source

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -639,13 +639,17 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "basedpyright" },
+    { name = "pytest" },
 ]
 
 [package.metadata]
 requires-dist = [{ name = "datacurve-pier", editable = "vendor/pier" }]
 
 [package.metadata.requires-dev]
-dev = [{ name = "basedpyright", specifier = ">=1.39.9" }]
+dev = [
+    { name = "basedpyright", specifier = ">=1.39.9" },
+    { name = "pytest", specifier = ">=8.4.2" },
+]
 
 [[package]]
 name = "fastapi"
@@ -963,6 +967,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e7/72/c600ae4f68c28fc19f9c31b9403053e5dbb8cace2e6842c7b7c3e4d42fe9/importlib_metadata-8.9.0.tar.gz", hash = "sha256:58850626cef4bd2df100378b0f2aea9724a7b92f10770d547725b047078f99ee", size = 56140, upload-time = "2026-03-20T16:56:26.362Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/f9/97f2ca8bb3ec6e4b1d64f983ebe98b9a192faddff67fac3d6303a537e670/importlib_metadata-8.9.0-py3-none-any.whl", hash = "sha256:e0f761b6ea91ced3b0844c14c9d955224d538105921f8e6754c00f6ca79fba7f", size = 27220, upload-time = "2026-03-20T16:56:25.07Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -1508,6 +1521,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "postgrest"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1702,6 +1724,22 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Hardens Atomic's shared eval bootstrap so a nonzero status from sourcing an existing `nvm.sh` does not abort otherwise usable installs, while preserving explicit capability checks and fatal NVM download failures.

Fixes #1951.

## Changes

- guard NVM downloads with a non-empty `nvm.sh` check and tolerate only the source command's status before validating `nvm`
- reuse a shared guarded runtime environment in the Pier and Harbor adapters, with a hard failure when neither NVM nor Atomic is available
- add shell-level pytest coverage for successful and nonzero NVM sourcing, ineffective NVM, failed downloads, unsafe version specs, and adapter wiring
- document the eval test command and update the uv development lockfile

## Validation

- `cd evals && uv run pytest` — 13 passed
- `bun run typecheck` — passed
- `bun run lint` — passed
- pre-push hooks — passed, including lint, file-length checks, and unit tests
- detached tmux simulation — both required NVM source-status scenarios passed
- representative Ubuntu Docker build — installed Node v22.23.1, set Node 22 as default, installed Atomic, and ran `atomic --version` successfully

## Notes

Alpine continues to use distribution Node/npm with the existing Node.js 18 minimum-version check. No package changelog entry is included because `evals/` is repository infrastructure.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Hardens the eval bootstrap and adapter runtime setup.
- Tolerates nonzero NVM source status while retaining explicit capability and download-failure checks.
- Reuses the guarded runtime environment in Pier and Harbor.
- Adds shell-level regression tests, test documentation, pytest configuration, and lockfile updates.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The targeted pytest suite was executed and 13 tests were collected.
- All 13 tests passed and the run exited with code 0.
- The run stopped after the targeted suite succeeded, and unrelated checks such as Docker, tmux, benchmarks, submodule initialization, and broad sync were not attempted.

<a href="https://app.greptile.com/trex/runs/15425934/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| evals/prerequisites.py | Adds the shared guarded runtime loader and narrows source-status tolerance to NVM initialization. |
| evals/atomic_pier.py | Routes Pier version checks and evaluation launches through the shared runtime bootstrap. |
| evals/atomic_harbor.py | Routes Harbor version checks and evaluation launches through the shared runtime bootstrap. |
| evals/tests/test_prerequisites.py | Adds regression coverage for NVM source behavior, download failures, capability checks, input validation, and adapter wiring. |
| evals/pyproject.toml | Adds pytest as an eval development dependency and configures test discovery. |
| evals/uv.lock | Locks pytest and its transitive dependencies for the eval environment. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Eval adapter starts] --> B[Load persisted eval environment]
  B --> C{Non-empty nvm.sh exists?}
  C -- Yes --> D[Source nvm.sh; tolerate source status]
  C -- No --> E[Skip NVM source]
  D --> F{NVM or Atomic available?}
  E --> F
  F -- Yes --> G[Run Atomic version or evaluation command]
  F -- No --> H[Exit with explicit error]
```

<sub>Reviews (2): Last reviewed commit: ["test(evals): assert shared runtime-guard..."](https://github.com/bastani-inc/atomic/commit/094faf4174b53266d472af795c551ec89b7c5ec2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46334157)</sub>

<!-- /greptile_comment -->