### PR TITLE
fix(workflows): keep DBOS executor launched across host-session replacement

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,9 +62,13 @@ jobs:
             - name: Mintlify docs validation
               if: runner.os == 'Linux' && github.event_name == 'pull_request'
               working-directory: packages/coding-agent/docs
+              # Pinned: mintlify@4.2.732 depends on @mintlify/editor@0.0.246,
+              # which is missing from the npm registry (404) and breaks
+              # `bunx mintlify@latest` for every PR. Unpin once upstream
+              # publishes a resolvable release.
               run: |
-                  bunx --bun mintlify@latest validate
-                  bunx --bun mintlify@latest broken-links
+                  bunx --bun mintlify@4.2.731 validate
+                  bunx --bun mintlify@4.2.731 broken-links
             - name: Build @bastani/atomic package
               working-directory: packages/coding-agent
               run: bun run build

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Workflow prompt guidance now instructs agents to give each workflow invocation its own intercom group by default — unless the user requests otherwise — by minting one invocation-scoped literal group name inside the workflow's `run` function (e.g. `"myflow-" + randomUUID()`) and passing it via the `group` option on each stage, task, or parallel step that should share it; `group: true`/`"auto"` mints one shared UUID group per `ctx.parallel(...)` set but a fresh UUID per non-parallel stage. This keeps stage and subagent intercom chatter isolated from the parent chat and other concurrent runs, since ungrouped sessions all share the `"default"` group; subagent inheritance, capability gating, and cross-group `contact_supervisor` escalation are unchanged.
 
+### Fixed
+
+- Fixed host-session replacement (`/new`, `/resume`, `/fork`, `/reload`) leaving the process-global DBOS executor stopped so every subsequent workflow run in the same Atomic process failed at its first durable checkpoint with `` `DBOS.launch()` must be called before running workflows ``. The DBOS executor lifetime is now process-scoped: process-preserving session boundaries flush pending durable writes but keep the executor launched, and SDK shutdown is reserved for actual process exit (`quit`/`beforeExit`), which still flushes and shuts down exactly once. Defense in depth: the durable-backend factory revalidates its memoized backend against the current DBOS lifecycle generation and never hands out a stopped backend (post-shutdown initialization fails loudly instead of silently degrading to a non-durable backend), the extension runtime no longer caches a permanently resolved readiness promise across lifecycle generations, and root workflow registration is durably flushed before startup admission so a stopped or unhealthy backend fails before workflow code executes any side effects. ([#1957](https://github.com/bastani-inc/atomic/issues/1957))
+
 ## [0.9.11-alpha.2] - 2026-07-21
 
 ### Fixed

--- a/packages/workflows/src/durable/dbos-lifecycle.ts
+++ b/packages/workflows/src/durable/dbos-lifecycle.ts
@@ -15,7 +15,8 @@ export type DbosLifecycleState =
   | "launching"
   | "ready"
   | "failed"
-  | "shutting_down";
+  | "shutting_down"
+  | "shut_down";
 
 export class DbosDurabilityError extends Error {
   constructor(message: string, options?: ErrorOptions) {
@@ -28,6 +29,16 @@ export class DbosNotReadyError extends DbosDurabilityError {
   constructor() {
     super("DBOS workflow durability is not ready. Await initializeDurableBackend() before accessing workflows.");
     this.name = "DbosNotReadyError";
+  }
+}
+
+export class DbosShutdownError extends DbosDurabilityError {
+  constructor() {
+    super(
+      "DBOS workflow durability has been shut down in this process. "
+      + "Durable workflows can no longer start; restart Atomic to restore durability.",
+    );
+    this.name = "DbosShutdownError";
   }
 }
 type DbosConfigurator = () => Promise<ConfiguredDbosDurability>;
@@ -78,6 +89,10 @@ export async function configureDbosOnce(): Promise<ConfiguredDbosDurability> {
 
 export async function launchDbosOnce(): Promise<void> {
   if (failure !== undefined) throw failure;
+  // The executor is process-scoped and stops exactly once, at process exit.
+  // Post-shutdown launches must fail loudly instead of returning a backend
+  // whose SDK launched marker has been cleared.
+  if (state === "shutting_down" || state === "shut_down") throw new DbosShutdownError();
   const durability = await configureDbosOnce();
   launchPromise ??= (async () => {
     state = "launching";
@@ -133,12 +148,23 @@ export async function shutdownDbos(): Promise<void> {
     state = "shutting_down";
     await durability.backend.flush();
     await durability.shutdown();
+    state = "shut_down";
   })().catch((error: unknown) => {
     failure = durabilityFailure("shutdown", error);
     state = "failed";
     throw failure;
   });
   await shutdownPromise;
+}
+
+/**
+ * Flush queued durable writes without stopping the process-scoped executor.
+ * Used at process-preserving host-session boundaries (`/new`, `/resume`,
+ * `/fork`, `/reload`) where the DBOS executor must stay launched.
+ */
+export async function flushDbos(): Promise<void> {
+  if (state !== "ready" || active === undefined) return;
+  await active.backend.flush();
 }
 
 export function dbosLifecycleState(): DbosLifecycleState {

--- a/packages/workflows/src/durable/factory.ts
+++ b/packages/workflows/src/durable/factory.ts
@@ -3,6 +3,8 @@
 import { InMemoryDurableBackend, type DurableWorkflowBackend } from "./backend.js";
 import {
   DbosNotReadyError,
+  DbosShutdownError,
+  dbosLifecycleState,
   getReadyDbosBackend,
   getReadyDbosBackendSync,
 } from "./dbos-lifecycle.js";
@@ -11,9 +13,22 @@ let injectedBackend: DurableWorkflowBackend | undefined;
 let initializedBackend: DurableWorkflowBackend | undefined;
 let initializing: Promise<DurableWorkflowBackend> | undefined;
 
+/**
+ * A memoized backend is only reusable while its lifecycle generation is
+ * healthy. The in-memory degraded backend has no external lifecycle; a
+ * persistent (DBOS) backend is usable only while the process-scoped DBOS
+ * executor is still `ready` — never after shutdown.
+ */
+function isMemoizedBackendUsable(backend: DurableWorkflowBackend): boolean {
+  return !backend.persistent || dbosLifecycleState() === "ready";
+}
+
 /** Return the injected test backend or the process-wide initialized backend. */
 export function getDurableBackend(): DurableWorkflowBackend {
-  const backend = injectedBackend ?? initializedBackend ?? getReadyDbosBackendSync();
+  const memoized = initializedBackend !== undefined && isMemoizedBackendUsable(initializedBackend)
+    ? initializedBackend
+    : undefined;
+  const backend = injectedBackend ?? memoized ?? getReadyDbosBackendSync();
   if (backend === undefined) throw new DbosNotReadyError();
   return backend;
 }
@@ -44,9 +59,20 @@ export function createInMemoryTestBackend(): InMemoryDurableBackend {
  */
 export async function initializeDurableBackend(): Promise<DurableWorkflowBackend> {
   if (injectedBackend !== undefined) return injectedBackend;
-  if (initializedBackend !== undefined) return initializedBackend;
+  if (initializedBackend !== undefined) {
+    if (isMemoizedBackendUsable(initializedBackend)) return initializedBackend;
+    // Never hand out a backend from a stopped lifecycle generation.
+    initializedBackend = undefined;
+    initializing = undefined;
+  }
   initializing ??= getReadyDbosBackend()
-    .catch((error: unknown) => degradeToNonDurableBackend(error))
+    .catch((error: unknown) => {
+      // Post-shutdown initialization is a process-exit race, not a
+      // provisioning failure: fail loudly instead of silently degrading to a
+      // non-durable backend.
+      if (error instanceof DbosShutdownError) throw error;
+      return degradeToNonDurableBackend(error);
+    })
     .then((backend) => {
       initializedBackend = backend;
       return backend;

--- a/packages/workflows/src/durable/index.ts
+++ b/packages/workflows/src/durable/index.ts
@@ -26,9 +26,11 @@ export {
 export {
   DbosDurabilityError,
   DbosNotReadyError,
+  DbosShutdownError,
   configureDbosOnce,
   launchDbosOnce,
   getReadyDbosBackend,
+  flushDbos,
   shutdownDbos,
 } from "./dbos-lifecycle.js";
 export {

--- a/packages/workflows/src/engine/run-durable-admission.ts
+++ b/packages/workflows/src/engine/run-durable-admission.ts
@@ -1,0 +1,50 @@
+/**
+ * Durable root-run registration and startup admission.
+ *
+ * Root registration/status must be durably persisted before startup admission
+ * or workflow code runs: a stopped or unhealthy backend fails here, before
+ * any side effects execute (issue #1957).
+ */
+
+import type { DurableWorkflowBackend, WorkflowRegistrationInput } from "../durable/backend.js";
+import type { WorkflowSerializableValue } from "../shared/types.js";
+
+/** Build the root registration handle, or `undefined` when the run must not (re-)register. */
+export function durableRootRegistrationForRun(args: {
+  readonly runId: string;
+  readonly name: string;
+  readonly inputs: Readonly<Record<string, unknown>>;
+  readonly createdAt: number;
+  readonly hasPersistence: boolean;
+  readonly isChildRun: boolean;
+  readonly continuationSourceId: string | undefined;
+}): WorkflowRegistrationInput | undefined {
+  const shouldRegister = !args.isChildRun
+    && (args.continuationSourceId === undefined || args.continuationSourceId !== args.runId);
+  if (!shouldRegister) return undefined;
+  return {
+    workflowId: args.runId,
+    name: args.name,
+    inputs: args.inputs as Record<string, WorkflowSerializableValue>,
+    createdAt: args.createdAt,
+    status: "running" as const,
+    rootWorkflowId: args.runId,
+    resumable: true,
+    ...(args.hasPersistence ? { sessionFile: undefined } : {}),
+  };
+}
+
+/** Register/mark the root run and flush so admission requires healthy durable persistence. */
+export async function admitDurableRootRun(args: {
+  readonly backend: DurableWorkflowBackend;
+  readonly runId: string;
+  readonly isChildRun: boolean;
+  readonly registration: WorkflowRegistrationInput | undefined;
+}): Promise<void> {
+  if (args.registration !== undefined) {
+    args.backend.registerWorkflow(args.registration);
+  } else if (!args.isChildRun) {
+    args.backend.setWorkflowStatus(args.runId, "running");
+  }
+  if (!args.isChildRun) await args.backend.flush();
+}

--- a/packages/workflows/src/engine/run.ts
+++ b/packages/workflows/src/engine/run.ts
@@ -47,6 +47,7 @@ import { finalizeDurableTerminalStatus } from "./run-durable-finalize.js";
 import { createDurableStageSessionRecorder } from "./run-durable-stage-session.js";
 import type { DurableWorkflowBackend } from "../durable/backend.js";
 import { createDurableCachedStageRecorder, createDurableStageDeps } from "./run-durable-topology.js";
+import { admitDurableRootRun, durableRootRegistrationForRun } from "./run-durable-admission.js";
 
 type WorkflowRunInputArgument = Parameters<typeof resolveAndValidateInputs>[1];
 
@@ -312,18 +313,11 @@ export async function run<
     },
     runWorkflow: run,
   });
-  const durableRootWorkflowRegistration = {
-    workflowId: runId,
-    name: def.name,
-    inputs: resolvedInputs as Record<string, import("../shared/types.js").WorkflowSerializableValue>,
-    createdAt: runSnapshot.startedAt,
-    status: "running" as const,
-    rootWorkflowId: runId,
-    resumable: true,
-    ...(opts.persistence !== undefined ? { sessionFile: undefined } : {}),
-  };
-  const shouldRegisterDurableRoot = opts.parentRun === undefined
-    && (opts.continuation === undefined || opts.continuation.source.id !== runId);
+  const durableRootRegistration = durableRootRegistrationForRun({
+    runId, name: def.name, inputs: resolvedInputs, createdAt: runSnapshot.startedAt,
+    hasPersistence: opts.persistence !== undefined, isChildRun: opts.parentRun !== undefined,
+    continuationSourceId: opts.continuation?.source.id,
+  });
   const tool = createToolPrimitive({
     workflowId: runId,
     backend: durableBackend,
@@ -408,11 +402,11 @@ export async function run<
       }
     }
 
-    if (shouldRegisterDurableRoot) {
-      durableBackend.registerWorkflow({ ...durableRootWorkflowRegistration, ...workflowInvocationMetadata(inputRuntimeDefaults, workflowInvocationCwd, gitWorktreeSetupCache) });
-    } else if (opts.parentRun === undefined) {
-      durableBackend.setWorkflowStatus(runId, "running");
-    }
+    await admitDurableRootRun({
+      backend: durableBackend, runId, isChildRun: opts.parentRun !== undefined,
+      registration: durableRootRegistration === undefined ? undefined
+        : { ...durableRootRegistration, ...workflowInvocationMetadata(inputRuntimeDefaults, workflowInvocationCwd, gitWorktreeSetupCache) },
+    });
     if (opts.deferWorkflowStart === true) opts.onWorkflowStartReady?.();
     const rawResult = await runWorkflowDefinitionCallback(def.name, runId, () => def.run(ctx));
     if (ownController.signal.aborted) {

--- a/packages/workflows/src/extension/extension-lifecycle.ts
+++ b/packages/workflows/src/extension/extension-lifecycle.ts
@@ -12,7 +12,7 @@ import type { ExtensionAPI } from "./public-types.js";
 import type { WorkflowExtensionRuntimeState } from "./extension-runtime-state.js";
 import { deAdvertiseAskUserQuestionWhenHeadless, formatStartupDiagnostics } from "./workflow-command-surfaces.js";
 import { inFlightRunCount } from "./workflow-targets.js";
-import { shutdownDbos } from "../durable/dbos-lifecycle.js";
+import { flushDbos, shutdownDbos } from "../durable/dbos-lifecycle.js";
 
 let processShutdownInstalled = false;
 
@@ -25,6 +25,19 @@ function shutdownDbosQuietly(): Promise<void> {
   return shutdownDbos().catch((error: unknown) => {
     const detail = error instanceof Error ? error.message : String(error);
     console.error(`atomic-workflows: DBOS durability shutdown failed: ${detail}`);
+  });
+}
+
+/**
+ * Process-preserving host-session boundaries (`/new`, `/resume`, `/fork`,
+ * `/reload`) must NOT stop the process-scoped DBOS executor: the replacement
+ * session reuses it for subsequent workflow runs. Flush pending durable
+ * writes instead, and reserve SDK shutdown for actual process exit.
+ */
+function flushDbosQuietly(): Promise<void> {
+  return flushDbos().catch((error: unknown) => {
+    const detail = error instanceof Error ? error.message : String(error);
+    console.error(`atomic-workflows: DBOS durability flush failed: ${detail}`);
   });
 }
 
@@ -135,6 +148,7 @@ export function registerWorkflowLifecycleHandlers(
     deps.storeWidgetRef.current = null;
     runtimeState.resetWorkflowDiscoveryForSession();
     runtimeState.setNotificationsActive(false);
-    await shutdownDbosQuietly();
+    if (reason === "quit") await shutdownDbosQuietly();
+    else await flushDbosQuietly();
   });
 }

--- a/packages/workflows/src/extension/runtime.ts
+++ b/packages/workflows/src/extension/runtime.ts
@@ -135,10 +135,12 @@ export function createExtensionRuntime(opts: ExtensionRuntimeOpts = {}): Extensi
   const jobs = opts.jobs;
   const runtimeCwd = opts.cwd ?? process.cwd();
   const resolveDefaultStageSessionDir = opts.resolveDefaultStageSessionDir;
-  let dbosReady: Promise<void> | undefined;
   const ensureDbosReady = async (): Promise<void> => {
-    dbosReady ??= initializeDurableBackend().then(() => undefined);
-    await dbosReady;
+    // Deliberately not memoized: the factory revalidates its memoized backend
+    // against the current DBOS lifecycle generation, so caching a permanently
+    // resolved promise here could mask a backend stopped after a
+    // host-session replacement (issue #1957).
+    await initializeDurableBackend();
   };
 
   function runOptions(policy?: WorkflowExecutionPolicy): RunOpts {

--- a/test/unit/durable-dbos-session-replacement.test.ts
+++ b/test/unit/durable-dbos-session-replacement.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Regression tests for issue #1957 — host-session replacement (`/new`,
+ * `/resume`, `/fork`, `/reload`) must not stop the process-scoped DBOS
+ * executor. Only actual process exit (`quit`) shuts DBOS down, and a stopped
+ * backend must never be handed out or admit new workflow runs.
+ */
+
+import { afterEach, describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import {
+  DbosDurableBackend,
+  type ConfiguredDbosDurability,
+  type DbosSdkHandle,
+} from "../../packages/workflows/src/durable/dbos-backend.js";
+import {
+  DbosShutdownError,
+  dbosLifecycleState,
+  resetDbosLifecycleForTests,
+  shutdownDbos,
+} from "../../packages/workflows/src/durable/dbos-lifecycle.js";
+import {
+  getDurableBackend,
+  initializeDurableBackend,
+  setDurableBackend,
+} from "../../packages/workflows/src/durable/factory.js";
+import { InMemoryDurableBackend } from "../../packages/workflows/src/durable/backend.js";
+import { registerWorkflowLifecycleHandlers } from "../../packages/workflows/src/extension/extension-lifecycle.js";
+import type { ExtensionAPI } from "../../packages/workflows/src/extension/public-types.js";
+import type { WorkflowExtensionRuntimeState } from "../../packages/workflows/src/extension/extension-runtime-state.js";
+import { launchDetachedUntilStartup } from "../../packages/workflows/src/runs/background/startup-admission.js";
+import { createStore } from "../../packages/workflows/src/shared/store.js";
+import { createCancellationRegistry } from "../../packages/workflows/src/runs/background/cancellation-registry.js";
+import { createJobTracker } from "../../packages/workflows/src/runs/background/job-tracker.js";
+import { workflow } from "../../packages/workflows/src/authoring/workflow.js";
+import type { WorkflowDefinition } from "../../packages/workflows/src/shared/types.js";
+
+const DBOS_NOT_LAUNCHED_MESSAGE = "`DBOS.launch()` must be called before running workflows.";
+
+/**
+ * Fake DBOS SDK that enforces the real SDK's launched invariant: every
+ * durable write throws the exact production error unless the executor is
+ * currently launched.
+ */
+function launchEnforcingHarness() {
+  const events: string[] = [];
+  let launched = false;
+  const requireLaunched = () => {
+    if (!launched) throw new TypeError(DBOS_NOT_LAUNCHED_MESSAGE);
+  };
+  const sdk: DbosSdkHandle = {
+    launch: async () => { launched = true; },
+    shutdown: async () => { launched = false; },
+    startWorkflow: async () => { requireLaunched(); events.push("start"); },
+    retrieveWorkflow: async () => undefined,
+    cancelWorkflow: async () => { requireLaunched(); },
+    resumeWorkflow: async () => { requireLaunched(); },
+    listAllWorkflows: async () => [],
+    listStepRecords: async () => [],
+    recordStepOutput: async () => { requireLaunched(); events.push("record"); },
+    deleteWorkflowData: async () => { requireLaunched(); },
+  };
+  const durability: ConfiguredDbosDurability = {
+    backend: new DbosDurableBackend(sdk),
+    launch: async () => { launched = true; events.push("launch"); },
+    shutdown: async () => { launched = false; events.push("shutdown"); },
+  };
+  return { events, durability, isLaunched: () => launched };
+}
+
+type SessionEventHandler = (event: unknown, ctx?: unknown) => Promise<unknown>;
+
+/** Register the real lifecycle handlers and capture `session_shutdown`. */
+function captureSessionShutdownHandler(): SessionEventHandler {
+  const handlers = new Map<string, SessionEventHandler>();
+  const pi = {
+    on: (type: string, handler: SessionEventHandler) => { handlers.set(type, handler); },
+  } as unknown as ExtensionAPI;
+  const runtimeState = {
+    resetWorkflowDiscoveryForSession: () => {},
+    setNotificationsActive: () => {},
+  } as unknown as WorkflowExtensionRuntimeState;
+  registerWorkflowLifecycleHandlers(pi, {
+    runtimeState,
+    storeWidgetRef: { current: null },
+    intercomControlRef: { current: null },
+  });
+  const handler = handlers.get("session_shutdown");
+  assert.ok(handler !== undefined, "session_shutdown handler must be registered");
+  return handler;
+}
+
+function registerDurableRoot(backend: ReturnType<typeof getDurableBackend>, workflowId: string): void {
+  backend.registerWorkflow({
+    workflowId,
+    name: workflowId,
+    inputs: {},
+    createdAt: Date.now(),
+    status: "running",
+  });
+}
+
+afterEach(() => {
+  setDurableBackend(undefined);
+  resetDbosLifecycleForTests();
+});
+
+describe("issue #1957 — DBOS survives host-session replacement", () => {
+  for (const reason of ["new", "resume", "fork", "reload"] as const) {
+    test.serial(`session_shutdown(${reason}) flushes but keeps DBOS launched for the next session`, async () => {
+      const { events, durability, isLaunched } = launchEnforcingHarness();
+      setDurableBackend(undefined);
+      resetDbosLifecycleForTests(async () => durability);
+      const sessionShutdown = captureSessionShutdownHandler();
+
+      const backend = await initializeDurableBackend();
+      registerDurableRoot(backend, `before-${reason}`);
+      await backend.flush();
+      assert.equal(dbosLifecycleState(), "ready");
+
+      await sessionShutdown({ reason });
+
+      // The executor is process-scoped: no SDK shutdown at this boundary.
+      assert.equal(events.includes("shutdown"), false);
+      assert.equal(isLaunched(), true);
+      assert.equal(dbosLifecycleState(), "ready");
+
+      // The replacement session reuses the same launched backend and its
+      // durable writes succeed (this threw `DBOS.launch()`… before the fix).
+      const nextBackend = await initializeDurableBackend();
+      assert.equal(nextBackend, backend);
+      registerDurableRoot(nextBackend, `after-${reason}`);
+      await nextBackend.flush();
+      assert.equal(events.filter((event) => event === "start").length, 2);
+    });
+  }
+
+  test.serial("session_shutdown(quit) flushes and shuts DBOS down exactly once", async () => {
+    const { events, durability, isLaunched } = launchEnforcingHarness();
+    setDurableBackend(undefined);
+    resetDbosLifecycleForTests(async () => durability);
+    const sessionShutdown = captureSessionShutdownHandler();
+
+    const backend = await initializeDurableBackend();
+    registerDurableRoot(backend, "quit-run");
+
+    await sessionShutdown({ reason: "quit" });
+    await sessionShutdown({ reason: "quit" });
+
+    assert.equal(events.filter((event) => event === "shutdown").length, 1);
+    assert.equal(events.at(-1), "shutdown");
+    assert.equal(isLaunched(), false);
+    assert.equal(dbosLifecycleState(), "shut_down");
+  });
+
+  test.serial("post-shutdown initialization never returns a stopped backend", async () => {
+    const { durability } = launchEnforcingHarness();
+    setDurableBackend(undefined);
+    resetDbosLifecycleForTests(async () => durability);
+
+    await initializeDurableBackend();
+    await shutdownDbos();
+
+    // Neither async initialization nor the sync accessor may hand out the
+    // memoized stopped backend, and there is no silent non-durable downgrade.
+    await assert.rejects(initializeDurableBackend(), DbosShutdownError);
+    assert.throws(() => getDurableBackend());
+  });
+});
+
+describe("issue #1957 — startup admission requires durable root persistence", () => {
+  class StoppedFlushBackend extends InMemoryDurableBackend {
+    override async flush(): Promise<void> {
+      throw new TypeError(DBOS_NOT_LAUNCHED_MESSAGE);
+    }
+  }
+
+  test.serial("a backend that cannot persist the root blocks admission before workflow code runs", async () => {
+    setDurableBackend(new StoppedFlushBackend());
+    let workflowBodyRan = false;
+    const def = workflow({
+      name: "admission-guard-wf",
+      description: "",
+      inputs: {},
+      outputs: {},
+      run: async () => {
+        workflowBodyRan = true;
+        return {};
+      },
+    }) as WorkflowDefinition;
+
+    const launch = launchDetachedUntilStartup(def, {}, {
+      store: createStore(),
+      cancellation: createCancellationRegistry(),
+      jobs: createJobTracker(),
+    });
+    const admission = await launch.wait;
+
+    assert.equal(admission.started, false);
+    assert.equal(workflowBodyRan, false);
+    if (admission.started === false) {
+      const message = admission.resultError
+        ?? (admission.error instanceof Error ? admission.error.message : String(admission.error));
+      assert.match(message ?? "", /DBOS\.launch\(\)/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1957 — after DBOS initialized in a long-lived Atomic process, a process-preserving host-session replacement (`/new`, `/resume`, `/fork`, `/reload`) shut down the process-global DBOS executor while the memoized durable backend stayed installed. The next workflow run in the same process was reported as started, executed stage side effects, and then failed at its first awaited durable write with:

```text
`DBOS.launch()` must be called before running workflows.
```

## Changes

**Process-scoped DBOS executor lifetime** (`extension-lifecycle.ts`, `dbos-lifecycle.ts`)
- `session_shutdown` for `new`/`resume`/`fork`/`reload` now calls the new `flushDbos()` (flush pending durable writes, keep the executor launched) instead of `shutdownDbos()`.
- SDK shutdown is reserved for actual process exit (`quit` and the `beforeExit` backstop) and still flushes and shuts down exactly once.
- `shutdownDbos()` now transitions to a terminal `shut_down` state; post-shutdown launches fail loudly with the new `DbosShutdownError` instead of surfacing the raw SDK invariant later.

**Lifecycle defense in depth** (`factory.ts`, `runtime.ts`)
- `initializeDurableBackend()` / `getDurableBackend()` revalidate the memoized backend against the current DBOS lifecycle generation and never hand out a persistent backend unless the lifecycle is `ready`.
- Post-shutdown initialization rethrows `DbosShutdownError` instead of silently degrading to the non-durable in-memory backend.
- `ExtensionRuntime` no longer caches a permanently resolved readiness promise across lifecycle generations.

**Startup admission requires durable root persistence** (`engine/run.ts`, new `engine/run-durable-admission.ts`)
- Root workflow registration/status is durably flushed before startup admission (`onWorkflowStartReady`) and before workflow code executes, so a stopped or unhealthy backend fails before any side effects. Extracted into `run-durable-admission.ts` to honor the 500-line file gate.

**Regression coverage** (`test/unit/durable-dbos-session-replacement.test.ts`)
- Exercises the real `session_shutdown` handler with a fake SDK that enforces DBOS's launched invariant: initialize → durable write → `session_shutdown` for each of `new`/`resume`/`fork`/`reload` → second initialization returns the same launched backend and its durable write succeeds, with no SDK shutdown at the boundary.
- `quit` flushes and shuts down exactly once; repeated quits stay idempotent.
- Post-shutdown initialization rejects with `DbosShutdownError` and the sync accessor refuses to return a stopped backend.
- A backend that cannot persist the root blocks startup admission before workflow code runs, surfacing the DBOS error.

## Notes

- `bun run test:unit`: 3974 pass / 0 fail (7 new regression tests); `bun run typecheck`, `bun run lint`, and `bun run check:file-length` all green.
- Verified end-to-end with tmux against the real CLI, real embedded-Postgres DBOS backend, and a dummy staged workflow: the bug reproduces on a build of the pre-fix base commit and is gone on this branch. Full proof transcript in the PR comment below.
- Changelog entry added under `packages/workflows/CHANGELOG.md` `[Unreleased]`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes DBOS durability across Atomic host-session replacement. The main changes are:

- Keeps the DBOS executor launched across `/new`, `/resume`, `/fork`, and `/reload` by flushing instead of shutting down.
- Reserves DBOS shutdown for `quit` and process exit, with a terminal `shut_down` lifecycle state.
- Revalidates memoized durable backends before returning them after lifecycle changes.
- Flushes root workflow registration before startup admission so workflow code does not run before durable persistence succeeds.
- Adds tests for session replacement, quit idempotency, post-shutdown access, and startup admission failure.
- Pins Mintlify docs validation in CI to a resolvable version.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The DBOS lifecycle changes are narrowly scoped, keep shutdown idempotent, and gate workflow startup on durable persistence. Tests cover the reported session-replacement failure and the new shutdown/admission paths. No accepted bugs were found.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the regression tests with bun test v1.3.10 (30e609e0) and confirmed all tests passed (7 pass, 0 fail) across 1 file, completing in about 740 ms.
- Executed the TypeScript type-check with tsc --noEmit and confirmed a clean type-check run (exit code 0).
- Ran the test and type-check commands in the foreground with a 120-second timeout and captured logs under trex-artifacts.

<a href="https://app.greptile.com/trex/runs/15495497/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/test.yml | Pins Mintlify validation to a known resolvable version while preserving the existing PR-only Linux docs validation flow. |
| packages/workflows/CHANGELOG.md | Adds an Unreleased shipped-fix entry for the DBOS lifecycle/session-replacement behavior. |
| packages/workflows/src/durable/dbos-lifecycle.ts | Adds terminal DBOS shutdown state, explicit post-shutdown errors, and a flush-only path for process-preserving session boundaries. |
| packages/workflows/src/durable/factory.ts | Revalidates memoized persistent backends against DBOS readiness and avoids non-durable fallback after intentional DBOS shutdown. |
| packages/workflows/src/durable/index.ts | Exports the new DBOS shutdown error and flush-only lifecycle helper. |
| packages/workflows/src/engine/run-durable-admission.ts | Extracts durable root registration and flushes root persistence before workflow startup is admitted. |
| packages/workflows/src/engine/run.ts | Routes root workflow startup through the new durable admission helper before invoking workflow code. |
| packages/workflows/src/extension/extension-lifecycle.ts | Changes non-quit session shutdown to flush DBOS without stopping the process-scoped executor. |
| packages/workflows/src/extension/runtime.ts | Removes the permanently memoized DBOS readiness promise so each command revalidates the backend factory. |
| test/unit/durable-dbos-session-replacement.test.ts | Adds tests for session replacement, quit idempotency, post-shutdown backend rejection, and startup-admission failure. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
participant Host as Atomic host session
participant Lifecycle as extension-lifecycle
participant DBOS as DBOS lifecycle
participant Factory as durable factory
participant Run as workflow run
participant Backend as durable backend

Host->>Lifecycle: session_shutdown(new/resume/fork/reload)
Lifecycle->>DBOS: flushDbos()
DBOS->>Backend: flush pending writes
Note over DBOS: executor remains ready
Host->>Factory: initializeDurableBackend()
Factory->>DBOS: getReadyDbosBackend()
DBOS-->>Factory: launched backend
Host->>Run: start workflow
Run->>Backend: registerWorkflow / setWorkflowStatus(running)
Run->>Backend: flush()
Backend-->>Run: persisted before admission
Run-->>Host: onWorkflowStartReady()
Run->>Run: execute workflow body

Host->>Lifecycle: session_shutdown(quit)
Lifecycle->>DBOS: shutdownDbos()
DBOS->>Backend: flush pending writes
DBOS->>DBOS: "SDK shutdown, state=shut_down"
```

<sub>Reviews (2): Last reviewed commit: ["ci: pin mintlify docs validation to 4.2...."](https://github.com/bastani-inc/atomic/commit/f92bf0741d49dffe0b7c2b88a8b0ed1d535597bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46495114)</sub>

<!-- /greptile_comment -->