### PR TITLE
chore(release): stage changelog for 0.9.11-alpha.4 prerelease

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.11-alpha.4] - 2026-07-22
+
 ### Changed
 
 - Installed builds now ship the builtin workflows extension as a single prebundled ESM file. Loading it previously resolved and transpiled a ~300-file TypeScript module graph per launch, which dominated interactive-engine startup on Windows (~7 s on a test VM, now ~1.1 s, ~6x faster) ([#1962](https://github.com/bastani-inc/atomic/issues/1962)). Source checkouts still load the raw TypeScript sources.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.11-alpha.4] - 2026-07-22
+
 ### Added
 
 - Added the opt-in `autoAttach` workflow-definition field, which opens the graph overlay when an interactive top-level named workflow is launched through `/workflow <name>` or the registered `workflow` tool without changing headless launches, nested workflow composition, or the existing input-form launch path.


### PR DESCRIPTION
## Summary

Stages release notes for the **0.9.11-alpha.4** prerelease (base: `main`).

- `packages/coding-agent/CHANGELOG.md`: move pending `[Unreleased]` entries under a new `## [0.9.11-alpha.4] - 2026-07-22` section
- `packages/workflows/CHANGELOG.md`: same for the workflows package

## Notes

- Changelog-only diff; all package manifests, lockfiles, Cargo files, and generated version files remain at the versionless `0.0.0` placeholder.
- Version stamping happens only on the detached `Release 0.9.11-alpha.4` commit via `scripts/cut-release.ts` after this PR merges; the tag push starts `publish.yml`.

## Validation

- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun run check:file-length` ✅
- `bun run test:unit` ✅ (via pre-commit hooks)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Stages the 0.9.11-alpha.4 prerelease notes.
- Moves pending coding-agent changes and fixes into a dated release section.
- Moves pending workflows additions, behavior changes, and fixes into the corresponding release section.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with one non-blocking omission in the workflows prerelease notes.

The staged notes accurately describe the listed changes, but the workflows section does not mention the newly shipped guidance for consulting the configured model catalog before pinning stage models.

packages/workflows/CHANGELOG.md

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the general-contract-validation-proof and confirmed that it captured the executed command, working directory, relevant output, and exit status in the log.

<a href="https://app.greptile.com/trex/runs/15535255/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/CHANGELOG.md | Accurately stages the coding-agent changes shipped since alpha.3, with no material omission identified. |
| packages/workflows/CHANGELOG.md | Accurately describes the listed workflows changes but omits one shipped model-catalog authoring-guidance update. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/workflows/CHANGELOG.md:9
**Document model-catalog guidance**

The staged notes omit the shipped workflow-authoring guidance that directs agents to consult `model-selection.md` and query the configured model catalog before pinning stage models, leaving this user-facing change undocumented in the prerelease notes.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.11-alpha.4 ..."](https://github.com/bastani-inc/atomic/commit/d102a0d7c871bdd13b139b360591666d4edc3833) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46575374)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->