### PR TITLE
fix(test): isolate shared workflow store to stop cross-file unit test leak

### DIFF
--- a/test/unit/executor-run-5.test.ts
+++ b/test/unit/executor-run-5.test.ts
@@ -116,6 +116,10 @@ describe("executor.run", () => {
             parent,
             {},
             {
+                // Isolate this run from the shared singleton store: without an
+                // explicit store, the failed run would leak into other test
+                // files that assert on the default store's contents.
+                store: createStore(),
                 adapters: {
                     prompt: {
                         prompt: async (text) => {

--- a/test/unit/workflow-tool-durable-replay.test.ts
+++ b/test/unit/workflow-tool-durable-replay.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, test } from "bun:test";
+import { afterEach, beforeEach, describe, test } from "bun:test";
 import assert from "node:assert/strict";
 import { Type } from "typebox";
 import { workflow } from "../../packages/workflows/src/authoring/workflow.js";
@@ -23,6 +23,13 @@ class TrackingHydrationBackend extends InMemoryDurableBackend {
     this.hydrationCalls += 1;
   }
 }
+
+beforeEach(() => {
+  // Other test files may run workflows against the shared singleton store;
+  // clear it so the durable-only replay assertions below start from a clean
+  // slate regardless of cross-file execution order.
+  store.clear();
+});
 
 afterEach(async () => {
   stageControlRegistry.clear();


### PR DESCRIPTION
## Summary

Fixes the flaky `test (linux-x64)` required-check failure that blocked prerelease 0.9.11-alpha.4 (PR #1969): a unit test leaked a failed run into the shared singleton workflow store, breaking `workflow-tool-durable-replay.test.ts` depending on cross-file test execution order.

## Changes

- `test/unit/executor-run-5.test.ts`: the "ctx.workflow rejects non-workflow definitions" test was the only test in the file calling `run()` without an explicit store, so its failed `direct-definition-validation-parent` run registered in the default singleton store (`engine/run.ts` falls back to `opts.store ?? defaultStore`). It now passes an isolated `createStore()`.
- `test/unit/workflow-tool-durable-replay.test.ts`: added a defensive `beforeEach(() => store.clear())` so its durable-only replay assertions (which require an empty shared store) are independent of cross-file execution order.

## Notes

- Root cause evidence: [failing linux-x64 job](https://github.com/bastani-inc/atomic/actions/runs/29985168337/job/89135318644) shows the leaked run in the `store.runs()` deep-equal diff at `workflow-tool-durable-replay.test.ts:63`, failing on both bounded retry attempts.
- The leak only manifests when `executor-run-5.test.ts` runs before `workflow-tool-durable-replay.test.ts`; bun's test file ordering differs between platforms, which is why it reproduced on linux-x64 CI but not locally on macOS.
- Verified locally: both affected files pass, full `bun run test:unit` (3987 tests) passes, `typecheck`/`lint` clean.
- Test-infrastructure-only change; no changelog entry per repo changelog rules.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes workflow unit tests independent of shared singleton-store state.
- Uses a fresh store for the failed validation run in `executor-run-5.test.ts`.
- Clears the singleton workflow store before each durable replay test.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with both changes directly improving test isolation without altering production behavior.

The isolated store preserves the validation test’s return-value assertions, while the replay suite clears shared store state before each serial test and retains comprehensive asynchronous teardown afterward.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The reviewer examined the general-contract-validation-proof and noted that, in the pre-change durable replay, the direct-definition-validation-parent run left by executor-run-5 failed with exit 1.
- The reviewer then validated the post-change durable replay where the same ordered command completed with 10 pass, 0 fail and exit 0.
- The reviewer linked the failure location and leaked run identity to demonstrate that Bun executed the files in the leak-producing relationship.
- The reviewer inspected the two log artifacts to corroborate the before and after outcomes and ensure evidence is consistently tied to the proof.

<a href="https://app.greptile.com/trex/runs/15536503/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/unit/executor-run-5.test.ts | Correctly supplies a compatible isolated store to prevent the failed run from contaminating unrelated tests. |
| test/unit/workflow-tool-durable-replay.test.ts | Adds safe per-test singleton-store cleanup while retaining existing teardown for jobs, stage controls, and the durable backend. |

<sub>Reviews (1): Last reviewed commit: ["fix(test): isolate shared workflow store..."](https://github.com/bastani-inc/atomic/commit/269109d914a461749c1c2b45379e486fd0704ea8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46577762)</sub>

<!-- /greptile_comment -->