### PR TITLE
docs(changelog): prepare 0.9.11-alpha.4 prerelease notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.11-alpha.4] - 2026-07-23
+
 ### Changed
 
 - Installed builds now ship the builtin workflows extension as a single prebundled ESM file. Loading it previously resolved and transpiled a ~300-file TypeScript module graph per launch, which dominated interactive-engine startup on Windows (~7 s on a test VM, now ~1.1 s, ~6x faster) ([#1962](https://github.com/bastani-inc/atomic/issues/1962)). Source checkouts still load the raw TypeScript sources.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.11-alpha.4] - 2026-07-23
+
 ### Added
 
 - Added the opt-in `autoAttach` workflow-definition field, which opens the graph overlay when an interactive top-level named workflow is launched through `/workflow <name>` or the registered `workflow` tool without changing headless launches, nested workflow composition, or the existing input-form launch path.


### PR DESCRIPTION
## Summary

Prepare the coding-agent and workflows changelogs for the `0.9.11-alpha.4` prerelease while keeping the release base versionless.

## Changes

- Add the `0.9.11-alpha.4` release heading to `packages/coding-agent/CHANGELOG.md`.
- Add the `0.9.11-alpha.4` release heading to `packages/workflows/CHANGELOG.md`.
- Leave package manifests, lockfiles, Cargo metadata, and generated version checks at `0.0.0`.

## Validation

- `bun test test/unit/bump-version-script.test.ts test/unit/publish-release-workflow.test.ts test/ci/ci-workflow-contracts.test.ts`
- Pre-commit and pre-push hooks (`bun run lint`, `bun run check:file-length`, `bun run test:unit`, and repository integrity checks)
- Confirmed the branch diff against `main` contains only the two changelog files.

## Notes

This PR only prepares release notes. It does not merge, tag, publish, or dispatch publication.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares versionless changelog entries for the 0.9.11-alpha.4 prerelease.
- Adds the dated 0.9.11-alpha.4 release heading to the coding-agent changelog.
- Adds the same release heading to the workflows changelog.
- Leaves the Unreleased sections available for subsequent changes.

<h3>Confidence Score: 5/5</h3>

The changelog-only PR appears safe to merge.

Both files add the intended, consistently dated prerelease heading while preserving the Unreleased section and existing release-note content.

No files require additional attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the general contract validation for the release notes suite and confirmed the command completed with 21 passing tests and 0 failures.
- Verified release-note manifests report version 0.0.0 and that the manifest checks exited cleanly with exit code 0.
- Captured and reviewed the git diff outputs against main, confirming the release notes scope is unchanged and the diff checks completed with exit code 0.

<a href="https://app.greptile.com/trex/runs/15538068/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/CHANGELOG.md | Adds a correctly formatted 0.9.11-alpha.4 heading above the existing release notes without changing their content. |
| packages/workflows/CHANGELOG.md | Adds a correctly formatted 0.9.11-alpha.4 heading above the existing release notes without changing their content. |

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.11-alpha.4 ..."](https://github.com/bastani-inc/atomic/commit/919a0264003ed61e6439836a8b19d65cd699c31f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46580831)</sub>

<!-- /greptile_comment -->