### PR TITLE
fix(prompts): move writing rules to core guidelines

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Added Orwell's six writing rules from “Politics and the English Language” to the core default system prompt's `Guidelines` section so every standard Atomic session receives them, while removing the bundled workflow guidance's requirement to announce an inline-or-workflow mode before the first tool call.
+
 ## [0.9.11-alpha.4] - 2026-07-23
 
 ### Changed

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -109,6 +109,15 @@ Use context files for project conventions, commands, safety rules, and preferenc
 
 ### System Prompt Files
 
+Atomic's default `Guidelines` section applies Orwell's six writing rules to every standard session:
+
+1. Never use a familiar printed metaphor, simile, or figure of speech.
+2. Never use a long word where a short one will do.
+3. Cut every word that can be cut.
+4. Use active rather than passive voice where possible.
+5. Prefer everyday English to foreign phrases, scientific terms, and jargon.
+6. Break any rule rather than say anything outright barbarous.
+
 Replace the default system prompt with:
 
 - `.atomic/SYSTEM.md` for a project

--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -174,15 +174,6 @@ Rich custom workflows can compose the [common workflow patterns](#common-workflo
 
 If inline work drifts past roughly ten exploratory tool calls without an artifact, edit, or commit, or repeats a "verify one more thing" loop, save the findings to a context file and hand the task to the best-fit named or custom workflow through `reads`. Sunk research is transferable, not a reason to continue inline.
 
-The workflow tool's model-visible communication guidance follows Orwell's six rules from “Politics and the English Language”:
-
-1. Never use a familiar printed metaphor, simile, or figure of speech.
-2. Never use a long word where a short one will do.
-3. Cut every word that can be cut.
-4. Use active rather than passive voice where possible.
-5. Prefer everyday English to foreign phrases, scientific terms, and jargon.
-6. Break any rule rather than say anything outright barbarous.
-
 | User goal | Use |
 |-----------|-----|
 | Run, inspect, connect to, pause, interrupt, quit, resume, or check status for an existing workflow | `/workflow ...` or `workflow({ action: ... })` |

--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -166,13 +166,22 @@ Workflows are the default execution path when a request is non-trivial or combin
 
 Loop or stop-condition phrasing is an especially strong workflow signal: `do X until Y`, `repeat until`, `iterate until`, `review/fix until passing`, `run checks and fix until green`, and `keep going until done` define control flow and convergence criteria that should be tracked.
 
-Use direct chat only for tiny, deterministic, low-risk answers or edits where stage tracking clearly costs more than it adds, typically a single-file/no-test/no-review change. Decide inline versus workflow before the first tool call; reconnaissance is already inline execution. Once workflow fit is clear, limit pre-workflow reconnaissance to the few reads needed to sharpen the objective and validation criteria, and put deeper research or behavior probing inside the run.
+Use direct chat only for tiny, deterministic, low-risk answers or edits where stage tracking clearly costs more than it adds, typically a single-file/no-test/no-review change. Choose direct chat or a workflow based on that fit; reconnaissance is already inline execution. Once workflow fit is clear, limit pre-workflow reconnaissance to the few reads needed to sharpen the objective and validation criteria, and put deeper research or behavior probing inside the run.
 
 Workflow-first does not require builtins, monolithic workflows, or a force-fit builtin: a builtin that matches 60% of the task and fights the other 40% is worse than a small custom graph. Discover named builtin, project, user, and package workflows; or author a task-specific TypeScript `workflow({...})` inline with normal coding tools whenever the task needs richer branching, dynamic fan-out, artifacts, structured outputs, child workflows, human input, gates, retries, or loops.
 
 Rich custom workflows can compose the [common workflow patterns](#common-workflow-patterns): classify and branch at runtime, fan out and synthesize artifacts, run worker/verifier/reducer repair cycles, generate and filter or tournament-rank candidates, and loop until explicit evidence says the work is done. Workflow definitions are composable TypeScript modules — see [Workflow Composition](#workflow-composition). Atomic can write the definition, reload workflow resources, and run it for the current task; the workflow tool has no create action.
 
 If inline work drifts past roughly ten exploratory tool calls without an artifact, edit, or commit, or repeats a "verify one more thing" loop, save the findings to a context file and hand the task to the best-fit named or custom workflow through `reads`. Sunk research is transferable, not a reason to continue inline.
+
+The workflow tool's model-visible communication guidance follows Orwell's six rules from “Politics and the English Language”:
+
+1. Never use a familiar printed metaphor, simile, or figure of speech.
+2. Never use a long word where a short one will do.
+3. Cut every word that can be cut.
+4. Use active rather than passive voice where possible.
+5. Prefer everyday English to foreign phrases, scientific terms, and jargon.
+6. Break any rule rather than say anything outright barbarous.
 
 | User goal | Use |
 |-----------|-----|
@@ -198,7 +207,7 @@ The shapes, cheapest first:
 
 #### The self-prompt: pre-launch workflow architecture
 
-For every non-trivial workflow task, perform a short workflow-architecture pass before the first launch. Decide before the first tool call and state the execution mode; reconnaissance already counts as inline execution. Derive the task's implementation lifecycle needs, whole-codebase research needs, independent work slices, competing strategies, exact API/type/build contracts, schema or generated-artifact contracts, state-transition/lifecycle behavior, deterministic stop conditions, and required evidence.
+For every non-trivial workflow task, perform a short workflow-architecture pass before the first launch. Choose the execution shape before starting substantive work; reconnaissance already counts as inline execution. Derive the task's implementation lifecycle needs, whole-codebase research needs, independent work slices, competing strategies, exact API/type/build contracts, schema or generated-artifact contracts, state-transition/lifecycle behavior, deterministic stop conditions, and required evidence.
 
 Use this compact coverage matrix internally (it may stay concise for a straightforward task), and let every unresolved material row change the graph choice:
 

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -16,6 +16,15 @@ const DEFAULT_PROMPT_TOOLS = [
   "todo",
 ] as const;
 
+const DEFAULT_COMMUNICATION_GUIDELINES = [
+  "Never use a familiar printed metaphor, simile, or figure of speech.",
+  "Never use a long word where a short one will do.",
+  "Cut every word that can be cut.",
+  "Use active rather than passive voice where possible.",
+  "Prefer everyday English to foreign phrases, scientific terms, and jargon.",
+  "Break any rule rather than say anything outright barbarous.",
+] as const;
+
 export interface SystemPromptModel {
   /** Provider identifier for the selected model. */
   provider: string;
@@ -171,6 +180,10 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
   }
 
   // Always include these
+  for (const guideline of DEFAULT_COMMUNICATION_GUIDELINES) {
+    addGuideline(guideline);
+  }
+
   addGuideline("Be concise in your responses");
   addGuideline("Show file paths clearly when working with files");
 

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "vitest";
 import { buildSystemPrompt } from "../src/core/system-prompt.ts";
 
+const DEFAULT_COMMUNICATION_GUIDELINES = `- Never use a familiar printed metaphor, simile, or figure of speech.
+- Never use a long word where a short one will do.
+- Cut every word that can be cut.
+- Use active rather than passive voice where possible.
+- Prefer everyday English to foreign phrases, scientific terms, and jargon.
+- Break any rule rather than say anything outright barbarous.`;
+
 describe("buildSystemPrompt", () => {
 	describe("empty tools", () => {
 		test("shows (none) for empty tools list", () => {
@@ -147,6 +154,31 @@ describe("buildSystemPrompt", () => {
 
 			expect(prompt.match(/- Use dynamic_tool for summaries\./g)).toHaveLength(1);
 		});
+	});
+
+	test("includes all six core communication rules without promptGuidelines", () => {
+		const prompt = buildSystemPrompt({
+			selectedTools: [],
+			contextFiles: [],
+			skills: [],
+			cwd: process.cwd(),
+		});
+
+		expect(prompt).toContain(`Guidelines:\n${DEFAULT_COMMUNICATION_GUIDELINES}`);
+	});
+
+	test("keeps core communication rules when tool promptGuidelines are present", () => {
+		const prompt = buildSystemPrompt({
+			selectedTools: [],
+			promptGuidelines: ["**Workflows**: Workflow-specific sentinel."],
+			contextFiles: [],
+			skills: [],
+			cwd: process.cwd(),
+		});
+		const guidelines = prompt.slice(prompt.indexOf("Guidelines:\n"), prompt.indexOf("\n\nAtomic documentation"));
+
+		expect(guidelines).toContain("- **Workflows**: Workflow-specific sentinel.");
+		expect(guidelines).toContain(DEFAULT_COMMUNICATION_GUIDELINES);
 	});
 
 	describe("workflow guidance", () => {

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Strengthened the existing Goal and Ralph reviewer prompts with a conditional contract-probe playbook for exact external-consumer APIs, build/feature matrices, schema optionality, state transitions, configuration precedence, low-level feature-flag independence, and permissive inputs. Reviewers now record independent probe outcomes in existing evidence fields and withhold approval when a material literal clause remains unverified, without changing reviewer counts, schemas, or convergence semantics. ([#1973](https://github.com/bastani-inc/atomic/issues/1973))
 - Strengthened model-visible workflow routing guidance with a pre-launch requirement/risk/evidence coverage pass, a one-launch composition commitment, concrete graph-selection signals, and bounded skeptical-reviewer loops whose model-selected probes are executed authoritatively through durable `ctx.tool(...)` verifier gates rather than model self-report ([#1974](https://github.com/bastani-inc/atomic/issues/1974)).
+- Updated the workflow tool's model-visible guidance to stop requiring an inline-or-workflow announcement before the first tool call while retaining workflow-fit routing, and added Orwell's six communication rules from “Politics and the English Language.”
 
 ## [0.9.11-alpha.4] - 2026-07-23
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -10,7 +10,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Strengthened the existing Goal and Ralph reviewer prompts with a conditional contract-probe playbook for exact external-consumer APIs, build/feature matrices, schema optionality, state transitions, configuration precedence, low-level feature-flag independence, and permissive inputs. Reviewers now record independent probe outcomes in existing evidence fields and withhold approval when a material literal clause remains unverified, without changing reviewer counts, schemas, or convergence semantics. ([#1973](https://github.com/bastani-inc/atomic/issues/1973))
 - Strengthened model-visible workflow routing guidance with a pre-launch requirement/risk/evidence coverage pass, a one-launch composition commitment, concrete graph-selection signals, and bounded skeptical-reviewer loops whose model-selected probes are executed authoritatively through durable `ctx.tool(...)` verifier gates rather than model self-report ([#1974](https://github.com/bastani-inc/atomic/issues/1974)).
-- Updated the workflow tool's model-visible guidance to stop requiring an inline-or-workflow announcement before the first tool call while retaining workflow-fit routing, and added Orwell's six communication rules from “Politics and the English Language.”
 
 ## [0.9.11-alpha.4] - 2026-07-23
 

--- a/packages/workflows/src/extension/workflow-prompts.ts
+++ b/packages/workflows/src/extension/workflow-prompts.ts
@@ -12,7 +12,6 @@ export const WORKFLOW_TOOL_DESCRIPTION =
 
 export const DEFAULT_PROMPT_GUIDANCE: string[] = [
   `**Workflows**: Treat workflows as the default execution path for any non-trivial task and for any request that has inherent structure plus an objective you can make verifiable. Use the \`workflow\` tool for existing named workflows; when the task needs a graph that is not installed, author a custom TypeScript \`workflow({...})\` inline with normal coding tools, reload workflow resources, and run it.
-  - Decide the execution mode before your first tool call on a new request and state it in one short line: inline (tiny, deterministic, low-risk) or workflow. Reconnaissance counts as inline execution, so an unstated "explore first" default must not silently commit you to an unbounded inline session.
   - Workflow fit check: prefer a workflow for implementation, build, debug/diagnosis, bug-fix, migration, new-feature, scoped multi-file, or docs/code changes with validation; and whenever there are multiple steps, dependencies, handoffs, uncertainty, review/validation needs, long-running work, measurable done criteria, or an outcome that needs evidence.
   - Treat loop or stop-condition wording as a strong workflow signal, especially "do X until Y", "repeat until", "iterate until", "review/fix until passing", "run checks and fix until green", "keep going until done", or any prompt that names an approval gate or evidence requirement.
   - Do not force-fit an installed workflow or builtin such as \`goal\` or \`ralph\`. When another graph better matches the task, write a task-specific TypeScript workflow inline. Rich custom workflows may use deterministic branching, dynamic fan-out, child workflows, artifacts, structured outputs, human-in-the-loop prompts, gates, retries, and explicit stop conditions.
@@ -30,6 +29,13 @@ export const DEFAULT_PROMPT_GUIDANCE: string[] = [
   - Budget reconnaissance: once workflow fit is clear, keep pre-workflow exploration to a few quick reads that sharpen the objective and validation criteria. Put deep research, upstream/design comparison, and behavior probing inside the workflow. Pass large context through files/artifacts and \`reads\` rather than injecting it into prompts.
   - Course-correct instead of drifting: after roughly ten exploratory tool calls with no artifact, edit, or commit, or repeated "let me verify one more thing" loops, stop, write findings to a context file, and hand the task to the best-fit named or custom workflow. Sunk inline research transfers through files; it is not a reason to stay inline.
   - Only skip workflows for tiny, deterministic, low-risk answers or direct edits where stage tracking clearly costs more than it adds, typically a single-file/no-test/no-review change or a simple answer.`,
+  `**Communication**: Follow Orwell's six rules from "Politics and the English Language":
+  1. Never use a familiar printed metaphor, simile, or figure of speech.
+  2. Never use a long word where a short one will do.
+  3. Cut every word that can be cut.
+  4. Use active rather than passive voice where possible.
+  5. Prefer everyday English to foreign phrases, scientific terms, and jargon.
+  6. Break any rule rather than say anything outright barbarous.`,
   `**Workflow discovery and lifecycle**:
   - For unfamiliar named workflows, discover with \`action: "list"\`, inspect with \`action: "get"\` or \`action: "inputs"\`, and run with \`action: "run"\`, \`workflow\`, and validated \`inputs\`; do not invent workflow names or input keys.
   - In interactive chat, named workflow launches run in the background. Run \`/workflow connect <run>\` to see agents working and chat with and steer each stage. Inspection and control calls (\`status\`, \`stages\`, \`stage\`, \`transcript\`, \`send\`, \`pause\`, \`resume\`, \`interrupt\`, \`quit\`) remain available while work runs.

--- a/packages/workflows/src/extension/workflow-prompts.ts
+++ b/packages/workflows/src/extension/workflow-prompts.ts
@@ -29,13 +29,6 @@ export const DEFAULT_PROMPT_GUIDANCE: string[] = [
   - Budget reconnaissance: once workflow fit is clear, keep pre-workflow exploration to a few quick reads that sharpen the objective and validation criteria. Put deep research, upstream/design comparison, and behavior probing inside the workflow. Pass large context through files/artifacts and \`reads\` rather than injecting it into prompts.
   - Course-correct instead of drifting: after roughly ten exploratory tool calls with no artifact, edit, or commit, or repeated "let me verify one more thing" loops, stop, write findings to a context file, and hand the task to the best-fit named or custom workflow. Sunk inline research transfers through files; it is not a reason to stay inline.
   - Only skip workflows for tiny, deterministic, low-risk answers or direct edits where stage tracking clearly costs more than it adds, typically a single-file/no-test/no-review change or a simple answer.`,
-  `**Communication**: Follow Orwell's six rules from "Politics and the English Language":
-  1. Never use a familiar printed metaphor, simile, or figure of speech.
-  2. Never use a long word where a short one will do.
-  3. Cut every word that can be cut.
-  4. Use active rather than passive voice where possible.
-  5. Prefer everyday English to foreign phrases, scientific terms, and jargon.
-  6. Break any rule rather than say anything outright barbarous.`,
   `**Workflow discovery and lifecycle**:
   - For unfamiliar named workflows, discover with \`action: "list"\`, inspect with \`action: "get"\` or \`action: "inputs"\`, and run with \`action: "run"\`, \`workflow\`, and validated \`inputs\`; do not invent workflow names or input keys.
   - In interactive chat, named workflow launches run in the background. Run \`/workflow connect <run>\` to see agents working and chat with and steer each stage. Inspection and control calls (\`status\`, \`stages\`, \`stage\`, \`transcript\`, \`send\`, \`pause\`, \`resume\`, \`interrupt\`, \`quit\`) remain available while work runs.

--- a/test/unit/execution-routing-guidance.test.ts
+++ b/test/unit/execution-routing-guidance.test.ts
@@ -53,17 +53,21 @@ describe("workflow-first execution routing", () => {
     }
   });
 
-  test("makes Orwell's six communication rules model-visible in order", () => {
+  test("keeps all six core communication rules out of workflow promptGuidelines", () => {
     const modelVisibleWorkflowGuidance = workflowGuidance.join("\n");
-    const expectedCommunicationGuidance = `**Communication**: Follow Orwell's six rules from "Politics and the English Language":
-  1. Never use a familiar printed metaphor, simile, or figure of speech.
-  2. Never use a long word where a short one will do.
-  3. Cut every word that can be cut.
-  4. Use active rather than passive voice where possible.
-  5. Prefer everyday English to foreign phrases, scientific terms, and jargon.
-  6. Break any rule rather than say anything outright barbarous.`;
+    const coreCommunicationRules = [
+      "Never use a familiar printed metaphor, simile, or figure of speech.",
+      "Never use a long word where a short one will do.",
+      "Cut every word that can be cut.",
+      "Use active rather than passive voice where possible.",
+      "Prefer everyday English to foreign phrases, scientific terms, and jargon.",
+      "Break any rule rather than say anything outright barbarous.",
+    ];
 
-    expect(modelVisibleWorkflowGuidance).toContain(expectedCommunicationGuidance);
+    expect(modelVisibleWorkflowGuidance).not.toContain("**Communication**:");
+    for (const rule of coreCommunicationRules) {
+      expect(modelVisibleWorkflowGuidance).not.toContain(rule);
+    }
   });
 
   test("treats loop and stop-condition phrasing as a strong workflow signal", () => {

--- a/test/unit/execution-routing-guidance.test.ts
+++ b/test/unit/execution-routing-guidance.test.ts
@@ -36,16 +36,34 @@ describe("workflow-first execution routing", () => {
     }
   });
 
-  test("requires an early routing decision and prevents inline drift", () => {
+  test("keeps early routing guidance without forcing a mode announcement", () => {
     for (const phrase of [
-      "Decide the execution mode before your first tool call",
-      "Reconnaissance counts as inline execution",
       "Budget reconnaissance",
       "roughly ten exploratory tool calls",
       "Sunk inline research transfers through files",
     ]) {
       expect(modelVisibleRouting).toContain(phrase);
     }
+
+    for (const forcedAnnouncement of [
+      "Decide the execution mode before your first tool call",
+      "state it in one short line: inline",
+    ]) {
+      expect(modelVisibleRouting).not.toContain(forcedAnnouncement);
+    }
+  });
+
+  test("makes Orwell's six communication rules model-visible in order", () => {
+    const modelVisibleWorkflowGuidance = workflowGuidance.join("\n");
+    const expectedCommunicationGuidance = `**Communication**: Follow Orwell's six rules from "Politics and the English Language":
+  1. Never use a familiar printed metaphor, simile, or figure of speech.
+  2. Never use a long word where a short one will do.
+  3. Cut every word that can be cut.
+  4. Use active rather than passive voice where possible.
+  5. Prefer everyday English to foreign phrases, scientific terms, and jargon.
+  6. Break any rule rather than say anything outright barbarous.`;
+
+    expect(modelVisibleWorkflowGuidance).toContain(expectedCommunicationGuidance);
   });
 
   test("treats loop and stop-condition phrasing as a strong workflow signal", () => {


### PR DESCRIPTION
## Summary

Move Orwell's six writing rules into Atomic's core default system-prompt Guidelines so every standard coding-agent session receives them, independent of workflow tooling. Remove the workflow-specific requirement to announce `inline` or `workflow` before the first tool call while preserving the remaining workflow-fit guidance.

## Changes

- Add all six writing rules to the unconditional core Guidelines generated by `buildSystemPrompt`.
- Remove the forced mode announcement from bundled workflow prompt guidance and align workflow documentation.
- Add focused core tests proving the rules appear without workflow `promptGuidelines` and remain present alongside tool guidance.
- Add workflow routing coverage proving neither the announcement nor the six core rules come from workflow guidance.
- Document the default Guidelines and record the user-visible change in `packages/coding-agent/CHANGELOG.md` under `Unreleased`.

## Testing

- Focused system-prompt tests: 12 passed
- Focused routing tests: 21 passed
- Root unit tests: 3,992 passed
- Coding-agent suite: 2,754 passed, 30 skipped (latest independent reviewer run)
- `bun run typecheck` — passed
- `bun run lint` — passed
- `bun run check:file-length` — passed
- Documentation link validation — passed
- Push hooks (`lint`, file-length, root unit tests, repository checks) — passed
- `git diff --check origin/main` — passed

## Notes

The correction is limited to core/workflow prompt text, focused tests, user-facing documentation, and the current Unreleased coding-agent changelog. Released changelog sections are unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refines model-visible workflow and communication guidance.
- Removes the requirement to announce an execution mode before the first tool call while preserving workflow-fit routing guidance.
- Adds Orwell’s six communication rules to the default system prompt.
- Updates focused regression tests, workflow documentation, usage documentation, and the changelog.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains within the scope of the follow-up review.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The unit test file execution-routing-guidance.test.ts ran with AGENT=1 bun test and completed with exit code 0, reporting 21 passed, 0 failed, and 215 assertions.
- The system prompt tests under the coding-agent package ran with bun run --cwd packages/coding-agent test -- test/system-prompt.test.ts and completed with exit code 0, reporting 1 file and 12 tests passed.
- Before/after logs captured the exact commands, working directories, test counts, and exit codes for both test runs.

<a href="https://app.greptile.com/trex/runs/15599782/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/src/core/system-prompt.ts | Adds six ordered communication guidelines to the default generated system prompt. |
| packages/workflows/src/extension/workflow-prompts.ts | Removes the model-visible requirement to announce inline or workflow mode before using tools. |
| packages/coding-agent/test/system-prompt.test.ts | Adds coverage confirming the communication guidelines appear with and without tool-specific guidance. |
| test/unit/execution-routing-guidance.test.ts | Verifies routing guidance remains while the forced announcement and duplicated communication rules remain absent. |

<sub>Reviews (2): Last reviewed commit: ["fix(prompts): move writing rules to core..."](https://github.com/bastani-inc/atomic/commit/301b2f9af9c53dfcd85fbe3cfb41803bdbe6c752) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46703997)</sub>

<!-- /greptile_comment -->