### PR TITLE
docs(changelog): prepare 0.9.11-alpha.5 prerelease notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.11-alpha.5] - 2026-07-23
+
 ### Changed
 
 - Added Orwell's six writing rules from “Politics and the English Language” to the core default system prompt's `Guidelines` section so every standard Atomic session receives them, while removing the bundled workflow guidance's requirement to announce an inline-or-workflow mode before the first tool call.

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.11-alpha.5] - 2026-07-23
+
 ### Changed
 
 - Generalized model-visible subagent orchestration guidance across parent chats and workflow stages. Orchestrators now preserve each agent's declared model and fallback policy by default; agents without a policy use only catalog-available, role-appropriate Pareto recommendations and otherwise remain unpinned. Explicit overrides require an exact user request or documented task need, and every workflow or orchestrator invocation shares one invocation-specific, non-default Intercom group across its delegated children while retaining `contact_supervisor` escalation.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.11-alpha.5] - 2026-07-23
+
 ### Changed
 
 - Strengthened the existing Goal and Ralph reviewer prompts with a conditional contract-probe playbook for exact external-consumer APIs, build/feature matrices, schema optionality, state transitions, configuration precedence, low-level feature-flag independence, and permissive inputs. Reviewers now record independent probe outcomes in existing evidence fields and withhold approval when a material literal clause remains unverified, without changing reviewer counts, schemas, or convergence semantics. ([#1973](https://github.com/bastani-inc/atomic/issues/1973))


### PR DESCRIPTION
## Summary

Prepare the package changelogs for the `0.9.11-alpha.5` prerelease while keeping the release base versionless.

## Changes

- Add the `0.9.11-alpha.5` section to the coding-agent changelog.
- Add the `0.9.11-alpha.5` section to the subagents changelog.
- Add the `0.9.11-alpha.5` section to the workflows changelog.
- Keep package manifests, lockfiles, Cargo files, shrinkwrap data, and generated native version checks at `0.0.0`.

## Validation

- Confirmed the branch diff contains only the three intended `CHANGELOG.md` files.
- Ran the Bun-based versionless-base check across all eight package manifests and workspaces, lockfiles, Cargo metadata, shrinkwrap data, and generated native checks.
- Commit and push hooks passed `bun run lint`, `bun run check:file-length`, and all 3,996 unit tests.
- An earlier loaded-suite run hit the known 4-second foreground-intercom watchdog once; the focused Bun test passed 21 consecutive reruns, and both later full hook runs passed.

## Notes

This PR only prepares release notes. It does not merge, stamp versions, tag, dispatch publication, or publish packages.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prepares the versionless base for the 0.9.11-alpha.5 prerelease.
- Adds release-note sections for coding-agent prompt guidance changes.
- Documents subagent orchestration and debugger updates.
- Documents Goal orchestration, reviewer, routing, and model-fallback updates.

<h3>Confidence Score: 5/5</h3>

The documentation-only PR appears safe to merge.

The new changelog headings preserve the expected release-note section structure, and no concrete inaccurate or release-breaking content was identified.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the general contract validation for versionless-base captures and the head diff allowlist, and both checks exited with success.
- The head diff allowlist produced PASS: exact three-file changelog allowlist matched, confirming the contract expectation.
- Created a preserved inspection script to document the exact assertions executed during validation.
- Collected artifacts including four logs and the preserved TypeScript script to enable review of the results.

<a href="https://app.greptile.com/trex/runs/15656899/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/CHANGELOG.md | Adds an accurately bounded 0.9.11-alpha.5 section describing the shipped default-prompt changes. |
| packages/subagents/CHANGELOG.md | Adds 0.9.11-alpha.5 notes consistent with the shipped orchestration-guidance and debugger changes. |
| packages/workflows/CHANGELOG.md | Adds 0.9.11-alpha.5 notes for the Goal, reviewer, routing, and fallback-order changes. |

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.11-alpha.5 ..."](https://github.com/bastani-inc/atomic/commit/f053c2ffd074caa4366ba6b00f805859d3a2810e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46822161)</sub>

<!-- /greptile_comment -->