### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,17 @@
 
 ## Built for developers who want assurance
 
-Atomic grew from collective work on coding agents and developer infrastructure where plausible output was not enough. As agents become more capable, the harness around them must become more deliberate.
+ Your engineering process should be yours, not tied to any single tool, agent, or model. A harness encodes that process: how work is scoped, divided, checked, verified, and approved.
 
-Developers should control what agents see, how work is divided, what crosses boundaries, what evidence must exist, which checks permit progress, and where humans decide. Context, orchestration, and verification are core infrastructure. They should be inspectable, changeable, and owned by the developers who use them.
+ Atomic is the first verifiable coding agent runtime for building your own harness. A set of composable, verifiable harnesses can form the foundation of your software factory.
+ 
+ Build your process as workflows with scoped context, model choice, tools, handoffs, artifacts, retries, executable checks, review gates, and human approvals. 
+  
+ Atomic’s primitives are built for the software engineering lifecycle. Verification is built into the exeuction model. 
+ 
+ Atomic is open so you can inspect and adapt it. You own the workflow, the evidence, and the rules for completion.
 
-Closed platforms may have more resources or distribution. Atomic builds this infrastructure in the open so developers can inspect it, adapt it, and own it.
-
-Build in the open. Question the defaults. Keep control of the process. ☠︎
+ Own your intelligence. Build in the open. Question the defaults. Keep control of the process. ☠︎
 
 ---
 


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/1992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787456580&installation_model_id=10562&pr_number=1992&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F1992&signature=9c06522fe0ae98288dd3f18d2fc3e8e876a4582c1405732d775fca23e27d9006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the README’s developer-assurance section.
- Reframes Atomic as a verifiable runtime for user-owned engineering workflows.
- Describes composable harnesses, workflow primitives, verification, and ownership.
- Revises the closing statement around open development and control.

<h3>Confidence Score: 4/5</h3>

The PR is safe to merge after addressing the non-blocking typo and inconsistent indentation in the updated README copy.

The change only affects documentation, with the accepted concerns limited to a misspelling and accidental leading whitespace in the revised section.

README.md

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran docs:check for the coding-agent package with bun run in the repository; the command exited with status 0 and reported Docs link validation passed for 37 Markdown/MDX files and 37 docs pages.

<a href="https://app.greptile.com/trex/runs/15692844/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Replaces product-positioning copy with an expanded workflow-focused description, but introduces a spelling error and inconsistent paragraph indentation. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
README.md:48
**Correct execution spelling**

The updated product description misspells “execution” as “exeuction,” leaving an obvious typo in the repository’s public-facing documentation.

### Issue 2 of 2
README.md:42-52
**Remove accidental paragraph indentation**

Every paragraph and blank line added in this section contains leading whitespace, unlike the rest of the README. Removing it keeps the Markdown source consistent and avoids unintended indentation in renderers that preserve single leading spaces.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Update README.md"](https://github.com/bastani-inc/atomic/commit/c0469f47cec89972b5da72da1c352fbb79a11b3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46893524)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->