### PR TITLE
fix(rpc): remove frame size limit

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Reworked interactive startup and ordinary working motion around Atomic's revision-3 identity system: the ∀ banner assembles inward in whole-column steps before its identity and manifesto beat land; main and workflow-stage work surfaces keep the exact one-cell `∀` visible while following a pronounced, theme-aware dark → accent → bright/bold → accent → dark luminance ramp at an 88ms cadence and retaining all 453 original randomized whimsical working verbs. Optional partial theme palettes can specify any phase exactly—including the approved Catppuccin Mocha prototype and terminal indices 0–255—while omitted tones derive from semantic selected-surface, accent, and text roles. `NO_COLOR` retains regular/bold activity without foreground-color escapes; reduced motion keeps a static regular accent `∀`; extension indicator frame and interval values remain verbatim while their phase/cadence restarts each turn; and factual status/prompt/receipt surfaces keep precedence. The inline icon and longest message fit tested standard/64-column layouts ([#1883](https://github.com/bastani-inc/atomic/issues/1883)).
+- Removed the fixed 1 MiB size limit from RPC and isolated interactive-engine JSONL transport. Commands, responses, events, queued writes, and render frames now pass through in full instead of being rejected, dropped, or truncated; clients remain responsible for the memory and latency cost of large records ([#1985](https://github.com/bastani-inc/atomic/issues/1985)).
 
 ### Fixed
 

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -32,6 +32,8 @@ If a complete saved provider/model default names a provider that remains unsuppo
 
 RPC mode uses strict JSONL semantics with LF (`\n`) as the only record delimiter.
 
+Atomic does not impose a size limit on RPC or isolated interactive-engine JSONL records. Commands, responses, events, and render frames are serialized in full. Clients and extensions must account for the memory and latency cost of large records and must not add a smaller line limit unless they intend to reject valid Atomic output.
+
 This matters for clients:
 - Split records on `\n` only
 - Accept optional `\r\n` input by stripping a trailing `\r`

--- a/packages/coding-agent/src/modes/interactive-engine/engine-custom-ui.ts
+++ b/packages/coding-agent/src/modes/interactive-engine/engine-custom-ui.ts
@@ -5,7 +5,6 @@ import type { KeybindingsManager } from "../../core/keybindings.ts";
 import type { Theme } from "../interactive/theme/theme.ts";
 import { theme } from "../interactive/theme/theme.ts";
 import {
-	INTERACTIVE_ENGINE_MAX_FRAME_BYTES,
 	isJsonValue,
 	parseInteractiveEngineCommand,
 	serializeInteractiveEngineMessage,
@@ -87,18 +86,6 @@ function jsonResult(value: object | boolean | null | number | string | undefined
 	return decoded;
 }
 
-function boundedLines(lines: string[]): string[] {
-	let remaining = INTERACTIVE_ENGINE_MAX_FRAME_BYTES - 512;
-	const bounded: string[] = [];
-	for (const line of lines) {
-		if (remaining <= 0) break;
-		const bytes = Buffer.from(line, "utf8");
-		const next = bytes.length <= remaining ? line : bytes.subarray(0, remaining).toString("utf8");
-		bounded.push(next);
-		remaining -= Buffer.byteLength(next, "utf8");
-	}
-	return bounded;
-}
 
 export class EngineCustomUiService {
 	private readonly widgetIds = new Map<string, string>();
@@ -246,7 +233,7 @@ export class EngineCustomUiService {
 					type: "engine_custom_frame",
 					componentId: command.componentId,
 					requestId: command.requestId,
-					lines: boundedLines(lines),
+					lines,
 				})).catch((error: Error) => this.send({
 					type: "engine_custom_frame",
 					componentId: command.componentId,

--- a/packages/coding-agent/src/modes/interactive-engine/engine-render-service.ts
+++ b/packages/coding-agent/src/modes/interactive-engine/engine-render-service.ts
@@ -6,7 +6,6 @@ import type { CustomMessage } from "../../core/messages.ts";
 import { CustomMessageComponent } from "../interactive/components/custom-message.ts";
 import { ToolExecutionComponent } from "../interactive/components/tool-execution.ts";
 import {
-	INTERACTIVE_ENGINE_MAX_FRAME_BYTES,
 	type InteractiveEngineCommand,
 	type InteractiveEngineMessage,
 	parseInteractiveEngineCommand,
@@ -53,18 +52,6 @@ class RenderTerminal implements Terminal {
 	setProgress(): void {}
 }
 
-function boundedLines(lines: string[]): string[] {
-	let remaining = INTERACTIVE_ENGINE_MAX_FRAME_BYTES - 512;
-	const result: string[] = [];
-	for (const line of lines) {
-		if (remaining <= 0) break;
-		const bytes = Buffer.from(line);
-		const value = bytes.length <= remaining ? line : bytes.subarray(0, remaining).toString("utf8");
-		result.push(value);
-		remaining -= Buffer.byteLength(value, "utf8");
-	}
-	return result;
-}
 
 export class EngineRenderService {
 	private readonly records = new Map<string, RenderRecord>();
@@ -152,7 +139,7 @@ export class EngineRenderService {
 		if (command.result) {
 			tool.updateResult(command.result as unknown as Parameters<ToolExecutionComponent["updateResult"]>[0], command.isPartial);
 		}
-		return boundedLines(tool.render(command.width));
+		return tool.render(command.width);
 	}
 
 	private renderMessage(command: MessageRenderCommand): string[] {
@@ -172,7 +159,7 @@ export class EngineRenderService {
 			record.terminal.columns = Math.max(1, command.width);
 		}
 		record.component.setExpanded(command.expanded);
-		return boundedLines(record.component.render(command.width));
+		return record.component.render(command.width);
 	}
 
 	private disposeRecord(id: string): void {

--- a/packages/coding-agent/src/modes/interactive-engine/protocol.ts
+++ b/packages/coding-agent/src/modes/interactive-engine/protocol.ts
@@ -3,7 +3,6 @@ import type { HostInputFormField, HostSessionPickerRow } from "../../core/extens
 import type { KeyId } from "../../core/keybindings.ts";
 
 export const INTERACTIVE_ENGINE_PROTOCOL_VERSION = 1;
-export const INTERACTIVE_ENGINE_MAX_FRAME_BYTES = 1_048_576;
 
 export interface JsonObject {
 	[key: string]: JsonValue;
@@ -199,7 +198,6 @@ function parseKeybindingState(value: JsonValue | undefined): EngineKeybindingSta
 }
 
 function parseJsonObject(line: string): JsonObject | undefined {
-	if (Buffer.byteLength(line, "utf8") > INTERACTIVE_ENGINE_MAX_FRAME_BYTES) return undefined;
 	let value: JsonValue;
 	try {
 		value = JSON.parse(line) as JsonValue;
@@ -316,11 +314,7 @@ export function parseInteractiveEngineCommand(line: string): InteractiveEngineCo
 }
 
 export function serializeInteractiveEngineFrame(message: InteractiveEngineMessage | InteractiveEngineCommand): string {
-	const line = JSON.stringify(message);
-	if (Buffer.byteLength(line, "utf8") > INTERACTIVE_ENGINE_MAX_FRAME_BYTES) {
-		throw new Error("Interactive engine frame exceeds 1 MiB");
-	}
-	return `${line}\n`;
+	return `${JSON.stringify(message)}\n`;
 }
 
 export const serializeInteractiveEngineMessage = serializeInteractiveEngineFrame;

--- a/packages/coding-agent/src/modes/rpc/jsonl.ts
+++ b/packages/coding-agent/src/modes/rpc/jsonl.ts
@@ -7,43 +7,30 @@ export function serializeJsonLine(value: object | boolean | null | number | stri
 
 export interface JsonlReaderOptions {
 	maxBytesPerTurn?: number;
-	maxFrameBytes?: number;
-	/** @deprecated Use maxFrameBytes. Retained for source compatibility; measured as UTF-8 bytes. */
-	maxLineChars?: number;
 	maxLinesPerTurn?: number;
-	onOversizedLine?: () => void;
 }
 
 /**
- * Attach a strict LF-only, UTF-8 byte-bounded JSONL reader.
+ * Attach a strict LF-only JSONL reader.
  *
  * The stream is paused before queued chunks are drained, so one turn cannot parse
- * an unbounded number of frames. Oversized records are discarded through their LF;
- * the next bounded record remains readable.
+ * an unbounded number of frames.
  */
 export function attachJsonlLineReader(
 	stream: Readable,
 	onLine: (line: string) => void,
 	options: JsonlReaderOptions = {},
 ): () => void {
-	const maxFrameBytes = options.maxFrameBytes ?? options.maxLineChars ?? Number.POSITIVE_INFINITY;
 	const maxBytesPerTurn = options.maxBytesPerTurn ?? Number.POSITIVE_INFINITY;
 	const maxLinesPerTurn = options.maxLinesPerTurn ?? Number.POSITIVE_INFINITY;
 	const chunks: Buffer[] = [];
 	let frameParts: Buffer[] = [];
 	let frameBytes = 0;
-	let discarding = false;
 	let scheduled: ReturnType<typeof setImmediate> | undefined;
 	let ended = false;
 	let detached = false;
 
 	const finishFrame = (): void => {
-		if (discarding) {
-			discarding = false;
-			frameParts = [];
-			frameBytes = 0;
-			return;
-		}
 		const frame = Buffer.concat(frameParts, frameBytes);
 		frameParts = [];
 		frameBytes = 0;
@@ -59,15 +46,8 @@ export function attachJsonlLineReader(
 			const newline = chunk.indexOf(0x0a, offset);
 			const end = newline !== -1 && newline < budgetEnd ? newline : budgetEnd;
 			const part = chunk.subarray(offset, end);
-			if (!discarding && frameBytes + part.length <= maxFrameBytes) {
-				if (part.length > 0) frameParts.push(part);
-				frameBytes += part.length;
-			} else if (!discarding) {
-				discarding = true;
-				frameParts = [];
-				frameBytes = 0;
-				options.onOversizedLine?.();
-			}
+			if (part.length > 0) frameParts.push(part);
+			frameBytes += part.length;
 			offset = end;
 			if (newline === end) {
 				offset += 1;
@@ -99,7 +79,7 @@ export function attachJsonlLineReader(
 		}
 		if (chunks.length > 0) schedule();
 		else if (ended) {
-			if (!discarding && frameBytes > 0) finishFrame();
+			if (frameBytes > 0) finishFrame();
 			frameParts = [];
 			frameBytes = 0;
 		} else stream.resume();
@@ -115,7 +95,7 @@ export function attachJsonlLineReader(
 			clearImmediate(scheduled);
 			scheduled = undefined;
 			drain();
-		} else if (chunks.length === 0 && !discarding && frameBytes > 0) finishFrame();
+		} else if (chunks.length === 0 && frameBytes > 0) finishFrame();
 	};
 	stream.on("data", onData);
 	stream.on("end", onEnd);

--- a/packages/coding-agent/src/modes/rpc/queued-writer.ts
+++ b/packages/coding-agent/src/modes/rpc/queued-writer.ts
@@ -4,41 +4,27 @@ interface PendingFrame {
 	bytes: Buffer;
 	resolve?: () => void;
 	reject?: (error: Error) => void;
-	key?: string;
 }
 
-export interface BoundedWriterOptions {
-	maxFrameBytes: number;
-	maxQueuedBytes: number;
-}
 
-/** A byte-accounted, one-write-at-a-time stream writer with replaceable updates. */
-export class BoundedWriter {
+/** A one-write-at-a-time stream writer with replaceable updates. */
+export class QueuedWriter {
 	private readonly critical: PendingFrame[] = [];
 	private readonly coalesced = new Map<string, PendingFrame>();
-	private readonly capacityWaiters = new Set<() => void>();
 	private queuedBytes = 0;
 	private pumping = false;
 	private closedError: Error | undefined;
 
 	private readonly stream: Writable;
-	private readonly options: BoundedWriterOptions;
 
-	constructor(
-		stream: Writable,
-		options: BoundedWriterOptions,
-	) {
+	constructor(stream: Writable) {
 		this.stream = stream;
-		this.options = options;
 	}
 
 	get pendingBytes(): number { return this.queuedBytes; }
 
 	async write(text: string): Promise<void> {
-		const bytes = this.frame(text);
-		while (!this.closedError && this.queuedBytes + bytes.length > this.options.maxQueuedBytes) {
-			await new Promise<void>((resolve) => this.capacityWaiters.add(resolve));
-		}
+		const bytes = Buffer.from(text, "utf8");
 		if (this.closedError) throw this.closedError;
 		await new Promise<void>((resolve, reject) => {
 			this.critical.push({ bytes, resolve, reject });
@@ -49,12 +35,10 @@ export class BoundedWriter {
 
 	offerLatest(key: string, text: string): boolean {
 		if (this.closedError) return false;
-		const bytes = this.frame(text);
+		const bytes = Buffer.from(text, "utf8");
 		const previous = this.coalesced.get(key);
-		const nextBytes = this.queuedBytes - (previous?.bytes.length ?? 0) + bytes.length;
-		if (nextBytes > this.options.maxQueuedBytes) return false;
 		if (previous) this.queuedBytes -= previous.bytes.length;
-		this.coalesced.set(key, { bytes, key });
+		this.coalesced.set(key, { bytes });
 		this.queuedBytes += bytes.length;
 		this.pump();
 		return true;
@@ -66,17 +50,8 @@ export class BoundedWriter {
 		for (const frame of this.critical.splice(0)) frame.reject?.(error);
 		this.coalesced.clear();
 		this.queuedBytes = 0;
-		this.wakeCapacityWaiters();
 	}
 
-	private frame(text: string): Buffer {
-		const bytes = Buffer.from(text, "utf8");
-		const payloadBytes = bytes.at(-1) === 0x0a ? bytes.length - 1 : bytes.length;
-		if (payloadBytes > this.options.maxFrameBytes) {
-			throw new Error(`RPC frame exceeds ${this.options.maxFrameBytes} bytes`);
-		}
-		return bytes;
-	}
 
 	private next(): PendingFrame | undefined {
 		const critical = this.critical.shift();
@@ -98,7 +73,6 @@ export class BoundedWriter {
 			let frame: PendingFrame | undefined;
 			while (!this.closedError && (frame = this.next())) {
 				this.queuedBytes -= frame.bytes.length;
-				this.wakeCapacityWaiters();
 				await new Promise<void>((resolve, reject) => {
 					this.stream.write(frame!.bytes, (error) => error ? reject(error) : resolve());
 				});
@@ -111,10 +85,5 @@ export class BoundedWriter {
 			this.pumping = false;
 			if (!this.closedError && (this.critical.length > 0 || this.coalesced.size > 0)) this.pump();
 		}
-	}
-
-	private wakeCapacityWaiters(): void {
-		for (const resolve of this.capacityWaiters) resolve();
-		this.capacityWaiters.clear();
 	}
 }

--- a/packages/coding-agent/src/modes/rpc/rpc-client-process.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client-process.ts
@@ -5,8 +5,6 @@ import { join } from "node:path";
 import { flushPersistentCompileCache } from "../../utils/compile-cache.ts";
 import { killProcessTree, trackDetachedChildPid, untrackDetachedChildPid } from "../../utils/shell.ts";
 import { sleep } from "../../utils/sleep.ts";
-import type { ActivityWatchdogDiagnostic } from "../interactive-engine/activity-watchdog.ts";
-import { INTERACTIVE_ENGINE_MAX_FRAME_BYTES } from "../interactive-engine/protocol.ts";
 
 export interface RpcClientProcessOptions {
 	cliPath: string;
@@ -77,19 +75,6 @@ export async function terminateRpcClientProcess(child: ChildProcess, processTree
 	if (guardianFile) await rm(guardianFile, { force: true });
 }
 
-export function createInteractiveJsonlOptions(
-	enabled: boolean,
-	onDiagnostic: ((diagnostic: ActivityWatchdogDiagnostic) => void) | undefined,
-): { maxBytesPerTurn?: number; maxFrameBytes?: number; onOversizedLine?: () => void } {
-	if (!enabled) return {};
-	return {
-		maxBytesPerTurn: 256 * 1024,
-		maxFrameBytes: INTERACTIVE_ENGINE_MAX_FRAME_BYTES,
-		onOversizedLine: () => onDiagnostic?.({
-			activity: undefined,
-			elapsedMs: 0,
-			level: "unresponsive",
-			message: "Interactive engine violated the 1 MiB protocol frame limit; pending requests were cancelled",
-		}),
-	};
+export function createInteractiveJsonlOptions(enabled: boolean): { maxBytesPerTurn?: number } {
+	return enabled ? { maxBytesPerTurn: 256 * 1024 } : {};
 }

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -1,11 +1,11 @@
 
 import type { ChildProcess } from "node:child_process";
 import type { ImageContent } from "@earendil-works/pi-ai/compat";
-import { BoundedWriter } from "./bounded-writer.ts";
+import { QueuedWriter } from "./queued-writer.ts";
 import { attachJsonlLineReader, serializeJsonLine } from "./jsonl.ts";
 import type { ActivityWatchdogDiagnostic } from "../interactive-engine/activity-watchdog.ts";
 import { InteractiveEngineMonitor } from "../interactive-engine/engine-monitor.ts";
-import { INTERACTIVE_ENGINE_MAX_FRAME_BYTES, serializeInteractiveEngineFrame, type EngineKeybindingState, type InteractiveEngineCommand, type InteractiveEngineMessage } from "../interactive-engine/protocol.ts";
+import { serializeInteractiveEngineFrame, type EngineKeybindingState, type InteractiveEngineCommand, type InteractiveEngineMessage } from "../interactive-engine/protocol.ts";
 import { sleep } from "../../utils/sleep.ts";
 import { createInteractiveJsonlOptions, spawnRpcClientProcess, terminateRpcClientProcess } from "./rpc-client-process.ts";
 import { RpcClientApi, type RpcCommandBody } from "./rpc-client-api.ts";
@@ -92,7 +92,6 @@ export class RpcClient extends RpcClientApi {
 	private engineMessageListeners: Array<(message: InteractiveEngineMessage) => void> = [];
 	private latestEngineKeybindingState: EngineKeybindingState | undefined;
 	private pendingEngineMessages: InteractiveEngineMessage[] = [];
-	private pendingEngineMessageBytes = 0;
 	private pendingRequests: Map<string, { resolve: (response: RpcResponse) => void; reject: (error: Error) => void }> =
 		new Map();
 	private requestId = 0;
@@ -100,7 +99,7 @@ export class RpcClient extends RpcClientApi {
 	private exitError: Error | null = null;
 	private engineMonitor: InteractiveEngineMonitor | undefined;
 	private eventBuffer: RpcEventBuffer | undefined;
-	private stdinWriter: BoundedWriter | undefined;
+	private stdinWriter: QueuedWriter | undefined;
 	private generation = 0;
 	private readonly activeActivityIds = new Set<string>();
 	private enginePid: number | undefined;
@@ -155,10 +154,7 @@ export class RpcClient extends RpcClientApi {
 			interactiveEngine: this.engineMonitor !== undefined,
 		});
 		this.process = childProcess;
-		this.stdinWriter = new BoundedWriter(childProcess.stdin!, {
-			maxFrameBytes: INTERACTIVE_ENGINE_MAX_FRAME_BYTES,
-			maxQueuedBytes: 2 * INTERACTIVE_ENGINE_MAX_FRAME_BYTES,
-		});
+		this.stdinWriter = new QueuedWriter(childProcess.stdin!);
 
 		childProcess.once("exit", (code, signal) => {
 			if (generation !== this.generation) return;
@@ -192,19 +188,10 @@ export class RpcClient extends RpcClientApi {
 				: `${Buffer.from(next).subarray(-256 * 1024).toString("utf8")}\n[stderr truncated]`;
 			process.stderr.write(data);
 		});
-		const readerOptions = createInteractiveJsonlOptions(
-			this.engineMonitor !== undefined,
-			this.options.interactiveEngine?.onDiagnostic,
-		);
+		const readerOptions = createInteractiveJsonlOptions(this.engineMonitor !== undefined);
 		this.stopReadingStdout = attachJsonlLineReader(childProcess.stdout!, (line) => {
 			if (generation === this.generation) this.handleLine(line);
-		}, {
-			...readerOptions,
-			onOversizedLine: () => {
-				readerOptions.onOversizedLine?.();
-				if (generation === this.generation) this.failTransport(new Error("Interactive engine emitted an oversized RPC frame"));
-			},
-		});
+		}, readerOptions);
 		if (this.engineMonitor) await this.engineMonitor.waitUntilReady();
 		else await sleep(100);
 
@@ -261,7 +248,6 @@ export class RpcClient extends RpcClientApi {
 	onInteractiveEngineMessage(listener: (message: InteractiveEngineMessage) => void): () => void {
 		this.engineMessageListeners.push(listener);
 		for (const message of this.pendingEngineMessages.splice(0)) listener(message);
-		this.pendingEngineMessageBytes = 0;
 		return () => {
 			const index = this.engineMessageListeners.indexOf(listener);
 			if (index !== -1) this.engineMessageListeners.splice(index, 1);
@@ -348,15 +334,7 @@ export class RpcClient extends RpcClientApi {
 	}
 	private emitInteractiveEngineMessage(message: InteractiveEngineMessage): void {
 		if (this.engineMessageListeners.length === 0 && message.type.startsWith("engine_custom_")) {
-			const bytes = Buffer.byteLength(JSON.stringify(message), "utf8");
-			while (this.pendingEngineMessages.length > 0 && this.pendingEngineMessageBytes + bytes > INTERACTIVE_ENGINE_MAX_FRAME_BYTES) {
-				const removed = this.pendingEngineMessages.shift()!;
-				this.pendingEngineMessageBytes -= Buffer.byteLength(JSON.stringify(removed), "utf8");
-			}
-			if (bytes <= INTERACTIVE_ENGINE_MAX_FRAME_BYTES) {
-				this.pendingEngineMessages.push(message);
-				this.pendingEngineMessageBytes += bytes;
-			}
+			this.pendingEngineMessages.push(message);
 		}
 		for (const listener of this.engineMessageListeners) listener(message);
 	}
@@ -390,7 +368,7 @@ export class RpcClient extends RpcClientApi {
 			activity: undefined, elapsedMs: 0, level: "unresponsive", message: error.message,
 		});
 	}
-	private requireWriter(): BoundedWriter {
+	private requireWriter(): QueuedWriter {
 		if (!this.stdinWriter) throw new Error("Agent process stdin is not writable");
 		return this.stdinWriter;
 	}

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -22,7 +22,7 @@ import { EngineInputFormService } from "../interactive-engine/engine-input-form.
 import { EngineRenderService } from "../interactive-engine/engine-render-service.ts";
 import { EngineSessionPickerService } from "../interactive-engine/engine-session-picker.ts";
 import { startInteractiveEngineLiveness } from "../interactive-engine/engine-child-liveness.ts";
-import { INTERACTIVE_ENGINE_MAX_FRAME_BYTES, serializeInteractiveEngineMessage } from "../interactive-engine/protocol.ts";
+import { serializeInteractiveEngineMessage } from "../interactive-engine/protocol.ts";
 import { attachJsonlLineReader } from "./jsonl.ts";
 import { createRpcCommandHandler } from "./rpc-command-handler.ts";
 import { createRpcInputLineHandler } from "./rpc-input.ts";
@@ -181,8 +181,6 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 		const scheduleInputLine = createRpcInputScheduler(handleInputLine);
 		const detachJsonl = attachJsonlLineReader(process.stdin, scheduleInputLine, {
 			maxBytesPerTurn: 256 * 1024,
-			maxFrameBytes: INTERACTIVE_ENGINE_MAX_FRAME_BYTES,
-			onOversizedLine: () => output({ type: "response", command: "parse", success: false, error: "RPC command exceeded the 1 MiB frame limit" }),
 		});
 		return () => {
 			detachJsonl();

--- a/packages/coding-agent/src/modes/rpc/rpc-output-buffer.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-output-buffer.ts
@@ -1,41 +1,10 @@
 import { writeRawStdout } from "../../core/output-guard.ts";
-import { INTERACTIVE_ENGINE_MAX_FRAME_BYTES } from "../interactive-engine/protocol.ts";
 import type { RpcOutput, RpcOutputRecord } from "./rpc-responses.ts";
 
-const MAX_STRING_BYTES = 64 * 1024;
-const MAX_ARRAY_ITEMS = 128;
 
-function boundedValue(value: object | boolean | null | number | string, depth = 0): object | boolean | null | number | string {
-	if (typeof value === "string") {
-		if (Buffer.byteLength(value, "utf8") <= MAX_STRING_BYTES) return value;
-		return `${Buffer.from(value).subarray(0, MAX_STRING_BYTES).toString("utf8")}\n[RPC payload truncated]`;
-	}
-	if (value === null || typeof value !== "object") return value;
-	if (depth >= 8) return "[RPC payload depth truncated]";
-	if (Array.isArray(value)) return value.slice(0, MAX_ARRAY_ITEMS).map((entry) =>
-		boundedValue(entry as object | boolean | null | number | string, depth + 1));
-	const result: Record<string, object | boolean | null | number | string> = {};
-	for (const [key, entry] of Object.entries(value)) {
-		if (entry !== undefined) result[key] = boundedValue(entry as object | boolean | null | number | string, depth + 1);
-	}
-	return result;
+export function serializeRpcOutputRecord(record: RpcOutputRecord): string {
+	return `${JSON.stringify(record)}\n`;
 }
-
-function serializeBounded(record: RpcOutputRecord): string {
-	let line = JSON.stringify(record);
-	if (Buffer.byteLength(line, "utf8") <= INTERACTIVE_ENGINE_MAX_FRAME_BYTES) return `${line}\n`;
-	line = JSON.stringify(boundedValue(record));
-	if (Buffer.byteLength(line, "utf8") <= INTERACTIVE_ENGINE_MAX_FRAME_BYTES) return `${line}\n`;
-	const identity = record as { type?: string; id?: string; command?: string };
-	return `${JSON.stringify({
-		type: identity.type ?? "transport_error",
-		...(identity.id ? { id: identity.id } : {}),
-		...(identity.command ? { command: identity.command } : {}),
-		success: false,
-		error: "RPC record exceeded the 1 MiB transport limit",
-	})}\n`;
-}
-
 export class RpcOutputBuffer {
 	private readonly updates = new Map<string, RpcOutputRecord>();
 	private timer: ReturnType<typeof setTimeout> | undefined;
@@ -56,13 +25,13 @@ export class RpcOutputBuffer {
 			return;
 		}
 		this.flush();
-		writeRawStdout(serializeBounded(record));
+		writeRawStdout(serializeRpcOutputRecord(record));
 	}
 
 	private flush(): void {
 		if (this.timer) clearTimeout(this.timer);
 		this.timer = undefined;
-		for (const record of this.updates.values()) writeRawStdout(serializeBounded(record));
+		for (const record of this.updates.values()) writeRawStdout(serializeRpcOutputRecord(record));
 		this.updates.clear();
 	}
 }

--- a/packages/coding-agent/test/rpc-unbounded-frames.test.ts
+++ b/packages/coding-agent/test/rpc-unbounded-frames.test.ts
@@ -1,0 +1,77 @@
+import { Readable, Writable } from "node:stream";
+import { describe, expect, test } from "vitest";
+import {
+	parseInteractiveEngineMessage,
+	serializeInteractiveEngineMessage,
+} from "../src/modes/interactive-engine/protocol.ts";
+import { attachJsonlLineReader, serializeJsonLine } from "../src/modes/rpc/jsonl.ts";
+import { QueuedWriter } from "../src/modes/rpc/queued-writer.ts";
+import { serializeRpcOutputRecord } from "../src/modes/rpc/rpc-output-buffer.ts";
+
+const LARGE_TEXT = "x".repeat(2 * 1024 * 1024);
+
+describe("unbounded RPC records", () => {
+	test("reads a JSONL command larger than 1 MiB across drain turns", async () => {
+		const input = serializeJsonLine({ type: "prompt", message: LARGE_TEXT });
+		const stream = Readable.from([Buffer.from(input)]);
+		const line = await new Promise<string>((resolve) => {
+			attachJsonlLineReader(stream, resolve, { maxBytesPerTurn: 64 * 1024 });
+		});
+
+		expect(JSON.parse(line)).toEqual({ type: "prompt", message: LARGE_TEXT });
+	});
+
+	test("serializes RPC output larger than 1 MiB without truncation", () => {
+		const line = serializeRpcOutputRecord({ type: "message_end", message: { content: LARGE_TEXT } });
+
+		expect(JSON.parse(line)).toEqual({ type: "message_end", message: { content: LARGE_TEXT } });
+	});
+
+	test("round-trips interactive engine frames larger than 1 MiB", () => {
+		const frame = serializeInteractiveEngineMessage({
+			type: "engine_custom_frame",
+			componentId: "large",
+			requestId: 1,
+			lines: [LARGE_TEXT],
+		});
+
+		expect(parseInteractiveEngineMessage(frame.trimEnd())).toEqual({
+			type: "engine_custom_frame",
+			componentId: "large",
+			requestId: 1,
+			lines: [LARGE_TEXT],
+		});
+	});
+
+	test("writes queued frames larger than 1 MiB", async () => {
+		const chunks: Buffer[] = [];
+		const stream = new Writable({
+			write(chunk: Buffer, _encoding, callback) {
+				chunks.push(Buffer.from(chunk));
+				callback();
+			},
+		});
+		const writer = new QueuedWriter(stream);
+		const frame = serializeJsonLine({ type: "prompt", message: LARGE_TEXT });
+
+		await writer.write(frame);
+
+		expect(Buffer.concat(chunks).toString("utf8")).toBe(frame);
+	});
+
+	test("accepts coalesced render frames larger than 1 MiB", async () => {
+		let resolveChunk!: (chunk: Buffer) => void;
+		const chunkWritten = new Promise<Buffer>((resolve) => { resolveChunk = resolve; });
+		const stream = new Writable({
+			write(chunk: Buffer, _encoding, callback) {
+				resolveChunk(Buffer.from(chunk));
+				callback();
+			},
+		});
+		const writer = new QueuedWriter(stream);
+		const frame = serializeJsonLine({ type: "engine_message_render", message: LARGE_TEXT });
+
+		expect(writer.offerLatest("render:large", frame)).toBe(true);
+		expect((await chunkWritten).toString("utf8")).toBe(frame);
+	});
+});

--- a/test/unit/execution-routing-guidance.test.ts
+++ b/test/unit/execution-routing-guidance.test.ts
@@ -10,7 +10,7 @@ import { SUBAGENT_TOOL_DESCRIPTION } from "../../packages/subagents/src/extensio
 const repositoryRoot = resolve(import.meta.dir, "../..");
 
 async function readRepositoryFile(path: string): Promise<string> {
-  return Bun.file(resolve(repositoryRoot, path)).text();
+  return (await Bun.file(resolve(repositoryRoot, path)).text()).replaceAll("\r\n", "\n");
 }
 
 const combinedGuidance = [...workflowGuidance, ...subagentGuidance].join("\n");

--- a/test/unit/interactive-engine-isolation.test.ts
+++ b/test/unit/interactive-engine-isolation.test.ts
@@ -172,17 +172,16 @@ test.serial("blocking extension initialization cannot delay creation of the inte
 	assert.ok(maximumGap(ticks) <= 100, "host heartbeat stalled during extension initialization");
 });
 
-test("interactive JSONL drainage discards oversized frames before parsing", async () => {
-	const stream = Readable.from([`${"x".repeat(1_100_000)}\n{\"ok\":true}\n`]);
+test("interactive JSONL drainage preserves frames larger than 1 MiB", async () => {
+	const large = "x".repeat(1_100_000);
+	const stream = Readable.from([`${large}\n{\"ok\":true}\n`]);
 	const lines: string[] = [];
-	let oversized = 0;
-	const ended = new Promise<void>((resolve) => stream.once("end", resolve));
-	attachJsonlLineReader(stream, (line) => lines.push(line), {
-		maxLineChars: 1_048_576,
-		maxLinesPerTurn: 64,
-		onOversizedLine: () => { oversized += 1; },
+	await new Promise<void>((resolve) => {
+		attachJsonlLineReader(stream, (line) => {
+			lines.push(line);
+			if (lines.length === 2) resolve();
+		}, { maxBytesPerTurn: 64 * 1024, maxLinesPerTurn: 64 });
 	});
-	await ended;
-	assert.equal(oversized, 1);
-	assert.deepEqual(lines, ['{\"ok\":true}']);
+	assert.equal(lines[0], large);
+	assert.equal(lines[1], '{\"ok\":true}');
 });

--- a/test/unit/interactive-engine-transport.test.ts
+++ b/test/unit/interactive-engine-transport.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { Readable, Writable } from "node:stream";
 import { runSynchronousCallback, setCallbackActivityReporter } from "../../packages/coding-agent/src/core/callback-activity.ts";
 import { ActivityWatchdog, shouldRenderEngineDiagnosticAsChatError, type ActivityWatchdogDiagnostic } from "../../packages/coding-agent/src/modes/interactive-engine/activity-watchdog.ts";
-import { BoundedWriter } from "../../packages/coding-agent/src/modes/rpc/bounded-writer.ts";
+import { QueuedWriter } from "../../packages/coding-agent/src/modes/rpc/queued-writer.ts";
 import { attachJsonlLineReader } from "../../packages/coding-agent/src/modes/rpc/jsonl.ts";
 
 class SlowWritable extends Writable {
@@ -12,31 +12,28 @@ class SlowWritable extends Writable {
 	}
 }
 
-test("interactive JSONL limits UTF-8 bytes and preserves the following frame", async () => {
-	const oversized = JSON.stringify({ value: "🙂".repeat(300_000) });
-	const stream = Readable.from([`${oversized}\n{"type":"terminal"}\n`]);
+test("interactive JSONL preserves large UTF-8 frames", async () => {
+	const large = JSON.stringify({ value: "🙂".repeat(300_000) });
+	const stream = Readable.from([`${large}\n{\"type\":\"terminal\"}\n`]);
 	const lines: string[] = [];
-	let violations = 0;
-	attachJsonlLineReader(stream, (line) => lines.push(line), {
-		maxFrameBytes: 1_048_576,
-		maxBytesPerTurn: 128 * 1024,
-		onOversizedLine: () => { violations += 1; },
+	await new Promise<void>((resolve) => {
+		attachJsonlLineReader(stream, (line) => {
+			lines.push(line);
+			if (lines.length === 2) resolve();
+		}, { maxBytesPerTurn: 128 * 1024 });
 	});
-	await new Promise<void>((resolve) => stream.once("end", () => setTimeout(resolve, 10)));
-	assert.equal(violations, 1);
-	assert.deepEqual(lines, ['{"type":"terminal"}']);
+	assert.equal(lines[0], large);
+	assert.equal(lines[1], '{\"type\":\"terminal\"}');
 });
 
-test("bounded writer applies byte admission pressure without losing critical frames", async () => {
-	const writer = new BoundedWriter(new SlowWritable(), { maxFrameBytes: 1024, maxQueuedBytes: 2048 });
-	const writes: Promise<void>[] = [];
-	let peak = 0;
+test("queued writer preserves large critical frames", async () => {
+	const writer = new QueuedWriter(new SlowWritable());
+	const writes = [writer.write(`${JSON.stringify({ value: "x".repeat(2 * 1024 * 1024) })}\n`)];
 	for (let index = 0; index < 100; index += 1) {
 		writes.push(writer.write(`${JSON.stringify({ index, value: "x".repeat(400) })}\n`));
-		peak = Math.max(peak, writer.pendingBytes);
 	}
 	await Promise.all(writes);
-	assert.ok(peak <= 2048, `queued ${peak} bytes`);
+	assert.equal(writer.pendingBytes, 0);
 });
 
 test("activity watchdog retains nested and concurrent attribution", async () => {


### PR DESCRIPTION
## Summary

Remove Atomic's fixed 1 MiB RPC and isolated interactive-engine frame limit to match upstream `earendil-works/pi` JSONL behavior. Large commands, responses, events, queued writes, and render frames now pass through in full.

## Changes

- Remove input and output frame-size checks, truncation, rejection, and transport-failure fallbacks.
- Remove the interactive-engine protocol cap and render-line bounding.
- Replace the byte-bounded writer with an unbounded queued writer that still serializes critical writes and coalesces stale render updates.
- Preserve per-turn JSONL drain budgets for event-loop fairness without limiting total record size.
- Add regressions for commands, output, engine frames, critical writes, and coalesced render frames above 1 MiB.
- Document the unbounded framing contract and its memory/latency trade-off.

## Testing

- `bun run lint`
- `bun run check:file-length`
- `AGENT=1 bun run test:unit` — 4,127 passed
- `AGENT=1 bun run --cwd packages/coding-agent test` — 2,881 passed, 30 skipped
- `bun run --cwd packages/coding-agent build`
- `bun run --cwd packages/coding-agent docs:check`
- `bun run check:shrinkwrap`
- Pre-commit and pre-push hooks

Supersedes #2008 and #2017.
Closes #1985.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787622073&installation_model_id=10562&pr_number=2019&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2019&signature=e27564b3615df647125217cc33e5afdb11afbccfd761ae1e551188ec0038b323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the fixed 1 MiB framing limit throughout RPC and isolated interactive-engine transport.
- Preserves complete large commands, responses, events, render frames, and queued writes.
- Retains per-turn JSONL drain budgets and stale-render coalescing.
- Adds large-frame regression coverage and documents the unbounded framing contract.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no eligible blocking follow-up failures identified.

No blocking failure remains within the scope of the previous review threads.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused regression test for rpc-unbounded-frames.test.ts in the coding-agent package using Bun with a 120-second timeout, and the process exited with code 0.
- Vitest reported that 1 test file passed and 5 tests passed, indicating the test run completed successfully.
- Noted Bun runtime version 1.3.10 is below the manifest requirement of \>=1.3.14, but the focused regression completed without a finding.
- Captured two log artifacts to support verification of the test run and results.

<a href="https://app.greptile.com/trex/runs/15895912/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/src/modes/rpc/jsonl.ts | Removes frame-size rejection while retaining per-turn byte and line drain budgets. |
| packages/coding-agent/src/modes/rpc/queued-writer.ts | Replaces the bounded writer with serialized critical writes and latest-value coalescing. |
| packages/coding-agent/src/modes/rpc/rpc-client.ts | Adopts unbounded transport framing and removes pending interactive-message byte eviction. |
| packages/coding-agent/src/modes/rpc/rpc-output-buffer.ts | Serializes complete RPC output records without truncation or transport-error substitution. |
| packages/coding-agent/src/modes/interactive-engine/protocol.ts | Removes interactive-engine parsing and serialization frame-size checks. |
| packages/coding-agent/test/rpc-unbounded-frames.test.ts | Adds regression coverage for multi-megabyte input, output, engine, critical-write, and coalesced frames. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Client["RPC client"] -->|Unbounded JSONL command| Reader["JSONL reader"]
  Reader --> Scheduler["RPC input scheduler"]
  Scheduler --> Handler["RPC command handler"]
  Handler --> Output["RPC output buffer"]
  Output -->|Unbounded JSONL response/event| Client
  Host["Interactive host"] <-->|Unbounded engine frames| Engine["Isolated interactive engine"]
```

<sub>Reviews (2): Last reviewed commit: ["test: normalize workflow docs line endin..."](https://github.com/bastani-inc/atomic/commit/c04403d8dd09a4e0ae63bf1080752acf302c33d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47309807)</sub>

<!-- /greptile_comment -->