### PR TITLE
docs(workflows): add scope guard composition pattern

### DIFF
--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -34,6 +34,7 @@ Default to a workflow for non-trivial work with a verifiable objective — see [
 - [When to Use Workflows](#when-to-use-workflows)
 - [Built-in Workflows](#built-in-workflows)
 - [Writing a Workflow](#writing-a-workflow)
+- [Scope-Guard Starter Pattern](#scope-guard-starter-pattern)
 - [The `workflow()` Definition](#the-workflow-definition)
 - [WorkflowContext](#workflowcontext)
 - [Task and Stage Options](#task-and-stage-options)
@@ -1166,6 +1167,409 @@ If a parent workflow exits through `ctx.exit(...)` while a child workflow is in 
 The child executor writes each skipped child `workflow.stage.end` exactly once before its child `workflow.run.end`, and parent exit finalization waits for that child cleanup before writing the parent `workflow.run.end`, so restored sessions do not reconstruct the child as interrupted or failed. The skipped parent boundary clears any live child-run edge before store or persistence updates, so status/graph views do not display stale child stages from a boundary that did not complete. A delayed parent branch that calls `ctx.workflow(...)` after the exit gate is selected does not create a boundary or child run.
 
 Continuation replay treats the parent child-workflow boundary as the durable checkpoint: a previously completed child boundary replays with the original exposed outputs and without re-running the child, while a child that failed or was interrupted before completion starts again from the beginning on continuation. If `ctx.exit(...)` wins while a completed boundary is being replayed but before replay finalization, the boundary is finalized as skipped and its preloaded child metadata is omitted from store, persistence, restore, and expanded graph views.
+
+## Scope-Guard Starter Pattern
+
+Use a scope guard when a worker may find valid adjacent work and a later reviewer or repair stage could treat that finding as part of the current task. The guard is an independent reviewer built from existing workflow composition. It controls scope only: code reviewers and deterministic checks still decide whether the candidate is correct.
+
+Do not add a `watchdog` field, stage option, or custom runtime primitive for this pattern. Choose the lightest existing shape that fits the boundary:
+
+| Need | Shape |
+|---|---|
+| One check at a plan, handoff, repair, or completion boundary | A fresh `ctx.task(...)` downstream of the worker |
+| One checker session that needs several prompts or explicit timing | A fresh `ctx.stage(...)`, with all of its turns completed before downstream dependency work starts |
+| Steering while the worker generation is open | Fresh guard and forked worker items in one `ctx.parallel(...)`, using inherited same-group Intercom |
+
+### Canonical scope contract
+
+Create one inspectable contract artifact before guarded work starts. Treat it as immutable for that run and include:
+
+- the literal objective;
+- required scope and allowed files or systems;
+- explicit non-goals;
+- stage boundaries and expected lifecycle order; and
+- acceptance criteria and required evidence.
+
+Every worker, guard, reviewer, and repair continuation reads the same path. Do not copy the contract into several prompts that can drift, and do not let a stage overwrite it. If a human changes the objective, write a new versioned contract and start a new guarded unit of work instead of silently changing the active contract.
+
+Large plans, diffs, logs, reviewer reports, and decision history belong in artifacts. Pass their paths with `reads` where the primitive supports it, tell fresh stages to read the needed sections, and keep Intercom messages short. A fresh guard must not rely on a sibling transcript or hidden graph state.
+
+### Decision contract and actions
+
+For each proposed material expansion, the guard records one evidence-backed classification and action:
+
+| Classification | Evidence threshold | Action |
+|---|---|---|
+| `required` | The literal objective, stated review feedback, acceptance criteria, or required validation directly demands it. | Permit the smallest change that satisfies that demand. |
+| `dependent` | The selected in-scope implementation would otherwise violate a cited existing contract or proven prerequisite. | Permit only the prerequisite and record the contract that makes it necessary. |
+| `follow-up` | The finding is valid but the current objective and selected implementation do not require it. | Record it once and continue without implementing it. It does not block this run. |
+| `unclear` | Evidence cannot decide a material product, public API, security, migration, or scope choice. | Block that expansion and request a supervisor or human decision through a blocking Intercom exchange or `ctx.ui`. |
+
+Use a stable key for each proposal, such as `public-error-shape` or `transport-timeout`. Keep one row per key, merge repeated evidence into that row, and cap the log (the examples use 20 entries). Do not let the guard and worker echo the same finding back and forth. The persisted decision artifact is the source for later review and repair stages; chat messages only steer the open turn.
+
+A useful decision record contains `key`, `classification`, concrete `evidence`, and `action`. A guard failure or missing coordination channel never means approval.
+
+### Fallback policy
+
+Pick and document one policy before the run:
+
+| Policy | When Intercom or the guard is unavailable |
+|---|---|
+| `warn` | Mark live steering unavailable, forbid unreviewed expansion, and run a fresh boundary `ctx.task(...)` before the next material change. |
+| `block` | Stop before expansion and request a decision with `ctx.ui`; in headless mode, fail with the unresolved decision instead of widening scope. |
+| `off` | Skip the guard only because the workflow author or user explicitly disabled it. Preserve the original scope and do not infer approval for adjacent work. |
+
+Use `block` for risky public contracts, data changes, security behavior, releases, or publication. `warn` is a practical default when a boundary review can replace live steering. Never degrade silently from `block` to `warn` or from guarded execution to `off`.
+
+Intercom capability is tool-gated. A stage with `noTools: "all"`, a `tools` allowlist that omits `intercom`, or `excludedTools: ["intercom"]` cannot use live steering. Use a boundary task or the selected fallback policy for that stage.
+
+### Lifecycle, topology, and context rules
+
+- Keep the graph acyclic. A boundary guard is an ordinary downstream reviewer node. Live Intercom steering is activity inside already-running parallel stages, not a new graph edge.
+- Never make a guard watch itself, recursively start another guard, reopen a terminal task, or add a dependency from the current frontier to an ancestor. Complete all turns on a retained guard before starting downstream dependency work.
+- Messages admitted before a worker generation closes drain through that stage boundary. Late messages do not reopen or mutate its terminal workflow state. Give each live branch a bounded stop rule; `ctx.parallel(...)` releases downstream work only after all started branches settle, even when one finishes first.
+- Persist decisions under stable keys. Pause/resume, model fallback, durable replay, and nested workflows then reread the artifact instead of sending duplicate interventions.
+- Omit `group` for ordinary use. The worker, guard, nested workflows, and delegated subagents inherit the top-level workflow invocation's stable Intercom group. Set an explicit group only for intentional isolation; an override separates that stage from ordinary same-group peers.
+- Use `context: "fresh"` for guards, reviewers, and judges. They should see only the contract, candidate, decision artifacts, and current files.
+- Use `context: "fork"` plus `forkFromSessionFile` for implementation, debugging, and repair roles that need continuity with an owned earlier session. `context: "fork"` alone does not name a fork source; an initial worker with no prior lineage may start fresh. A later continuation should use the earlier worker's `sessionFile` when available. Do not fork an independent guard from the worker it judges.
+- Send a forked continuation only the delta after the fork point: new evidence, the decision artifact, any human answer, and the next action. Keep the full shared contract in its canonical file.
+
+Expected lifecycle state is not a defect. If the contract says `candidate → validation → approval → push/publish`, a guard at the candidate or validation boundary must not reject the patch merely because it is unpushed or unpublished. Only the later publication stage owns that action.
+
+### Runnable boundary-task example
+
+Use a fresh task when one check at a material boundary is enough. This complete project workflow keeps the worker lineage coherent, saves a structured decision log, and sends ambiguity to `ctx.ui` before the continuation:
+
+```ts
+// .atomic/workflows/scope-guard-boundary.ts
+import { workflow } from "@bastani/workflows";
+import { Type, type Static } from "typebox";
+
+const decisionLogSchema = Type.Object(
+  {
+    decisions: Type.Array(
+      Type.Object(
+        {
+          key: Type.String(),
+          classification: Type.Union([
+            Type.Literal("required"),
+            Type.Literal("dependent"),
+            Type.Literal("follow-up"),
+            Type.Literal("unclear"),
+          ]),
+          evidence: Type.Array(Type.String(), { minItems: 1 }),
+          action: Type.String(),
+        },
+        { additionalProperties: false },
+      ),
+      { maxItems: 20 },
+    ),
+  },
+  { additionalProperties: false },
+);
+
+type DecisionLog = Static<typeof decisionLogSchema>;
+
+function continueWorker(sessionFile: string | undefined) {
+  return sessionFile === undefined
+    ? { context: "fork" as const }
+    : { context: "fork" as const, forkFromSessionFile: sessionFile };
+}
+
+export default workflow({
+  name: "scope-guard-boundary",
+  description: "Check scope at an implementation boundary.",
+  inputs: {
+    scope_contract: Type.String(),
+    artifact_dir: Type.String({ default: ".atomic/workflows/runs/scope-guard-boundary" }),
+  },
+  outputs: {
+    decision_log: Type.String(),
+  },
+  run: async (ctx) => {
+    const contract = ctx.inputs.scope_contract;
+    const candidate = `${ctx.inputs.artifact_dir}/candidate.md`;
+    const decisionLog = `${ctx.inputs.artifact_dir}/scope-decisions.json`;
+
+    const worker = await ctx.task("prepare candidate", {
+      context: "fresh",
+      reads: [contract],
+      prompt: [
+        `Read the immutable scope contract at ${contract}.`,
+        "Implement only the required scope and summarize changed files and evidence.",
+        "Do not implement valid adjacent findings; include them in the candidate summary.",
+      ].join("\n"),
+      output: candidate,
+      outputMode: "file-only",
+    });
+
+    const checked = await ctx.task("scope boundary", {
+      context: "fresh",
+      reads: [contract, candidate],
+      schema: decisionLogSchema,
+      prompt: [
+        `Read ${contract} and ${candidate}. Inspect the current candidate.`,
+        "Classify each material expansion as required, dependent, follow-up, or unclear.",
+        "Cite concrete evidence and state the action. Return at most 20 unique keys.",
+        "Follow-up work must not block. Unclear expansion requires a human decision.",
+        "Judge scope only; do not approve implementation correctness.",
+      ].join("\n"),
+      output: decisionLog,
+      outputMode: "file-only",
+    });
+
+    if (checked.structured === undefined) throw new Error("scope guard returned no decision log");
+    const decisions = checked.structured as DecisionLog;
+    const unclear = decisions.decisions.filter((item) => item.classification === "unclear");
+    const humanDecision = unclear.length === 0
+      ? "No unclear scope decisions."
+      : await ctx.ui.editor([
+          "Resolve these scope decisions before the worker continues:",
+          ...unclear.map((item) => `- ${item.key}: ${item.evidence.join("; ")}`),
+        ].join("\n"));
+
+    await ctx.task("continue worker", {
+      ...continueWorker(worker.sessionFile),
+      reads: [contract, decisionLog],
+      prompt: [
+        `Read the decision log at ${decisionLog}.`,
+        `Human decision: ${humanDecision}`,
+        "Apply only required and dependent actions. Record follow-up items without implementing them.",
+        "The original contract and output rules remain unchanged.",
+      ].join("\n"),
+    });
+
+    return { decision_log: decisionLog };
+  },
+});
+```
+
+The materialized order is `prepare candidate → scope boundary → optional human prompt → continue worker`. Each step is new downstream work; no edge points back to the original worker.
+
+### Runnable retained-stage example
+
+Use `ctx.stage(...)` when one independent checker needs a retained conversation. Run its tracked `prompt()` once, then use `sendUserMessage(...)` for a bounded post-prompt turn on that same session; a second tracked `prompt()` on the finalized stage is invalid.
+
+```ts
+// .atomic/workflows/scope-guard-retained.ts
+import { workflow } from "@bastani/workflows";
+import { Type } from "typebox";
+
+function continueWorker(sessionFile: string | undefined) {
+  return sessionFile === undefined
+    ? { context: "fork" as const }
+    : { context: "fork" as const, forkFromSessionFile: sessionFile };
+}
+
+export default workflow({
+  name: "scope-guard-retained",
+  description: "Retain one independent checker for a bounded multi-turn review.",
+  inputs: {
+    scope_contract: Type.String(),
+    artifact_dir: Type.String({ default: ".atomic/workflows/runs/scope-guard-retained" }),
+  },
+  outputs: {
+    decision_log: Type.String(),
+  },
+  run: async (ctx) => {
+    const contract = ctx.inputs.scope_contract;
+    const candidate = `${ctx.inputs.artifact_dir}/candidate.md`;
+    const decisionLog = `${ctx.inputs.artifact_dir}/scope-decisions.md`;
+
+    const worker = await ctx.task("prepare candidate", {
+      context: "fresh",
+      reads: [contract],
+      prompt: `Read ${contract}, prepare the scoped candidate, and summarize evidence.`,
+      output: candidate,
+      outputMode: "file-only",
+    });
+
+    const guard = ctx.stage("retained scope guard", { context: "fresh" });
+    await guard.prompt([
+      `Read the immutable contract at ${contract} and candidate at ${candidate}.`,
+      "Classify each material proposal as required, dependent, follow-up, or unclear.",
+      "Write one deduplicated row per stable key, at most 20 rows, with evidence and action.",
+      "Follow-up means record only; unclear means request a human decision.",
+      "Judge scope only, not implementation correctness.",
+    ].join("\n"), { output: decisionLog, outputMode: "file-only" });
+    await guard.sendUserMessage([
+      `Recheck the complete candidate against ${contract}.`,
+      `If evidence changes a classification, use the write tool to replace ${decisionLog}.`,
+      "Keep the artifact complete, deduplicated, and bounded to 20 rows; do not return a delta.",
+      "If no decision changes, leave the artifact unchanged and say so.",
+    ].join("\n"));
+
+
+    const humanDecision = await ctx.ui.editor(
+      `Review ${decisionLog}. Resolve each unclear row, or state that none remain.`,
+    );
+
+    await ctx.task("apply retained decision", {
+      ...continueWorker(worker.sessionFile),
+      reads: [contract, decisionLog],
+      prompt: [
+        `Read ${decisionLog}.`,
+        `Human decision: ${humanDecision}`,
+        "Apply required and dependent actions only. Do not implement follow-up rows.",
+      ].join("\n"),
+    });
+
+    return { decision_log: decisionLog };
+  },
+});
+```
+
+The tracked prompt creates the guard node and decision artifact. `sendUserMessage(...)` starts one retained follow-on turn after that node finalizes; it does not create or reopen graph work. The follow-on updates the artifact directly only when evidence changes, and it finishes before the human prompt or worker continuation starts.
+
+### Runnable live-parallel example
+
+Use a live peer only when steering during generation adds clear value. Both branches omit `group`, so Atomic places them in the workflow invocation's same Intercom group. The guard first performs a bounded Intercom status handshake and returns; later blocking `intercom.ask` calls can reopen its retained conversation for classification. After both parallel branches settle, a fresh task reads that transcript and persists the final deduplicated decision artifact. Normal late sends are not part of this handshake.
+
+```ts
+// .atomic/workflows/scope-guard-live.ts
+import { workflow } from "@bastani/workflows";
+import { Type, type Static } from "typebox";
+
+const coordinationSchema = Type.Object(
+  {
+    status: Type.Union([
+      Type.Literal("available"),
+      Type.Literal("unavailable"),
+      Type.Literal("off"),
+    ]),
+    evidence: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+type Coordination = Static<typeof coordinationSchema>;
+
+function workerContext(sessionFile: string | undefined) {
+  return sessionFile === undefined
+    ? { context: "fresh" as const }
+    : { context: "fork" as const, forkFromSessionFile: sessionFile };
+}
+
+export default workflow({
+  name: "scope-guard-live",
+  description: "Run a worker with a live same-group scope peer.",
+  inputs: {
+    scope_contract: Type.String(),
+    worker_session_file: Type.Optional(Type.String({
+      description: "Earlier worker session to continue; omit when no worker lineage exists.",
+    })),
+    fallback_policy: Type.Union([
+      Type.Literal("warn"),
+      Type.Literal("block"),
+      Type.Literal("off"),
+    ], { default: "warn" }),
+    artifact_dir: Type.String({ default: ".atomic/workflows/runs/scope-guard-live" }),
+  },
+  outputs: {
+    decision_log: Type.String(),
+    review: Type.String(),
+  },
+  run: async (ctx) => {
+    const contract = ctx.inputs.scope_contract;
+    const fallbackPolicy = ctx.inputs.fallback_policy;
+    const candidate = `${ctx.inputs.artifact_dir}/candidate.md`;
+    const coordinationPath = `${ctx.inputs.artifact_dir}/scope-coordination.json`;
+    const decisionLog = `${ctx.inputs.artifact_dir}/scope-decisions.md`;
+
+    const branches = await ctx.parallel(
+      [
+        {
+          name: "worker",
+          ...workerContext(ctx.inputs.worker_session_file),
+          reads: [contract],
+          prompt: [
+            `Read the immutable scope contract at ${contract}.`,
+            `The declared Intercom fallback policy is ${fallbackPolicy}.`,
+            "Unless policy is off, connect to Intercom and find the scope-guard peer in this workflow group.",
+            "Before material expansion, send at most 20 blocking asks with a stable key and evidence.",
+            "Apply required or dependent replies only. Record follow-up findings without implementing them.",
+            "For an unclear reply, wait for human input instead of widening scope.",
+            "If Intercom is unavailable: warn forbids expansion, block stops before expansion, and off keeps the original scope without a guard.",
+            "Return the complete candidate summary; do not send a late ready notice.",
+          ].join("\n"),
+          output: candidate,
+          outputMode: "file-only",
+        },
+        {
+          name: "scope guard",
+          context: "fresh",
+          reads: [contract],
+          schema: coordinationSchema,
+          prompt: [
+            `Read the immutable scope contract at ${contract}.`,
+            `The declared fallback policy is ${fallbackPolicy}.`,
+            "If policy is off, do not connect; return status off with evidence.",
+            "Otherwise call intercom status once and return available or unavailable with evidence.",
+            "When a later blocking ask reopens this conversation, classify its stable key as required, dependent, follow-up, or unclear.",
+            "Reply with concrete evidence and one action. Do not approve implementation correctness.",
+            "Never originate another guard or send a normal late message.",
+          ].join("\n"),
+          output: coordinationPath,
+          outputMode: "file-only",
+        },
+      ],
+      { concurrency: 2, failFast: true },
+    );
+
+    const guardResult = branches[1];
+    if (guardResult?.structured === undefined) throw new Error("scope guard returned no coordination status");
+    const coordination = guardResult.structured as Coordination;
+    const transcriptReads = coordination.status === "available" && guardResult.sessionFile !== undefined
+      ? [guardResult.sessionFile]
+      : [];
+    const effectiveStatus = fallbackPolicy === "off"
+      ? "off"
+      : transcriptReads.length === 1 ? "available" : "unavailable";
+    const humanDecision = effectiveStatus === "unavailable" && fallbackPolicy === "block"
+      ? await ctx.ui.editor("Intercom is unavailable. Resolve scope before any blocked expansion continues.")
+      : "No fallback human decision required.";
+
+    if (fallbackPolicy === "off") {
+      await ctx.task("record scope guard off", {
+        context: "fresh",
+        prompt: "Record that the scope guard was explicitly off and that no expansion was approved.",
+        output: decisionLog,
+        outputMode: "file-only",
+      });
+    } else {
+      await ctx.task("persist scope decisions", {
+        context: "fresh",
+        reads: [contract, candidate, coordinationPath, ...transcriptReads],
+        prompt: [
+          `Read ${contract}, ${candidate}, ${coordinationPath}, and any supplied guard transcript.`,
+          `Effective coordination status: ${effectiveStatus}. Fallback policy: ${fallbackPolicy}.`,
+          `Fallback human decision: ${humanDecision}`,
+          "Persist one complete decision log with at most 20 unique stable keys.",
+          "Classify each expansion as required, dependent, follow-up, or unclear with evidence and action.",
+          "When warn has no transcript, perform the fresh boundary scope check here.",
+          "Follow-up does not block. Unclear remains blocked unless the human decision resolves it.",
+        ].join("\n"),
+        output: decisionLog,
+        outputMode: "file-only",
+      });
+    }
+
+    const review = await ctx.task("independent correctness review", {
+      context: "fresh",
+      reads: [contract, candidate, decisionLog],
+      prompt: [
+        `Read ${contract}, ${candidate}, and ${decisionLog}.`,
+        "Inspect the current files and run the required checks.",
+        "Review correctness independently; do not turn follow-up scope findings into blockers.",
+      ].join("\n"),
+    });
+
+    return { decision_log: decisionLog, review: review.text };
+  },
+});
+```
+
+The parallel fan-out has one shared parent frontier and downstream persistence waits for both branches. Blocking asks use the guard's retained conversation; the fresh persistence task turns the final transcript into the bounded artifact before correctness review. If Intercom is unavailable, `warn` runs that task as a boundary check, `block` requires `ctx.ui`, and `off` records that no guard approval exists.
 
 ## The `workflow()` Definition
 
@@ -3465,6 +3869,7 @@ Before implementing or shipping a non-trivial workflow, answer these questions:
 - **Context size:** Can downstream stages succeed from the handoff alone? Should large transcripts, logs, or research bundles be summarized or saved as artifacts?
 - **Control flow:** Should the workflow use `ctx.chain`, `ctx.parallel`, `ctx.ui`, bounded loops, `failFast`, or `fallbackModels`?
 - **Acyclic topology:** What node and dependency shape can each branch, bounded loop, and nested workflow boundary materialize? Which stages repeat, does each iteration create distinct tracked work with stable identity and call order, and what is the current frontier before each repeat? Could any proposed parent edge target the node itself or an ancestor? Are nested children composed through `ctx.workflow(...)` boundaries rather than recursive `run` invocation? Redesign or stop before launch if any self-edge or back-edge remains.
+- **Scope control:** Could valid adjacent findings expand the patch? If so, where will a fresh scope guard read the immutable contract, how will it classify and persist bounded decisions, which `warn`/`block`/`off` fallback applies, and which worker session owns any forked continuation?
 - **User experience:** Are stage names readable in status and graph views? Is the final output compact? Are important artifacts saved with stable paths?
 - **Validation:** What success criteria, review gates, deterministic checks, or evaluator stages prove the workflow did the right thing? Are model gates schema-backed instead of regex/prose-matched, and do adaptive gates run as focused model stages with explicit tool/check instructions?
 - **Final actions:** Does the workflow distinguish implementation/review convergence from post-approval final actions such as PR/MR/review creation, release tagging, deployment, or publication? Are reviewers and reducers prompted to approve and hand off when implementation and validation criteria are proven and only an explicitly authorized final action remains?
@@ -3490,6 +3895,7 @@ Good workflows are information-flow systems, not just prompt sequences. Keep sta
 - Do not write stage prompts that depend on hidden workflow-wide awareness; make each model stage locally scoped and self-described ([Locally Scoped Stage Prompts](#locally-scoped-stage-prompts)).
 - Do not parse model gate decisions from ad-hoc prose with regular expressions; configure `schema` on a focused workflow item and consume `result.structured`.
 - Do not make reviewers fail an implementation gate solely because an authorized final action has not run yet. Represent that remainder as a post-approval next action (for example `finalActionRemaining` / `nextAction`) and let the final stage perform it.
+- Do not let scope guards approve correctness or turn follow-up findings into blockers. Keep scope decisions separate from code review and deterministic validation, and do not reject expected pre-publication state assigned to a later lifecycle stage.
 - Return compact structured decisions and save large artifacts to files; artifact handoffs should still use files when the next stage does not need the whole payload in context.
 
 These mistakes cover workflow tool usage and authoring. For run-prompt anti-patterns, see the [Anti-patterns](#anti-patterns) table in [Workflow Best Practices](#workflow-best-practices).
@@ -3690,7 +4096,7 @@ Summarize root cause, proposed fix, files involved, validation plan, and remaini
 
 For workflows larger than one tracked task, choose a small control-flow pattern before writing prompts. **Workflow authors should favor these common patterns by default:** naming the pattern up front keeps the stage graph understandable, makes validation gates explicit, and helps reviewers see why work is split across model sessions. Reach for a bespoke structure only when none of these patterns fit.
 
-These patterns are composable and the headings below link to runnable builtins. For example, a migration workflow can nest [**fan-out-and-synthesize**](#six-composable-pattern-builtins) for call-site fixes, [**adversarial-verification**](#six-composable-pattern-builtins) per patch, and [**loop-until-done**](#six-composable-pattern-builtins) while tests still fail. Import and compose the builtin definitions instead of copying their prompts/graphs.
+The first six patterns below have runnable builtins. For example, a migration workflow can nest [**fan-out-and-synthesize**](#six-composable-pattern-builtins) for call-site fixes, [**adversarial-verification**](#six-composable-pattern-builtins) per patch, and [**loop-until-done**](#six-composable-pattern-builtins) while tests still fail. Import and compose the builtin definitions instead of copying their prompts/graphs. **Scope guard** is an authoring starter pattern rather than a builtin; compose its [boundary-task, retained-stage, or live-parallel form](#scope-guard-starter-pattern) from current primitives.
 
 These graph patterns organize work **inside one root lifecycle**. They do not replace the [task-queue rule](#task-queues-and-software-factories): independent whole implementation items normally get separate top-level runs and failure boundaries, while real dependency clusters may use these patterns inside each cluster run.
 
@@ -3702,6 +4108,7 @@ These graph patterns organize work **inside one root lifecycle**. They do not re
 | **Generate-and-filter** | You need many candidate ideas, plans, names, fixes, or hypotheses before selecting the best few. | Generator fan-out → dedupe/filter stage → optional verifier/judge → final shortlist. |
 | **Tournament** | The whole task is subjective or approach-sensitive, and comparative judgment is more reliable than absolute scoring. | Several agents attempt the same task → pairwise judges compare results → bracket reducer returns winners. |
 | **Loop until done** | The amount of work is unknown up front, such as finding all failures, mining repeated issues, or iterating until checks pass. | Bounded loop with an explicit stop condition, progress ledger, per-iteration artifacts, and a max-iteration escape hatch. |
+| **Scope guard** | A worker or repair stage may turn valid adjacent findings into unplanned work. | Immutable contract artifact → fresh boundary or live scope checker → bounded decision artifact → forked worker continuation; correctness review stays separate. |
 
 #### Pattern diagrams
 
@@ -3872,6 +4279,7 @@ Best practices:
 - Pick **generate-and-filter** when output quality depends on exploring a large option space.
 - Pick **tournament** when multiple whole-solution strategies should compete under one rubric.
 - Pick **loop until done** when the workflow should continue until evidence says it is finished, not until a preselected number of stages completes.
+- Pick **scope guard** when valid adjacent findings could expand a worker or repair stage beyond its immutable contract; choose a boundary task by default and live parallel steering only when timing requires it.
 
 Record the selected pattern in your spec or workflow README, then adapt the diagram to the stage graph. If the final design does not resemble any common pattern, explain why in the workflow's design notes.
 

--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -1519,12 +1519,15 @@ export default workflow({
     const guardResult = branches[1];
     if (guardResult?.structured === undefined) throw new Error("scope guard returned no coordination status");
     const coordination = guardResult.structured as Coordination;
-    const transcriptReads = coordination.status === "available" && guardResult.sessionFile !== undefined
-      ? [guardResult.sessionFile]
-      : [];
+    const guardTranscript = coordination.status === "available"
+      ? guardResult.sessionFile
+      : undefined;
+    const transcriptReads = guardTranscript === undefined ? [] : [guardTranscript];
     const effectiveStatus = fallbackPolicy === "off"
       ? "off"
-      : transcriptReads.length === 1 ? "available" : "unavailable";
+      : coordination.status === "available" && guardTranscript !== undefined
+        ? "available"
+        : "unavailable";
     const humanDecision = effectiveStatus === "unavailable" && fallbackPolicy === "block"
       ? await ctx.ui.editor("Intercom is unavailable. Resolve scope before any blocked expansion continues.")
       : "No fallback human decision required.";

--- a/test/unit/workflow-scope-guard-guidance.test.ts
+++ b/test/unit/workflow-scope-guard-guidance.test.ts
@@ -1,0 +1,280 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, test } from "bun:test";
+import {
+  createStore,
+  mockSession,
+  run,
+  structuredOutputMockSession,
+  type CreateAgentSessionOptions,
+  type StageSessionRuntime,
+  type WorkflowDefinition,
+} from "./executor-shared.js";
+
+const repositoryRoot = resolve(import.meta.dir, "../..");
+const documentationPath = resolve(repositoryRoot, "packages/coding-agent/docs/workflows.md");
+
+async function readDocumentation(): Promise<string> {
+  return (await Bun.file(documentationPath).text()).replaceAll("\r\n", "\n");
+}
+
+function extractExample(documentation: string, filename: string): string {
+  const marker = `// .atomic/workflows/${filename}`;
+  const opening = `\`\`\`ts\n${marker}\n`;
+  const tail = documentation.split(opening)[1];
+  if (tail === undefined) throw new Error(`missing ${filename} example`);
+  const body = tail.split("\n```", 1)[0];
+  if (body === undefined) throw new Error(`unterminated ${filename} example`);
+  return `${marker}\n${body}\n`;
+}
+
+async function loadExample(
+  documentation: string,
+  filename: string,
+  directory: string,
+): Promise<{ readonly definition: WorkflowDefinition; readonly source: string }> {
+  const source = extractExample(documentation, filename);
+  const examplePath = resolve(directory, filename);
+  await writeFile(examplePath, source);
+  const loaded = (await import(`${pathToFileURL(examplePath).href}?test=${filename}-${Date.now()}`)) as {
+    readonly default: WorkflowDefinition;
+  };
+  return { definition: loaded.default, source };
+}
+
+function textSession(stageName: string, prompts: Map<string, string[]>): StageSessionRuntime {
+  return {
+    ...mockSession(),
+    sessionFile: undefined,
+    async prompt(text: string) {
+      const stagePrompts = prompts.get(stageName) ?? [];
+      stagePrompts.push(text);
+      prompts.set(stageName, stagePrompts);
+    },
+    getLastAssistantText() {
+      return `output from ${stageName}`;
+    },
+  };
+}
+
+function testUi(onEditor: () => void = () => {}): {
+  input: (prompt: string) => Promise<string>;
+  confirm: (message: string) => Promise<boolean>;
+  select: <T extends string>(message: string, options: readonly T[]) => Promise<T>;
+  editor: (initial?: string) => Promise<string>;
+} {
+  return {
+    input: async () => "input",
+    confirm: async () => true,
+    select: async <T extends string>(_message: string, options: readonly T[]) => options[0]!,
+    editor: async () => {
+      onEditor();
+      return "No unclear decisions remain.";
+    },
+  };
+}
+
+describe("workflow scope-guard guidance", () => {
+  test("locks the scope contract, decision actions, fallback, and lifecycle rules", async () => {
+    const documentation = await readDocumentation();
+
+    for (const phrase of [
+      "one inspectable contract artifact",
+      "Treat it as immutable for that run",
+      "literal objective",
+      "required scope and allowed files or systems",
+      "explicit non-goals",
+      "stage boundaries and expected lifecycle order",
+      "acceptance criteria and required evidence",
+      "`required`",
+      "`dependent`",
+      "`follow-up`",
+      "`unclear`",
+      "one row per key",
+      "cap the log",
+      "A guard failure or missing coordination channel never means approval",
+      "`warn`",
+      "`block`",
+      "`off`",
+      "Expected lifecycle state is not a defect",
+      "must not reject the patch merely because it is unpushed or unpublished",
+      "It controls scope only",
+    ]) {
+      expect(documentation).toContain(phrase);
+    }
+  });
+
+  test("locks acyclic role-based context and inherited-group guidance", async () => {
+    const documentation = await readDocumentation();
+
+    for (const phrase of [
+      "A boundary guard is an ordinary downstream reviewer node",
+      "Live Intercom steering is activity inside already-running parallel stages, not a new graph edge",
+      "Never make a guard watch itself",
+      "Late messages do not reopen or mutate its terminal workflow state",
+      "releases downstream work only after all started branches settle",
+      "Pause/resume, model fallback, durable replay, and nested workflows",
+      "Omit `group` for ordinary use",
+      "delegated subagents inherit the top-level workflow invocation's stable Intercom group",
+      "Use `context: \"fresh\"` for guards, reviewers, and judges",
+      "Use `context: \"fork\"` plus `forkFromSessionFile` for implementation, debugging, and repair roles",
+      "`context: \"fork\"` alone does not name a fork source",
+      "use the earlier worker's `sessionFile` when available",
+      "Send a forked continuation only the delta after the fork point",
+      "Complete all turns on a retained guard before starting downstream dependency work",
+    ]) {
+      expect(documentation).toContain(phrase);
+    }
+  });
+
+  test("keeps all three starter examples loadable and on current APIs", async () => {
+    const documentation = await readDocumentation();
+    const examples = [
+      {
+        filename: "scope-guard-boundary.ts",
+        name: "scope-guard-boundary",
+        api: "ctx.task(\"scope boundary\"",
+        inputs: ["scope_contract", "artifact_dir"],
+      },
+      {
+        filename: "scope-guard-retained.ts",
+        name: "scope-guard-retained",
+        api: "ctx.stage(\"retained scope guard\"",
+        inputs: ["scope_contract", "artifact_dir"],
+      },
+      {
+        filename: "scope-guard-live.ts",
+        name: "scope-guard-live",
+        api: "ctx.parallel(",
+        inputs: ["scope_contract", "worker_session_file", "fallback_policy", "artifact_dir"],
+      },
+    ] as const;
+    const tempDirectory = await mkdtemp(resolve(repositoryRoot, "test", ".scope-guard-examples-"));
+
+    try {
+      for (const example of examples) {
+        const { definition, source } = await loadExample(documentation, example.filename, tempDirectory);
+        expect(source).toContain(example.api);
+        expect(source).toContain("context: \"fresh\"");
+        expect(source).toContain("context: \"fork\"");
+        expect(source).not.toContain("watchdog:");
+        if (example.name === "scope-guard-retained") {
+          expect(source.match(/guard\.prompt\(/g)).toHaveLength(1);
+          expect(source).toContain("guard.sendUserMessage(");
+        }
+        if (example.name === "scope-guard-live") {
+          expect(source).toContain("forkFromSessionFile: sessionFile");
+          expect(source).toContain("fallback_policy:");
+          expect(source).toContain("ctx.task(\"persist scope decisions\"");
+          expect(source).toContain("{ concurrency: 2, failFast: true }");
+          expect(source).not.toContain("group:");
+          expect(source.indexOf("ctx.parallel(")).toBeLessThan(source.indexOf("persist scope decisions"));
+          expect(source.indexOf("persist scope decisions")).toBeLessThan(source.indexOf("independent correctness review"));
+        }
+
+        expect(definition.name).toBe(example.name);
+        expect(Object.keys(definition.inputs)).toEqual([...example.inputs]);
+        expect(definition.outputs).toHaveProperty("decision_log");
+      }
+    } finally {
+      await rm(tempDirectory, { recursive: true, force: true });
+    }
+  });
+
+  test("executes the retained post-prompt lifecycle", async () => {
+    const documentation = await readDocumentation();
+    const tempDirectory = await mkdtemp(resolve(repositoryRoot, "test", ".scope-guard-retained-run-"));
+    const contract = resolve(tempDirectory, "scope.md");
+    const prompts = new Map<string, string[]>();
+
+    try {
+      await writeFile(contract, "# Immutable scope\nOnly edit docs.\n");
+      const { definition } = await loadExample(documentation, "scope-guard-retained.ts", tempDirectory);
+      const result = await run(definition, { scope_contract: contract, artifact_dir: tempDirectory }, {
+        cwd: tempDirectory,
+        store: createStore(),
+        ui: testUi(),
+        adapters: {
+          agentSession: {
+            async create(_options, meta) {
+              return textSession(meta?.stageName ?? "unknown", prompts);
+            },
+          },
+        },
+      });
+
+      expect(result.status).toBe("completed");
+      expect(prompts.get("retained scope guard")).toHaveLength(2);
+      expect(prompts.get("retained scope guard")?.[1]).toContain("Recheck the complete candidate");
+      expect(await Bun.file(resolve(tempDirectory, "scope-decisions.md")).exists()).toBe(true);
+    } finally {
+      await rm(tempDirectory, { recursive: true, force: true });
+    }
+  });
+
+  test("executes live persistence and the block fallback", async () => {
+    const documentation = await readDocumentation();
+    const tempDirectory = await mkdtemp(resolve(repositoryRoot, "test", ".scope-guard-live-run-"));
+    const contract = resolve(tempDirectory, "scope.md");
+    const guardTranscript = resolve(tempDirectory, "guard.jsonl");
+
+    try {
+      await writeFile(contract, "# Immutable scope\nOnly edit docs.\n");
+      await writeFile(guardTranscript, "guard classification transcript\n");
+      const { definition } = await loadExample(documentation, "scope-guard-live.ts", tempDirectory);
+      const execute = async (
+        status: "available" | "unavailable",
+        fallbackPolicy: "warn" | "block",
+        artifactDir: string,
+        onEditor: () => void,
+      ) => {
+        const stageNames: string[] = [];
+        return await run(definition, {
+          scope_contract: contract,
+          fallback_policy: fallbackPolicy,
+          artifact_dir: artifactDir,
+        }, {
+          cwd: tempDirectory,
+          store: createStore(),
+          ui: testUi(onEditor),
+          adapters: {
+            agentSession: {
+              async create(options: CreateAgentSessionOptions, meta) {
+                const stageName = meta?.stageName ?? "unknown";
+                stageNames.push(stageName);
+                if (stageName === "scope guard") {
+                  return {
+                    ...structuredOutputMockSession(options, { status, evidence: `intercom ${status}` }),
+                    sessionFile: status === "available" ? guardTranscript : undefined,
+                  };
+                }
+                return textSession(stageName, new Map());
+              },
+            },
+          },
+          onRunEnd: () => {
+            expect(stageNames.indexOf("persist scope decisions")).toBeLessThan(
+              stageNames.indexOf("independent correctness review"),
+            );
+          },
+        });
+      };
+
+      const availableDir = resolve(tempDirectory, "available");
+      let editorCalls = 0;
+      const available = await execute("available", "warn", availableDir, () => { editorCalls += 1; });
+      expect(available.status).toBe("completed");
+      expect(editorCalls).toBe(0);
+      expect(await Bun.file(resolve(availableDir, "scope-decisions.md")).exists()).toBe(true);
+
+      const blockedDir = resolve(tempDirectory, "blocked");
+      const blocked = await execute("unavailable", "block", blockedDir, () => { editorCalls += 1; });
+      expect(blocked.status).toBe("completed");
+      expect(editorCalls).toBe(1);
+      expect(await Bun.file(resolve(blockedDir, "scope-decisions.md")).exists()).toBe(true);
+    } finally {
+      await rm(tempDirectory, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/unit/workflow-scope-guard-guidance.test.ts
+++ b/test/unit/workflow-scope-guard-guidance.test.ts
@@ -246,7 +246,8 @@ describe("workflow scope-guard guidance", () => {
                 if (stageName === "scope guard") {
                   return {
                     ...structuredOutputMockSession(options, { status, evidence: `intercom ${status}` }),
-                    sessionFile: status === "available" ? guardTranscript : undefined,
+                    // A normal stage transcript can exist even when Intercom is unavailable.
+                    sessionFile: guardTranscript,
                   };
                 }
                 return textSession(stageName, new Map());


### PR DESCRIPTION
## Summary

- document boundary-task, retained-stage, and live-peer scope guard composition
- define required, dependent, follow-up, and unclear decisions with bounded artifacts and fallback policies
- clarify role-based fresh/fork context lineage, inherited Intercom groups, and acyclic lifecycle behavior
- add focused tests for the runnable examples and key guidance

## Validation

- `bun test test/unit/workflow-scope-guard-guidance.test.ts`
- `bun run docs:check` from `packages/coding-agent`
- commit hooks: lint, file-length, and full unit suite

Closes #2018

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787625925&installation_model_id=10562&pr_number=2020&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2020&signature=5d6beaf03417dbeb622e3350f590854f156b9833345fb5bb52c0efdf9657704e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds scope-guard workflow guidance and focused executable documentation tests.
- Documents boundary-task, retained-stage, and live-parallel composition patterns.
- Defines scope classifications, fallback policies, context lineage, and lifecycle constraints.
- Corrects coordination availability handling by requiring both an available status and a guard transcript.
- Adds tests covering example loading, retained-stage behavior, decision persistence, and unavailable-with-transcript block fallback.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The code-execution proof-of-work run completed with exit code 0 and a recorded duration, and the runtime log preserves the exact command, working directory, and complete focused-test output.
- The workflow-scope-guard-guidance.log artifact is available for review and provides auditable runtime evidence via an accessible URL.

<a href="https://app.greptile.com/trex/runs/15898245/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/docs/workflows.md | Adds comprehensive scope-guard composition guidance and fixes coordination availability detection by checking both structured status and transcript presence. |
| test/unit/workflow-scope-guard-guidance.test.ts | Adds focused tests for documentation contracts, runnable examples, retained-stage lifecycle, and the unavailable-coordination block fallback. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Contract[Immutable scope contract] --> Worker[Worker candidate]
  Contract --> Guard[Fresh scope guard]
  Worker --> Guard
  Guard --> Decisions[Bounded decision artifact]
  Decisions --> Continuation[Forked worker continuation]
  Decisions --> Review[Independent correctness review]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(workflows): honor unavailable guard..."](https://github.com/bastani-inc/atomic/commit/cebadc9a6b212c04c6d8714e013b0bd56c4e36d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47313891)</sub>

<!-- /greptile_comment -->