### PR TITLE
docs(workflows): add task-complexity judgment guidance

### DIFF
--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -255,6 +255,37 @@ When an arbitrary task-specific workflow has plausible-but-wrong contract risk, 
 
 Use `ctx.tool` for workflow-owned external checks and side effects that benefit from durable checkpointing. Leave pure transformations as ordinary TypeScript; do not wrap every model-stage action in a tool call. A custom-loop pre-launch declaration must name the skeptical reviewer, deterministic verifier gates, how model-selected plans become tool executions, how evidence reaches evaluation/repair, and the bounded success/failure condition.
 
+#### Judging task complexity
+
+Complexity is a property of risk, not effort. Score a task on five axes and let the **worst axis dominate** — complexity is not the sum:
+
+| Axis | Low | High |
+|---|---|---|
+| **Blast radius** | one file, one function | crosses module/package boundaries; touches shared contracts (APIs, schemas, migrations) |
+| **Uncertainty** | the exact edit is known before opening the file | the location or cause of the behavior is unknown |
+| **Verifiability cost** | type-checker or a glance confirms it | multi-step validation: build + tests + runtime behavior + artifact checks |
+| **Dependency structure** | independent steps | ordered handoffs where an early mistake propagates |
+| **Failure cost** | reversible edit | wire formats, published APIs, data migrations, releases |
+
+A one-line change to a serialization format is complex (high failure cost, exact contract). A 500-line mechanical rename is simple (zero uncertainty, type-checker-verified). The common trap is judging by effort instead of risk: long-but-mechanical is simple; short-but-contractual is not.
+
+Fast tells, usable in the first 30 seconds:
+
+- **Done-condition test:** if the success condition does not fit in one sentence, the task is complex or underspecified — clarify before guessing.
+- **The "and" test:** "fix X and update docs and add a test" is three tasks in one sentence; enumerate and classify each.
+- **Loop words:** "until it passes", "keep trying" make the task at least moderate — iteration is expected.
+- **Working-memory test:** more than about three interacting constraints at once means complex.
+
+**Threshold.** A task earns a workflow when at least two of these are true, or any one is strongly true:
+
+1. Two or more distinct phases with a real handoff (research → implement, implement → verify), not just steps.
+2. The done-condition needs proof — tests, builds, review, or a contract check. If "how do you know it works?" is a fair question, a verification stage is waiting to exist.
+3. Iteration is expected — an anticipated repair loop, not a straight line.
+4. Failure cost is high — even a one-line change gets adversarial verification.
+5. The work outlives one attention span — losing mid-task state is a real risk.
+
+The honest form of the threshold is a comparison: workflow overhead is roughly constant and small, while the cost of being wrong inline scales with uncertainty × failure cost — so the line crosses at "moderate" on any single axis. Guard against the ratchet failure mode: a task that looked simple, then accumulated exploratory calls, ad-hoc fixes, and an untracked mental TODO list is a workflow being run badly in-head; apply the ten-call rule from [When to Use Workflows](#when-to-use-workflows). Map axes to action: all low → inline now; only uncertainty high → short recon, then re-judge; any axis high with a checkable outcome → workflow with a stage producing evidence for the worst axis; failure cost high → add deterministic or adversarial gates regardless of the rest. When the mapping stays ambiguous, fall through to the [scoring rubric](#scoring-rubric) below.
+
 #### Scoring rubric
 
 When the ladder is ambiguous, score the task on six dimensions (0–2 each):


### PR DESCRIPTION
## Summary

Adds a `Judging task complexity` subsection to `packages/coding-agent/docs/workflows.md`, distilling agent-facing guidance on how to judge whether a task warrants a workflow before choosing an execution shape.

## Changes

- Five risk axes (blast radius, uncertainty, verifiability cost, dependency structure, failure cost) with a worst-axis-dominates rule: complexity is a property of risk, not effort
- Fast 30-second tells: done-condition test, the "and" test, loop words, working-memory test
- An explicit workflow-worthiness threshold (two-of-five criteria, or any one strongly true) framed as constant workflow overhead vs. uncertainty × failure-cost of being wrong inline
- An axes-to-action map that falls through to the existing scoring rubric, plus the ratchet failure mode tied to the existing ten-call rule

## Notes

Placed between the pre-launch self-prompt and the scoring rubric so the flow reads: architecture pass → complexity judgment → rubric tie-breaker. Docs-only; all pre-commit hooks (lint, file-length, unit tests) passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787706402&installation_model_id=10562&pr_number=2031&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2031&signature=31194321dec9509faeeb57ac3a6b1c7faa7bea49d30f0cb78d1b1b41e16b5613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds agent-facing guidance for deciding task complexity and selecting an execution shape.
- Defines five risk axes and fast complexity indicators.
- Introduces a workflow-worthiness threshold and axes-to-action mapping.
- Connects complexity judgment to the existing scoring rubric and ten-call rule.

<h3>Confidence Score: 4/5</h3>

The documentation change is safe to merge, though its conflicting single-axis thresholds should be reconciled to make agent routing deterministic.

The new section simultaneously requires two qualifying criteria or one strongly true criterion and says that a moderate value on any single axis crosses the workflow threshold.

**Files Needing Attention:** packages/coding-agent/docs/workflows.md

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the docs-validation log to verify the exact command outputs, working directory, and exit codes, and confirmed both checks exited with code 0.

<a href="https://app.greptile.com/trex/runs/15960987/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/coding-agent/docs/workflows.md | Adds comprehensive task-complexity guidance, but two statements define inconsistent workflow thresholds for a single moderately elevated axis. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/coding-agent/docs/workflows.md`, line 297 ([link](https://github.com/bastani-inc/atomic/blob/c024a16153dd11cb4d539d40ace578c3be2ea554/packages/coding-agent/docs/workflows.md#L297)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Conflicting single-axis thresholds**

   The explicit threshold requires two qualifying criteria or one strongly true criterion, while this sentence says a moderate value on any single axis crosses the workflow threshold. These rules give agents opposite execution-shape decisions for the same task, so they should use one consistent cutoff.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/coding-agent/docs/workflows.md
   Line: 297

   Comment:
   **Conflicting single-axis thresholds**

   The explicit threshold requires two qualifying criteria or one strongly true criterion, while this sentence says a moderate value on any single axis crosses the workflow threshold. These rules give agents opposite execution-shape decisions for the same task, so they should use one consistent cutoff.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/coding-agent/docs/workflows.md:297
**Conflicting single-axis thresholds**

The explicit threshold requires two qualifying criteria or one strongly true criterion, while this sentence says a moderate value on any single axis crosses the workflow threshold. These rules give agents opposite execution-shape decisions for the same task, so they should use one consistent cutoff.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(workflows): add task-complexity jud..."](https://github.com/bastani-inc/atomic/commit/c024a16153dd11cb4d539d40ace578c3be2ea554) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47448129)</sub>

<!-- /greptile_comment -->