### PR TITLE
docs(changelog): cut release notes for 0.9.11-alpha.6

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.11-alpha.6] - 2026-07-28
+
 ### Added
 
 - Added execution-time session metadata to built-in, SDK/factory, direct, workflow-stage, and isolated bash execution through `ATOMIC_SESSION_ID`, `ATOMIC_SESSION_FILE`, `ATOMIC_PROVIDER`, `ATOMIC_MODEL`, and `ATOMIC_REASONING_LEVEL`, with exact `PI_*` compatibility aliases and safe omission of unsaved session files. Direct RPC bash now emits request-correlated, ordered `bash_execution_update` events that distinguish stdout from stderr, supports concurrent requests and per-request cancellation, and keeps streaming, cancellation, one terminal response, and exactly-once starting-session persistence intact across new/switch/import/fork/clone session replacement and RPC shutdown ([#1995](https://github.com/bastani-inc/atomic/issues/1995)).

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.11-alpha.6] - 2026-07-28
+
 ### Removed
 
 - Removed Cursor MCP configuration discovery and the `cursor` compatibility import kind ([#1994](https://github.com/bastani-inc/atomic/issues/1994)).

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.11-alpha.6] - 2026-07-28
+
 ### Removed
 
 - Removed the Cursor-specific HTTP/2 native transport, generated N-API exports, transport-only dependencies, metadata, and attribution ([#1994](https://github.com/bastani-inc/atomic/issues/1994)).

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.11-alpha.6] - 2026-07-28
+
 ### Changed
 
 - Adopted Claude Opus 5 across every builtin subagent `fallbackModels` policy and normalized provider ordering. Each Anthropic family now lists its direct `anthropic/...` candidate ahead of the `github-copilot/...` mirror, Opus 5 leads the Anthropic group (`:high` for the debugger, `:low` elsewhere), `claude-fable-5` gains its missing Copilot mirror, and the OpenRouter tail lists `openrouter/anthropic/claude-opus-5` before the older Anthropic mirrors.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.11-alpha.6] - 2026-07-28
+
 ### Added
 
 - Added opt-in `ctx.tool(..., { failureMode: "return" })` outcomes for checks that may fail during repair flows. Exhausted callback failures now preserve bounded, best-effort redacted `exitCode`, `stdout`, and `stderr` as typed durable data; replay returns the same outcome without rerunning the callback; failed tool nodes remain truthful while explicit downstream repair and bounded reruns continue; and default failures, cancellation, admission errors, and storage faults still throw ([#1993](https://github.com/bastani-inc/atomic/issues/1993)).


### PR DESCRIPTION
## Summary

Prepares the release notes for prerelease **0.9.11-alpha.6**.

Promotes the accumulated `[Unreleased]` entries into a dated `## [0.9.11-alpha.6] - 2026-07-28` section in the five packages that have user-facing changes:

- `packages/coding-agent/CHANGELOG.md` — session metadata env vars (`ATOMIC_*` / `PI_*`) across bash execution paths; request-correlated `bash_execution_update` RPC events
- `packages/mcp/CHANGELOG.md` — removed Cursor MCP configuration discovery and the `cursor` import kind
- `packages/natives/CHANGELOG.md` — removed the Cursor-specific HTTP/2 native transport and its N-API exports
- `packages/subagents/CHANGELOG.md` — Claude Opus 5 adopted across builtin subagent `fallbackModels`, normalized provider ordering
- `packages/workflows/CHANGELOG.md` — opt-in `ctx.tool(..., { failureMode: "return" })` outcomes for repair flows

`packages/intercom` and `packages/web-access` have no unreleased entries and are intentionally untouched.

## Versionless base

This is a **changelog-only** diff. Every package manifest, `bun.lock` entry, Cargo manifest/lock, and generated version file remains at the `0.0.0` placeholder. Only `scripts/cut-release.ts` stamps the real version, on the detached `Release 0.9.11-alpha.6` commit created after this PR merges.

## Validation

- `bun run typecheck` — passed
- `bun run check:file-length` — passed (2492 files)
- `bun run lint` — passed (prek)
- `bun run test:unit` — passed (prek)
- Diff verified changelog-only; all manifests confirmed at `0.0.0`

## Next steps

Not part of this stage: no merge, tag, or publish here. After required checks pass and this PR merges, `scripts/cut-release.ts 0.9.11-alpha.6 --base main --push` stamps and pushes the tag, which starts `publish.yml`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787849039&installation_model_id=10562&pr_number=2054&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2054&signature=caecfb2b53e8b30ce3e299ed0520e09e470fb85e5dcbb647f2f45b6e5143f56d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->