### PR TITLE
docs(changelog): cut release notes for 0.9.11-alpha.7

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.11-alpha.7] - 2026-07-28
+
 ### Changed
 
 - Synchronized the complete bundled `impeccable` skill tree with pbakaus/impeccable at `14c27e43af190cbed3793d0b76e33feea4a8859a` (previously `630fc2682a5bd39b25a8e61f74b6b3f14f2b1e21`). Impeccable 4.0.3 replaces the brand/product register split with four surface modes (Persuade, Operate, Read, Experience), routes work through new `routing.md`, `new-work.md`, and mandatory `craft-floor.md` guidance in place of the deprecated `craft` ownership model, adds a `doctor` drift check with repair steps, adds documenter and finish-reviewer agents with degraded-mode reference fallbacks, adds surface briefs plus concept/composition catalogs, staleness checks, and image generation, and expands live review with generation preflight, source search and locking, poll lanes, and TanStack support alongside updated detector rules, static-HTML analysis, hooks, and platform guidance. Atomic's divergences are preserved: scanner-based HTML/script/style/comment filtering, argument-separated `git check-ignore`, backslash-safe live-preview selector escaping, the CodeQL CSS-property fix, and no removed-editor hook/provider compatibility.


### PR DESCRIPTION
## Summary

Promotes the accumulated `[Unreleased]` entries in `packages/coding-agent/CHANGELOG.md` into a dated `[0.9.11-alpha.7]` section ahead of the `0.9.11-alpha.7` prerelease.

## Scope

- Changelog-only diff (`packages/coding-agent/CHANGELOG.md`, +2 lines).
- Every package manifest, lockfile, Cargo manifest, and generated version file stays at the `0.0.0` placeholder.
- Only `scripts/cut-release.ts` stamps the real version, on the detached `Release 0.9.11-alpha.7` commit after this PR merges.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run check:file-length`
- `bun run test:unit`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787883322&installation_model_id=10562&pr_number=2058&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2058&signature=2aa6917409fa3c8124da0791d3895a257733fc09c6034d37998a2eb1a311b675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Promotes the accumulated coding-agent changelog entries from Unreleased into a dated 0.9.11-alpha.7 release section.

<h3>Confidence Score: 5/5</h3>

The changelog-only PR appears safe to merge.

The new heading follows the existing changelog format and remains compatible with the repository's release-note extraction behavior.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the release-changelog typecheck for step 02 completed successfully, with the log capturing the exact command, working directory, Bun version, TypeScript invocation, and a successful exit status.

<a href="https://app.greptile.com/trex/runs/16327085/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/CHANGELOG.md | Adds a correctly formatted 0.9.11-alpha.7 release heading above the existing release notes without changing their content. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): cut release notes for 0..."](https://github.com/bastani-inc/atomic/commit/061553e5c0e7477fa91b1b2f0d01d4aae8fc2d13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48186680)</sub>

<!-- /greptile_comment -->