### PR TITLE
fix(auth): never roll back OAuth credentials on failed post-login model refresh

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OAuth logins being destroyed by an unrelated model-catalog refresh, matching upstream pi's behavior. After a successful `/login`, a timed-out (aborted) or partially failed catalog refresh threw `Model refresh aborted after OAuth login` and rolled the freshly acquired tokens back to the previous credential. Because providers rotate refresh tokens, that rollback could permanently strand a server-side-invalidated credential — every send then failed with `invalid_grant` ("Refresh token not found or invalid") and every re-login was rolled back again, typically on machines with slow routes to catalog endpoints. Freshly persisted OAuth credentials now always survive the post-login refresh: per-provider refresh errors and refresh timeouts no longer fail the login in either the direct interactive or isolated-engine path, and models fall back to the cached snapshot.
+
 ## [0.9.11-alpha.7] - 2026-07-28
 
 ### Changed

--- a/packages/coding-agent/src/modes/interactive/interactive-auth-login.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-auth-login.ts
@@ -5,10 +5,9 @@ import { isOAuthLoginCancelled } from "../../core/oauth-provider-bridge.ts";
 
 InteractiveModeBase.prototype.completeProviderAuthentication = async function(this: InteractiveModeBase, providerId: string, providerName: string, authType: "oauth" | "api_key", previousModel: Model<Api> | undefined, options: { modelsRefreshed?: boolean } = {}): Promise<void> {
 	if (!options.modelsRefreshed) {
-		const result = await this.session.modelRegistry.refresh();
-		const providerError = result.errors.get(providerId);
-		if (providerError) throw providerError;
-		if (result.aborted) throw new Error(`Model refresh aborted after authenticating ${providerName}`);
+		// Upstream pi parity: a failed or timeout-aborted catalog refresh after a
+		// completed login is non-fatal; models fall back to the cached snapshot.
+		await this.session.modelRegistry.refresh();
 	}
 
     const actionLabel =

--- a/packages/coding-agent/src/modes/rpc/rpc-provider-auth.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-provider-auth.ts
@@ -125,26 +125,16 @@ export class RpcProviderAuth {
 		credential: AuthCredential,
 		signal: AbortSignal,
 	): Promise<void> {
-		const storage = session.modelRegistry.authStorage;
-		const previous = storage.get(provider);
-		const credentialStore = storage.asCredentialStore();
+		const credentialStore = session.modelRegistry.authStorage.asCredentialStore();
 		if (signal.aborted) throw normalizeOAuthLoginError(signal.reason, signal);
 		await credentialStore.modify(provider, async () => credential);
-		try {
-			if (signal.aborted) throw normalizeOAuthLoginError(signal.reason, signal);
-			const result = await session.modelRegistry.refresh();
-			const failures = [...result.errors.entries()];
-			if (failures.length > 0) {
-				throw new Error(failures.map(([id, error]) => `${id}: ${error.message}`).join("; "));
-			}
-			if (signal.aborted) throw normalizeOAuthLoginError(signal.reason, signal);
-			if (result.aborted) throw new Error("Model refresh aborted after OAuth login");
-			session.refreshCurrentModelFromRegistry();
-		} catch (error) {
-			if (previous === undefined) await credentialStore.delete(provider);
-			else await credentialStore.modify(provider, async () => previous);
-			throw error;
-		}
+		// Upstream pi parity: once fresh OAuth tokens are persisted, the catalog
+		// refresh outcome (per-provider errors or a timeout-aborted result) must
+		// not fail the login or touch the stored credential. Refresh tokens are
+		// rotated by providers, so rolling back here would re-install a
+		// server-side-invalidated credential (permanent invalid_grant).
+		await session.modelRegistry.refresh();
+		session.refreshCurrentModelFromRegistry();
 	}
 
 	private catalog(session: AgentSession): RpcModelCatalog {

--- a/packages/coding-agent/test/interactive-auth-login.test.ts
+++ b/packages/coding-agent/test/interactive-auth-login.test.ts
@@ -209,34 +209,38 @@ describe("post-login model refresh", () => {
 		});
 	}
 
-	it("keeps a provider-specific model refresh failure visible after credential commit", async () => {
-		const refreshFailure = new Error("catalog unavailable");
-		const showStatus = vi.fn();
-		const harness = {
-			session: {
-				modelRegistry: {
-					refresh: async () => ({ aborted: false, errors: new Map([["corp-oauth", refreshFailure]]) }),
-					getAvailable: () => [],
+	for (const outcome of [
+		{ label: "reports provider errors", result: { aborted: false, errors: new Map([["corp-oauth", new Error("catalog unavailable")]]) } },
+		{ label: "aborts on timeout", result: { aborted: true, errors: new Map() } },
+	]) {
+		it(`completes login when the post-login model refresh ${outcome.label}`, async () => {
+			const showStatus = vi.fn();
+			const harness = {
+				session: {
+					modelRegistry: {
+						refresh: async () => outcome.result,
+						getAvailable: () => [],
+					},
 				},
-			},
-			updateAvailableProviderCount: vi.fn(),
-			setupAutocompleteProvider: vi.fn(),
-			footer: { invalidate: vi.fn() },
-			updateEditorBorderColor: vi.fn(),
-			showStatus,
-			showError: vi.fn(),
-			maybeWarnAboutAnthropicSubscriptionAuth: vi.fn(),
-			checkDaxnutsEasterEgg: vi.fn(),
-		};
-		const complete = InteractiveModeBase.prototype.completeProviderAuthentication as (
-			this: typeof harness,
-			providerId: string,
-			providerName: string,
-			authType: "oauth" | "api_key",
-			previousModel: Model<Api> | undefined,
-		) => Promise<void>;
+				updateAvailableProviderCount: vi.fn(),
+				setupAutocompleteProvider: vi.fn(),
+				footer: { invalidate: vi.fn() },
+				updateEditorBorderColor: vi.fn(),
+				showStatus,
+				showError: vi.fn(),
+				maybeWarnAboutAnthropicSubscriptionAuth: vi.fn(),
+				checkDaxnutsEasterEgg: vi.fn(),
+			};
+			const complete = InteractiveModeBase.prototype.completeProviderAuthentication as (
+				this: typeof harness,
+				providerId: string,
+				providerName: string,
+				authType: "oauth" | "api_key",
+				previousModel: Model<Api> | undefined,
+			) => Promise<void>;
 
-		await expect(complete.call(harness, "corp-oauth", "Corp OAuth", "oauth", undefined)).rejects.toBe(refreshFailure);
-		expect(showStatus).not.toHaveBeenCalled();
-	});
+			await complete.call(harness, "corp-oauth", "Corp OAuth", "oauth", undefined);
+			expect(showStatus).toHaveBeenCalledWith(expect.stringContaining("Logged in to Corp OAuth"));
+		});
+	}
 });

--- a/packages/coding-agent/test/rpc-oauth-login.test.ts
+++ b/packages/coding-agent/test/rpc-oauth-login.test.ts
@@ -357,7 +357,7 @@ describe("isolated engine OAuth", () => {
 		expect(caught).toMatchObject({ message: "Login cancelled", cause: abort });
 		expect({ applied, reloaded }).toEqual({ applied: 0, reloaded: 0 });
 	});
-	it("rolls back the acquired credential when post-login model refresh fails", async () => {
+	it("keeps the acquired credential when post-login model refresh reports provider errors", async () => {
 		const { harness, runtime } = await createRuntimeHarness();
 		harness.authStorage.set("corp-oauth", { type: "api_key", key: "previous" });
 		harness.session.modelRegistry.registerProvider("corp-oauth", {
@@ -368,10 +368,9 @@ describe("isolated engine OAuth", () => {
 				getApiKey: (credential) => credential.access,
 			},
 		});
-		const refreshFailure = new Error("catalog unavailable");
 		harness.session.modelRegistry.refresh = async () => ({
 			aborted: false,
-			errors: new Map([["corp-oauth", refreshFailure]]),
+			errors: new Map([["corp-oauth", new Error("catalog unavailable")]]),
 		});
 		const handler = createRpcCommandHandler({
 			runtimeHost: runtime,
@@ -381,13 +380,14 @@ describe("isolated engine OAuth", () => {
 			output: () => {},
 		});
 
-		await expect(handler({
+		const response = await handler({
 			id: "login", type: "login_provider", provider: "corp-oauth", authType: "oauth",
-		})).rejects.toThrow("catalog unavailable");
-		expect(harness.authStorage.get("corp-oauth")).toEqual({ type: "api_key", key: "previous" });
+		});
+		expect(response).toMatchObject({ success: true, data: { provider: "corp-oauth", cancelled: false } });
+		expect(harness.authStorage.get("corp-oauth")).toMatchObject({ type: "oauth", access: "new-secret" });
 	});
 
-	it("keeps a post-acquisition AbortError from model refresh visible", async () => {
+	it("keeps a thrown post-login model refresh failure visible without rolling back", async () => {
 		const { harness, runtime } = await createRuntimeHarness();
 		harness.authStorage.set("corp-oauth", { type: "api_key", key: "previous" });
 		harness.session.modelRegistry.registerProvider("corp-oauth", {
@@ -411,10 +411,10 @@ describe("isolated engine OAuth", () => {
 		await expect(handler({
 			id: "login", type: "login_provider", provider: "corp-oauth", authType: "oauth",
 		})).rejects.toThrow("refresh transport aborted");
-		expect(harness.authStorage.get("corp-oauth")).toEqual({ type: "api_key", key: "previous" });
+		expect(harness.authStorage.get("corp-oauth")).toMatchObject({ type: "oauth", access: "new-secret" });
 	});
 
-	it("rolls back when model refresh reports an aborted result", async () => {
+	it("completes login and keeps the credential when model refresh reports an aborted result", async () => {
 		const { harness, runtime } = await createRuntimeHarness();
 		harness.authStorage.set("corp-oauth", { type: "api_key", key: "previous" });
 		harness.session.modelRegistry.registerProvider("corp-oauth", {
@@ -434,9 +434,10 @@ describe("isolated engine OAuth", () => {
 			output: () => {},
 		});
 
-		await expect(handler({
+		const response = await handler({
 			id: "login", type: "login_provider", provider: "corp-oauth", authType: "oauth",
-		})).rejects.toThrow("Model refresh aborted after OAuth login");
-		expect(harness.authStorage.get("corp-oauth")).toEqual({ type: "api_key", key: "previous" });
+		});
+		expect(response).toMatchObject({ success: true, data: { provider: "corp-oauth", cancelled: false } });
+		expect(harness.authStorage.get("corp-oauth")).toMatchObject({ type: "oauth", access: "new-secret" });
 	});
 });


### PR DESCRIPTION
## Summary

Restores upstream pi's invariant that a completed OAuth login can never be undone by the model-catalog refresh that follows it. This fixes a Linux-reported trap where `/login` always failed with `Model refresh aborted after OAuth login` and every send then failed with `invalid_grant` ("Refresh token not found or invalid").

## Root cause

After a successful OAuth login, Atomic ran a full catalog refresh (hard 15 s timeout) and treated an aborted or partially failed result as a login failure, rolling the freshly persisted tokens back to the previous credential (`rpc-provider-auth.ts:persistOAuthAndRefresh`) or throwing after commit (`interactive-auth-login.ts:completeProviderAuthentication`). Providers rotate refresh tokens, so the rollback could re-install a server-side-invalidated credential — a permanent `invalid_grant` that no re-login could escape, since each re-login was rolled back the same way. Any machine with a slow route to catalog endpoints (e.g. `pi.dev`) hit this deterministically. Upstream pi ignores the refresh outcome after login (`ModelRuntime.login`), so it cannot enter this state.

## Changes

- `rpc-provider-auth.ts`: persist the credential, run the post-login refresh best-effort, drop the rollback and the aborted/per-provider-error classification. A thrown refresh still propagates but no longer unpersists tokens.
- `interactive-auth-login.ts`: drop the provider-error and refresh-aborted throws after a completed login; models fall back to the cached snapshot.
- Regression tests updated in `rpc-oauth-login.test.ts` and `interactive-auth-login.test.ts`: credentials survive provider-error, thrown, and aborted refreshes; added an aborted-refresh interactive case.
- Changelog entry under `[Unreleased]`.

## Notes

- Verified with `bun run typecheck`, `bun run lint`, `bun run check:file-length`, and `bunx vitest --run test/rpc-oauth-login.test.ts test/interactive-auth-login.test.ts` (21/21 pass).
- Not addressed here (possible follow-up): failed catalog fetches never set `lastModified`, so they bypass the 4-hour revalidation window and retry on every refresh — identical to upstream, but it keeps `/model` slow on machines with unreachable catalog endpoints.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787892126&installation_model_id=10562&pr_number=2059&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2059&signature=048fe80e8729288b13d8f264f74a48ed96dc0afd0de17f7c46d0825551779e52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR preserves newly acquired OAuth credentials when the post-login model-catalog refresh fails.
- Treats returned provider errors and aborted refresh results as non-fatal in interactive and RPC login flows.
- Removes credential rollback after the RPC credential commit.
- Updates regression coverage for provider-error, thrown-error, and aborted-refresh outcomes.
- Documents the behavior change in the coding-agent changelog.

<h3>Confidence Score: 3/5</h3>

This PR should not merge until RPC cancellation during the post-commit refresh is distinguished from a successful login without rolling back the rotated credential.

An abort during model refresh resolves as an aborted result, but the changed RPC path ignores that result and returns cancelled false, allowing one login request to produce both a successful cancellation acknowledgment and a successful login response.

**Files Needing Attention:** packages/coding-agent/src/modes/rpc/rpc-provider-auth.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified the cancellation flow by executing the real RPC command with the OAuth harness, pausing ModelRegistry.refresh after credential persistence, and confirming cancel\_login\_provider returned success before the refresh aborted, while the correlated login\_provider response showed success with cancelled: false and the OAuth credential remained stored.
- Observed the test run completed with exit code 0, duration 5.918s, and all Vitest tests passing (2/2 files, 21/21 tests) according to the run log, with no additional setups or services started.

<a href="https://app.greptile.com/trex/runs/16340450/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/src/modes/rpc/rpc-provider-auth.ts | Preserves committed OAuth credentials across refresh failures, but now reports success when cancellation arrives during the post-commit refresh. |
| packages/coding-agent/src/modes/interactive/interactive-auth-login.ts | Makes returned provider errors and aborted refresh results non-fatal after interactive authentication. |
| packages/coding-agent/test/rpc-oauth-login.test.ts | Updates credential-survival regression cases but does not cover cancellation after credential persistence. |
| packages/coding-agent/test/interactive-auth-login.test.ts | Verifies interactive login completion for provider-error and aborted refresh results. |
| packages/coding-agent/CHANGELOG.md | Documents that post-login catalog refresh outcomes no longer roll back OAuth credentials. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant RPC as RpcProviderAuth
  participant Store as Auth Storage
  participant Registry as Model Registry
  Client->>RPC: login_provider
  RPC->>Store: Persist new OAuth credential
  RPC->>Registry: refresh(signal)
  Client->>RPC: cancel_login_provider
  RPC->>Registry: Abort signal
  Registry-->>RPC: "{ aborted: true }"
  RPC-->>Client: Login success, cancelled: false
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/src/modes/rpc/rpc-provider-auth.ts:136-137
**Cancellation reports login success**

When `cancel_login_provider` arrives after the credential is persisted but during the catalog refresh, `refresh()` returns an aborted result normally and this path continues to report `cancelled: false`. The client consequently receives both a successful cancellation acknowledgment and a successful login response.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): never roll back OAuth credent..."](https://github.com/bastani-inc/atomic/commit/500ce86193660527ce2eccb67bf58cafe07839b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48212793)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->