### PR TITLE
docs(changelog): cut release notes for 0.9.11-alpha.8

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.11-alpha.8] - 2026-07-29
+
 ### Breaking Changes
 
 - Replaced Atomic's legacy extension OAuth registration bridge with provider-owned authentication from `@earendil-works/pi-ai`. Extensions must declare OAuth or API-key authentication on their provider registration. The package root no longer exports the bridge functions `registerOAuthProvider`, `resetOAuthProviders`, `getOAuthApiKey`, `getOAuthProvider`, or `getOAuthProviders`, nor the bridge and credential/status types `LegacyOAuthProvider`, `OAuthProviderDescriptor`, `ApiKeyCredential`, `AuthCredential`, `AuthStatus`, or `OAuthCredential`; import current credential types from `@earendil-works/pi-ai` and use provider-owned authentication instead. The internal legacy registration/refresh machinery and custom API-key login hooks beyond pi's provider contract were also removed.


### PR DESCRIPTION
## Summary

Cuts release notes for prerelease `0.9.11-alpha.8`, promoting the accumulated `[Unreleased]` entries in `packages/coding-agent/CHANGELOG.md` under a dated `## [0.9.11-alpha.8]` heading.

Changelog-only diff. No package manifest, lockfile, Cargo manifest, or generated version file is touched: the release base stays versionless at `0.0.0`, and `scripts/cut-release.ts` stamps the real version on the detached `Release 0.9.11-alpha.8` commit after this PR merges.

## Release contents

**Breaking Changes**
- Legacy extension OAuth registration bridge replaced by provider-owned authentication from `@earendil-works/pi-ai`.
- Model configuration follows pi's single-file `ModelConfig` contract (one `models.json` from the active agent directory).
- Model-catalog refresh adopts pi's timeout semantics; the `/model` selector owns its 15s refresh timeout.
- `streamSimple` implementations are scoped to their registered provider and `ModelRuntime`.
- Remote catalogs publish refreshed models in memory before persisting.
- `AuthStorage` implements pi's async `CredentialStore` contract; sync compatibility surface removed.
- `ModelRegistry` is constructed from a `ModelRuntime` and exposes only the thin compatibility facade.
- `CreateAgentSessionOptions` drops the `authStorage` and `modelRegistry` overrides in favor of `modelRuntime`.

**Changed**
- Adopted pi's provider-owned `ModelRuntime` architecture for model composition, credentials, streaming, and catalog refresh.

**Fixed**
- OAuth logins are no longer destroyed by an unrelated model-catalog refresh.
- `/model` no longer reports a llama.cpp refresh failure for users without a llama.cpp server.
- RPC `save_provider_credential` writes now persist to `auth.json` across restarts.
- GitHub Copilot `COPILOT_GITHUB_TOKEN` auth is routed to the correct API host, fixing `421 Misdirected Request`.

## Validation

- `bun run typecheck` — passed
- `bun run check:file-length` — passed
- `bun run lint`, `bun run check:file-length`, `bun run test:unit` via prek pre-commit hooks — passed
- Verified every `packages/*/package.json` remains at `0.0.0`

## Notes

Do not merge, tag, or publish from this stage. Tagging happens only after merge, via `scripts/cut-release.ts`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787964121&installation_model_id=10562&pr_number=2067&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2067&signature=f30f2c4abbf778bf6c2d1be34c2d8bfe8a02c496ac1a0247d517072c9a279f29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Cuts the accumulated coding-agent release notes into the dated `0.9.11-alpha.8` prerelease section while leaving `Unreleased` empty for future entries.

The changelog was checked against its parent revision: the moved notes are unchanged, the new alpha.8 heading immediately follows `Unreleased`, alpha.8 remains before alpha.7, and the diff is free of whitespace errors. No defects were found.

<h3>Confidence Score: 5/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the pre-cut release notes to confirm content lived under Unreleased and that there was no alpha.8 heading.
- Verified after the cut that Unreleased is empty, alpha.8 follows it and precedes alpha.7, with content exactly matching the prior Unreleased block.
- Ran the changelog release-cut validation script to confirm the exact content preservation during the move.
- Reviewed the validation script's results to confirm a successful preservation of the prior Unreleased content.

<a href="https://app.greptile.com/trex/runs/16504255/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): cut release notes for 0..."](https://github.com/bastani-inc/atomic/commit/040f0ffdf5907c174cee70d398dfd588a70e8ad5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48539597)</sub>

<!-- /greptile_comment -->