### PR TITLE
fix(ci): bound every release dependency fetch so a stalled mirror cannot skip the publish graph

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,12 +41,12 @@ jobs:
       version: ${{ steps.verify.outputs.version }}
       npm-tag: ${{ steps.verify.outputs.npm-tag }}
     steps:
-      - uses: useblacksmith/checkout@v1
+      - uses: useblacksmith/checkout@01ab2a058dd0d41e292217b76582a6f9867c02ce # v1.0.0-beta
         with:
           ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
           persist-credentials: false
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
       - name: Verify tag commit identity
@@ -74,31 +74,59 @@ jobs:
     name: Native ${{ matrix.platform }} ${{ matrix.arch }}
     needs: integrity
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 15
+    # Per-leg wall-clock budgets, sized from the last eight releases. One
+    # 15-minute cap covering six legs whose real work spans 55s to 443s detects
+    # nothing: run 30517879019 (0.9.11-alpha.8) spent 13m27s inside a single
+    # stalled Zig mirror, was cancelled 8s after its artifact upload had
+    # already succeeded, and a cancelled `needs` dependency then skipped the
+    # payload build, draft staging, npm publication, and release publication.
+    # These job caps are hang detectors. The stall detectors are the per-step
+    # `timeout-minutes` on every acquisition step below.
+    timeout-minutes: ${{ matrix.timeout_minutes }}
+    env:
+      # cargo-xwin downloads both x86_64 and aarch64 CRT/SDK by default. Each
+      # Windows leg links exactly one of them.
+      XWIN_ARCH: ${{ matrix.arch == 'x64' && 'x86_64' || 'aarch64' }}
     strategy:
       fail-fast: false
       matrix:
+        # timeout_minutes caps the job; build_timeout_minutes caps the compile
+        # step alone, from that leg's own measured p100 compile.
         include:
-          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: linux, arch: x64, target: x86_64-unknown-linux-gnu }
-          - { runner: blacksmith-4vcpu-ubuntu-2404-arm, platform: linux, arch: arm64, target: aarch64-unknown-linux-gnu }
-          - { runner: macos-26-intel, platform: darwin, arch: x64, target: x86_64-apple-darwin }
-          - { runner: blacksmith-6vcpu-macos-26, platform: darwin, arch: arm64, target: aarch64-apple-darwin }
-          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: win32, arch: x64, target: x86_64-pc-windows-msvc }
-          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: win32, arch: arm64, target: aarch64-pc-windows-msvc }
+          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: linux, arch: x64, target: x86_64-unknown-linux-gnu, timeout_minutes: 7, build_timeout_minutes: 5 }
+          - { runner: blacksmith-4vcpu-ubuntu-2404-arm, platform: linux, arch: arm64, target: aarch64-unknown-linux-gnu, timeout_minutes: 8, build_timeout_minutes: 5 }
+          - { runner: macos-26-intel, platform: darwin, arch: x64, target: x86_64-apple-darwin, timeout_minutes: 9, build_timeout_minutes: 8 }
+          - { runner: blacksmith-6vcpu-macos-26, platform: darwin, arch: arm64, target: aarch64-apple-darwin, timeout_minutes: 5, build_timeout_minutes: 5 }
+          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: win32, arch: x64, target: x86_64-pc-windows-msvc, timeout_minutes: 10, build_timeout_minutes: 5 }
+          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: win32, arch: arm64, target: aarch64-pc-windows-msvc, timeout_minutes: 10, build_timeout_minutes: 5 }
     steps:
-      - uses: useblacksmith/checkout@v1
+      # useblacksmith/checkout consumes a Blacksmith sticky disk. Sticky disks
+      # are ext4 block devices, so they exist only on Blacksmith Linux runners.
+      # The win32 legs cross-compile on Linux and keep the git mirror. On
+      # blacksmith-6vcpu-macos-26 the action blocked 78s in 8 of 8 releases on
+      # `gRPC connection test failed` before falling back to a normal clone.
+      - uses: useblacksmith/checkout@01ab2a058dd0d41e292217b76582a6f9867c02ce # v1.0.0-beta
+        if: runner.os == 'Linux'
         with:
           ref: ${{ env.SOURCE_REF }}
           persist-credentials: false
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: runner.os != 'Linux'
+        with:
+          ref: ${{ env.SOURCE_REF }}
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
       # rustup needs the bare target. Linux's napi build separately receives
       # the glibc-suffixed target consumed by cargo-zigbuild.
-      - uses: dtolnay/rust-toolchain@stable
+      # 4 minutes bounds a rustup fetch that took 135s on Native win32 arm64 in
+      # run 29987786023 against a 4-14s norm across eight releases.
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        timeout-minutes: 4
         with:
           toolchain: 1.97.0
           targets: ${{ matrix.target }}
@@ -124,33 +152,107 @@ jobs:
         if: matrix.arch == 'x64'
         shell: bash
         run: echo 'RUSTFLAGS=-C target-cpu=x86-64-v2' >> "$GITHUB_ENV"
+      # Two community Zig mirrors have stalled a release. Run 30517879019
+      # (0.9.11-alpha.8, 2026-07-30): zig.bcr.ist trickled for 795.9s and then
+      # succeeded. Run 30416909872 (0.9.11-alpha.7, 2026-07-29):
+      # zigmirror.hryx.net burned 437.6s on a TCP connect that never completed
+      # before failing over to a mirror that served the file in 5.2s.
+      # setup-zig fetches the community mirror list at run time and shuffles
+      # it, and applies no per-mirror deadline, so the wait is bounded only by
+      # the job budget. 2 minutes is 3.2x the worst healthy acquisition
+      # measured over eight releases (37s). The retry re-shuffles the
+      # 16-mirror list, so a stall now costs at most 4 minutes and fails
+      # loudly instead of silently cancelling the release graph.
       - name: Setup zig for portable Linux GNU builds
+        id: zig
         if: matrix.platform == 'linux'
-        uses: mlugg/setup-zig@v2
+        continue-on-error: true
+        timeout-minutes: 2
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.16.0
+          # RUNNER_ENVIRONMENT is not github-hosted on Blacksmith, so setup-zig
+          # would otherwise copy Zig into an /opt/hostedtoolcache that dies
+          # with the VM (1.4-7.3s of pure loss).
+          use-tool-cache: false
+          # This is the global .zig-cache entry, not the tarball cache. It has
+          # missed on every release tag and its save key embeds the run id and
+          # attempt, so it can never be reused. Disabling it also keeps a
+          # killed attempt's post step inert, so the retry below cannot add a
+          # duplicate-key save failure.
+          use-cache: false
+      - name: Retry zig acquisition on a re-shuffled mirror list
+        if: matrix.platform == 'linux' && steps.zig.outcome == 'failure'
+        timeout-minutes: 2
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.16.0
+          use-tool-cache: false
+          use-cache: false
+      # An unversioned taiki-e tool resolves to @latest, floating the build
+      # toolchain of a published, provenance-signed native artifact with no
+      # diff. Both currently resolve to 0.23.0.
       - name: Install cargo-zigbuild for portable Linux GNU builds
         if: matrix.platform == 'linux'
-        uses: taiki-e/install-action@v2
+        timeout-minutes: 3
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
-          tool: cargo-zigbuild
+          tool: cargo-zigbuild@0.23.0
       - name: Install Windows cross-compile tooling
         if: matrix.platform == 'win32'
+        timeout-minutes: 5
         run: |
           sudo apt-get update
           sudo apt-get install -y clang lld llvm
       - name: Install cargo-xwin
         if: matrix.platform == 'win32'
-        uses: taiki-e/install-action@v2
+        timeout-minutes: 3
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
-          tool: cargo-xwin
+          tool: cargo-xwin@0.23.0
+      # cargo-xwin defaults XWIN_CACHE_DIR to dirs::cache_dir()/cargo-xwin.
+      # Pinning it keeps the populate step, the build step, and the
+      # actions/cache path in agreement regardless of XDG_CACHE_HOME.
+      - name: Resolve MSVC CRT cache directory
+        if: matrix.platform == 'win32'
+        shell: bash
+        run: echo "XWIN_CACHE_DIR=$HOME/.cache/cargo-xwin" >> "$GITHUB_ENV"
+      # The MSVC CRT and Windows SDK download is the largest standing cost in
+      # this job: 3m46s to 6m19s per Windows leg, on every release, uncached,
+      # for a ~25s compile. Key epoch `xwin-v1`: XWIN_SDK_VERSION and
+      # XWIN_CRT_VERSION default to "latest", so a hit pins the leg to
+      # whichever SDK was first stored under this key. That is more
+      # reproducible than resolving "latest" on every release, and bumping the
+      # epoch is the deliberate lever for an SDK refresh.
+      - name: Restore MSVC CRT and Windows SDK
+        if: matrix.platform == 'win32'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/cargo-xwin
+          key: xwin-v1-${{ matrix.arch }}-17
+      # 8 minutes is 1.27x the worst full download measured over five releases
+      # (6m19s, Native win32 arm64, run 30416909872). Per-leg XWIN_ARCH should
+      # cut that materially, but this bound is sized on what has been measured,
+      # not on the expected saving.
+      - name: Populate MSVC CRT cache on miss
+        if: matrix.platform == 'win32'
+        timeout-minutes: 8
+        env:
+          XWIN_ACCEPT_LICENSE: "1"
+        run: cargo-xwin xwin cache xwin
+      # With the CRT fetch hoisted into its own bounded step, this step is a
+      # compile. Each budget is that leg's measured p100 compile over eight
+      # releases times at least 1.4: linux x64 62s, linux arm64 152s, darwin
+      # arm64 40s, darwin x64 335s, and ~25s on both Windows legs once the CRT
+      # is acquired above.
       - name: Build native binding
+        timeout-minutes: ${{ matrix.build_timeout_minutes }}
         env:
           CROSS_TARGET: ${{ matrix.platform != 'darwin' && steps.target.outputs.build-target || '' }}
           NATIVE_TARGET: ${{ matrix.platform == 'darwin' && matrix.target || '' }}
           XWIN_ACCEPT_LICENSE: "1"
         run: bun run --cwd packages/natives build
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: atomic-natives-${{ matrix.platform }}-${{ matrix.arch }}
           path: packages/natives/native/*.node
@@ -163,17 +265,18 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
-      - uses: useblacksmith/checkout@v1
+      - uses: useblacksmith/checkout@01ab2a058dd0d41e292217b76582a6f9867c02ce # v1.0.0-beta
         with:
           ref: ${{ env.SOURCE_REF }}
           persist-credentials: false
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        timeout-minutes: 4
         with:
           toolchain: 1.97.0
       - name: Build Linux x64 archive
@@ -205,17 +308,21 @@ jobs:
     runs-on: blacksmith-4vcpu-windows-2025
     timeout-minutes: 15
     steps:
-      - uses: useblacksmith/checkout@v1
+      # blacksmith-4vcpu-windows-2025 has no sticky disk, so the Blacksmith
+      # git-mirror checkout warns and falls back to a standard clone anyway.
+      # Ask for the clone directly.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.SOURCE_REF }}
           persist-credentials: false
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        timeout-minutes: 4
         with:
           toolchain: 1.97.0
       - name: Build Windows x64 archive
@@ -251,14 +358,14 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:
-      - uses: useblacksmith/checkout@v1
+      - uses: useblacksmith/checkout@01ab2a058dd0d41e292217b76582a6f9867c02ce # v1.0.0-beta
         with:
           ref: ${{ env.SOURCE_REF }}
           persist-credentials: false
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
@@ -267,7 +374,7 @@ jobs:
           bun install --frozen-lockfile
           bun run check:shrinkwrap
       - name: Download native bindings
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: atomic-natives-*
           path: packages/natives/native
@@ -319,7 +426,7 @@ jobs:
             const actual = Object.keys(root.optionalDependencies ?? {});
             if (actual.length !== 6 || actual.some((name) => !expected.has(name) || root.optionalDependencies[name] !== process.env.VERSION)) throw new Error("native optionalDependencies must be the six exact-version platform packages");'
       - name: Upload release payload
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-payload-${{ env.RELEASE_TAG }}
           path: |
@@ -339,7 +446,7 @@ jobs:
     env:
       GH_REPO: ${{ github.repository }}
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-payload-${{ env.RELEASE_TAG }}
       - name: Validate and stage draft release
@@ -368,11 +475,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-payload-${{ env.RELEASE_TAG }}
           path: payload
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,13 @@ jobs:
         # 10m while building or smoke-testing the release archive.
         timeout-minutes: ${{ matrix.timeout_minutes }}
         steps:
-            - uses: useblacksmith/checkout@v1
+            # useblacksmith/checkout consumes a Blacksmith sticky disk. Sticky
+            # disks are ext4 block devices and exist only on Blacksmith Linux
+            # runners, so on blacksmith-4vcpu-windows-2025 the action warns
+            # ("sticky disks are not supported on Windows runners") and falls
+            # back to a standard clone. Ask Windows for the clone directly.
+            - uses: useblacksmith/checkout@01ab2a058dd0d41e292217b76582a6f9867c02ce # v1.0.0-beta
+              if: runner.os == 'Linux'
               with:
                   # LFS fixtures are required by the coding-agent test suite.
                   lfs: true
@@ -39,16 +45,30 @@ jobs:
                   # release tooling. Blacksmith's git mirror keeps this checkout
                   # inexpensive while preserving those repository-wide checks.
                   fetch-depth: 0
-            - uses: oven-sh/setup-bun@v2
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              if: runner.os != 'Linux'
               with:
-                  bun-version: latest
+                  lfs: true
+                  fetch-depth: 0
+            - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+              with:
+                  # Pinned to match publish.yml. `latest` cannot be cached by
+                  # setup-bun, so every job on every run re-downloaded Bun from
+                  # GitHub releases, and the suite tested a different Bun from
+                  # the one that builds the shipped artifact.
+                  bun-version: 1.3.14
             # Node is required by test/integration/installed-package-node-extensions.test.ts,
             # which smoke-tests the built npm package under the Node runtime (the
             # `atomic` bin runs via `#!/usr/bin/env node` for npm/bun installs).
-            - uses: actions/setup-node@v7
+            - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: 24
-            - uses: dtolnay/rust-toolchain@stable
+            - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+              timeout-minutes: 4
+              with:
+                  # Required once the action is pinned by SHA: the version is
+                  # otherwise taken from the branch name in the `uses:` ref.
+                  toolchain: stable
             - name: Install dependencies
               run: bun install --frozen-lockfile
             - name: Typecheck
@@ -68,6 +88,7 @@ jobs:
               # which is missing from the npm registry (404) and breaks
               # `bunx mintlify@latest` for every PR. Unpin once upstream
               # publishes a resolvable release.
+              timeout-minutes: 5
               run: |
                   bunx --bun mintlify@4.2.731 validate
                   bunx --bun mintlify@4.2.731 broken-links
@@ -203,7 +224,7 @@ jobs:
                   }
             - name: Upload flaky-test diagnostics
               if: always()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: test-diagnostics-${{ matrix.binary_platform }}
                   path: .ci-diagnostics/

--- a/.github/workflows/warm-toolchain-cache.yml
+++ b/.github/workflows/warm-toolchain-cache.yml
@@ -1,0 +1,90 @@
+name: Warm toolchain cache
+
+# Every release tag pays a cold Zig and MSVC CRT fetch. `actions/cache` entries
+# are scoped per branch or tag, with a read fallback to the default branch;
+# `publish.yml` only ever runs on `refs/tags/*` and nothing on `main` writes
+# these keys, so the fallback scope is empty and every release is a guaranteed
+# cold download from a community mirror and from Microsoft.
+#
+# This workflow performs only those two acquisitions on `main` so the
+# default-branch scope holds fresh entries. It writes nothing and builds
+# nothing.
+#
+# GATE: this is deliberately dispatch-only. Whether a `refs/tags/*` run can
+# read a `refs/heads/main` cache entry on Blacksmith's colocated cache is
+# documented but unverified for this repository. Run the experiment in
+# docs/ci.md ("Warming the release toolchain caches") first: dispatch this
+# workflow on `main`, then dispatch `publish.yml` against an existing tag and
+# check whether the Linux legs log `Cache hit for: setup-zig-tarball-...`. Add
+# a daily `schedule:` trigger here only after that hit is observed; entries
+# evict after 7 days of inactivity, so a daily run is what keeps them alive.
+# If the fallback does not apply, delete this file: the per-step bounds in
+# `publish.yml` are what actually hold the line, and this is only an
+# optimisation.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: warm-toolchain-cache
+  cancel-in-progress: true
+
+jobs:
+  zig-tarball:
+    name: Warm zig ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: blacksmith-4vcpu-ubuntu-2404, arch: x64 }
+          - { runner: blacksmith-4vcpu-ubuntu-2404-arm, arch: arm64 }
+    steps:
+      # setup-zig writes `setup-zig-tarball-zig-<host arch>-linux-0.16.0`, so
+      # the aarch64 key needs an arm64 runner. Keep the version, the tool-cache
+      # setting, and the global-cache setting identical to `publish.yml`, or
+      # this warms a key that job never reads.
+      - name: Fetch and cache the Zig tarball
+        timeout-minutes: 4
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.16.0
+          use-tool-cache: false
+          use-cache: false
+
+  msvc-crt:
+    name: Warm MSVC CRT ${{ matrix.arch }}
+    # Both Windows legs of `native-artifacts` cross-compile on this Linux
+    # runner spec, so both CRT keys are written here.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x64, arm64]
+    env:
+      XWIN_ARCH: ${{ matrix.arch == 'x64' && 'x86_64' || 'aarch64' }}
+    steps:
+      - name: Install cargo-xwin
+        timeout-minutes: 3
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
+        with:
+          tool: cargo-xwin@0.23.0
+      - name: Resolve MSVC CRT cache directory
+        shell: bash
+        run: echo "XWIN_CACHE_DIR=$HOME/.cache/cargo-xwin" >> "$GITHUB_ENV"
+      # The key epoch must match `publish.yml`. Bumping it there without
+      # bumping it here leaves the release paying a cold download again.
+      - name: Restore MSVC CRT and Windows SDK
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/cargo-xwin
+          key: xwin-v1-${{ matrix.arch }}-17
+      - name: Populate MSVC CRT cache on miss
+        timeout-minutes: 8
+        env:
+          XWIN_ACCEPT_LICENSE: "1"
+        run: cargo-xwin xwin cache xwin

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -23,6 +23,11 @@ Release tag push (`0.9.10` or `0.9.10-alpha.1`)
    ├─ publish-npm: tokenless OIDC publication, skipping existing versions
    ├─ publish-github-release: undraft only after npm succeeds
    └─ cleanup-draft-github-release: delete a draft when later work fails
+
+Manual dispatch on `main`
+└─ warm-toolchain-cache.yml
+   ├─ zig-tarball: fetch Zig on Linux x64 and arm64
+   └─ msvc-crt: fetch the MSVC CRT and Windows SDK for each Windows arch
 ```
 
 This release graph follows pi's draft-first publication shape. Public GitHub Release publication remains last so users never see a release whose npm publication failed.
@@ -96,6 +101,130 @@ The old publisher built both Linux GNU bindings directly on Ubuntu 24.04, so its
 
 The build job downloads the six same-run bindings, generates the six platform npm packages, and populates the root native package's exact-version optional dependencies without publishing during preparation.
 
+### Dependency-fetch bounds in the native matrix
+
+`native-artifacts` compiles for 20–30 s on Linux and Windows. Everything else in
+its budget is a third-party download, and two releases have been damaged by one.
+
+| Release | Run | Leg | Stall |
+| --- | --- | --- | --- |
+| `0.9.11-alpha.7` (2026-07-29) | `30416909872` | Native linux x64 | `zigmirror.hryx.net` held a TCP connect open for **437.6 s**, then the next mirror served the tarball in 5.2 s |
+| `0.9.11-alpha.8` (2026-07-30) | `30517879019` | Native linux arm64 | `zig.bcr.ist` trickled for **795.9 s** and then succeeded; the job was cancelled by its 15-minute cap 8 s after `actions/upload-artifact` had already succeeded, and `build`, `stage-github-release`, `publish-npm`, and `publish-github-release` were all skipped, so the tag shipped nothing |
+
+`mlugg/setup-zig` fetches the community mirror list at run time and shuffles it,
+and applies no per-mirror deadline, so before this change the only bound on a
+stalled mirror was the job budget.
+
+**Step bounds are the stall detector; job caps are only hang detectors.** A job
+cap cannot distinguish a stall from slow work, and cancelling a job silently
+skips every job that `needs` it. Each acquisition step therefore carries its own
+`timeout-minutes`:
+
+| Step | Bound | Basis |
+| --- | --- | --- |
+| `mlugg/setup-zig`, plus one retry | 2 min each | 3.2× the worst healthy acquisition over eight releases (37 s); the retry re-shuffles the 16-mirror list, so a stall costs at most 4 min and fails loudly |
+| `dtolnay/rust-toolchain` | 4 min | one rustup fetch took 135 s against a 4–14 s norm |
+| `taiki-e/install-action` | 3 min | |
+| `apt-get` LLVM install | 5 min | |
+| `cargo-xwin xwin cache xwin` | 8 min | 1.27× the worst measured full CRT/SDK download (6 m 19 s) |
+| `Build native binding` | `matrix.build_timeout_minutes` | that leg's measured p100 compile × ≥1.4 |
+
+Job caps replace the former blanket `timeout-minutes: 15`, which was 16× the
+real work of the fastest leg and 2× that of the slowest:
+
+| Leg | Healthy p100 | Cap |
+| --- | --- | --- |
+| linux x64 | 107 s | 7 min |
+| linux arm64 | 233 s | 8 min |
+| darwin x64 | 387 s | 9 min |
+| darwin arm64 | 61 s after the checkout change | 5 min |
+| win32 x64 | 351 s | 10 min |
+| win32 arm64 | 443 s | 10 min |
+
+`native-artifacts` sets an explicit `name:`, so these matrix columns do not
+rename its jobs. Re-measure before tightening any of them further, and never
+tighten a leg on fewer than five samples: a cap below a real p100 turns a slow
+but healthy run into the cancellation this section exists to prevent.
+
+### MSVC CRT cache epoch
+
+Both Windows legs cross-compile with `cargo-xwin`, which downloaded the MSVC CRT
+and Windows SDK on every release: 3 m 46 s to 6 m 19 s per leg, for a ~25 s
+compile. That download now happens in its own bounded step behind an
+`actions/cache` entry keyed `xwin-v1-<arch>-17`, and each leg sets `XWIN_ARCH` so
+it stops downloading the architecture it does not link.
+
+`XWIN_SDK_VERSION` and `XWIN_CRT_VERSION` default to `latest`, so the key cannot
+express the content version: a cache hit pins the leg to whichever SDK was first
+stored under that key. That is more reproducible than resolving `latest` on every
+release, but it means **the `v1` epoch in the key is the only lever for a
+deliberate SDK refresh**. To force one, bump the epoch (`xwin-v2-…`) in both
+`.github/workflows/publish.yml` and `.github/workflows/warm-toolchain-cache.yml`
+in the same change; a CI contract test asserts the two keys stay equal. The
+trailing `17` is `XWIN_VERSION`, the Visual Studio major version.
+
+### Warming the release toolchain caches
+
+`actions/cache` entries are scoped per branch or tag with a read fallback to the
+default branch. `publish.yml` only ever runs on `refs/tags/*` and nothing on
+`main` writes the Zig or CRT keys, so every release tag has been a guaranteed
+cold fetch on both Linux legs (six of six observed misses; a re-run of the *same*
+tag hits).
+
+`.github/workflows/warm-toolchain-cache.yml` performs only those two
+acquisitions so the default-branch scope holds fresh entries. It is
+**dispatch-only and deliberately not yet scheduled**: whether a `refs/tags/*` run
+can read a `refs/heads/main` entry on Blacksmith's colocated cache is documented
+but unverified here. Verify it before relying on it:
+
+1. Dispatch `warm-toolchain-cache.yml` on `main` and confirm the
+   `setup-zig-tarball-zig-x86_64-linux-0.16.0` save.
+2. Dispatch `publish.yml` against an existing tag with `source_ref` set.
+3. Check whether the Linux legs log `Cache hit for: setup-zig-tarball-…`.
+
+A hit justifies adding a daily `schedule:` trigger, which is what keeps the
+entries alive (they evict after 7 days of inactivity). A miss means the warm
+workflow buys nothing and should be deleted; the step bounds above, not the
+cache, are what hold the line.
+
+### Sticky-disk checkout is Linux-only
+
+`useblacksmith/checkout@v1` consumes a Blacksmith sticky disk. Sticky disks are
+ext4 block devices, so they exist only on Blacksmith **Linux** runners. On
+`blacksmith-4vcpu-windows-2025` the action warns (`sticky disks are not supported
+on Windows runners`) and falls back to a standard clone; on
+`blacksmith-6vcpu-macos-26` it blocked 78 s on a gRPC connect timeout in eight of
+eight releases before falling back. The warning's advice to "remove the sticky
+disk step" is misleading — there is no sticky-disk step, the checkout action is
+the consumer.
+
+Both workflows therefore use `useblacksmith/checkout` behind
+`if: runner.os == 'Linux'` and `actions/checkout` otherwise. The two `win32` legs
+of `native-artifacts` cross-compile on Linux and keep the git mirror. Do not
+remove the mirror from a Linux leg: `test.yml` checks out with `fetch-depth: 0`
+and `lfs: true`, which the mirror serves in about 8 s.
+
+### Pinned actions and build tools
+
+Every third-party action in all three workflows is pinned to a full commit SHA
+with a trailing `# vX.Y.Z` comment, following upstream pi's convention.
+`publish.yml` carries `contents: write` and `id-token: write` in its graph, so a
+compromised floating tag anywhere in it is a release-integrity event.
+`.github/dependabot.yml` already runs the `github-actions` ecosystem weekly and
+maintains both the pins and the comments.
+
+`taiki-e/install-action` is given exact tool versions (`cargo-zigbuild@0.23.0`,
+`cargo-xwin@0.23.0`). Unversioned, it resolves to `@latest`, which floats the
+build toolchain of a published, provenance-signed native artifact with no diff.
+`test.yml` pins `bun-version: 1.3.14` to match `publish.yml`; `latest` cannot be
+cached by `setup-bun` and left the suite testing a different Bun from the one
+that builds the shipped artifact.
+
+A SHA pin would not have prevented either Zig stall: `mlugg/setup-zig@v2`
+resolved to the same commit in the failing attempt and the succeeding re-run, and
+the mirror list is fetched at run time rather than shipped in the action. The
+pins are supply-chain hygiene, not a fix for this incident.
+
 ### Binary smoke tests
 
 Linux and Windows x64 each run `scripts/build-binaries.sh` for their platform, extract the resulting archive, check required bundled files, run `--version`, and start `--no-session` from a clean temporary directory. Expected no-model/no-key exits are accepted; extension-load failures and unexpected exits fail the job.
@@ -154,6 +283,7 @@ Repository-wide workflow permissions are read-only. Only draft staging, undrafti
 | --- | --- | --- |
 | `.github/workflows/test.yml` | selected pushes and every pull request | workspace tests and cross-platform release smoke |
 | `.github/workflows/publish.yml` | release tag push; manual recovery dispatch | verify, build, stage draft, publish npm, undraft, clean failed drafts |
+| `.github/workflows/warm-toolchain-cache.yml` | manual dispatch (see gate above) | write the Zig and MSVC CRT cache keys into the default-branch scope |
 
 ## Release checklist
 

--- a/test/ci/ci-workflow-contracts.test.ts
+++ b/test/ci/ci-workflow-contracts.test.ts
@@ -11,6 +11,8 @@ import {
 
 const root = fileURLToPath(new URL("../..", import.meta.url));
 const publishPath = join(root, ".github/workflows/publish.yml");
+const testPath = join(root, ".github/workflows/test.yml");
+const warmPath = join(root, ".github/workflows/warm-toolchain-cache.yml");
 
 function jobBlock(workflow: string, name: string, next?: string): string {
   const start = workflow.indexOf(`  ${name}:`);
@@ -25,6 +27,23 @@ function stepBlock(workflow: string, name: string, next: string): string {
   const end = workflow.indexOf(`- name: ${next}`, start + 1);
   assert.notEqual(end, -1, `missing next step: ${next}`);
   return workflow.slice(start, end);
+}
+
+/** Split a job block into its individual steps, indentation-agnostically. */
+function jobSteps(block: string): string[] {
+  const header = /^(\s*)steps:$/mu.exec(block);
+  assert.ok(header, "job declares no steps");
+  const body = block.slice(header.index + header[0].length);
+  const first = /^([ \t]+)- /mu.exec(body);
+  assert.ok(first, "job declares no steps");
+  return body.split(new RegExp(`^${first[1] as string}- `, "gmu")).slice(1);
+}
+
+/** Every job in a workflow, paired with its own block. */
+function jobBlocks(workflow: string): [string, string][] {
+  const jobs = workflow.slice(workflow.indexOf("\njobs:\n"));
+  const names = [...jobs.matchAll(/^  ([a-z][a-z0-9-]*):$/gmu)].map(([, name]) => name as string);
+  return names.map((name, index) => [name, jobBlock(jobs, name, names[index + 1])]);
 }
 
 test("test workflow preserves its two-platform matrix and deterministic contracts", async () => {
@@ -181,7 +200,15 @@ test("native release matrix pins all shipped targets and the Linux glibc floor",
   assert.match(native, /name: atomic-natives-\$\{\{ matrix\.platform \}\}-\$\{\{ matrix\.arch \}\}/);
   assert.match(native, /macos-26-intel/);
   assert.match(native, /blacksmith-6vcpu-macos-26/);
-  assert.doesNotMatch(native, /run-id:|github-token:|artifact_lookup|cache/iu);
+  assert.doesNotMatch(native, /run-id:|github-token:|artifact_lookup/iu);
+  // The job may cache third-party toolchain acquisitions and nothing else.
+  // Caching Cargo build output would make a provenance-signed artifact depend
+  // on restored build state.
+  assert.doesNotMatch(native, /rust-cache|sccache|CARGO_TARGET_DIR/iu);
+  assert.deepEqual(
+    [...native.matchAll(/^\s+path: (\S+)$/gmu)].map(([, value]) => value),
+    ["~/.cache/cargo-xwin", "packages/natives/native/*.node"],
+  );
 });
 
 test("release build retains Atomic native, smoke, shrinkwrap, metadata, and asset contracts", async () => {
@@ -235,4 +262,140 @@ test("cut-release still creates the detached version-stamped tag", async () => {
   assert.match(script, /Release-base-ref: \$\{baseRef\}\\nRelease-base-sha: \$\{baseSha\}/);
   assert.match(script, /git -C \$\{ROOT\} push origin \$\{version\}/);
   assert.doesNotMatch(script, /Bun\.sleep|setTimeout/);
+});
+
+/**
+ * Run 30517879019 (`Publish 0.9.11-alpha.8`) spent 13m27s inside one stalled
+ * Zig mirror, was cancelled by the blanket 15-minute job cap 8s after its
+ * artifact upload had already succeeded, and the cancelled `needs` dependency
+ * then skipped the payload build, the draft, npm, and the release. A job cap
+ * cannot detect that; only a bound on the acquisition step itself can.
+ */
+test("native-artifacts bounds every dependency acquisition step", async () => {
+  const native = jobBlock(await Bun.file(publishPath).text(), "native-artifacts", "linux-binary-smoke");
+  const steps = jobSteps(native);
+  const budget = (needle: string): number => {
+    const matches = steps.filter((step) => step.includes(needle));
+    assert.equal(matches.length, 1, `expected exactly one step containing: ${needle}`);
+    const bound = /^\s*timeout-minutes: (\d+)$/mu.exec(matches[0] as string);
+    assert.ok(bound, `unbounded acquisition step: ${needle}`);
+    return Number(bound[1]);
+  };
+  assert.equal(budget("uses: dtolnay/rust-toolchain@"), 4);
+  assert.equal(budget("tool: cargo-zigbuild@"), 3);
+  assert.equal(budget("tool: cargo-xwin@"), 3);
+  assert.equal(budget("apt-get install"), 5);
+  assert.equal(budget("cargo-xwin xwin cache xwin"), 8);
+
+  const zigSteps = steps.filter((step) => step.includes("mlugg/setup-zig@"));
+  assert.equal(zigSteps.length, 2, "the Zig acquisition must keep exactly one bounded retry");
+  const [zig, retry] = zigSteps as [string, string];
+  assert.match(zig, /id: zig\n\s+if: matrix\.platform == 'linux'\n\s+continue-on-error: true\n\s+timeout-minutes: 2\n/u);
+  assert.match(retry, /if: matrix\.platform == 'linux' && steps\.zig\.outcome == 'failure'\n\s+timeout-minutes: 2\n/u);
+  for (const step of zigSteps) {
+    // The tool cache is copied into an ephemeral VM, and the global Zig cache
+    // has never been read back on a release tag. Disabling both also keeps a
+    // killed attempt's post step inert so the retry adds no failure mode.
+    assert.match(step, /use-tool-cache: false/u);
+    assert.match(step, /use-cache: false/u);
+  }
+
+  for (const step of steps) {
+    if (!/uses: (dtolnay|mlugg|taiki-e)\//u.test(step)) continue;
+    assert.match(step, /timeout-minutes: \d+/u, `unbounded acquisition step:\n${step}`);
+  }
+});
+
+/**
+ * `useblacksmith/checkout` consumes a Blacksmith sticky disk. Sticky disks are
+ * ext4 block devices, so they exist only on Blacksmith Linux runners; the
+ * Windows leg warns and falls back, and the macOS ARM leg blocked 78s on a
+ * gRPC connect timeout in 8 of 8 releases before falling back.
+ */
+test("sticky-disk checkout stays on Blacksmith Linux runners", async () => {
+  for (const path of [publishPath, testPath, warmPath]) {
+    const workflow = await Bun.file(path).text();
+    for (const [name, block] of jobBlocks(workflow)) {
+      const runsOn = /^\s+runs-on: (\S+)$/mu.exec(block)?.[1] ?? "";
+      for (const step of jobSteps(block)) {
+        if (!step.includes("useblacksmith/")) continue;
+        const guarded = /if: runner\.os == 'Linux'/u.test(step);
+        assert.ok(
+          guarded || /^blacksmith-\dvcpu-ubuntu/u.test(runsOn),
+          `${path}: job ${name} requests a sticky disk on ${runsOn || "a matrix runner"}`,
+        );
+      }
+    }
+  }
+  const publish = await Bun.file(publishPath).text();
+  assert.doesNotMatch(jobBlock(publish, "windows-binary-smoke", "build"), /useblacksmith/u);
+  for (const block of [
+    jobBlock(publish, "native-artifacts", "linux-binary-smoke"),
+    jobBlock(await Bun.file(testPath).text(), "test"),
+  ]) {
+    assert.match(block, /uses: useblacksmith\/checkout@[0-9a-f]{40}[^\n]*\n\s+if: runner\.os == 'Linux'/u);
+    assert.match(block, /uses: actions\/checkout@[0-9a-f]{40}[^\n]*\n\s+if: runner\.os != 'Linux'/u);
+  }
+});
+
+test("every third-party action is pinned to a full commit SHA with a version comment", async () => {
+  for (const path of [publishPath, testPath, warmPath]) {
+    const workflow = await Bun.file(path).text();
+    const uses = [...workflow.matchAll(/^\s*(?:- )?uses: (\S+)(.*)$/gmu)];
+    assert.ok(uses.length > 0, `${path} declares no actions`);
+    for (const [, action, trailer] of uses) {
+      assert.match(action as string, /^[\w.-]+\/[\w.-]+@[0-9a-f]{40}$/u, `${path}: ${action} is not SHA-pinned`);
+      assert.match(trailer as string, /^ # v?[\w.-]+$/u, `${path}: ${action} needs a version comment`);
+    }
+  }
+});
+
+test("the shipped build toolchain and Bun do not float", async () => {
+  const publish = await Bun.file(publishPath).text();
+  const warm = await Bun.file(warmPath).text();
+  for (const workflow of [publish, warm]) {
+    for (const [, tool] of workflow.matchAll(/^\s+tool: (\S+)$/gmu)) {
+      assert.match(tool as string, /^cargo-(zigbuild|xwin)@\d+\.\d+\.\d+$/u, `floating build tool: ${tool}`);
+    }
+  }
+  const bunVersions = new Set(
+    [...`${publish}\n${await Bun.file(testPath).text()}`.matchAll(/bun-version: (\S+)/gu)].map(([, value]) => value as string),
+  );
+  assert.deepEqual([...bunVersions], ["1.3.14"], "test.yml and publish.yml must exercise one pinned Bun");
+});
+
+test("each native leg declares its own measured job and compile budget", async () => {
+  const native = jobBlock(await Bun.file(publishPath).text(), "native-artifacts", "linux-binary-smoke");
+  assert.match(native, /^    timeout-minutes: \$\{\{ matrix\.timeout_minutes \}\}$/mu);
+  assert.match(native, /- name: Build native binding\n\s+timeout-minutes: \$\{\{ matrix\.build_timeout_minutes \}\}/u);
+  const legs = [...native.matchAll(/platform: (\w+), arch: (\w+),[^}]*timeout_minutes: (\d+), build_timeout_minutes: (\d+)/gu)]
+    .map(([, platform, arch, job, build]) => `${platform} ${arch} ${job}/${build}`);
+  assert.deepEqual(legs, [
+    "linux x64 7/5",
+    "linux arm64 8/5",
+    "darwin x64 9/8",
+    "darwin arm64 5/5",
+    "win32 x64 10/5",
+    "win32 arm64 10/5",
+  ]);
+  // The single blanket cap that covered six legs spanning 55s to 443s of real
+  // work must not come back.
+  assert.doesNotMatch(native, /timeout-minutes: 15/u);
+});
+
+test("the toolchain warm workflow stays read-only, gated, and key-compatible", async () => {
+  const warm = await Bun.file(warmPath).text();
+  const publish = await Bun.file(publishPath).text();
+  assert.match(warm, /permissions:\s*\n\s*contents: read/u);
+  assert.doesNotMatch(warm, /contents: write|id-token: write|npm publish|gh release|upload-artifact/u);
+  // Gated: whether a refs/tags/* run reads a refs/heads/main cache entry on
+  // Blacksmith's colocated cache is documented but unverified here, so the
+  // daily schedule lands only after the docs/ci.md experiment observes a hit.
+  assert.match(warm, /^on:\n  workflow_dispatch:\n/mu);
+  assert.doesNotMatch(warm, /\n\s+schedule:/u);
+  const key = /key: (xwin-v\d+-\$\{\{ matrix\.arch \}\}-\d+)/u;
+  assert.equal(key.exec(warm)?.[1], key.exec(publish)?.[1], "warm and release CRT cache keys must match");
+  const zigVersion = /uses: mlugg\/setup-zig@[^\n]*\n\s+with:\n\s+version: (\S+)/u;
+  assert.equal(zigVersion.exec(warm)?.[1], zigVersion.exec(publish)?.[1], "warm and release Zig versions must match");
+  assert.match(await Bun.file(join(root, "docs/ci.md")).text(), /xwin-v1/u);
 });

--- a/test/ci/ci-workflow-contracts.test.ts
+++ b/test/ci/ci-workflow-contracts.test.ts
@@ -14,6 +14,18 @@ const publishPath = join(root, ".github/workflows/publish.yml");
 const testPath = join(root, ".github/workflows/test.yml");
 const warmPath = join(root, ".github/workflows/warm-toolchain-cache.yml");
 
+/**
+ * File text with platform-neutral newlines.
+ *
+ * These contracts assert on what the repository stores, which is LF. But
+ * `.gitattributes` marks `*.yml` as `text` without `eol=lf`, so the Windows
+ * runner checks the workflows out as CRLF, and any pattern here containing a
+ * literal `\n` would then pass on Linux and fail on Windows.
+ */
+async function readText(path: string): Promise<string> {
+  return (await Bun.file(path).text()).replaceAll("\r\n", "\n");
+}
+
 function jobBlock(workflow: string, name: string, next?: string): string {
   const start = workflow.indexOf(`  ${name}:`);
   assert.notEqual(start, -1, `missing job: ${name}`);
@@ -47,7 +59,7 @@ function jobBlocks(workflow: string): [string, string][] {
 }
 
 test("test workflow preserves its two-platform matrix and deterministic contracts", async () => {
-  const workflow = await Bun.file(join(root, ".github/workflows/test.yml")).text();
+  const workflow = await readText(join(root, ".github/workflows/test.yml"));
   const testJob = jobBlock(workflow, "test");
   assert.match(testJob, /^[ \t]+name: test \(\$\{\{ matrix\.os \}\}, \$\{\{ matrix\.binary_platform \}\}\)$/mu);
   const matrixContexts = [...testJob.matchAll(/^[ \t]+- os: (\S+)\s+binary_platform: (\S+)$/gmu)]
@@ -92,24 +104,24 @@ test("every Bun test suite entry point declares one shared per-test timeout", as
     budgets.add(timeout[1] as string);
   }
   assert.equal(budgets.size, 1, `suite timeouts diverged: ${[...budgets].join(", ")}`);
-  assert.doesNotMatch(await Bun.file(join(root, "bunfig.toml")).text(), /^\s*timeout\s*=/mu);
+  assert.doesNotMatch(await readText(join(root, "bunfig.toml")), /^\s*timeout\s*=/mu);
   assert.match(
-    await Bun.file(join(root, ".github/workflows/test.yml")).text(),
+    await readText(join(root, ".github/workflows/test.yml")),
     /run-flaky-test-suite\.ts/u,
   );
 });
 
 test("active CI workflows contain no removed Cursor builtin smoke checks", async () => {
   for (const path of [join(root, ".github/workflows/test.yml"), publishPath]) {
-    assert.doesNotMatch(await Bun.file(path).text(), /builtin\/cursor/iu, path);
+    assert.doesNotMatch(await readText(path), /builtin\/cursor/iu, path);
   }
 });
 
 test("binary staging and every release smoke verify the exact builtin directory set", async () => {
   const checker = /scripts\/assert-builtin-set\.ts/u;
-  const testWorkflow = await Bun.file(join(root, ".github/workflows/test.yml")).text();
-  const publishWorkflow = await Bun.file(publishPath).text();
-  const buildScript = await Bun.file(join(root, "scripts/build-binaries.sh")).text();
+  const testWorkflow = await readText(join(root, ".github/workflows/test.yml"));
+  const publishWorkflow = await readText(publishPath);
+  const buildScript = await readText(join(root, "scripts/build-binaries.sh"));
 
   assert.match(stepBlock(testWorkflow, "Smoke test Linux release archive", "Smoke test Windows release archive"), checker);
   assert.match(stepBlock(testWorkflow, "Smoke test Windows release archive", "Upload flaky-test diagnostics"), checker);
@@ -122,7 +134,7 @@ test("binary staging and every release smoke verify the exact builtin directory 
 });
 
 test("publish workflow has direct tag and recovery triggers", async () => {
-  const workflow = await Bun.file(publishPath).text();
+  const workflow = await readText(publishPath);
   assert.match(workflow, /push:\s*\n\s*tags:/);
   assert.match(workflow, /"\[0-9\]\*\.\[0-9\]\*\.\[0-9\]\*"/);
   assert.match(workflow, /workflow_dispatch:\s*\n\s*inputs:\s*\n\s*tag:[\s\S]*required: true[\s\S]*source_ref:[\s\S]*required: false/);
@@ -131,7 +143,7 @@ test("publish workflow has direct tag and recovery triggers", async () => {
 });
 
 test("publish workflow uses one lightweight integrity gate", async () => {
-  const workflow = await Bun.file(publishPath).text();
+  const workflow = await readText(publishPath);
   const integrity = jobBlock(workflow, "integrity", "native-artifacts");
   assert.equal([...workflow.matchAll(/^  integrity:$/gmu)].length, 1);
   assert.match(integrity, /ref: \$\{\{ env\.RELEASE_TAG \}\}/);
@@ -143,7 +155,7 @@ test("publish workflow uses one lightweight integrity gate", async () => {
 });
 
 test("publish graph stages a draft before npm and undrafts last", async () => {
-  const workflow = await Bun.file(publishPath).text();
+  const workflow = await readText(publishPath);
   for (const job of ["integrity", "native-artifacts", "linux-binary-smoke", "windows-binary-smoke", "build", "stage-github-release", "publish-npm", "publish-github-release", "cleanup-draft-github-release"]) {
     assert.match(workflow, new RegExp(`^  ${job}:$`, "mu"));
   }
@@ -157,7 +169,7 @@ test("publish graph stages a draft before npm and undrafts last", async () => {
 });
 
 test("publish permissions, timeouts, runners, and OIDC are least privilege", async () => {
-  const workflow = await Bun.file(publishPath).text();
+  const workflow = await readText(publishPath);
   assert.match(workflow.slice(0, workflow.indexOf("jobs:")), /permissions:\s*\n\s*contents: read/);
   const npm = jobBlock(workflow, "publish-npm", "publish-github-release");
   assert.match(npm, /environment: npm-publish/);
@@ -178,7 +190,7 @@ test("publish permissions, timeouts, runners, and OIDC are least privilege", asy
 });
 
 test("native release matrix pins all shipped targets and the Linux glibc floor", async () => {
-  const workflow = await Bun.file(publishPath).text();
+  const workflow = await readText(publishPath);
   const native = jobBlock(workflow, "native-artifacts", "linux-binary-smoke");
   for (const target of [
     "x86_64-unknown-linux-gnu",
@@ -212,7 +224,7 @@ test("native release matrix pins all shipped targets and the Linux glibc floor",
 });
 
 test("release build retains Atomic native, smoke, shrinkwrap, metadata, and asset contracts", async () => {
-  const workflow = await Bun.file(publishPath).text();
+  const workflow = await readText(publishPath);
   assert.match(workflow, /"win32-arm64-msvc"/);
   assert.match(workflow, /atomic-windows-arm64\.zip/);
   assert.match(workflow, /bun run check:shrinkwrap/);
@@ -235,7 +247,7 @@ test("obsolete release workflow files and publisher-only verifiers are absent", 
 
 
 test("developer release setup documents only the direct publish workflow", async () => {
-  const setup = await Bun.file(join(root, "DEV_SETUP.md")).text();
+  const setup = await readText(join(root, "DEV_SETUP.md"));
   assert.match(setup, /tag push starts `\.github\/workflows\/publish\.yml` directly/u);
   assert.match(setup, /trusted publishers with workflow filename `publish\.yml` and environment `npm-publish`/u);
   for (const forbidden of [
@@ -257,7 +269,7 @@ test("release-base metadata remains available to the versionless cut flow", () =
 });
 
 test("cut-release still creates the detached version-stamped tag", async () => {
-  const script = await Bun.file(join(root, "scripts/cut-release.ts")).text();
+  const script = await readText(join(root, "scripts/cut-release.ts"));
   assert.match(script, /canonicalReleaseBaseRef\(baseBranch\)/);
   assert.match(script, /Release-base-ref: \$\{baseRef\}\\nRelease-base-sha: \$\{baseSha\}/);
   assert.match(script, /git -C \$\{ROOT\} push origin \$\{version\}/);
@@ -272,7 +284,7 @@ test("cut-release still creates the detached version-stamped tag", async () => {
  * cannot detect that; only a bound on the acquisition step itself can.
  */
 test("native-artifacts bounds every dependency acquisition step", async () => {
-  const native = jobBlock(await Bun.file(publishPath).text(), "native-artifacts", "linux-binary-smoke");
+  const native = jobBlock(await readText(publishPath), "native-artifacts", "linux-binary-smoke");
   const steps = jobSteps(native);
   const budget = (needle: string): number => {
     const matches = steps.filter((step) => step.includes(needle));
@@ -314,7 +326,7 @@ test("native-artifacts bounds every dependency acquisition step", async () => {
  */
 test("sticky-disk checkout stays on Blacksmith Linux runners", async () => {
   for (const path of [publishPath, testPath, warmPath]) {
-    const workflow = await Bun.file(path).text();
+    const workflow = await readText(path);
     for (const [name, block] of jobBlocks(workflow)) {
       const runsOn = /^\s+runs-on: (\S+)$/mu.exec(block)?.[1] ?? "";
       for (const step of jobSteps(block)) {
@@ -327,11 +339,11 @@ test("sticky-disk checkout stays on Blacksmith Linux runners", async () => {
       }
     }
   }
-  const publish = await Bun.file(publishPath).text();
+  const publish = await readText(publishPath);
   assert.doesNotMatch(jobBlock(publish, "windows-binary-smoke", "build"), /useblacksmith/u);
   for (const block of [
     jobBlock(publish, "native-artifacts", "linux-binary-smoke"),
-    jobBlock(await Bun.file(testPath).text(), "test"),
+    jobBlock(await readText(testPath), "test"),
   ]) {
     assert.match(block, /uses: useblacksmith\/checkout@[0-9a-f]{40}[^\n]*\n\s+if: runner\.os == 'Linux'/u);
     assert.match(block, /uses: actions\/checkout@[0-9a-f]{40}[^\n]*\n\s+if: runner\.os != 'Linux'/u);
@@ -340,7 +352,7 @@ test("sticky-disk checkout stays on Blacksmith Linux runners", async () => {
 
 test("every third-party action is pinned to a full commit SHA with a version comment", async () => {
   for (const path of [publishPath, testPath, warmPath]) {
-    const workflow = await Bun.file(path).text();
+    const workflow = await readText(path);
     const uses = [...workflow.matchAll(/^\s*(?:- )?uses: (\S+)(.*)$/gmu)];
     assert.ok(uses.length > 0, `${path} declares no actions`);
     for (const [, action, trailer] of uses) {
@@ -351,21 +363,21 @@ test("every third-party action is pinned to a full commit SHA with a version com
 });
 
 test("the shipped build toolchain and Bun do not float", async () => {
-  const publish = await Bun.file(publishPath).text();
-  const warm = await Bun.file(warmPath).text();
+  const publish = await readText(publishPath);
+  const warm = await readText(warmPath);
   for (const workflow of [publish, warm]) {
     for (const [, tool] of workflow.matchAll(/^\s+tool: (\S+)$/gmu)) {
       assert.match(tool as string, /^cargo-(zigbuild|xwin)@\d+\.\d+\.\d+$/u, `floating build tool: ${tool}`);
     }
   }
   const bunVersions = new Set(
-    [...`${publish}\n${await Bun.file(testPath).text()}`.matchAll(/bun-version: (\S+)/gu)].map(([, value]) => value as string),
+    [...`${publish}\n${await readText(testPath)}`.matchAll(/bun-version: (\S+)/gu)].map(([, value]) => value as string),
   );
   assert.deepEqual([...bunVersions], ["1.3.14"], "test.yml and publish.yml must exercise one pinned Bun");
 });
 
 test("each native leg declares its own measured job and compile budget", async () => {
-  const native = jobBlock(await Bun.file(publishPath).text(), "native-artifacts", "linux-binary-smoke");
+  const native = jobBlock(await readText(publishPath), "native-artifacts", "linux-binary-smoke");
   assert.match(native, /^    timeout-minutes: \$\{\{ matrix\.timeout_minutes \}\}$/mu);
   assert.match(native, /- name: Build native binding\n\s+timeout-minutes: \$\{\{ matrix\.build_timeout_minutes \}\}/u);
   const legs = [...native.matchAll(/platform: (\w+), arch: (\w+),[^}]*timeout_minutes: (\d+), build_timeout_minutes: (\d+)/gu)]
@@ -384,8 +396,8 @@ test("each native leg declares its own measured job and compile budget", async (
 });
 
 test("the toolchain warm workflow stays read-only, gated, and key-compatible", async () => {
-  const warm = await Bun.file(warmPath).text();
-  const publish = await Bun.file(publishPath).text();
+  const warm = await readText(warmPath);
+  const publish = await readText(publishPath);
   assert.match(warm, /permissions:\s*\n\s*contents: read/u);
   assert.doesNotMatch(warm, /contents: write|id-token: write|npm publish|gh release|upload-artifact/u);
   // Gated: whether a refs/tags/* run reads a refs/heads/main cache entry on
@@ -397,5 +409,5 @@ test("the toolchain warm workflow stays read-only, gated, and key-compatible", a
   assert.equal(key.exec(warm)?.[1], key.exec(publish)?.[1], "warm and release CRT cache keys must match");
   const zigVersion = /uses: mlugg\/setup-zig@[^\n]*\n\s+with:\n\s+version: (\S+)/u;
   assert.equal(zigVersion.exec(warm)?.[1], zigVersion.exec(publish)?.[1], "warm and release Zig versions must match");
-  assert.match(await Bun.file(join(root, "docs/ci.md")).text(), /xwin-v1/u);
+  assert.match(await readText(join(root, "docs/ci.md")), /xwin-v1/u);
 });


### PR DESCRIPTION
## Incident

`Publish 0.9.11-alpha.8` ([run 30517879019](https://github.com/bastani-inc/atomic/actions/runs/30517879019)) produced a tag that shipped nothing.

| Time (UTC) | Event |
| --- | --- |
| 05:53:23 | `Native linux arm64` starts on `blacksmith-4vcpu-ubuntu-2404-arm` |
| 05:53:54.86 | `Cache miss. Fetching Zig 0.16.0` |
| 05:53:55.40 | `Attempting mirror: https://zig.bcr.ist` (16-mirror list, shuffled per run) |
| 06:07:10.56 | `Fetch took 795944 ms` — the mirror eventually **succeeded**; it never failed over |
| 06:07:22 → 06:08:18 | `Build native binding`, 56 s |
| 06:08:19 | `actions/upload-artifact` **succeeded** |
| 06:08:27 | job `cancelled` by `timeout-minutes: 15`, **8 s after its last useful step** |
| 06:08:28 | `build`, `stage-github-release`, `publish-npm`, `publish-github-release` all `skipped` |

Not a one-off. [Run 30416909872](https://github.com/bastani-inc/atomic/actions/runs/30416909872) (`alpha.7`), `Native linux x64`, 24 hours earlier:

```
02:29:03.11  Attempting mirror: https://zigmirror.hryx.net/zig
02:36:14.79  Mirror failed with error: Error: connect ETIMEDOUT 23.93.214.244:443
02:36:19.98  Fetch took 437603 ms
```

7 m 18 s on a TCP connect that never completed, then the next mirror served the file in 5.2 s. Two of the last six releases, ~33 % incidence. `alpha.7` survived only because it drew a 7-minute stall instead of a 13-minute one.

## Mechanism

`native-artifacts` compiles for 20–30 s. Everything else in its budget is a third-party download, and none of them was bounded.

`mlugg/setup-zig` fetches `https://ziglang.org/download/community-mirrors.txt` **at run time** and shuffles it with `Math.random()`. It applies no per-mirror deadline, so the only bound on a stalled mirror was the job budget. A job cap cannot tell a stall from slow work; and because `native-artifacts` is a `needs` dependency, a `cancelled` conclusion silently skips the entire downstream release graph — including, here, an artifact that had already uploaded successfully.

The cache does not save a release either: `publish.yml` only runs on `refs/tags/*`, nothing on `main` writes those keys, so the default-branch read fallback scope is empty. Six of six observed release-tag misses; a re-run of the *same* tag hits.

Two things the brief assumed that the evidence does not support, stated here rather than used as justification:

- **A SHA pin would not have prevented this.** `mlugg/setup-zig@v2` resolved to the same commit `d1434d0` in both the failing attempt and the succeeding re-run. The mirror list is not in the action.
- **`timeout-minutes: 15` was not too generous.** The worst legitimate leg was 443 s, so 15 min was only 2.0×. Lowering it alone would have started cancelling healthy Windows legs; raising it would have turned a 13-minute stall into a "successful" 16-minute release.

## Changes

Measurements below are from the last eight `publish.yml` runs (`alpha.1`…`alpha.8`), per-step, via the Actions API.

### 1. Bound the Zig acquisition, with one re-randomised retry — the load-bearing fix

`timeout-minutes: 2` + `continue-on-error: true`, then a retry gated on `steps.zig.outcome == 'failure'`. 2 min is 3.2× the worst healthy acquisition (37 s, linux arm64). The retry re-shuffles the 16-mirror list, so a stall now costs at most 4 minutes and fails loudly, with `fail-fast: false` letting the other five legs finish and leaving a warm tarball cache for the re-run (proved: the alpha.8 re-run took 1 m 46 s).

`use-tool-cache: false` drops a 1.4–7.3 s copy into an `/opt/hostedtoolcache` that dies with the VM. `use-cache: false` disables the **global** `.zig-cache` entry — verified separately from the tarball cache in `main.js`; it has missed on every release tag and its save key embeds run id and attempt, so it can never be reused. It also keeps a killed attempt's `post.js` inert, so the retry cannot introduce a duplicate-key save failure. The tarball cache is untouched.

### 2. Bound the remaining acquisitions

`dtolnay/rust-toolchain` 4 min (one fetch took **135 s** on `Native win32 arm64` in run 29987786023 against a 4–14 s norm), `taiki-e/install-action` 3 min, the LLVM `apt-get` install 5 min.

### 3. Cache the MSVC CRT and split acquisition from build

`cargo-xwin` downloaded the CRT and Windows SDK on **every** release: 3 m 46 s – 6 m 19 s per Windows leg, for a ~25 s compile. It now runs in its own step (`cargo-xwin xwin cache xwin`, 8 min) behind an `actions/cache` entry keyed `xwin-v1-${{ matrix.arch }}-17`, with per-leg `XWIN_ARCH` so each leg stops downloading the arch it does not link.

`XWIN_CACHE_DIR` is pinned to `$HOME/.cache/cargo-xwin` via `GITHUB_ENV` so the populate step, the build step, and the cache path agree regardless of `XDG_CACHE_HOME`. `cargo-xwin` writes a `DONE` marker listing downloaded arches and skips when the requested arch is present, so a restored cache genuinely prevents the download.

**Deviation from the plan, with the measurement:** the plan specified 6 min. The worst measured full download is **6 m 19 s** (`Native win32 arm64`, run 30416909872), so a 6-minute bound would have failed that run. 8 min is 1.27× the measured p100. Per-leg `XWIN_ARCH` should cut it materially, but the bound is sized on what has been measured, not on the expected saving; tighten after one release provides data.

### 4. Right-size `timeout-minutes` per leg

| Leg | Healthy p100 | Cap | Factor | Was |
| --- | --- | --- | --- | --- |
| linux x64 | 107 s | 7 min | 3.9× | 15 min |
| linux arm64 | 233 s | 8 min | 2.1× | 15 min |
| darwin x64 | 387 s | 9 min | 1.40× | 15 min |
| darwin arm64 | 61 s (after §5) | 5 min | 4.9× | 15 min |
| win32 x64 | 351 s | 10 min | 1.71× | 15 min |
| win32 arm64 | 443 s | 10 min | 1.35× | 15 min |

Every cap drops. Windows is 10 rather than the planned 9 because the 8-minute CRT bound in §3 must fit inside it. `Build native binding` also gets a per-leg `matrix.build_timeout_minutes` — **a blanket 5 min would have cancelled `darwin x64`, whose compile reached 335 s**, so that leg gets 8.

`native-artifacts` already sets an explicit `name:`, so the new matrix columns do not rename its jobs and no status-check context changes.

### 5. Stop requesting sticky disks where they cannot exist

Sticky disks are ext4 block devices — Blacksmith **Linux** only. `useblacksmith/checkout` is the consumer (the warning's advice to "remove the sticky disk step" is misleading; there is no such step). It now runs behind `if: runner.os == 'Linux'`, with `actions/checkout` otherwise, in both workflows. The two `win32` legs cross-compile on Linux and keep the mirror; `test.yml`'s Linux leg keeps it too, because `fetch-depth: 0` + `lfs: true` costs ~8 s through the mirror.

Removes **78 s** from the darwin arm64 leg (8 of 8 releases, `gRPC connection test failed`) and silences the Windows warning.

### 6. Pin what floats

`cargo-zigbuild@0.23.0` and `cargo-xwin@0.23.0` — unversioned they resolve to `@latest`, floating the build toolchain of a published, provenance-signed native artifact with no diff. `bun-version: 1.3.14` in `test.yml` to match `publish.yml`; `latest` cannot be cached by `setup-bun` and left the suite testing a different Bun from the one that builds the shipped artifact. `timeout-minutes: 5` on the Mintlify step.

Full-SHA pins with `# vX.Y.Z` comments for every third-party action in all three workflows, on independent supply-chain merit: `publish.yml`'s graph carries `contents: write` and `id-token: write`. `.github/dependabot.yml` already runs `github-actions` weekly and maintains the pins. `dtolnay/rust-toolchain` is pinned to the `v1` tag, whose `action.yml` requires an explicit `toolchain:` — `test.yml` now passes `toolchain: stable` for that reason.

### 7. `warm-toolchain-cache.yml` — added, gated, **not scheduled**

Performs only the Zig and CRT acquisitions on `main` so the default-branch cache scope is not empty.

It is `workflow_dispatch`-only. The plan called for a daily schedule *gated on* first verifying that a `refs/tags/*` run can read a `refs/heads/main` cache entry on Blacksmith's colocated cache. That gate cannot be satisfied before merge, and the one candidate counter-example in the logs turned out not to be written by `main`. Shipping a daily job whose entire value is unproven is not defensible, so the schedule is one line away and `docs/ci.md` records the exact three-step experiment that unlocks it. If the fallback does not apply, delete the file — the step bounds are what hold the line; the cache is only an optimisation.

### 8. Docs and contract tests

`docs/ci.md` records both Zig stalls with dates, runs and durations; that step bounds are the stall detector and job caps are hang detectors; the `xwin-v1` key epoch and how to force an SDK refresh; that `useblacksmith/checkout` is Linux-only here; and the warm-cache experiment.

Six new `test:ci-contracts` invariants: every acquisition step in `native-artifacts` is bounded (including a generic guard so a future `dtolnay`/`mlugg`/`taiki-e` step cannot arrive unbounded); no job requests a sticky disk off a Blacksmith Linux runner; every action is SHA-pinned with a version comment; the build tools and Bun do not float; each leg declares both budgets and `timeout-minutes: 15` cannot come back; the warm workflow stays read-only, ungated-schedule-free, and key-compatible with the publisher.

## What is *not* touched

The release integrity boundary is unchanged: the tag / package-version / commit-subject checks, OIDC-only npm publication with `id-token: write` confined to `publish-npm`, the draft-first staging order, `contents: write` confined to staging/undrafting/cleanup, `GLIBC_FLOOR=2.17`, and all six build targets. The existing contract tests covering all of that still pass untouched.

No `packages/*/CHANGELOG.md` entry: CI-only infrastructure per AGENTS.md.

## Validation

Local, all green: `bun run typecheck`, `bun run lint`, `bun run check:file-length`, `bun run test:ci-contracts` (25 pass), `bun run test:unit` (via the prek commit hook), GitHub Actions schema validation of all three workflows via `@action-validator/cli`, and YAML parse.

Verified against upstream sources rather than assumed: `use-tool-cache` and `use-cache` inputs and their scope in `mlugg/setup-zig@d1434d0`; that `post.js` cannot fail when `use-cache` is false; that `cargo-xwin xwin cache xwin` is a real subcommand honouring `XWIN_ARCH`/`XWIN_CACHE_DIR` with `XWIN_VERSION` defaulting to 17; that `dtolnay/rust-toolchain@v1` requires an explicit `toolchain`; and every pinned SHA against its tag.

## What remains unproven until the next real release

`publish.yml` cannot be exercised by CI before merge. Every change here is individually revertible.

1. **The bounds have never fired.** No stall has been forced against this workflow. The intended behaviour — leg fails at ~4 min with both Zig attempts logged, rather than being cancelled at 15 — is inferred from `continue-on-error` + `timeout-minutes` semantics, not observed.
2. **The `xwin-v1` cache has never been restored.** The first release still pays the (bounded) download. Confirm `⏬ Downloading MSVC CRT` is absent on the second run of the same ref, and that both `win32` legs still produce a loadable `.node` (`windows-binary-smoke` and `ATOMIC_REQUIRE_NATIVE_BINDING_SMOKE` already assert this).
3. **Per-leg `XWIN_ARCH` savings are unmeasured.** Treated as a bonus, not a premise; the 8-minute bound assumes no saving at all.
4. **The default-branch cache read fallback is unverified** — hence §7 shipping dispatch-only.
5. **The new caps have not met a slow runner day.** `darwin x64` at 1.40× and `win32 arm64` at 1.35× are the thinnest. If either cancels a healthy leg, raise that one number; do not restore a blanket cap.
6. **`bun install --frozen-lockfile`, `setup-bun`, `setup-node`, and checkout remain unbounded** inside the job caps. They are Blacksmith-cached or first-party and have never been observed to stall; adding bounds is cheap if that changes.

Compare per-leg wall clock against the table in §4 after the next prerelease cut.

Do not merge, tag, or publish from this branch beyond normal review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787986394&installation_model_id=10562&pr_number=2072&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2072&signature=4f6a96d026215dd4066f5df962b4b7dd19c0369b62469f07fb31fec2e96d19d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds explicit time limits and retries around native release dependency downloads, pins CI actions and build-tool versions, selects checkout actions by runner platform, and adds a manually dispatched workflow to warm Zig and MSVC toolchain caches.

The suspected cache-warming defect was disproved by executing the pinned setup-zig action with the release configuration. With `use-cache: false`, the action still restores its versioned Zig compiler-tarball cache; only the separate Zig build cache is disabled. The warm workflow and release workflow use compatible Zig and MSVC cache contracts.

<h3>Confidence Score: 4/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I executed the pinned mlugg/setup-zig action with use-cache=true and use-cache=false to compare cache behavior, and observed that with use-cache=false the setup-zig tarball was restored (setup-zig-tarball-zig-x86\_64-linux-0.16.0) even though there was no separate global Zig cache restore.
- I inspected the MSVC cache path and key in both workflows and the pinned actions/cache post-save implementation, and confirmed that a cache miss saves ~/.cache/cargo-xwin after cargo-xwin xwin cache xwin completes.
- I verified that warm-toolchain-cache.yml and publish.yml invoke the pinned action with version 0.16.0, use-tool-cache false, and use-cache false, and confirmed that the pinned action restores/saves the tarball unconditionally while the .zig-cache block is guarded; the cache post-save saves the xwin directory on miss.

<a href="https://app.greptile.com/trex/runs/16539654/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): read workflow contracts with pl..."](https://github.com/bastani-inc/atomic/commit/03f42d4ff17c51dff21d6cbb832e5d8a80c2fb3b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48603226)</sub>

<!-- /greptile_comment -->