### PR TITLE
ci: guard Blacksmith runner coverage and trim workflow comments

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -79,11 +79,11 @@ plugins/**/run.cmd text eol=lf
 *.lock     text eol=lf
 
 # Serialisation
-*.json     text
-*.toml     text
-*.xml      text
-*.yaml     text
-*.yml      text
+*.json     text eol=lf
+*.toml     text eol=lf
+*.xml      text eol=lf
+*.yaml     text eol=lf
+*.yml      text eol=lf
 
 # Archives
 *.7z       binary

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,37 +74,27 @@ jobs:
     name: Native ${{ matrix.platform }} ${{ matrix.arch }}
     needs: integrity
     runs-on: ${{ matrix.runner }}
-    # Per-leg wall-clock budgets, sized from the last eight releases. One
-    # 15-minute cap covering six legs whose real work spans 55s to 443s detects
-    # nothing: run 30517879019 (0.9.11-alpha.8) spent 13m27s inside a single
-    # stalled Zig mirror, was cancelled 8s after its artifact upload had
-    # already succeeded, and a cancelled `needs` dependency then skipped the
-    # payload build, draft staging, npm publication, and release publication.
-    # These job caps are hang detectors. The stall detectors are the per-step
-    # `timeout-minutes` on every acquisition step below.
+    # Job caps are hang detectors, sized per leg from the last eight releases.
+    # The per-step `timeout-minutes` below are the stall detectors. See docs/ci.md.
     timeout-minutes: ${{ matrix.timeout_minutes }}
     env:
-      # cargo-xwin downloads both x86_64 and aarch64 CRT/SDK by default. Each
-      # Windows leg links exactly one of them.
+      # cargo-xwin fetches both CRTs by default; each Windows leg links one.
       XWIN_ARCH: ${{ matrix.arch == 'x64' && 'x86_64' || 'aarch64' }}
     strategy:
       fail-fast: false
       matrix:
-        # timeout_minutes caps the job; build_timeout_minutes caps the compile
-        # step alone, from that leg's own measured p100 compile.
+        # timeout_minutes caps the job; build_timeout_minutes caps the compile step.
         include:
           - { runner: blacksmith-4vcpu-ubuntu-2404, platform: linux, arch: x64, target: x86_64-unknown-linux-gnu, timeout_minutes: 7, build_timeout_minutes: 5 }
           - { runner: blacksmith-4vcpu-ubuntu-2404-arm, platform: linux, arch: arm64, target: aarch64-unknown-linux-gnu, timeout_minutes: 8, build_timeout_minutes: 5 }
+          # Blacksmith macOS is Apple Silicon only, so darwin x64 stays GitHub-hosted.
           - { runner: macos-26-intel, platform: darwin, arch: x64, target: x86_64-apple-darwin, timeout_minutes: 9, build_timeout_minutes: 8 }
           - { runner: blacksmith-6vcpu-macos-26, platform: darwin, arch: arm64, target: aarch64-apple-darwin, timeout_minutes: 5, build_timeout_minutes: 5 }
           - { runner: blacksmith-4vcpu-ubuntu-2404, platform: win32, arch: x64, target: x86_64-pc-windows-msvc, timeout_minutes: 10, build_timeout_minutes: 5 }
           - { runner: blacksmith-4vcpu-ubuntu-2404, platform: win32, arch: arm64, target: aarch64-pc-windows-msvc, timeout_minutes: 10, build_timeout_minutes: 5 }
     steps:
-      # useblacksmith/checkout consumes a Blacksmith sticky disk. Sticky disks
-      # are ext4 block devices, so they exist only on Blacksmith Linux runners.
-      # The win32 legs cross-compile on Linux and keep the git mirror. On
-      # blacksmith-6vcpu-macos-26 the action blocked 78s in 8 of 8 releases on
-      # `gRPC connection test failed` before falling back to a normal clone.
+      # Sticky disks are Blacksmith-Linux-only; elsewhere this action stalls ~78s
+      # before falling back to a normal clone.
       - uses: useblacksmith/checkout@01ab2a058dd0d41e292217b76582a6f9867c02ce # v1.0.0-beta
         if: runner.os == 'Linux'
         with:
@@ -121,10 +111,8 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      # rustup needs the bare target. Linux's napi build separately receives
-      # the glibc-suffixed target consumed by cargo-zigbuild.
-      # 4 minutes bounds a rustup fetch that took 135s on Native win32 arm64 in
-      # run 29987786023 against a 4-14s norm across eight releases.
+      # rustup needs the bare target; Linux's napi build separately receives the
+      # glibc-suffixed target consumed by cargo-zigbuild.
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         timeout-minutes: 4
         with:
@@ -152,17 +140,9 @@ jobs:
         if: matrix.arch == 'x64'
         shell: bash
         run: echo 'RUSTFLAGS=-C target-cpu=x86-64-v2' >> "$GITHUB_ENV"
-      # Two community Zig mirrors have stalled a release. Run 30517879019
-      # (0.9.11-alpha.8, 2026-07-30): zig.bcr.ist trickled for 795.9s and then
-      # succeeded. Run 30416909872 (0.9.11-alpha.7, 2026-07-29):
-      # zigmirror.hryx.net burned 437.6s on a TCP connect that never completed
-      # before failing over to a mirror that served the file in 5.2s.
-      # setup-zig fetches the community mirror list at run time and shuffles
-      # it, and applies no per-mirror deadline, so the wait is bounded only by
-      # the job budget. 2 minutes is 3.2x the worst healthy acquisition
-      # measured over eight releases (37s). The retry re-shuffles the
-      # 16-mirror list, so a stall now costs at most 4 minutes and fails
-      # loudly instead of silently cancelling the release graph.
+      # Community Zig mirrors have stalled two releases (795.9s and 437.6s).
+      # setup-zig applies no per-mirror deadline, so bound it and retry once on a
+      # re-shuffled mirror list: a stall now costs at most 4 minutes and fails loudly.
       - name: Setup zig for portable Linux GNU builds
         id: zig
         if: matrix.platform == 'linux'
@@ -171,15 +151,10 @@ jobs:
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.16.0
-          # RUNNER_ENVIRONMENT is not github-hosted on Blacksmith, so setup-zig
-          # would otherwise copy Zig into an /opt/hostedtoolcache that dies
-          # with the VM (1.4-7.3s of pure loss).
+          # Blacksmith is not github-hosted, so the tool cache dies with the VM.
           use-tool-cache: false
-          # This is the global .zig-cache entry, not the tarball cache. It has
-          # missed on every release tag and its save key embeds the run id and
-          # attempt, so it can never be reused. Disabling it also keeps a
-          # killed attempt's post step inert, so the retry below cannot add a
-          # duplicate-key save failure.
+          # Global .zig-cache, not the tarball cache. Its save key embeds the run id,
+          # so it can never be reused, and disabling it keeps the retry's post step inert.
           use-cache: false
       - name: Retry zig acquisition on a re-shuffled mirror list
         if: matrix.platform == 'linux' && steps.zig.outcome == 'failure'
@@ -189,9 +164,8 @@ jobs:
           version: 0.16.0
           use-tool-cache: false
           use-cache: false
-      # An unversioned taiki-e tool resolves to @latest, floating the build
-      # toolchain of a published, provenance-signed native artifact with no
-      # diff. Both currently resolve to 0.23.0.
+      # Unversioned taiki-e tools resolve to @latest, floating the build toolchain
+      # of a provenance-signed artifact with no diff.
       - name: Install cargo-zigbuild for portable Linux GNU builds
         if: matrix.platform == 'linux'
         timeout-minutes: 3
@@ -210,41 +184,31 @@ jobs:
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cargo-xwin@0.23.0
-      # cargo-xwin defaults XWIN_CACHE_DIR to dirs::cache_dir()/cargo-xwin.
-      # Pinning it keeps the populate step, the build step, and the
-      # actions/cache path in agreement regardless of XDG_CACHE_HOME.
+      # Pinned so the populate step, the build step, and actions/cache agree
+      # regardless of XDG_CACHE_HOME.
       - name: Resolve MSVC CRT cache directory
         if: matrix.platform == 'win32'
         shell: bash
         run: echo "XWIN_CACHE_DIR=$HOME/.cache/cargo-xwin" >> "$GITHUB_ENV"
-      # The MSVC CRT and Windows SDK download is the largest standing cost in
-      # this job: 3m46s to 6m19s per Windows leg, on every release, uncached,
-      # for a ~25s compile. Key epoch `xwin-v1`: XWIN_SDK_VERSION and
-      # XWIN_CRT_VERSION default to "latest", so a hit pins the leg to
-      # whichever SDK was first stored under this key. That is more
-      # reproducible than resolving "latest" on every release, and bumping the
-      # epoch is the deliberate lever for an SDK refresh.
+      # Largest standing cost in this job: 3m46s-6m19s per Windows leg, every
+      # release, for a ~25s compile. A hit pins the leg to the SDK first stored
+      # under this key; bump the `xwin-v1` epoch to force a refresh.
       - name: Restore MSVC CRT and Windows SDK
         if: matrix.platform == 'win32'
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/cargo-xwin
           key: xwin-v1-${{ matrix.arch }}-17
-      # 8 minutes is 1.27x the worst full download measured over five releases
-      # (6m19s, Native win32 arm64, run 30416909872). Per-leg XWIN_ARCH should
-      # cut that materially, but this bound is sized on what has been measured,
-      # not on the expected saving.
+      # 1.27x the worst measured full download (6m19s), sized on measurement
+      # rather than on the saving XWIN_ARCH is expected to deliver.
       - name: Populate MSVC CRT cache on miss
         if: matrix.platform == 'win32'
         timeout-minutes: 8
         env:
           XWIN_ACCEPT_LICENSE: "1"
         run: cargo-xwin xwin cache xwin
-      # With the CRT fetch hoisted into its own bounded step, this step is a
-      # compile. Each budget is that leg's measured p100 compile over eight
-      # releases times at least 1.4: linux x64 62s, linux arm64 152s, darwin
-      # arm64 40s, darwin x64 335s, and ~25s on both Windows legs once the CRT
-      # is acquired above.
+      # The CRT fetch is hoisted above, so this is a compile: each budget is that
+      # leg's measured p100 times at least 1.4.
       - name: Build native binding
         timeout-minutes: ${{ matrix.build_timeout_minutes }}
         env:
@@ -308,9 +272,7 @@ jobs:
     runs-on: blacksmith-4vcpu-windows-2025
     timeout-minutes: 15
     steps:
-      # blacksmith-4vcpu-windows-2025 has no sticky disk, so the Blacksmith
-      # git-mirror checkout warns and falls back to a standard clone anyway.
-      # Ask for the clone directly.
+      # Windows has no sticky disk, so ask for the standard clone directly.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.SOURCE_REF }}
@@ -468,6 +430,8 @@ jobs:
   publish-npm:
     name: Publish npm packages
     needs: [integrity, stage-github-release]
+    # Must stay GitHub-hosted: npm trusted publishing rejects self-hosted runners,
+    # and Blacksmith registers through GitHub's org-level runner registration API.
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: npm-publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,25 +25,16 @@ jobs:
                       timeout_minutes: 15
             fail-fast: false
         runs-on: ${{ matrix.os }}
-        # Strict per-platform wall-clock budgets prevent a hung process from
-        # consuming GitHub's 360-minute default. Linux stays bounded at 10m;
-        # Windows gets 15m because two healthy runs passed every test but crossed
-        # 10m while building or smoke-testing the release archive.
+        # Bounded so a hung process cannot consume GitHub's 360-minute default.
         timeout-minutes: ${{ matrix.timeout_minutes }}
         steps:
-            # useblacksmith/checkout consumes a Blacksmith sticky disk. Sticky
-            # disks are ext4 block devices and exist only on Blacksmith Linux
-            # runners, so on blacksmith-4vcpu-windows-2025 the action warns
-            # ("sticky disks are not supported on Windows runners") and falls
-            # back to a standard clone. Ask Windows for the clone directly.
+            # Sticky disks are Blacksmith-Linux-only; Windows takes a standard clone.
             - uses: useblacksmith/checkout@01ab2a058dd0d41e292217b76582a6f9867c02ce # v1.0.0-beta
               if: runner.os == 'Linux'
               with:
                   # LFS fixtures are required by the coding-agent test suite.
                   lfs: true
-                  # Full history and tags support CI contract fixtures and local
-                  # release tooling. Blacksmith's git mirror keeps this checkout
-                  # inexpensive while preserving those repository-wide checks.
+                  # Full history and tags support CI contract fixtures and release tooling.
                   fetch-depth: 0
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               if: runner.os != 'Linux'
@@ -52,22 +43,17 @@ jobs:
                   fetch-depth: 0
             - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
               with:
-                  # Pinned to match publish.yml. `latest` cannot be cached by
-                  # setup-bun, so every job on every run re-downloaded Bun from
-                  # GitHub releases, and the suite tested a different Bun from
-                  # the one that builds the shipped artifact.
+                  # Pinned to match publish.yml; `latest` cannot be cached by setup-bun.
                   bun-version: 1.3.14
-            # Node is required by test/integration/installed-package-node-extensions.test.ts,
-            # which smoke-tests the built npm package under the Node runtime (the
-            # `atomic` bin runs via `#!/usr/bin/env node` for npm/bun installs).
+            # Node is required by installed-package-node-extensions.test.ts, which
+            # smoke-tests the built npm package under the Node runtime.
             - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: 24
             - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
               timeout-minutes: 4
               with:
-                  # Required once the action is pinned by SHA: the version is
-                  # otherwise taken from the branch name in the `uses:` ref.
+                  # Required once pinned by SHA: the version otherwise comes from the ref.
                   toolchain: stable
             - name: Install dependencies
               run: bun install --frozen-lockfile
@@ -84,10 +70,8 @@ jobs:
             - name: Mintlify docs validation
               if: runner.os == 'Linux' && github.event_name == 'pull_request'
               working-directory: packages/coding-agent/docs
-              # Pinned: mintlify@4.2.732 depends on @mintlify/editor@0.0.246,
-              # which is missing from the npm registry (404) and breaks
-              # `bunx mintlify@latest` for every PR. Unpin once upstream
-              # publishes a resolvable release.
+              # Pinned: mintlify@4.2.732 pulls a package missing from the registry.
+              # Unpin once upstream publishes a resolvable release.
               timeout-minutes: 5
               run: |
                   bunx --bun mintlify@4.2.731 validate

--- a/.github/workflows/warm-toolchain-cache.yml
+++ b/.github/workflows/warm-toolchain-cache.yml
@@ -1,26 +1,16 @@
 name: Warm toolchain cache
 
-# Every release tag pays a cold Zig and MSVC CRT fetch. `actions/cache` entries
-# are scoped per branch or tag, with a read fallback to the default branch;
-# `publish.yml` only ever runs on `refs/tags/*` and nothing on `main` writes
-# these keys, so the fallback scope is empty and every release is a guaranteed
-# cold download from a community mirror and from Microsoft.
+# `publish.yml` only runs on `refs/tags/*` and nothing on `main` writes the Zig
+# or MSVC CRT cache keys, so every release pays a cold download. This workflow
+# performs only those two acquisitions on `main` to populate the default-branch
+# scope. It builds nothing and writes nothing else.
 #
-# This workflow performs only those two acquisitions on `main` so the
-# default-branch scope holds fresh entries. It writes nothing and builds
-# nothing.
-#
-# GATE: this is deliberately dispatch-only. Whether a `refs/tags/*` run can
-# read a `refs/heads/main` cache entry on Blacksmith's colocated cache is
-# documented but unverified for this repository. Run the experiment in
-# docs/ci.md ("Warming the release toolchain caches") first: dispatch this
-# workflow on `main`, then dispatch `publish.yml` against an existing tag and
-# check whether the Linux legs log `Cache hit for: setup-zig-tarball-...`. Add
-# a daily `schedule:` trigger here only after that hit is observed; entries
-# evict after 7 days of inactivity, so a daily run is what keeps them alive.
-# If the fallback does not apply, delete this file: the per-step bounds in
-# `publish.yml` are what actually hold the line, and this is only an
-# optimisation.
+# GATE: dispatch-only on purpose. Whether a `refs/tags/*` run can read a
+# `refs/heads/main` cache entry on Blacksmith's colocated cache is unverified
+# here. Run the experiment in docs/ci.md ("Warming the release toolchain
+# caches") first, then add a daily `schedule:` only if the hit is observed
+# (entries evict after 7 days). If the fallback does not apply, delete this
+# file: the per-step bounds in `publish.yml` are what hold the line.
 on:
   workflow_dispatch:
 
@@ -43,10 +33,8 @@ jobs:
           - { runner: blacksmith-4vcpu-ubuntu-2404, arch: x64 }
           - { runner: blacksmith-4vcpu-ubuntu-2404-arm, arch: arm64 }
     steps:
-      # setup-zig writes `setup-zig-tarball-zig-<host arch>-linux-0.16.0`, so
-      # the aarch64 key needs an arm64 runner. Keep the version, the tool-cache
-      # setting, and the global-cache setting identical to `publish.yml`, or
-      # this warms a key that job never reads.
+      # Keep version and cache settings identical to `publish.yml`, or this warms
+      # a key that job never reads. The aarch64 key needs an arm64 runner.
       - name: Fetch and cache the Zig tarball
         timeout-minutes: 4
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
@@ -57,8 +45,7 @@ jobs:
 
   msvc-crt:
     name: Warm MSVC CRT ${{ matrix.arch }}
-    # Both Windows legs of `native-artifacts` cross-compile on this Linux
-    # runner spec, so both CRT keys are written here.
+    # Both Windows legs cross-compile on this Linux runner spec.
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     strategy:
@@ -76,8 +63,7 @@ jobs:
       - name: Resolve MSVC CRT cache directory
         shell: bash
         run: echo "XWIN_CACHE_DIR=$HOME/.cache/cargo-xwin" >> "$GITHUB_ENV"
-      # The key epoch must match `publish.yml`. Bumping it there without
-      # bumping it here leaves the release paying a cold download again.
+      # The key epoch must match `publish.yml`.
       - name: Restore MSVC CRT and Windows SDK
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:

--- a/test/ci/ci-workflow-contracts.test.ts
+++ b/test/ci/ci-workflow-contracts.test.ts
@@ -411,3 +411,23 @@ test("the toolchain warm workflow stays read-only, gated, and key-compatible", a
   assert.equal(zigVersion.exec(warm)?.[1], zigVersion.exec(publish)?.[1], "warm and release Zig versions must match");
   assert.match(await readText(join(root, "docs/ci.md")), /xwin-v1/u);
 });
+
+test("Blacksmith runners are used everywhere they are supported", async () => {
+  const publish = await readText(publishPath);
+  const test = await readText(testPath);
+  const warm = await readText(warmPath);
+  const hosted = [...`${publish}\n${test}\n${warm}`.matchAll(/(?:runs-on|runner): (?!\$\{\{)([^\s,}]+)/gu)]
+    .map(([, runner]) => runner)
+    .filter((runner) => !runner.startsWith("blacksmith-"));
+  // Only two jobs may stay GitHub-hosted, and each for a reason that a future
+  // "move everything to Blacksmith" pass must not quietly undo:
+  //   macos-26-intel - Blacksmith macOS is Apple Silicon only, so this is the
+  //     only runner that can produce the darwin x64 native binding.
+  //   ubuntu-latest  - npm trusted publishing rejects self-hosted runners, and
+  //     Blacksmith registers through GitHub's org-level registration API.
+  assert.deepEqual(hosted.sort(), ["macos-26-intel", "ubuntu-latest"]);
+  assert.match(publish, /# Blacksmith macOS is Apple Silicon only[^\n]*\n\s+- \{ runner: macos-26-intel/u);
+  assert.match(publish, /npm trusted publishing rejects self-hosted runners[\s\S]{0,160}?runs-on: ubuntu-latest/u);
+  // ubuntu-latest is only ever acceptable on the OIDC publish job.
+  assert.equal(jobBlock(publish, "publish-npm", "publish-github-release").includes("runs-on: ubuntu-latest"), true);
+});

--- a/test/ci/ci-workflow-contracts.test.ts
+++ b/test/ci/ci-workflow-contracts.test.ts
@@ -413,6 +413,41 @@ test("the toolchain warm workflow stays read-only, gated, and key-compatible", a
   assert.match(await readText(join(root, "docs/ci.md")), /xwin-v1/u);
 });
 
+type MatrixEntry = Record<string, string | number | boolean>;
+
+interface WorkflowMatrix {
+  include?: MatrixEntry[];
+  [key: string]: string[] | MatrixEntry[] | undefined;
+}
+
+interface Workflow {
+  jobs?: Record<string, { "runs-on"?: string | string[]; strategy?: { matrix?: WorkflowMatrix } }>;
+}
+
+/**
+ * Every runner a job can select.
+ *
+ * `runs-on: ${{ matrix.<key> }}` is resolved through the job's own matrix. Reading
+ * the literal alone would let `matrix: { os: [ubuntu-24.04] }` pick an unapproved
+ * GitHub-hosted runner that no contract here ever sees.
+ */
+function jobRunners(label: string, job: NonNullable<Workflow["jobs"]>[string]): string[] {
+  const runsOn = job["runs-on"] ?? [];
+  return (typeof runsOn === "string" ? [runsOn] : runsOn).flatMap((value) => {
+    const key = /^\$\{\{\s*matrix\.([\w-]+)\s*\}\}$/u.exec(value)?.[1];
+    if (key === undefined) {
+      // An expression this cannot resolve must not pass as a literal runner name.
+      assert.doesNotMatch(value, /\$\{\{/u, `${label}: unresolvable runs-on ${value}`);
+      return [value];
+    }
+    const matrix = job.strategy?.matrix ?? {};
+    const values = [...(matrix[key] ?? []), ...(matrix.include ?? []).map((entry) => entry[key])]
+      .filter((entry): entry is string => typeof entry === "string");
+    assert.ok(values.length > 0, `${label}: matrix.${key} names no runner`);
+    return values;
+  });
+}
+
 test("Blacksmith runners are used everywhere they are supported", async () => {
   const publish = await readText(publishPath);
   // Enumerate the directory rather than a fixed list: a workflow added later
@@ -422,12 +457,13 @@ test("Blacksmith runners are used everywhere they are supported", async () => {
     .filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))
     .sort();
   assert.ok(workflowFiles.length >= 3, "expected the workflows directory to be enumerable");
-  const allWorkflows = (await Promise.all(
-    workflowFiles.map(async (name) => readText(join(workflowDir, name))),
-  )).join("\n");
-  const hosted = [...allWorkflows.matchAll(/(?:runs-on|runner): (?!\$\{\{)([^\s,}]+)/gu)]
-    .map(([, runner]) => runner)
-    .filter((runner) => !runner.startsWith("blacksmith-"));
+  const hosted: string[] = [];
+  for (const file of workflowFiles) {
+    const workflow = Bun.YAML.parse(await readText(join(workflowDir, file))) as Workflow;
+    for (const [name, job] of Object.entries(workflow.jobs ?? {})) {
+      hosted.push(...jobRunners(`${file} ${name}`, job).filter((runner) => !runner.startsWith("blacksmith-")));
+    }
+  }
   // Only two jobs may stay GitHub-hosted, and each for a reason that a future
   // "move everything to Blacksmith" pass must not quietly undo:
   //   macos-26-intel - Blacksmith macOS is Apple Silicon only, so this is the

--- a/test/ci/ci-workflow-contracts.test.ts
+++ b/test/ci/ci-workflow-contracts.test.ts
@@ -1,6 +1,7 @@
 import { test } from "bun:test";
 import assert from "node:assert/strict";
 import { existsSync } from "node:fs";
+import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -414,9 +415,17 @@ test("the toolchain warm workflow stays read-only, gated, and key-compatible", a
 
 test("Blacksmith runners are used everywhere they are supported", async () => {
   const publish = await readText(publishPath);
-  const test = await readText(testPath);
-  const warm = await readText(warmPath);
-  const hosted = [...`${publish}\n${test}\n${warm}`.matchAll(/(?:runs-on|runner): (?!\$\{\{)([^\s,}]+)/gu)]
+  // Enumerate the directory rather than a fixed list: a workflow added later
+  // must not be able to introduce an unapproved GitHub-hosted runner unnoticed.
+  const workflowDir = join(root, ".github/workflows");
+  const workflowFiles = (await readdir(workflowDir))
+    .filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))
+    .sort();
+  assert.ok(workflowFiles.length >= 3, "expected the workflows directory to be enumerable");
+  const allWorkflows = (await Promise.all(
+    workflowFiles.map(async (name) => readText(join(workflowDir, name))),
+  )).join("\n");
+  const hosted = [...allWorkflows.matchAll(/(?:runs-on|runner): (?!\$\{\{)([^\s,}]+)/gu)]
     .map(([, runner]) => runner)
     .filter((runner) => !runner.startsWith("blacksmith-"));
   // Only two jobs may stay GitHub-hosted, and each for a reason that a future


### PR DESCRIPTION
Blacksmith is already used on every job that supports it. The two remaining GitHub-hosted jobs cannot move:

- `macos-26-intel` — Blacksmith macOS is Apple Silicon only, so this is the only runner that can build the darwin x64 native binding.
- `ubuntu-latest` (`publish-npm`) — npm trusted publishing [rejects self-hosted runners](https://docs.npmjs.com/trusted-publishers/), and Blacksmith registers through GitHub org-level runner registration.

Both now carry a one-line reason and a contract test, so a future "move everything to Blacksmith" pass cannot silently break provenance or ship an ARM binary as darwin x64.

Also sets `eol=lf` on `*.yml/*.yaml/*.json/*.toml/*.xml`. Only `*.md` and source extensions pinned LF before, so workflows checked out CRLF on Windows and any contract anchored on a literal newline silently matched nothing there — the cause of the Windows-only failure in #2072.

Comments added with the dependency-fetch bounds are condensed: operative constraint and measured number kept, incident narrative dropped (docs/ci.md carries it in full).

Validation: typecheck, lint, check:file-length, test:ci-contracts (26 pass), test:unit via prek, action-validator on all three workflows.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787990134&installation_model_id=10562&pr_number=2073&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2073&signature=993a57cda7ce8f4a23830cbcc6d2b1b743fc9d60f8f1f0e8b954221c3d7c2039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change strengthens CI runner-policy enforcement and standardizes configuration-file line endings. It now checks every workflow YAML file, resolves matrix-selected runners before applying the policy, preserves the two documented GitHub-hosted exceptions, and enforces LF for common configuration and serialization formats.

Focused checks exercised the previous bypass paths and confirmed that the updated contract rejects both an unapproved runner in a newly added YAML workflow and one selected through a matrix. Approved direct-matrix and `matrix.include` Blacksmith runner forms continue to pass. The CI workflow contract suite completed with 26 passing tests, TypeScript typechecking completed successfully, and the changed workflow files were confirmed to have LF line endings.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the CI policy checks enforce the intended runner boundary and the changed configuration files preserve LF formatting.

No defects remain. The exercised workflow cases cover both previously permissive paths and the approved matrix forms, while the CI contract suite and TypeScript checks pass.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I replayed isolated historical and current revisions with temporary workflow fixtures to validate contract behavior before and after the change.
- I confirmed approved direct-matrix and matrix.include Blacksmith runner forms pass, while an unresolved matrix runner expression fails closed.
- I executed evidence and observed outputs, including the before/after validation scripts, a 26-test CI contract run, a passing TypeScript typecheck, and LF line-ending validation.
- I reviewed the runner policy validation harness and the baseline and fail-closed fixture logs, along with the CI contract suite, typecheck, and LF checks, to confirm the updated contracts remain valid.
- The final assessment shows the before fixture passes and the after fixture fails closed, with all final contract, typecheck, and line-ending checks passing.

<a href="https://app.greptile.com/trex/runs/16596310/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["ci: resolve matrix-selected runners in t..."](https://github.com/bastani-inc/atomic/commit/2ac790fa0103b56bb3116761ee7032523d53adbe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48614255)</sub>

<!-- /greptile_comment -->