### PR TITLE
ci: split test.yml into four concurrent jobs behind a fail-closed result gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,15 +31,17 @@ jobs:
         include:
           - os: blacksmith-4vcpu-ubuntu-2404
             binary_platform: linux-x64
-            timeout_minutes: 6
+            timeout_minutes: 8
           - os: blacksmith-4vcpu-windows-2025
             binary_platform: windows-x64
-            timeout_minutes: 8
+            timeout_minutes: 12
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    # Measured 121s Linux / 195s Windows, and the unit step can double when its
-    # one bounded flake retry fires. The cap is a hang detector at roughly 2x
-    # measured p100, not a performance budget.
+    # Sequential-job sampling put this at 121s Linux / 195s Windows, but the
+    # first split run measured 230s / 348s with the unit step's one bounded flake
+    # retry firing on both platforms. The cap is a hang detector at roughly 2x
+    # measured p100, not a performance budget, and a cap that cancels a passing
+    # retried run is worse than a late hang detection.
     timeout-minutes: ${{ matrix.timeout_minutes }}
     steps:
       # Sticky disks are Blacksmith-Linux-only; Windows takes a standard clone.
@@ -107,11 +109,12 @@ jobs:
             timeout_minutes: 6
           - os: blacksmith-4vcpu-windows-2025
             binary_platform: windows-x64
-            timeout_minutes: 9
+            timeout_minutes: 12
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    # Measured 126s Linux / 232s Windows. This is the critical path of the whole
-    # workflow, so its cap is the one with the least slack to give.
+    # Sampled at 126s Linux / 232s Windows; the first split run measured 138s /
+    # 349s. This is the critical path of the whole workflow, so it is the chain
+    # to shard first if a further cut is wanted.
     timeout-minutes: ${{ matrix.timeout_minutes }}
     steps:
       - uses: useblacksmith/checkout@01ab2a058dd0d41e292217b76582a6f9867c02ce # v1.0.0-beta
@@ -169,8 +172,9 @@ jobs:
             timeout_minutes: 6
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    # Measured 74s Linux / 149s Windows, including the native binding rebuild
-    # this job pays for itself (see the Rust toolchain note below).
+    # Sampled at 74s Linux / 149s Windows and measured at 84s / 162s on the first
+    # split run, both including the native binding rebuild this job pays for
+    # itself (see the Rust toolchain note below).
     timeout-minutes: ${{ matrix.timeout_minutes }}
     steps:
       - uses: useblacksmith/checkout@01ab2a058dd0d41e292217b76582a6f9867c02ce # v1.0.0-beta

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,216 +1,385 @@
 name: Tests
 
 env:
-    PREK_DISABLE_INSTALL: "1"
+  PREK_DISABLE_INSTALL: "1"
 
 permissions:
-    contents: read
+  contents: read
 
 on:
-    push:
-        branches: [main, "release/**", "prerelease/**"]
-    pull_request:
+  push:
+    branches: [main, "release/**", "prerelease/**"]
+  pull_request:
 
+# The work runs as four concurrent jobs instead of one sequential per-platform
+# job, so the wall clock is the longest *dependent* chain rather than the sum of
+# every step. Steps stay together only when one consumes another's build output:
+#
+#   suites          build package -> unit -> integration
+#   agent-suite     build native bindings -> coding-agent vitest
+#   release-archive build package -> build-binaries.sh -> archive smoke
+#   static-checks   typecheck, file length, docs, Mintlify, CI contracts (Linux)
+#   test            result gate; carries the two required check contexts
+#
+# Nothing is passed between jobs as an artifact: rebuilding in parallel is
+# cheaper in wall clock than serializing on an upload/download pair.
 jobs:
-    test:
-        name: test (${{ matrix.os }}, ${{ matrix.binary_platform }})
-        strategy:
-            matrix:
-                include:
-                    - os: blacksmith-4vcpu-ubuntu-2404
-                      binary_platform: linux-x64
-                      timeout_minutes: 10
-                    - os: blacksmith-4vcpu-windows-2025
-                      binary_platform: windows-x64
-                      timeout_minutes: 15
-            fail-fast: false
-        runs-on: ${{ matrix.os }}
-        # Bounded so a hung process cannot consume GitHub's 360-minute default.
-        timeout-minutes: ${{ matrix.timeout_minutes }}
-        steps:
-            # Sticky disks are Blacksmith-Linux-only; Windows takes a standard clone.
-            - uses: useblacksmith/checkout@01ab2a058dd0d41e292217b76582a6f9867c02ce # v1.0.0-beta
-              if: runner.os == 'Linux'
-              with:
-                  # LFS fixtures are required by the coding-agent test suite.
-                  lfs: true
-                  # Full history and tags support CI contract fixtures and release tooling.
-                  fetch-depth: 0
-            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-              if: runner.os != 'Linux'
-              with:
-                  lfs: true
-                  fetch-depth: 0
-            - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-              with:
-                  # Pinned to match publish.yml; `latest` cannot be cached by setup-bun.
-                  bun-version: 1.3.14
-            # Node is required by installed-package-node-extensions.test.ts, which
-            # smoke-tests the built npm package under the Node runtime.
-            - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-              with:
-                  node-version: 24
-            - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-              timeout-minutes: 4
-              with:
-                  # Required once pinned by SHA: the version otherwise comes from the ref.
-                  toolchain: stable
-            - name: Install dependencies
-              run: bun install --frozen-lockfile
-            - name: Typecheck
-              if: runner.os == 'Linux'
-              run: bun run typecheck
-            - name: File length check
-              if: runner.os == 'Linux'
-              run: bun run check:file-length
-            - name: Docs link validation
-              if: runner.os == 'Linux'
-              working-directory: packages/coding-agent
-              run: bun run docs:check
-            - name: Mintlify docs validation
-              if: runner.os == 'Linux' && github.event_name == 'pull_request'
-              working-directory: packages/coding-agent/docs
-              # Pinned: mintlify@4.2.732 pulls a package missing from the registry.
-              # Unpin once upstream publishes a resolvable release.
-              timeout-minutes: 5
-              run: |
-                  bunx --bun mintlify@4.2.731 validate
-                  bunx --bun mintlify@4.2.731 broken-links
-            - name: Build @bastani/atomic package
-              working-directory: packages/coding-agent
-              run: bun run build
-            - name: Deterministic CI and release contracts
-              run: bun run test:ci-contracts
-            - name: Unit tests (one bounded flake retry)
-              run: >-
-                  bun run scripts/run-flaky-test-suite.ts --label "unit tests (${{ matrix.binary_platform }})"
-                  --no-retry-file flaky-test-suite-runner.test.ts
-                  -- bun run test:unit
-            - name: Integration tests (one bounded flake retry)
-              run: >-
-                  bun run scripts/run-flaky-test-suite.ts --label "integration tests (${{ matrix.binary_platform }})"
-                  -- bun run test:integration
-              env:
-                  # Hard-require the installed-package Node smoke where the package
-                  # build above guarantees dist/ exists on both supported hosts.
-                  ATOMIC_REQUIRE_INSTALLED_NODE_SMOKE: "1"
-            - name: Build native bindings for package tests
-              run: bun run --cwd packages/natives build
-            - name: coding-agent vitest suite (one bounded flake retry)
-              run: >-
-                  bun run scripts/run-flaky-test-suite.ts --label "coding-agent tests (${{ matrix.binary_platform }})"
-                  -- bun run --cwd packages/coding-agent --bun test
-              env:
-                  ATOMIC_REQUIRE_NATIVE_BINDING_SMOKE: "1"
-            - name: Build native release binary
-              shell: bash
-              run: ./scripts/build-binaries.sh --skip-install --skip-package-build --platform "${{ matrix.binary_platform }}"
-            - name: Smoke test Linux release archive
-              if: runner.os == 'Linux'
-              shell: bash
-              run: |
-                  set -euo pipefail
-                  smoke_dir="$RUNNER_TEMP/atomic-binary-smoke"
-                  rm -rf "$smoke_dir"
-                  mkdir -p "$smoke_dir"
-                  tar -xzf packages/coding-agent/binaries/atomic-linux-x64.tar.gz -C "$smoke_dir"
-                  "$smoke_dir/atomic/atomic" --version
-                  bun run scripts/assert-builtin-set.ts "$smoke_dir/atomic/builtin"
-                  for required_path in \
-                    builtin/workflows/package.json \
-                    builtin/workflows/src/extension/index.ts \
-                    builtin/subagents/package.json \
-                    builtin/subagents/src/extension/index.ts \
-                    builtin/mcp/package.json \
-                    builtin/mcp/index.ts \
-                    builtin/web-access/package.json \
-                    builtin/web-access/index.ts \
-                    builtin/intercom/package.json \
-                    builtin/intercom/index.ts \
-                    node_modules/@bastani/atomic-natives/package.json \
-                    node_modules/@bastani/atomic-natives/native/index.js \
-                    node_modules/@bastani/atomic-natives/native/atomic_natives.linux-x64-gnu.node \
-                    node_modules/@modelcontextprotocol/ext-apps/package.json \
-                    node_modules/@mozilla/readability/package.json; do
-                    test -f "$smoke_dir/atomic/$required_path" || {
-                      echo "Missing release archive path: $required_path" >&2
-                      exit 1
-                    }
-                  done
-                  # Run from a clean temp cwd so repo-local config (e.g. .mcp.json)
-                  # can't leak into the smoke run and hang startup.
-                  work_dir="$RUNNER_TEMP/atomic-binary-smoke-cwd"
-                  rm -rf "$work_dir"
-                  mkdir -p "$work_dir"
-                  set +e
-                  output=$(cd "$work_dir" && printf '' | "$smoke_dir/atomic/atomic" --no-session 2>&1)
-                  status=$?
-                  set -e
-                  echo "$output"
-                  if grep -q 'Failed to load extension' <<<"$output"; then
-                    exit 1
-                  fi
-                  if [ "$status" -ne 0 ] && ! grep -Eq 'No models available|No model selected|No API key found' <<<"$output"; then
-                    exit "$status"
-                  fi
-            - name: Smoke test Windows release archive
-              if: runner.os == 'Windows'
-              shell: pwsh
-              run: |
-                  $ErrorActionPreference = "Stop"
-                  $smokeDir = Join-Path $env:RUNNER_TEMP "atomic-binary-smoke"
-                  Remove-Item -Recurse -Force $smokeDir -ErrorAction SilentlyContinue
-                  New-Item -ItemType Directory -Path $smokeDir | Out-Null
-                  Expand-Archive -Path packages/coding-agent/binaries/atomic-windows-x64.zip -DestinationPath $smokeDir
-                  $atomic = Join-Path $smokeDir "atomic.exe"
-                  & $atomic --version
-                  if ($LASTEXITCODE -ne 0) {
-                    exit $LASTEXITCODE
-                  }
-                  bun run scripts/assert-builtin-set.ts (Join-Path $smokeDir "builtin")
-                  foreach ($requiredPath in @(
-                    "builtin/workflows/package.json",
-                    "builtin/workflows/src/extension/index.ts",
-                    "builtin/subagents/package.json",
-                    "builtin/subagents/src/extension/index.ts",
-                    "builtin/mcp/package.json",
-                    "builtin/mcp/index.ts",
-                    "builtin/web-access/package.json",
-                    "builtin/web-access/index.ts",
-                    "builtin/intercom/package.json",
-                    "builtin/intercom/index.ts",
-                    "node_modules/@bastani/atomic-natives/package.json",
-                    "node_modules/@bastani/atomic-natives/native/index.js",
-                    "node_modules/@bastani/atomic-natives/native/atomic_natives.win32-x64-msvc.node",
-                    "node_modules/@modelcontextprotocol/ext-apps/package.json",
-                    "node_modules/@mozilla/readability/package.json"
-                  )) {
-                    $archivePath = Join-Path $smokeDir $requiredPath
-                    if (-not (Test-Path $archivePath)) {
-                      throw "Missing release archive path: $requiredPath"
-                    }
-                  }
-                  # Run from a clean temp cwd so repo-local config (e.g. .mcp.json)
-                  # can't leak into the smoke run and hang startup.
-                  $workDir = Join-Path $env:RUNNER_TEMP "atomic-binary-smoke-cwd"
-                  Remove-Item -Recurse -Force $workDir -ErrorAction SilentlyContinue
-                  New-Item -ItemType Directory -Path $workDir | Out-Null
-                  Push-Location $workDir
-                  $output = "" | & $atomic --no-session 2>&1 | Out-String
-                  $status = $LASTEXITCODE
-                  Pop-Location
-                  Write-Host $output
-                  if ($output -match "Failed to load extension") {
-                    exit 1
-                  }
-                  if ($status -ne 0 -and $output -notmatch "No models available|No model selected|No API key found") {
-                    exit $status
-                  }
-            - name: Upload flaky-test diagnostics
-              if: always()
-              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-              with:
-                  name: test-diagnostics-${{ matrix.binary_platform }}
-                  path: .ci-diagnostics/
-                  if-no-files-found: ignore
-                  retention-days: 14
+  suites:
+    name: suites (${{ matrix.os }}, ${{ matrix.binary_platform }})
+    strategy:
+      matrix:
+        include:
+          - os: blacksmith-4vcpu-ubuntu-2404
+            binary_platform: linux-x64
+            timeout_minutes: 6
+          - os: blacksmith-4vcpu-windows-2025
+            binary_platform: windows-x64
+            timeout_minutes: 8
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    # Measured 121s Linux / 195s Windows, and the unit step can double when its
+    # one bounded flake retry fires. The cap is a hang detector at roughly 2x
+    # measured p100, not a performance budget.
+    timeout-minutes: ${{ matrix.timeout_minutes }}
+    steps:
+      # Sticky disks are Blacksmith-Linux-only; Windows takes a standard clone.
+      - uses: useblacksmith/checkout@01ab2a058dd0d41e292217b76582a6f9867c02ce # v1.0.0-beta
+        if: runner.os == 'Linux'
+        with:
+          # LFS fixtures are required by the coding-agent test suite.
+          lfs: true
+          # Full history and tags support CI contract fixtures and release tooling.
+          fetch-depth: 0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: runner.os != 'Linux'
+        with:
+          lfs: true
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          # Pinned to match publish.yml; `latest` cannot be cached by setup-bun.
+          bun-version: 1.3.14
+      # Node is required by installed-package-node-extensions.test.ts, which
+      # smoke-tests the built npm package under the Node runtime.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      # Both suites below consume this build. test/unit/pi-0.82.1-artifacts.test.ts
+      # silently degrades to test.skip when packages/coding-agent/dist is absent,
+      # so moving the unit suite out of this job would lose coverage without
+      # failing anything.
+      - name: Build @bastani/atomic package
+        working-directory: packages/coding-agent
+        run: bun run build
+      - name: Unit tests (one bounded flake retry)
+        run: >-
+          bun run scripts/run-flaky-test-suite.ts --label "unit tests (${{ matrix.binary_platform }})"
+          --no-retry-file flaky-test-suite-runner.test.ts
+          -- bun run test:unit
+      - name: Integration tests (one bounded flake retry)
+        run: >-
+          bun run scripts/run-flaky-test-suite.ts --label "integration tests (${{ matrix.binary_platform }})"
+          -- bun run test:integration
+        env:
+          # Hard-require the installed-package Node smoke where the package
+          # build above guarantees dist/ exists on both supported hosts.
+          ATOMIC_REQUIRE_INSTALLED_NODE_SMOKE: "1"
+      - name: Upload flaky-test diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          # Artifact names must be unique across every job in the run:
+          # actions/upload-artifact@v4+ fails the whole run on a duplicate.
+          name: test-diagnostics-suites-${{ matrix.binary_platform }}
+          path: .ci-diagnostics/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  agent-suite:
+    name: agent-suite (${{ matrix.os }}, ${{ matrix.binary_platform }})
+    strategy:
+      matrix:
+        include:
+          - os: blacksmith-4vcpu-ubuntu-2404
+            binary_platform: linux-x64
+            timeout_minutes: 6
+          - os: blacksmith-4vcpu-windows-2025
+            binary_platform: windows-x64
+            timeout_minutes: 9
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    # Measured 126s Linux / 232s Windows. This is the critical path of the whole
+    # workflow, so its cap is the one with the least slack to give.
+    timeout-minutes: ${{ matrix.timeout_minutes }}
+    steps:
+      - uses: useblacksmith/checkout@01ab2a058dd0d41e292217b76582a6f9867c02ce # v1.0.0-beta
+        if: runner.os == 'Linux'
+        with:
+          # The only LFS fixtures in the repository live under
+          # packages/coding-agent/test/fixtures, so this job genuinely needs them.
+          lfs: true
+          fetch-depth: 0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: runner.os != 'Linux'
+        with:
+          lfs: true
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        timeout-minutes: 4
+        with:
+          # Required once pinned by SHA: the version otherwise comes from the ref.
+          toolchain: stable
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      # packages/coding-agent/test/native-binding-exports.test.ts is hard-required
+      # by ATOMIC_REQUIRE_NATIVE_BINDING_SMOKE below, so the vitest suite must
+      # stay behind this build.
+      - name: Build native bindings for package tests
+        run: bun run --cwd packages/natives build
+      - name: coding-agent vitest suite (one bounded flake retry)
+        run: >-
+          bun run scripts/run-flaky-test-suite.ts --label "coding-agent tests (${{ matrix.binary_platform }})"
+          -- bun run --cwd packages/coding-agent --bun test
+        env:
+          ATOMIC_REQUIRE_NATIVE_BINDING_SMOKE: "1"
+      - name: Upload flaky-test diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-diagnostics-agent-suite-${{ matrix.binary_platform }}
+          path: .ci-diagnostics/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  release-archive:
+    name: release-archive (${{ matrix.os }}, ${{ matrix.binary_platform }})
+    strategy:
+      matrix:
+        include:
+          - os: blacksmith-4vcpu-ubuntu-2404
+            binary_platform: linux-x64
+            timeout_minutes: 5
+          - os: blacksmith-4vcpu-windows-2025
+            binary_platform: windows-x64
+            timeout_minutes: 6
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    # Measured 74s Linux / 149s Windows, including the native binding rebuild
+    # this job pays for itself (see the Rust toolchain note below).
+    timeout-minutes: ${{ matrix.timeout_minutes }}
+    steps:
+      - uses: useblacksmith/checkout@01ab2a058dd0d41e292217b76582a6f9867c02ce # v1.0.0-beta
+        if: runner.os == 'Linux'
+        with:
+          lfs: true
+          fetch-depth: 0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: runner.os != 'Linux'
+        with:
+          lfs: true
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+      # scripts/build-binaries.sh reuses packages/natives/native/*.node when they
+      # exist and otherwise builds them, so this job needs the Rust toolchain and
+      # pays the native build again rather than waiting on agent-suite. That is a
+      # runner-second cost, not a wall-clock one.
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        timeout-minutes: 4
+        with:
+          toolchain: stable
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Build @bastani/atomic package
+        working-directory: packages/coding-agent
+        run: bun run build
+      - name: Build native release binary
+        shell: bash
+        run: ./scripts/build-binaries.sh --skip-install --skip-package-build --platform "${{ matrix.binary_platform }}"
+      - name: Smoke test Linux release archive
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          smoke_dir="$RUNNER_TEMP/atomic-binary-smoke"
+          rm -rf "$smoke_dir"
+          mkdir -p "$smoke_dir"
+          tar -xzf packages/coding-agent/binaries/atomic-linux-x64.tar.gz -C "$smoke_dir"
+          "$smoke_dir/atomic/atomic" --version
+          bun run scripts/assert-builtin-set.ts "$smoke_dir/atomic/builtin"
+          for required_path in \
+            builtin/workflows/package.json \
+            builtin/workflows/src/extension/index.ts \
+            builtin/subagents/package.json \
+            builtin/subagents/src/extension/index.ts \
+            builtin/mcp/package.json \
+            builtin/mcp/index.ts \
+            builtin/web-access/package.json \
+            builtin/web-access/index.ts \
+            builtin/intercom/package.json \
+            builtin/intercom/index.ts \
+            node_modules/@bastani/atomic-natives/package.json \
+            node_modules/@bastani/atomic-natives/native/index.js \
+            node_modules/@bastani/atomic-natives/native/atomic_natives.linux-x64-gnu.node \
+            node_modules/@modelcontextprotocol/ext-apps/package.json \
+            node_modules/@mozilla/readability/package.json; do
+            test -f "$smoke_dir/atomic/$required_path" || {
+              echo "Missing release archive path: $required_path" >&2
+              exit 1
+            }
+          done
+          # Run from a clean temp cwd so repo-local config (e.g. .mcp.json)
+          # can't leak into the smoke run and hang startup.
+          work_dir="$RUNNER_TEMP/atomic-binary-smoke-cwd"
+          rm -rf "$work_dir"
+          mkdir -p "$work_dir"
+          set +e
+          output=$(cd "$work_dir" && printf '' | "$smoke_dir/atomic/atomic" --no-session 2>&1)
+          status=$?
+          set -e
+          echo "$output"
+          if grep -q 'Failed to load extension' <<<"$output"; then
+            exit 1
+          fi
+          if [ "$status" -ne 0 ] && ! grep -Eq 'No models available|No model selected|No API key found' <<<"$output"; then
+            exit "$status"
+          fi
+      - name: Smoke test Windows release archive
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $smokeDir = Join-Path $env:RUNNER_TEMP "atomic-binary-smoke"
+          Remove-Item -Recurse -Force $smokeDir -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path $smokeDir | Out-Null
+          Expand-Archive -Path packages/coding-agent/binaries/atomic-windows-x64.zip -DestinationPath $smokeDir
+          $atomic = Join-Path $smokeDir "atomic.exe"
+          & $atomic --version
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+          bun run scripts/assert-builtin-set.ts (Join-Path $smokeDir "builtin")
+          foreach ($requiredPath in @(
+            "builtin/workflows/package.json",
+            "builtin/workflows/src/extension/index.ts",
+            "builtin/subagents/package.json",
+            "builtin/subagents/src/extension/index.ts",
+            "builtin/mcp/package.json",
+            "builtin/mcp/index.ts",
+            "builtin/web-access/package.json",
+            "builtin/web-access/index.ts",
+            "builtin/intercom/package.json",
+            "builtin/intercom/index.ts",
+            "node_modules/@bastani/atomic-natives/package.json",
+            "node_modules/@bastani/atomic-natives/native/index.js",
+            "node_modules/@bastani/atomic-natives/native/atomic_natives.win32-x64-msvc.node",
+            "node_modules/@modelcontextprotocol/ext-apps/package.json",
+            "node_modules/@mozilla/readability/package.json"
+          )) {
+            $archivePath = Join-Path $smokeDir $requiredPath
+            if (-not (Test-Path $archivePath)) {
+              throw "Missing release archive path: $requiredPath"
+            }
+          }
+          # Run from a clean temp cwd so repo-local config (e.g. .mcp.json)
+          # can't leak into the smoke run and hang startup.
+          $workDir = Join-Path $env:RUNNER_TEMP "atomic-binary-smoke-cwd"
+          Remove-Item -Recurse -Force $workDir -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path $workDir | Out-Null
+          Push-Location $workDir
+          $output = "" | & $atomic --no-session 2>&1 | Out-String
+          $status = $LASTEXITCODE
+          Pop-Location
+          Write-Host $output
+          if ($output -match "Failed to load extension") {
+            exit 1
+          }
+          if ($status -ne 0 -and $output -notmatch "No models available|No model selected|No API key found") {
+            exit $status
+          }
+
+  static-checks:
+    name: static-checks (linux-x64)
+    # Platform-independent checks. They cost 30s in total and need neither the
+    # Rust toolchain nor Node, so they run once on Linux instead of twice.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 6
+    steps:
+      - uses: useblacksmith/checkout@01ab2a058dd0d41e292217b76582a6f9867c02ce # v1.0.0-beta
+        with:
+          lfs: true
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Typecheck
+        run: bun run typecheck
+      - name: File length check
+        run: bun run check:file-length
+      - name: Docs link validation
+        working-directory: packages/coding-agent
+        run: bun run docs:check
+      - name: Mintlify docs validation
+        if: github.event_name == 'pull_request'
+        working-directory: packages/coding-agent/docs
+        # Pinned: mintlify@4.2.732 pulls a package missing from the registry.
+        # Unpin once upstream publishes a resolvable release.
+        timeout-minutes: 5
+        run: |
+          bunx --bun mintlify@4.2.731 validate
+          bunx --bun mintlify@4.2.731 broken-links
+      - name: Deterministic CI and release contracts
+        run: bun run test:ci-contracts
+
+  # Result gate. This job exists to carry the two contexts required by
+  # repository ruleset 9310196:
+  #
+  #   test (blacksmith-4vcpu-ubuntu-2404, linux-x64)
+  #   test (blacksmith-4vcpu-windows-2025, windows-x64)
+  #
+  # Its matrix reproduces those exact strings and nothing else; the gate does no
+  # platform work, so both legs run on the Linux runner. `if: always()` is
+  # mandatory: a job whose `needs` failed is *skipped*, and GitHub counts a
+  # skipped required check as satisfied, which would turn a red suite green.
+  # `needs.<job>.result` collapses a matrix to one value, so each leg asserts
+  # every platform's work jobs, which is strictly stronger than the per-platform
+  # meaning this context had before.
+  test:
+    name: test (${{ matrix.os }}, ${{ matrix.binary_platform }})
+    needs: [suites, agent-suite, release-archive, static-checks]
+    if: always()
+    strategy:
+      matrix:
+        include:
+          - os: blacksmith-4vcpu-ubuntu-2404
+            binary_platform: linux-x64
+          - os: blacksmith-4vcpu-windows-2025
+            binary_platform: windows-x64
+      fail-fast: false
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
+    steps:
+      - name: Require every work job to have succeeded
+        shell: bash
+        run: |
+          set -euo pipefail
+          results="${{ join(needs.*.result, ',') }}"
+          echo "work job results: $results"
+          if [ -z "$results" ]; then
+            echo "No work job results were reported; failing closed." >&2
+            exit 1
+          fi
+          case ",$results," in
+            *,failure,*|*,cancelled,*|*,skipped,*)
+              echo "A required work job did not succeed: $results" >&2
+              exit 1
+              ;;
+          esac

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -6,10 +6,12 @@ Atomic publishes `@bastani/atomic` from `packages/coding-agent` and `@bastani/at
 
 ```text
 Pull request / selected branch push
-└─ test.yml (Linux and Windows matrix)
-   ├─ install, typecheck, file-length and docs checks
-   ├─ unit, integration, native, and coding-agent tests
-   └─ Linux and Windows release-archive smoke tests
+└─ test.yml (four concurrent work jobs + one result gate)
+   ├─ suites (Linux, Windows): build package -> unit -> integration
+   ├─ agent-suite (Linux, Windows): native bindings -> coding-agent vitest
+   ├─ release-archive (Linux, Windows): build package -> binaries -> smoke
+   ├─ static-checks (Linux): typecheck, file length, docs, Mintlify, contracts
+   └─ test (2 legs): result gate carrying both required contexts
 
 Release tag push (`0.9.10` or `0.9.10-alpha.1`)
 └─ publish.yml
@@ -34,19 +36,53 @@ This release graph follows pi's draft-first publication shape. Public GitHub Rel
 
 ## Tests (`test.yml`)
 
-The test workflow runs on pushes to `main`, `release/**`, and `prerelease/**`, and on every pull request. Its matrix is unchanged:
+The test workflow runs on pushes to `main`, `release/**`, and `prerelease/**`, and on every pull request. Its work runs as four independent jobs so the wall clock is one job's longest dependent chain rather than the sum of every step in file order.
 
-- `blacksmith-4vcpu-ubuntu-2404` with `linux-x64` archive coverage
-- `blacksmith-4vcpu-windows-2025` with `windows-x64` archive coverage
+| Job | Platforms | Chain | Linux | Windows |
+| --- | --- | --- | ---: | ---: |
+| `suites` | both | build `@bastani/atomic` -> unit -> integration | 121 s | 195 s |
+| `agent-suite` | both | build native bindings -> coding-agent vitest | 126 s | 232 s |
+| `release-archive` | both | build package -> `scripts/build-binaries.sh` -> archive smoke | 74 s | 149 s |
+| `static-checks` | Linux only | typecheck, file length, docs links, Mintlify, CI contracts | 30 s | – |
+| `test` | 2 gate legs | assert every work-job result is `success` | 15 s | – |
+
+The critical path is the Windows `agent-suite` chain, so the workflow costs about 247 s instead of the 452 s the single sequential job measured. Runner-seconds rise about 35 % (709 s to roughly 957 s); that is the price of the wall-clock cut.
+
+### Why steps are grouped this way
+
+Steps stay in one job only when one consumes another's build output. Nothing is passed between jobs as an artifact, because rebuilding in parallel is cheaper in wall clock than serializing on an upload/download pair.
+
+- `test/unit/pi-0.82.1-artifacts.test.ts` gates its assertions on `packages/coding-agent/dist` and degrades to `test.skip` with a warning when the build has not run, so the unit suite must stay behind the package build. Moving it into a build-less job would lose coverage without failing anything.
+- `test/integration/installed-package-node-extensions.test.ts` needs `dist/` and Node 24 and is hard-required by `ATOMIC_REQUIRE_INSTALLED_NODE_SMOKE=1`, so `suites` is the only job that installs Node.
+- `packages/coding-agent/test/native-binding-exports.test.ts` is hard-required by `ATOMIC_REQUIRE_NATIVE_BINDING_SMOKE=1`, so the vitest suite stays behind `bun run --cwd packages/natives build`.
+- `scripts/build-binaries.sh` reuses `packages/natives/native/*.node` when present and otherwise builds them, so `release-archive` carries its own Rust toolchain and pays that build again rather than waiting on `agent-suite`. `suites` and `static-checks` need no Rust at all.
+
+No suite uses `--parallel`, `--shard`, `--concurrent`, or `--max-concurrency`. `--parallel` implies `--isolate`, and 20 files in `test/unit` import 108 sibling `*.test.ts` files, so a fresh module registry per file re-executes those tests: 5407 executions against 4426 distinct tests, with the duplicates scored twice by the duration guard, once under contention. `--shard` is deterministic and roughly 1.85x faster locally, but it buys no wall clock while Windows `agent-suite` is the critical path. If a further cut is wanted, shard vitest first, then unit; that is worth roughly 70 s for a 60 % increase in runner count.
+
+### The `test` job is a result gate
 
 Repository ruleset `9310196` requires these exact job contexts:
 
 - `test (blacksmith-4vcpu-ubuntu-2404, linux-x64)`
 - `test (blacksmith-4vcpu-windows-2025, windows-x64)`
 
-The matrix job sets its display name from only `matrix.os` and `matrix.binary_platform` to keep those contexts stable. Per-platform timeout values remain matrix data, but they must not form part of the display name: without an explicit name, GitHub appends every matrix value, so timeout tuning would silently rename the required checks. Change the display-name contract and repository ruleset together; normal runner or timeout tuning must leave both contexts unchanged.
+The `test` job keeps its id, its two matrix rows, and a display name built from only `matrix.os` and `matrix.binary_platform`, so both strings survive the split byte-for-byte and no ruleset edit is needed. Without an explicit name GitHub appends every matrix value, so timeout tuning would silently rename the required checks; per-platform timeouts therefore stay out of the gate's matrix. Change the display-name contract and the repository ruleset together.
 
-Both legs install with Bun, build `@bastani/atomic`, run deterministic CI contracts and test suites, build native bindings, and smoke an installed release archive. Platform-independent typecheck, file-length, and documentation checks run on Linux. Archive smoke tests verify bundled builtins, native modules, runtime dependencies, `--version`, and startup far enough to reject extension-load failures.
+The gate does no platform work — both legs run on the Linux runner — and it exists to fail closed:
+
+- Moving work into new jobs without a gate would silently un-protect every step that left `test`. The two contexts would still exist and still go green.
+- `if: always()` is mandatory. A job whose `needs` failed is *skipped*, and GitHub counts a skipped required check as satisfied, which would turn a red suite green.
+- The gate fails on `failure`, `cancelled`, and `skipped`. Because `needs.<job>.result` collapses a matrix to one value, each leg asserts every platform's work jobs, which is strictly stronger than the per-platform meaning this context had before.
+
+If maintainers later prefer real per-job required contexts, that is a separate deliberate change: replace the two contexts in ruleset `9310196` with the eight work-job contexts in the same window as the workflow merge. Do not do both at once.
+
+### Per-job time limits
+
+The blanket 10/15-minute pair is gone. Each job declares its own cap as a hang detector at roughly 2x measured p100, with room for the one bounded flake retry it owns: `suites` 6/8, `agent-suite` 6/9, `release-archive` 5/6, `static-checks` 6, gate 5. An earlier Linux run showed `Unit tests` at 176 s, which is that retry firing rather than a slow suite; capacity planning uses 84 s and treats 176 s as the retried worst case.
+
+Every job that runs a suite through `scripts/run-flaky-test-suite.ts` uploads `.ci-diagnostics/` under a job-unique artifact name (`test-diagnostics-<job>-<binary_platform>`). `actions/upload-artifact@v4+` fails the entire run when two jobs upload the same name.
+
+Archive smoke tests verify bundled builtins, native modules, runtime dependencies, `--version`, and startup far enough to reject extension-load failures.
 
 ## Direct release trigger and recovery
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -46,7 +46,24 @@ The test workflow runs on pushes to `main`, `release/**`, and `prerelease/**`, a
 | `static-checks` | Linux only | typecheck, file length, docs links, Mintlify, CI contracts | 30 s | – |
 | `test` | 2 gate legs | assert every work-job result is `success` | 15 s | – |
 
-The critical path is the Windows `agent-suite` chain, so the workflow costs about 247 s instead of the 452 s the single sequential job measured. Runner-seconds rise about 35 % (709 s to roughly 957 s); that is the price of the wall-clock cut.
+Those are the per-step costs sampled from four sequential-job runs, which put the critical path on the Windows `agent-suite` chain at about 247 s against the 452 s (434–483 s, n=3 healthy) the single sequential job measured. Runner-seconds rise about 35 % (709 s to roughly 957 s); that is the price of the wall-clock cut.
+
+### Observed on the first split run (30527771985)
+
+| Job | queue | duration |
+| --- | ---: | ---: |
+| `static-checks (linux-x64)` | 9 s | 32 s |
+| `release-archive` Linux / Windows | 9 s / 42 s | 84 s / 162 s |
+| `agent-suite` Linux / Windows | 10 s / 68 s | 138 s / **349 s** |
+| `suites` Linux / Windows | 10 s / 45 s | 230 s / 348 s |
+| `test` gate, both legs | 8 s | 3 s / 4 s |
+| **whole run** | | **433 s** |
+
+Read this carefully before planning further work, because it says two different things.
+
+The topology behaved exactly as designed. All seven work jobs started within 68 s of run creation, so Blacksmith does not cap concurrency below seven and the queueing risk did not materialize. `static-checks` was green in 32 s, giving fast feedback on typecheck and file length that used to arrive only at the end of a 257 s job. The gate ran in 3–4 s.
+
+The saving was nevertheless only 452 s -> 433 s, because per-step costs on that run ran about 1.5x the sampled averages: Windows `coding-agent vitest` took 221 s against a 142 s sample, the Windows native binding build 63 s against 42 s, and the unit step fired its bounded flake retry on *both* platforms (Linux 101 s + 88 s, Windows 149 s + 117 s). The wall clock is now dominated by two steps rather than by fourteen, which is the point: sharding either one now has a direct effect, where before the split it would have been diluted by everything else in the job. Confirm the split's steady-state saving over several runs before deciding, and shard `coding-agent vitest` first.
 
 ### Why steps are grouped this way
 
@@ -78,7 +95,7 @@ If maintainers later prefer real per-job required contexts, that is a separate d
 
 ### Per-job time limits
 
-The blanket 10/15-minute pair is gone. Each job declares its own cap as a hang detector at roughly 2x measured p100, with room for the one bounded flake retry it owns: `suites` 6/8, `agent-suite` 6/9, `release-archive` 5/6, `static-checks` 6, gate 5. An earlier Linux run showed `Unit tests` at 176 s, which is that retry firing rather than a slow suite; capacity planning uses 84 s and treats 176 s as the retried worst case.
+The blanket 10/15-minute pair is gone. Each job declares its own cap as a hang detector at roughly 2x measured p100, with room for the one bounded flake retry it owns: `suites` 8/12, `agent-suite` 6/12, `release-archive` 5/6, `static-checks` 6, gate 5. The two Windows caps are 12 rather than the 8 and 9 that the sequential-job sampling implied, because the first split run measured 348 s and 349 s there; a cap that cancels a passing retried run is worse than a late hang detection. Every cap still sits under the 15-minute Windows blanket it replaced, and the contract test enforces that.
 
 Every job that runs a suite through `scripts/run-flaky-test-suite.ts` uploads `.ci-diagnostics/` under a job-unique artifact name (`test-diagnostics-<job>-<binary_platform>`). `actions/upload-artifact@v4+` fails the entire run when two jobs upload the same name.
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -48,22 +48,34 @@ The test workflow runs on pushes to `main`, `release/**`, and `prerelease/**`, a
 
 Those are the per-step costs sampled from four sequential-job runs, which put the critical path on the Windows `agent-suite` chain at about 247 s against the 452 s (434–483 s, n=3 healthy) the single sequential job measured. Runner-seconds rise about 35 % (709 s to roughly 957 s); that is the price of the wall-clock cut.
 
-### Observed on the first split run (30527771985)
+### Observed on the first two split runs (30527771985, 30528920082)
 
-| Job | queue | duration |
+| Job | run 1 | run 2 |
 | --- | ---: | ---: |
-| `static-checks (linux-x64)` | 9 s | 32 s |
-| `release-archive` Linux / Windows | 9 s / 42 s | 84 s / 162 s |
-| `agent-suite` Linux / Windows | 10 s / 68 s | 138 s / **349 s** |
-| `suites` Linux / Windows | 10 s / 45 s | 230 s / 348 s |
-| `test` gate, both legs | 8 s | 3 s / 4 s |
-| **whole run** | | **433 s** |
+| `static-checks (linux-x64)` | 32 s | 50 s |
+| `release-archive` Linux / Windows | 84 s / 162 s | 83 s / 175 s |
+| `suites` Linux / Windows | 230 s / 348 s | 147 s / 238 s |
+| `agent-suite` Linux / Windows | 138 s / **349 s** | 203 s / **380 s** |
+| `test` gate, both legs | 3 s / 4 s | 4 s / 5 s |
+| **whole run** | **433 s** | **440 s** |
 
 Read this carefully before planning further work, because it says two different things.
 
-The topology behaved exactly as designed. All seven work jobs started within 68 s of run creation, so Blacksmith does not cap concurrency below seven and the queueing risk did not materialize. `static-checks` was green in 32 s, giving fast feedback on typecheck and file length that used to arrive only at the end of a 257 s job. The gate ran in 3–4 s.
+The topology behaves exactly as designed. All seven work jobs started within 68 s of run creation, so Blacksmith does not cap concurrency below seven and the queueing risk did not materialize. `static-checks` was green in 32–50 s, giving feedback on typecheck and file length that used to arrive only at the end of a 257 s job. The gate costs 3–5 s. Both required contexts appear with byte-identical names.
 
-The saving was nevertheless only 452 s -> 433 s, because per-step costs on that run ran about 1.5x the sampled averages: Windows `coding-agent vitest` took 221 s against a 142 s sample, the Windows native binding build 63 s against 42 s, and the unit step fired its bounded flake retry on *both* platforms (Linux 101 s + 88 s, Windows 149 s + 117 s). The wall clock is now dominated by two steps rather than by fourteen, which is the point: sharding either one now has a direct effect, where before the split it would have been diluted by everything else in the job. Confirm the split's steady-state saving over several runs before deciding, and shard `coding-agent vitest` first.
+The saving is nevertheless about 15 s, not the estimated 205 s, because the sequential-job sampling that produced the table above understated the Windows steps by roughly 1.5x:
+
+| step | sampled | run 1 | run 2 |
+| --- | ---: | ---: | ---: |
+| Windows `coding-agent vitest` | 142 s | 221 s | 237 s |
+| Windows native binding build | 42 s | 63 s | 72 s |
+| Linux `coding-agent vitest` | 70 s | 78 s | 126 s |
+| Windows unit step | 127 s | 267 s (retried) | 150 s |
+| Linux unit step | 84 s | 190 s (retried) | 101 s |
+
+On both runs the critical path was Windows `agent-suite`, whose real cost is 349–380 s rather than the 232 s the estimate assumed. Run 1 also fired the unit step's one bounded flake retry on both platforms, from two different pre-existing flakes that each passed on the retry.
+
+The structural result still stands and is what matters for the next decision: wall clock is now dominated by **two** steps instead of fourteen. Sharding `coding-agent vitest` therefore has a direct effect where before the split it would have been diluted by everything else in the job. Each shard must repeat the native binding build, so the arithmetic to beat is `setup + native build + vitest/2`. Confirm the steady-state numbers over more runs first.
 
 ### Why steps are grouped this way
 

--- a/test/ci/ci-workflow-contracts.test.ts
+++ b/test/ci/ci-workflow-contracts.test.ts
@@ -4,6 +4,7 @@ import { existsSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { jobBlock, jobBlocks, jobSteps, namedStep, readText } from "./workflow-text.js";
 import {
   canonicalReleaseBaseRef,
   parseReleaseBaseTrailers,
@@ -16,73 +17,10 @@ const testPath = join(root, ".github/workflows/test.yml");
 const warmPath = join(root, ".github/workflows/warm-toolchain-cache.yml");
 
 /**
- * File text with platform-neutral newlines.
- *
- * These contracts assert on what the repository stores, which is LF. But
- * `.gitattributes` marks `*.yml` as `text` without `eol=lf`, so the Windows
- * runner checks the workflows out as CRLF, and any pattern here containing a
- * literal `\n` would then pass on Linux and fail on Windows.
+ * The `test` job's own topology contracts live in test-workflow-topology.test.ts.
+ * It is now a result gate over four concurrent work jobs, and the
+ * anti-un-protection assertions belong beside the ones describing that split.
  */
-async function readText(path: string): Promise<string> {
-  return (await Bun.file(path).text()).replaceAll("\r\n", "\n");
-}
-
-function jobBlock(workflow: string, name: string, next?: string): string {
-  const start = workflow.indexOf(`  ${name}:`);
-  assert.notEqual(start, -1, `missing job: ${name}`);
-  const end = next ? workflow.indexOf(`  ${next}:`, start + 1) : workflow.length;
-  return workflow.slice(start, end);
-}
-
-function stepBlock(workflow: string, name: string, next: string): string {
-  const start = workflow.indexOf(`- name: ${name}`);
-  assert.notEqual(start, -1, `missing step: ${name}`);
-  const end = workflow.indexOf(`- name: ${next}`, start + 1);
-  assert.notEqual(end, -1, `missing next step: ${next}`);
-  return workflow.slice(start, end);
-}
-
-/** Split a job block into its individual steps, indentation-agnostically. */
-function jobSteps(block: string): string[] {
-  const header = /^(\s*)steps:$/mu.exec(block);
-  assert.ok(header, "job declares no steps");
-  const body = block.slice(header.index + header[0].length);
-  const first = /^([ \t]+)- /mu.exec(body);
-  assert.ok(first, "job declares no steps");
-  return body.split(new RegExp(`^${first[1] as string}- `, "gmu")).slice(1);
-}
-
-/** Every job in a workflow, paired with its own block. */
-function jobBlocks(workflow: string): [string, string][] {
-  const jobs = workflow.slice(workflow.indexOf("\njobs:\n"));
-  const names = [...jobs.matchAll(/^  ([a-z][a-z0-9-]*):$/gmu)].map(([, name]) => name as string);
-  return names.map((name, index) => [name, jobBlock(jobs, name, names[index + 1])]);
-}
-
-test("test workflow preserves its two-platform matrix and deterministic contracts", async () => {
-  const workflow = await readText(join(root, ".github/workflows/test.yml"));
-  const testJob = jobBlock(workflow, "test");
-  assert.match(testJob, /^[ \t]+name: test \(\$\{\{ matrix\.os \}\}, \$\{\{ matrix\.binary_platform \}\}\)$/mu);
-  const matrixContexts = [...testJob.matchAll(/^[ \t]+- os: (\S+)\s+binary_platform: (\S+)$/gmu)]
-    .map(([, os, platform]) => `test (${os}, ${platform})`);
-  assert.deepEqual(matrixContexts, [
-    "test (blacksmith-4vcpu-ubuntu-2404, linux-x64)",
-    "test (blacksmith-4vcpu-windows-2025, windows-x64)",
-  ]);
-  assert.match(workflow, /blacksmith-4vcpu-ubuntu-2404/);
-  assert.match(workflow, /blacksmith-4vcpu-windows-2025/);
-  assert.match(workflow, /blacksmith-4vcpu-ubuntu-2404\s+binary_platform: linux-x64\s+timeout_minutes: 10/);
-  assert.match(workflow, /blacksmith-4vcpu-windows-2025\s+binary_platform: windows-x64\s+timeout_minutes: 15/);
-  assert.match(workflow, /timeout-minutes: \$\{\{ matrix\.timeout_minutes \}\}/);
-  assert.match(workflow, /name: Deterministic CI and release contracts[\s\S]*run: bun run test:ci-contracts/);
-  assert.match(workflow, /Smoke test Linux release archive/);
-  assert.match(workflow, /Smoke test Windows release archive/);
-  assert.match(
-    stepBlock(workflow, "coding-agent vitest suite (one bounded flake retry)", "Build native release binary"),
-    /ATOMIC_REQUIRE_NATIVE_BINDING_SMOKE: "1"/u,
-  );
-});
-
 /**
  * The per-test timeout budget lives in package.json and nowhere else.
  *
@@ -124,8 +62,12 @@ test("binary staging and every release smoke verify the exact builtin directory 
   const publishWorkflow = await readText(publishPath);
   const buildScript = await readText(join(root, "scripts/build-binaries.sh"));
 
-  assert.match(stepBlock(testWorkflow, "Smoke test Linux release archive", "Smoke test Windows release archive"), checker);
-  assert.match(stepBlock(testWorkflow, "Smoke test Windows release archive", "Upload flaky-test diagnostics"), checker);
+  // Both smoke steps now live in the release-archive job. Anchor on the job so
+  // the assertion does not depend on which step happens to follow them.
+  const archiveSteps = jobSteps(jobBlock(testWorkflow, "release-archive", "static-checks"));
+  for (const platform of ["Linux", "Windows"]) {
+    assert.match(namedStep(archiveSteps, `Smoke test ${platform} release archive`), checker);
+  }
   assert.equal(testWorkflow.split("scripts/assert-builtin-set.ts").length - 1, 2);
   assert.match(jobBlock(publishWorkflow, "linux-binary-smoke", "windows-binary-smoke"), checker);
   assert.match(jobBlock(publishWorkflow, "windows-binary-smoke", "build"), checker);
@@ -341,14 +283,22 @@ test("sticky-disk checkout stays on Blacksmith Linux runners", async () => {
     }
   }
   const publish = await readText(publishPath);
+  const testWorkflow = await readText(testPath);
   assert.doesNotMatch(jobBlock(publish, "windows-binary-smoke", "build"), /useblacksmith/u);
+  // Every cross-platform job in test.yml now checks out for itself, so each one
+  // must keep the Linux/non-Linux checkout pair.
+  const crossPlatformJobs = ["suites", "agent-suite", "release-archive"] as const;
+  const testJobs = new Map(jobBlocks(testWorkflow));
   for (const block of [
     jobBlock(publish, "native-artifacts", "linux-binary-smoke"),
-    jobBlock(await readText(testPath), "test"),
+    ...crossPlatformJobs.map((job) => testJobs.get(job) as string),
   ]) {
     assert.match(block, /uses: useblacksmith\/checkout@[0-9a-f]{40}[^\n]*\n\s+if: runner\.os == 'Linux'/u);
     assert.match(block, /uses: actions\/checkout@[0-9a-f]{40}[^\n]*\n\s+if: runner\.os != 'Linux'/u);
   }
+  // The Linux-only static-checks job needs no guard, and the result gate checks
+  // out nothing at all.
+  assert.doesNotMatch(testJobs.get("test") as string, /checkout/u);
 });
 
 test("every third-party action is pinned to a full commit SHA with a version comment", async () => {

--- a/test/ci/release-publisher-contracts.test.ts
+++ b/test/ci/release-publisher-contracts.test.ts
@@ -5,6 +5,7 @@ import { copyFileSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSyn
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { readText } from "./workflow-text.js";
 
 
 type NativeManifest = {
@@ -75,7 +76,7 @@ test("prepared native root tarball contains all six exact-version optional depen
 });
 
 test("publish pipeline prepares exact native package set and publishes in dependency order", async () => {
-  const workflow = await Bun.file(`${root}/.github/workflows/publish.yml`).text();
+  const workflow = await readText(`${root}/.github/workflows/publish.yml`);
   const expectedOrder = [
     ...nativePackageNames,
     "@bastani/atomic-natives",

--- a/test/ci/release-recovery-contracts.test.ts
+++ b/test/ci/release-recovery-contracts.test.ts
@@ -2,19 +2,13 @@ import { test } from "bun:test";
 import assert from "node:assert/strict";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { jobBlock, readText } from "./workflow-text.js";
 
 const root = fileURLToPath(new URL("../..", import.meta.url));
 const workflowPath = join(root, ".github/workflows/publish.yml");
 
-function jobBlock(workflow: string, name: string, next: string): string {
-  const start = workflow.indexOf(`  ${name}:`);
-  const end = workflow.indexOf(`  ${next}:`, start + 1);
-  assert.ok(start >= 0 && end > start, `${name} job block must exist`);
-  return workflow.slice(start, end);
-}
-
 test("release recovery defaults source_ref to the requested tag verbatim", async () => {
-  const workflow = await Bun.file(workflowPath).text();
+  const workflow = await readText(workflowPath);
   assert.match(workflow, /tag:[\s\S]*required: true[\s\S]*source_ref:[\s\S]*required: false/);
   assert.match(
     workflow,
@@ -23,7 +17,7 @@ test("release recovery defaults source_ref to the requested tag verbatim", async
 });
 
 test("integrity always verifies the tag while recovery builds the selected source_ref", async () => {
-  const workflow = await Bun.file(workflowPath).text();
+  const workflow = await readText(workflowPath);
   const integrity = jobBlock(workflow, "integrity", "native-artifacts");
   assert.match(integrity, /ref: \$\{\{ env\.RELEASE_TAG \}\}/);
   assert.doesNotMatch(integrity, /ref: \$\{\{ env\.SOURCE_REF \}\}/);
@@ -41,7 +35,7 @@ test("integrity always verifies the tag while recovery builds the selected sourc
 });
 
 test("recovery stays tag-scoped and cannot cancel the matching publication", async () => {
-  const workflow = await Bun.file(workflowPath).text();
+  const workflow = await readText(workflowPath);
   assert.match(workflow, /group: publish-\$\{\{ github\.event\.inputs\.tag \|\| github\.ref_name \}\}/);
   assert.match(workflow, /cancel-in-progress: false/);
   assert.match(workflow, /gh release create "\$RELEASE_TAG" --verify-tag --draft/);

--- a/test/ci/test-workflow-topology.test.ts
+++ b/test/ci/test-workflow-topology.test.ts
@@ -62,14 +62,15 @@ test("every work job the gate names exists and is otherwise independent", async 
 /**
  * Per-job wall-clock caps replace the blanket 10/15 minute pair. A cap is a hang
  * detector at roughly 2x measured p100 and must leave room for the one bounded
- * flake retry the job owns.
+ * flake retry the job owns: the first split run fired that retry on both
+ * platforms and took 230 s / 348 s in `suites` alone.
  */
 test("each split job declares its own measured timeout", async () => {
   const workflow = await readText(testPath);
   const blocks = await jobs();
   const caps: Record<string, [number, number]> = {
-    suites: [6, 8],
-    "agent-suite": [6, 9],
+    suites: [8, 12],
+    "agent-suite": [6, 12],
     "release-archive": [5, 6],
   };
   for (const [job, [linux, windows]] of Object.entries(caps)) {
@@ -82,8 +83,12 @@ test("each split job declares its own measured timeout", async () => {
   assert.match(blocks.get("static-checks") as string, /^[ \t]+timeout-minutes: 6$/mu);
   assert.match(blocks.get("test") as string, /^[ \t]+timeout-minutes: 5$/mu);
   // The blanket per-platform pair covered fourteen sequential steps and detected
-  // nothing about the step that actually hung.
+  // nothing about the step that actually hung. Every cap must also stay under
+  // the 15-minute Windows blanket it replaced.
   assert.doesNotMatch(workflow, /timeout_minutes: (10|15)\b/u);
+  for (const [, value] of workflow.matchAll(/^\s+timeout_minutes: (\d+)$/gmu)) {
+    assert.ok(Number(value) < 15, `cap ${value} is no tighter than the blanket it replaced`);
+  }
 });
 
 /**

--- a/test/ci/test-workflow-topology.test.ts
+++ b/test/ci/test-workflow-topology.test.ts
@@ -1,0 +1,183 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { jobBlock, jobBlocks, jobSteps, namedStep, readText, stepIndex } from "./workflow-text.js";
+
+const root = fileURLToPath(new URL("../..", import.meta.url));
+const testPath = join(root, ".github/workflows/test.yml");
+
+/** The work jobs the result gate must depend on, in file and `needs` order. */
+const WORK_JOBS = ["suites", "agent-suite", "release-archive", "static-checks"] as const;
+
+/** Job blocks keyed by job id, in file order. */
+async function jobs(): Promise<Map<string, string>> {
+  return new Map(jobBlocks(await readText(testPath)));
+}
+
+/**
+ * The two required contexts of repository ruleset 9310196 are produced by the
+ * `test` job's matrix and nothing else. Splitting work into new jobs silently
+ * un-protects every step that leaves `test`, and a `needs:` job without
+ * `if: always()` is *skipped* when a dependency fails — which GitHub counts as a
+ * satisfied required check. This contract is the guard against both.
+ */
+test("the test job is a fail-closed result gate carrying both required contexts", async () => {
+  const workflow = await readText(testPath);
+  const gate = jobBlock(workflow, "test");
+  assert.match(gate, /^[ \t]+name: test \(\$\{\{ matrix\.os \}\}, \$\{\{ matrix\.binary_platform \}\}\)$/mu);
+
+  const contexts = [...gate.matchAll(/^[ \t]+- os: (\S+)\s+binary_platform: (\S+)$/gmu)]
+    .map(([, os, platform]) => `test (${os}, ${platform})`);
+  assert.deepEqual(contexts, [
+    "test (blacksmith-4vcpu-ubuntu-2404, linux-x64)",
+    "test (blacksmith-4vcpu-windows-2025, windows-x64)",
+  ]);
+
+  assert.match(gate, /^[ \t]+if: always\(\)$/mu, "a skipped required check counts as passed");
+  assert.match(gate, new RegExp(`^[ \\t]+needs: \\[${WORK_JOBS.join(", ")}\\]$`, "mu"));
+
+  const steps = jobSteps(gate);
+  assert.equal(steps.length, 1, "the gate must do no work of its own");
+  const guard = steps[0] as string;
+  assert.match(guard, /join\(needs\.\*\.result, ','\)/u);
+  assert.match(guard, /\*,failure,\*\|\*,cancelled,\*\|\*,skipped,\*/u);
+  assert.match(guard, /exit 1/u);
+  assert.doesNotMatch(guard, /checkout|setup-bun|bun run/u);
+  // The gate is pure bookkeeping, so both legs run on Linux; a Windows runner
+  // would add its measured 33s queue for nothing.
+  assert.match(gate, /^[ \t]+runs-on: blacksmith-4vcpu-ubuntu-2404$/mu);
+});
+
+test("every work job the gate names exists and is otherwise independent", async () => {
+  const blocks = await jobs();
+  assert.deepEqual([...blocks.keys()], [...WORK_JOBS, "test"]);
+  for (const job of WORK_JOBS) {
+    const block = blocks.get(job) as string;
+    assert.doesNotMatch(block, /^[ \t]+needs:/mu, `${job} must not serialize behind another job`);
+  }
+});
+
+/**
+ * Per-job wall-clock caps replace the blanket 10/15 minute pair. A cap is a hang
+ * detector at roughly 2x measured p100 and must leave room for the one bounded
+ * flake retry the job owns.
+ */
+test("each split job declares its own measured timeout", async () => {
+  const workflow = await readText(testPath);
+  const blocks = await jobs();
+  const caps: Record<string, [number, number]> = {
+    suites: [6, 8],
+    "agent-suite": [6, 9],
+    "release-archive": [5, 6],
+  };
+  for (const [job, [linux, windows]] of Object.entries(caps)) {
+    const block = blocks.get(job) as string;
+    assert.match(block, new RegExp(`blacksmith-4vcpu-ubuntu-2404\\s+binary_platform: linux-x64\\s+timeout_minutes: ${linux}`, "u"), job);
+    assert.match(block, new RegExp(`blacksmith-4vcpu-windows-2025\\s+binary_platform: windows-x64\\s+timeout_minutes: ${windows}`, "u"), job);
+    assert.match(block, /timeout-minutes: \$\{\{ matrix\.timeout_minutes \}\}/u, job);
+    assert.match(block, /fail-fast: false/u, job);
+  }
+  assert.match(blocks.get("static-checks") as string, /^[ \t]+timeout-minutes: 6$/mu);
+  assert.match(blocks.get("test") as string, /^[ \t]+timeout-minutes: 5$/mu);
+  // The blanket per-platform pair covered fourteen sequential steps and detected
+  // nothing about the step that actually hung.
+  assert.doesNotMatch(workflow, /timeout_minutes: (10|15)\b/u);
+});
+
+/**
+ * Steps that consume a previous step's output stay in one job. Moving them apart
+ * would not fail: test/unit/pi-0.82.1-artifacts.test.ts degrades to `test.skip`
+ * without packages/coding-agent/dist, so the coverage would vanish quietly.
+ */
+test("build-consuming steps stay in the job that produced the build", async () => {
+  const blocks = await jobs();
+
+  const suites = jobSteps(blocks.get("suites") as string);
+  assert.ok(stepIndex(suites, "Build @bastani/atomic package") < stepIndex(suites, "Unit tests"));
+  assert.ok(stepIndex(suites, "Unit tests") < stepIndex(suites, "Integration tests"));
+  assert.match(namedStep(suites, "Integration tests"), /ATOMIC_REQUIRE_INSTALLED_NODE_SMOKE: "1"/u);
+  assert.match(blocks.get("suites") as string, /uses: actions\/setup-node@/u);
+  assert.doesNotMatch(blocks.get("suites") as string, /rust-toolchain/u);
+
+  const agent = jobSteps(blocks.get("agent-suite") as string);
+  assert.ok(stepIndex(agent, "Build native bindings for package tests") < stepIndex(agent, "coding-agent vitest suite"));
+  assert.match(namedStep(agent, "coding-agent vitest suite"), /ATOMIC_REQUIRE_NATIVE_BINDING_SMOKE: "1"/u);
+  assert.match(blocks.get("agent-suite") as string, /uses: dtolnay\/rust-toolchain@/u);
+
+  const archive = jobSteps(blocks.get("release-archive") as string);
+  assert.ok(stepIndex(archive, "Build @bastani/atomic package") < stepIndex(archive, "Build native release binary"));
+  assert.ok(stepIndex(archive, "Build native release binary") < stepIndex(archive, "Smoke test Linux release archive"));
+  assert.ok(stepIndex(archive, "Build native release binary") < stepIndex(archive, "Smoke test Windows release archive"));
+  // build-binaries.sh rebuilds packages/natives/native/*.node when they are
+  // absent, so this job needs Rust rather than a dependency on agent-suite.
+  assert.match(blocks.get("release-archive") as string, /uses: dtolnay\/rust-toolchain@/u);
+
+  const staticChecks = blocks.get("static-checks") as string;
+  assert.match(staticChecks, /^[ \t]+runs-on: blacksmith-4vcpu-ubuntu-2404$/mu);
+  assert.doesNotMatch(staticChecks, /rust-toolchain|setup-node/u);
+  for (const step of ["Typecheck", "File length check", "Docs link validation", "Mintlify docs validation", "Deterministic CI and release contracts"]) {
+    namedStep(jobSteps(staticChecks), step);
+  }
+  assert.match(namedStep(jobSteps(staticChecks), "Deterministic CI and release contracts"), /run: bun run test:ci-contracts/u);
+});
+
+/**
+ * `actions/upload-artifact@v4+` fails the entire run when two jobs upload the
+ * same artifact name, and three jobs previously emitted the identical
+ * `test-diagnostics-<platform>` name.
+ */
+test("every diagnostics upload has a job-unique artifact name", async () => {
+  const uploads = [...(await jobs())].flatMap(([job, block]) =>
+    jobSteps(block)
+      .filter((step) => step.includes("actions/upload-artifact@"))
+      .map((step) => {
+        const name = /^\s+name: (.+)$/mu.exec(step);
+        assert.ok(name, `${job}: upload-artifact step declares no artifact name`);
+        return (name[1] as string).trim();
+      }));
+  assert.ok(uploads.length >= 2, "the flaky-suite jobs must still preserve their diagnostics");
+  assert.equal(new Set(uploads).size, uploads.length, `duplicate artifact names: ${uploads.join(", ")}`);
+  for (const name of uploads) assert.match(name, /^test-diagnostics-[a-z-]+-\$\{\{ matrix\.binary_platform \}\}$/u);
+});
+
+/**
+ * The duration-headroom guard parses Bun's per-test `(pass) name [Nms]` records.
+ * Every suite must keep reaching it through an unmodified `bun run <script>`
+ * command: a bare `bun test` or an added `--parallel` would change the records
+ * the guard scores, and `--parallel` re-executes tests imported by an aggregator
+ * file so healthy tests get scored twice, once under contention.
+ */
+test("every retried suite still runs through the duration guard unmodified", async () => {
+  const workflow = await readText(testPath);
+  const invocations = [...workflow.matchAll(/-- (bun run [^\n]+)$/gmu)].map(([, command]) => (command as string).trim());
+  assert.deepEqual(invocations, [
+    "bun run test:unit",
+    "bun run test:integration",
+    "bun run --cwd packages/coding-agent --bun test",
+  ]);
+  assert.equal(workflow.split("run-flaky-test-suite.ts").length - 1, invocations.length);
+  assert.doesNotMatch(workflow, /--parallel|--shard|--concurrent|--max-concurrency/u);
+});
+
+/**
+ * `bun run test:ci-contracts` used to run on both platforms; it now runs only in
+ * the Linux-only static-checks job. The one thing the Windows leg contributed
+ * was a CRLF checkout, which `.gitattributes` now forecloses by pinning `*.yml`
+ * to `eol=lf`. Routing every workflow read through the newline-normalizing
+ * reader keeps that trap closed from the test side too, so neither a relaxed
+ * attribute nor a stray CRLF can quietly change what these patterns match.
+ */
+test("CI contract suites read workflow text through the normalizing reader", async () => {
+  const dir = join(root, "test/ci");
+  for (const entry of readdirSync(dir)) {
+    if (!entry.endsWith(".ts") || entry === "workflow-text.ts") continue;
+    const source = await readText(join(dir, entry));
+    assert.doesNotMatch(
+      source,
+      /Bun\.file\([^)]*\)\.text\(\)/u,
+      `${entry}: read workflow text with readText() so a CRLF checkout cannot change the match`,
+    );
+  }
+});

--- a/test/ci/workflow-text.ts
+++ b/test/ci/workflow-text.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+
+/**
+ * Workflow-text helpers shared by the CI contract suites.
+ *
+ * These contracts assert on what the repository stores, which is LF.
+ * `.gitattributes` now pins `*.yml` to `eol=lf`, so a CRLF checkout should no
+ * longer be possible; before that pin the Windows runner checked the workflows
+ * out as CRLF and any pattern containing a literal `\n` passed on Linux and
+ * failed on Windows. Every reader here still normalizes newlines so the suites
+ * cannot silently regress if that attribute is ever relaxed.
+ */
+export async function readText(path: string): Promise<string> {
+  return (await Bun.file(path).text()).replaceAll("\r\n", "\n");
+}
+
+/** The text of one job, from its `  <name>:` header to the next job or EOF. */
+export function jobBlock(workflow: string, name: string, next?: string): string {
+  const start = workflow.indexOf(`  ${name}:`);
+  assert.notEqual(start, -1, `missing job: ${name}`);
+  const end = next ? workflow.indexOf(`  ${next}:`, start + 1) : workflow.length;
+  return workflow.slice(start, end);
+}
+
+/** Split a job block into its individual steps, indentation-agnostically. */
+export function jobSteps(block: string): string[] {
+  const header = /^(\s*)steps:$/mu.exec(block);
+  assert.ok(header, "job declares no steps");
+  const body = block.slice(header.index + header[0].length);
+  const first = /^([ \t]+)- /mu.exec(body);
+  assert.ok(first, "job declares no steps");
+  return body.split(new RegExp(`^${first[1] as string}- `, "gmu")).slice(1);
+}
+
+/** Every job in a workflow, paired with its own block. */
+export function jobBlocks(workflow: string): [string, string][] {
+  const jobs = workflow.slice(workflow.indexOf("\njobs:\n"));
+  const names = [...jobs.matchAll(/^  ([a-z][a-z0-9-]*):$/gmu)].map(([, name]) => name as string);
+  return names.map((name, index) => [name, jobBlock(jobs, name, names[index + 1])]);
+}
+
+/** The step whose `- name:` starts with `prefix`, asserted to be unique. */
+export function namedStep(steps: string[], prefix: string): string {
+  const matches = steps.filter((step) => step.startsWith(`name: ${prefix}`));
+  assert.equal(matches.length, 1, `expected exactly one step named like: ${prefix}`);
+  return matches[0] as string;
+}
+
+/** Index of the step whose `- name:` starts with `prefix`, for ordering checks. */
+export function stepIndex(steps: string[], prefix: string): number {
+  const index = steps.findIndex((step) => step.startsWith(`name: ${prefix}`));
+  assert.notEqual(index, -1, `missing step: ${prefix}`);
+  return index;
+}


### PR DESCRIPTION
## What this does

`.github/workflows/test.yml` ran ~14 steps sequentially in one job per platform, so its wall clock was the sum of every step rather than the longest dependent chain. This splits the work into four independent jobs and keeps job id `test` as a fail-closed result gate.

| job | chain | Linux | Windows |
|---|---|---:|---:|
| `suites` | build package → unit → integration | 121 s | 195 s |
| `agent-suite` | native bindings → coding-agent vitest | 126 s | **232 s** |
| `release-archive` | build package → `build-binaries.sh` → archive smoke | 74 s | 149 s |
| `static-checks` (Linux only) | typecheck, file length, docs links, Mintlify, CI contracts | 30 s | – |
| `test` (gate, 2 legs) | assert every work-job result is `success` | 15 s | – |

Steps stay together only when one consumes another's build output: unit tests stay behind the package build (`test/unit/pi-0.82.1-artifacts.test.ts` silently `test.skip`s without `dist/`), integration stays behind the package build plus Node, vitest stays behind the natives build, and `release-archive` rebuilds natives itself because `scripts/build-binaries.sh` reuses or rebuilds `packages/natives/native/*.node`. Rust is dropped from `suites` and `static-checks`; Node is dropped from `static-checks`. The blanket 10/15-minute caps become measured per-job caps (`suites` 6/8, `agent-suite` 6/9, `release-archive` 5/6, `static-checks` 6, gate 5), each leaving room for the one bounded flake retry its job owns.

## Before / after wall clock

| | before | after |
|---|---:|---:|
| PR wall clock (max of both platform jobs) | **452 s** avg (434–483 s, n=3 healthy runs, GitHub API) | **~247 s** |
| saving | | **~205 s (45 %)**, 7 m 32 s → 4 m 07 s |
| Linux job | 257 s | 126 s |
| runner-seconds | 709 s | ~957 s (+35 %) |

The critical path today is the Windows job at 452 s. After the split its longest chain is 48 s setup + 42 s native bindings + 142 s coding-agent vitest = 232 s, plus a ~15 s Linux result gate. The runner-second rise is the deliberate price of the wall-clock cut, not a surprise.

## ⚠️ Measured on the first two split runs — read before merging

Both runs were green, but the estimate above did **not** hold. Recording it honestly:

| job | run 1 (30527771985) | run 2 (30528920082) |
|---|---:|---:|
| `static-checks (linux-x64)` | 32 s | 50 s |
| `release-archive` Linux / Windows | 84 s / 162 s | 83 s / 175 s |
| `suites` Linux / Windows | 230 s / 348 s | 147 s / 238 s |
| `agent-suite` Linux / Windows | 138 s / **349 s** | 203 s / **380 s** |
| `test` gate, both legs | 3 s / 4 s | 4 s / 5 s |
| **whole run** | **433 s** | **440 s** |

Baseline for comparison: **452 s** avg (434–483 s, n=3 healthy). Queue delays on run 1 were 9–10 s on Linux and 42–68 s on Windows.

**The topology worked exactly as designed.** All seven work jobs started within 68 s of run creation, so Blacksmith does not cap concurrency below seven and risk #1 (queueing) did not materialize. Both required contexts appeared with byte-identical names, the gate ran in 3–4 s, and `static-checks` was green in 32 s — feedback on typecheck and file length that previously arrived only at the end of a 257 s job.

**The saving is ~15 s, not ~205 s.** The sequential-job sampling the plan was built on understated every Windows step by roughly 1.5×:

| step | sampled | run 1 | run 2 |
|---|---:|---:|---:|
| Windows `coding-agent vitest` | 142 s | 221 s | 237 s |
| Windows native binding build | 42 s | 63 s | 72 s |
| Linux `coding-agent vitest` | 70 s | 78 s | 126 s |
| Windows unit step | 127 s | 267 s (retried) | 150 s |
| Linux unit step | 84 s | 190 s (retried) | 101 s |

On both runs the critical path was Windows `agent-suite`, whose real cost is 349–380 s rather than the 232 s the estimate assumed. That single number is where the plan's 247 s estimate came from, so the estimate cannot be recovered by tuning anything else.

On run 1 the unit step's one bounded flake retry fired on **both** platforms, from two different pre-existing flakes, each of which passed on the retry (run 2 had no retry at all):

- Linux: `isolated default main lists and executes engine-only /workflow and /workflows while the host has no extensions` (13.1 s, "Timed out waiting for fixture report") in `interactive-engine-default-main.test.ts`.
- Windows: `raw child stdout and stderr share the bounded telemetry budget` — one of the tests the plan already identified as timing-sensitive.

**Neither is caused by this PR.** `test/unit` is untouched by the diff and each job owns its own runner, so nothing here runs under added contention. They are reported, not repaired: repairing them is out of scope and would mean weakening assertions. The retry machinery behaved correctly and the duration guard printed its table on both platforms.

The useful structural result still stands: wall clock is now dominated by **two** steps instead of fourteen, so sharding `coding-agent vitest` (the plan's phase 2) now has a direct effect rather than a diluted one, and `static-checks` returns typecheck/file-length feedback in 32–50 s instead of at the end of a 257 s job. This PR deliberately does not shard anything, per the brief. `docs/ci.md` carries both runs so the next decision starts from measurements rather than from the estimate.

### Follow-up commit: two Windows caps widened

`suites` Windows at 348 s was 72 % of its 8-minute cap on the very first run, with the retry. A cap that cancels a *passing* retried run is worse than a late hang detection, so the second commit applies the plan's own "roughly 2× measured p100" rule to the newer measurement: `suites` 6/8 → **8/12**, `agent-suite` 6/9 → **6/12**, `release-archive` unchanged at 5/6, `static-checks` 6, gate 5. Every cap still sits under the 15-minute Windows blanket it replaced, and the contract test now enforces that ceiling as well as the exact values.

## Executed vs distinct test counts

Measured in this worktree, Bun 1.3.14, `bun install` fresh.

**`test/ci` — the suite this PR changes**

| run | executed | distinct |
|---|---:|---:|
| before (`bun run test:ci-contracts`) | 25 | 25 |
| after, run 1 | 31 | 31 |
| after, run 2 | 31 | 31 |
| after, run 3 | 31 | 31 |
| after, `--shard=1/2` | 22 | 22 |
| after, `--shard=2/2` | 9 | 9 |

All three full runs and the union of the two shards produce **byte-identical 31-name sets**, so the suite is order- and partition-independent. Distinct coverage grows 25 → 31: one test (`test workflow preserves its two-platform matrix and deterministic contracts`) is replaced by six stronger ones, and every assertion it made is still made. Nothing was removed.

**`test/unit` — unchanged by this PR, re-run to prove it**

| run | executed records | distinct | result |
|---|---:|---:|---|
| before, run 1 | 4427 | 4426 | pass, 123.2 s |
| before, run 2 | 4427 | 4426 | pass, 129.1 s |
| after, via `scripts/run-flaky-test-suite.ts -- bun run test:unit` | 4427 | 4426 | pass, 125.6 s, no retry |

(The 4427th record is the same `test.skip` name printed twice; Bun's own footer reports `Ran 4426 tests across 581 files` in every run.)

**`test/integration`**: 289 executed, 289 distinct, pass, through the flaky-suite runner.

## The 950 duplicate executions

They are real re-execution, not a reporting artifact, and this PR avoids them by **not** using `--parallel` anywhere.

`--parallel` implies `--isolate`. 20 files in `test/unit` import 108 sibling `*.test.ts` files (e.g. `executor.test.ts` imports 20+ siblings), and Bun also collects those 108 files in their own right. Sequentially the module registry is shared so the second collection is a no-op; under `--isolate` every file gets a fresh registry and each imported file's tests run twice. The arithmetic checks out: the sequential log attributes 607 records to the 20 aggregator headers and 360 to the 108 children = 967, against an observed excess of 981. A clean 8-file/24-test probe under `--parallel=4` executed each test exactly once, so `--parallel` does not duplicate by itself. The `subagents-attempt-watchdog.test.ts` header appearing 9 times is separate and benign: Bun's parallel reporter reprints the file header on every worker flush.

Consequence for the duration guard: every duplicated test is scored twice, once under contention, so the 70 % fail ratio starts firing on tests that are healthy sequentially. That alone disqualifies `--parallel` for this repository. A follow-up issue is worth filing for the redundant aggregator files, which already make "which file owns this test" depend on collection order.

## The 600 ms watchdog test

**Nothing was changed about it.** `test/unit/subagents-attempt-watchdog.test.ts` and `test/unit/subagents-attempt-watchdog-helpers.ts` are not deleted, skipped, weakened, or excluded, and the diff does not touch them.

Under a saturation proxy (`--parallel=12` on 12 cores, the same one-worker-per-core oversubscription `--parallel=4` would create on a 4 vCPU runner) the failure is a **class**, not one test, and it is unstable: three identical invocations failed 4, 3 and 3 tests, and the failing set changed between them. Fixing only the test named in the brief would not have made the first run green. The fixture sets a 1000 ms idle bound and a 4000 ms attempt cap for the whole file and individual tests tighten the wall cap to 600–700 ms; those bounds also apply to the healthy fallback attempt, so under contention the good child cannot produce first activity inside the idle window and the watchdog kills it. The wall-cap test already spends 928 ms of its 600 ms cap sequentially on an idle machine (330 ms of that is pure double child spawn).

The test is not wrong — the environment stops being able to serve a sub-second deadline. So this PR simply never runs the unit suite under contention. If parallel execution is revisited, the correct fix is to derive the fixture's idle bound from a spawn-latency baseline measured once per suite (`idleMs = max(1000, k × measured spawn ms)`) while leaving every assertion exact. Raising a magic constant would only move the cliff.

## Duration-headroom guard

Unchanged, because nothing it reads changed. Each split job still runs its own `scripts/run-flaky-test-suite.ts` invocation over an unmodified `bun run test:unit` / `bun run test:integration` / `bun run --cwd packages/coding-agent --bun test`, so budget resolution, `blind` detection and the 40 %/70 % ratios are untouched. Verified end to end in this worktree:

- unit: gate enabled, default budget 30000 ms, 4303 samples of 4426, **not blind**, 0 warn, 0 fail, explicit per-test budgets resolved (12000/20000/30000 ms).
- integration: gate enabled, 277 samples of 289, not blind, 0 warn, 0 fail, explicit budgets resolved (30000/60000/240000 ms).
- Both wrote their `.ci-diagnostics/<suite>-durations.md` table on a green run.

A new contract asserts the three retried suites still reach the guard through unmodified `bun run` commands and that `--parallel`, `--shard`, `--concurrent` and `--max-concurrency` appear nowhere in the workflow, so a future edit cannot silently reshape the records the guard scores.

`.ci-diagnostics` artifact names are now job-unique (`test-diagnostics-<job>-<binary_platform>`); `actions/upload-artifact@v4+` fails the whole run on a duplicate name.

## Required check names — no maintainer action needed

**No ruleset edit is required and no check name changes.** Ruleset `9310196` requires exactly:

- `test (blacksmith-4vcpu-ubuntu-2404, linux-x64)`
- `test (blacksmith-4vcpu-windows-2025, windows-x64)`

Job id `test` keeps those two matrix rows and the same `name: test (${{ matrix.os }}, ${{ matrix.binary_platform }})` expression, so both strings are byte-identical. It becomes a result gate with `if: always()` that fails on `failure`, `cancelled` **and** `skipped`.

The `skipped` case is the one that matters: a job whose `needs` failed is *skipped*, and GitHub counts a skipped required check as satisfied. Without `always()` plus an explicit result check, a failing suite would turn the required context green — strictly worse than today. Because `needs.<job>.result` collapses a matrix to one value, each gate leg asserts every platform's work jobs, which is strictly stronger than the per-platform meaning the context had before. The gate does no platform work, so both legs run on the Linux runner rather than burning a Windows runner and its measured 33 s queue.

If maintainers later prefer real per-job required contexts (which would remove the ~15 s gate), that is a separate deliberate change: replace the two contexts with the eight work-job contexts in the same window as the workflow merge. Do not do both at once.

**One thing to verify on the first run of this PR:** the estimate assumes 7 jobs start about as promptly as 2 do today (measured queue: Linux 9 s, Windows 33 s). Read `gh api .../jobs --jq '.jobs[]|{name,created_at,started_at}'`; if Windows queueing exceeds ~60 s, merge `release-archive` back into `suites` on Windows.

## Contract-test changes

`test/ci/ci-workflow-contracts.test.ts` shrinks: its workflow-text helpers move to a new `test/ci/workflow-text.ts` shared by all four CI contract suites, and the topology contracts land in a new `test/ci/test-workflow-topology.test.ts`:

- the gate's two contexts are derived from the gate job's own matrix, plus `if: always()`, its `needs` set, and that its single step fails on `failure|cancelled|skipped`;
- per-job caps replace the 10/15 pair, and `timeout_minutes: 10|15` may not come back;
- the vitest/native-binding adjacency is re-anchored inside `agent-suite`, and the smoke steps inside `release-archive`, so neither depends on file-order adjacency across jobs;
- the sticky-disk `useblacksmith`/`actions` checkout pair is asserted for each of the three cross-platform jobs, and the gate is asserted to check out nothing;
- artifact names must be unique across jobs.

Moving `test:ci-contracts` into a Linux-only job drops its only CRLF checkout (`.gitattributes` marks `*.yml` as `text` without `eol=lf`), so a new contract requires every CI contract suite to read workflow text through the newline-normalizing reader. That converts a platform-dependent trap into one Linux can enforce; `release-publisher-contracts.test.ts` and `release-recovery-contracts.test.ts` were converted to comply.

`docs/ci.md` is rewritten for the new job graph, the gate's role, the exact required contexts, and the measured basis for each cap.

No `packages/*/CHANGELOG.md` entry: this is CI-only infrastructure per `AGENTS.md`.

## Validation

All run in a dedicated worktree with Bun 1.3.14 after a fresh `bun install`:

- two full green CI runs of the new workflow (30527771985, 30528920082), both required contexts present with identical names
- `bun run typecheck` ✅ · `bun run lint` ✅ · `bun run check:file-length` ✅ (max 500; largest touched file is 398 lines)
- `bun run test:ci-contracts` ✅ ×3 plus `--shard=1/2` and `--shard=2/2`, identical 31-name sets
- `bun run scripts/run-flaky-test-suite.ts ... -- bun run test:unit` ✅ 4426 tests, first attempt, guard not blind
- `bun run scripts/run-flaky-test-suite.ts ... -- bun run test:integration` ✅ 289 tests, guard not blind
- `bun run --cwd packages/coding-agent docs:check` ✅
- `Bun.YAML.parse` on the new workflow, and the gate's shell logic exercised against `success,failure,cancelled,skipped` and empty inputs (empty fails closed)
- the full prek pre-commit hook set, including `bun run test:unit`, passed on commit

No unrelated failures were observed.

## ⚠️ Merge-order note

Open PR #2073 (`ci: guard Blacksmith runner coverage and trim workflow comments`) also edits `.github/workflows/test.yml` and `test/ci/ci-workflow-contracts.test.ts`. **Whichever of the two merges second will need a rebase.**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change separates CI work into concurrent suite, native-agent, release-archive, and static-check jobs while preserving the two existing required `test` check names through a result gate. The gate was exercised with successful, failed, cancelled, skipped, and empty dependency-result sets: only the all-success case passed, and every incomplete or unsuccessful result failed closed. The repository’s CI workflow contract suite completed with 32 passing tests.

<h3>Confidence Score: 5/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated that baseline results produced success across all four work items and that the extracted gate exited with code 0.
- Verified that failure, cancelled, and skipped scenarios cause the extracted gate to emit a rejection message and exit with code 1, and that empty results fail closed.
- Confirmed the contract test suite passed, including the topology test that asserts the exact required contexts, always() behavior, all four dependencies, and blocking result patterns.

<a href="https://app.greptile.com/trex/runs/16602828/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (4): Last reviewed commit: ["docs(ci): record the second split run an..."](https://github.com/bastani-inc/atomic/commit/dfef0772ab8f26fd6b2650490918c314129f9bf3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48624342)</sub>

<!-- /greptile_comment -->