### PR TITLE
fix(scripts): pick the matching prek launcher when npm runs install-hooks under Node

### DIFF
--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -10,8 +10,17 @@ if (installDisabled || isCi) {
 	process.exit(0);
 }
 
-const result = spawnSync(process.execPath, ["x", "--bun", "--no-install", "prek", "install", "--prepare-hooks"], {
-	shell: false,
+// npm runs lifecycle scripts under Node, so process.execPath is only Bun when
+// invoked via `bun run`. Pick the matching launcher; both resolve the local or
+// PATH-installed prek without fetching anything (mirrors the hooks:install script).
+const prekArgs = ["--no-install", "prek", "install", "--prepare-hooks"];
+const isBun = Boolean(process.versions.bun);
+const isWindows = process.platform === "win32";
+const [command, args] = isBun ? [process.execPath, ["x", "--bun", ...prekArgs]] : ["npx", prekArgs];
+
+const result = spawnSync(command, args, {
+	// npx is a .cmd shim on Windows and needs a shell to spawn.
+	shell: !isBun && isWindows,
 	stdio: "inherit",
 });
 


### PR DESCRIPTION
## Summary

`scripts/install-hooks.mjs` spawned `process.execPath x --bun ... prek`, which only works when the prepare script runs under Bun. npm runs lifecycle scripts under Node, so `npm install` silently failed to install hooks.

## Changes

- Detect the runtime via `process.versions.bun` and pick the matching launcher: `bun x --bun --no-install prek` under Bun, `npx --no-install prek` under Node.
- Use a shell only for the Node-on-Windows case, where `npx` is a `.cmd` shim.

## Notes

Neither path fetches anything (`--no-install`), mirroring the `hooks:install` npm script.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788046997&installation_model_id=10562&pr_number=2089&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2089&signature=a2be80b09741df2e60d7c815ca23b68a23705feb8e357f862ef08eccd63bf9c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change selects the appropriate local prek launcher for Node and Bun when installing Git hooks. In isolated Git repositories with package downloads disabled, `npm run prepare` and `bun scripts/install-hooks.mjs` both completed successfully and installed the `pre-commit` and `pre-push` hooks. The previous implementation was exercised through `npm run prepare`; it failed because Node attempted to execute `x` directly and left both hooks uninstalled.

<h3>Confidence Score: 5/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The harness ran trex-artifacts/pr2089-install-hooks-validation.sh in disposable repositories and finished with baseline\_node=1 current\_node=0 current\_bun=0 and HARNESS\_EXIT=0.
- The parent revision's npm run prepare failed while trying to resolve x, exited with code 1, and left both Git hooks absent.
- The PR revision's npm run prepare completed successfully and installed .git/hooks/pre-commit and .git/hooks/pre-push, whose shims invoke the locally installed prek binary.
- Running bun scripts/install-hooks.mjs also exited successfully and installed the same two hooks.
- All runs were performed with PREK\_DISABLE\_INSTALL, CI, and GITHUB\_ACTIONS unset, and offline mode with npm\_config\_offline=true, an unreachable npm registry, an empty Bun cache, and --no-install prevented package downloads.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(scripts): pick the matching prek lau..."](https://github.com/bastani-inc/atomic/commit/64ace2e744b035527ef5cc666669755eb958bfa0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48883776)</sub>

<!-- /greptile_comment -->