### PR TITLE
chore(hooks): auto-fix formatting in pre-commit before the verify-only check

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -18,6 +18,10 @@ repo = "local"
 hooks = [
   { id = "cargo-fmt", name = "cargo fmt --check", entry = "cargo fmt --check", language = "system", pass_filenames = false, files = "(^Cargo\\.toml$|^Cargo\\.lock$|^crates/.*\\.rs$|^rustfmt\\.toml$)" },
   { id = "cargo-clippy", name = "cargo clippy", entry = "cargo clippy --workspace --all-targets -- -D warnings", language = "system", pass_filenames = false, files = "(^Cargo\\.toml$|^Cargo\\.lock$|^crates/.*\\.rs$)" },
+  # Auto-fix formatting and safe lint issues on staged files before `check` verifies them.
+  # prek fails the hook when files are modified; re-stage and retry. `check` still runs the
+  # same verify-only command as CI, so hook/CI parity is preserved.
+  { id = "format", name = "biome check --write", entry = "npx --no-install biome check --write --no-errors-on-unmatched", language = "system", files = "\\.(ts|mjs)$" },
   # Renamed off the `bun-` prefix with the toolchain: these run under npm now.
   { id = "check", name = "npm run check", entry = "npm run check", language = "system", pass_filenames = false },
   { id = "test-unit", name = "npm run test:unit", entry = "npm run test:unit", language = "system", pass_filenames = false },


### PR DESCRIPTION
## Summary

Formatting drift currently fails the pre-commit `check` hook with a diff printout, forcing a manual `biome check --write` and a retry. This adds a fixer hook so the retry succeeds on the first attempt.

## Changes

- New `format` hook in `prek.toml`, ordered before `check`: `npx --no-install biome check --write --no-errors-on-unmatched` on staged `.ts`/`.mjs` files.
- prek fails the hook when it modifies files (standard fixer contract), so changes are re-staged and the commit retried.

## Notes

- `check` still runs the same verify-only `npm run check` as CI, so hook/CI parity is unchanged — the fixer only makes it pass sooner.
- Biome's `files.includes` config still applies to explicitly passed paths; `--no-errors-on-unmatched` keeps the hook green when every staged file is outside Biome's scope.
- Verified locally: a deliberately misformatted staged file is rewritten and the hook fails; a clean re-run passes.

Follow-up to #2089.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788047196&installation_model_id=10562&pr_number=2090&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2090&signature=23f9148757a69b088e5f330e4f8af02d1d885e5431e64d8feb6905d2dff471d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a pre-commit Biome fixer for staged `.ts` and `.mjs` files before the existing repository-wide checks.

The hook was exercised with an unformatted included `.mjs` file and an excluded `.ts` fixture. It formatted the included file, exited with a re-stage requirement after modifying it, and did not fail or modify the excluded file. No defects were found.

<h3>Confidence Score: 5/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the format hook in a disposable worktree containing deliberately unformatted included .mjs files and excluded .ts files; the hook exited with code 1 and reported files were modified, with the included file becoming an unstaged change and the excluded fixture remaining staged.
- Verified the exact hook command and observed the same results, including EXIT\_CODE: 1 and an unstaged change for the included file, while the excluded fixture stayed staged; the configuration shows file matching patterns and the explicit exclusion.
- Artifacts were collected to support review, including the disposable format-hook validation harness source and the before/after capture logs.
- The results align with the contract-validation objective, showing formatting is enforced for included files while exclusions remain respected.

<a href="https://app.greptile.com/trex/runs/16685471/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(hooks): auto-fix formatting in pre..."](https://github.com/bastani-inc/atomic/commit/b4ba38ff51acc90b3b3b9e2ceadc8c38fd57dad7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48884443)</sub>

<!-- /greptile_comment -->