### PR TITLE
test: probe the behaviour changes pi 0.83.0 brings in

### DIFF
--- a/research/pi-0.83.0-port-matrix.md
+++ b/research/pi-0.83.0-port-matrix.md
@@ -225,7 +225,7 @@ build that had broken every previously successful stop.
 | Nested worktree context files, RPC bash `user_bash`, resource metadata across reload | `test/unit/pi-0.83.0-inherited-surface-probes.test.ts` — a real `git worktree add` layout, an RPC bash command with and without an intercepting handler, and package-sourced skills/prompts/themes read back after a later `extendResources` |
 | Shorter OAuth refresh window (`#7168`, risk R2) | `test/unit/pi-0.83.0-oauth-refresh-window-probe.test.ts` — concurrent sessions over one shared `auth.json` refresh once, and a credential outside the window is not refreshed at all |
 | `actions/cache` 4.3.0 -> 6.1.0 (D1) | `test/ci/actions-cache-bump-contract.test.ts`, with `npm run test:ci-contracts` green |
-| `@dbos-inc/dbos-sdk` 4.24.16 (D2) | `test/unit/pi-0.83.0-dbos-replay-probe.test.ts` — the three required parts |
+| `@dbos-inc/dbos-sdk` 4.24.16 (D2) | `test/unit/pi-0.83.0-dbos-replay-probe.test.ts` — the three required parts, with the modelled kill crossing `DBOSJSON` itself rather than a clone |
 
 ## Verification for this branch
 

--- a/research/pi-0.83.0-port-matrix.md
+++ b/research/pi-0.83.0-port-matrix.md
@@ -212,6 +212,21 @@ layer, restated here because the inheritance claim above depends on them holding
 - **`pending` streaming stop reason** (`f9a49869`). The isolated-engine protocol is at version
   `2`; an unhandled `pending` reaching that protocol or the RPC message projection is a defect.
 
+## Probe coverage (P4, `pi-0.83.0/regression-probes`)
+
+The layer above this one closes the list above. Each probe also covers the path that
+*already worked*, because a probe that only asserts the new behaviour would pass against a
+build that had broken every previously successful stop.
+
+| Risk | Probe |
+| --- | --- |
+| Raw stop reasons | `test/unit/pi-0.83.0-stop-reason-probes.test.ts` — every raw reason that mapped to a successful stop still does, per provider family, over the real pi-ai streams; one unmapped reason per family proves the assertions discriminate |
+| `pending` across the four consumers | `test/unit/pi-0.83.0-pending-stop-reason-probes.test.ts` — `pending` measured as the reason every streaming partial carries, then driven through the isolated-engine protocol (version `2`), the RPC JSONL projection, branch summaries and the Verbatim Compaction planner |
+| Nested worktree context files, RPC bash `user_bash`, resource metadata across reload | `test/unit/pi-0.83.0-inherited-surface-probes.test.ts` — a real `git worktree add` layout, an RPC bash command with and without an intercepting handler, and package-sourced skills/prompts/themes read back after a later `extendResources` |
+| Shorter OAuth refresh window (`#7168`, risk R2) | `test/unit/pi-0.83.0-oauth-refresh-window-probe.test.ts` — concurrent sessions over one shared `auth.json` refresh once, and a credential outside the window is not refreshed at all |
+| `actions/cache` 4.3.0 -> 6.1.0 (D1) | `test/ci/actions-cache-bump-contract.test.ts`, with `npm run test:ci-contracts` green |
+| `@dbos-inc/dbos-sdk` 4.24.16 (D2) | `test/unit/pi-0.83.0-dbos-replay-probe.test.ts` — the three required parts |
+
 ## Verification for this branch
 
 ```

--- a/test/ci/actions-cache-bump-contract.test.ts
+++ b/test/ci/actions-cache-bump-contract.test.ts
@@ -1,0 +1,99 @@
+/**
+ * P4 gate for the `actions/cache` 4.3.0 -> 6.1.0 bump (design D1).
+ *
+ * Two majors in one step: v5 moved the action to the Node 24 runner runtime and
+ * v6 rebuilt it as ESM. Neither renames an input, so the failure mode this gate
+ * guards is not a syntax error — it is a two-major jump silently perturbing the
+ * check contexts and per-job timeout budgets that
+ * `test/ci/test-workflow-topology.test.ts` asserts, or the two cache users
+ * drifting apart so a warmed entry can never be read back.
+ *
+ * The strongest available statement about the required contexts is structural:
+ * every asserted context and budget is produced by `test.yml`, and `test.yml`
+ * does not use `actions/cache` at all. The rest of the file pins the bump where
+ * it does land.
+ */
+
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "vitest";
+import { jobBlocks, jobSteps, namedStep, readText } from "./workflow-text.js";
+
+const root = fileURLToPath(new URL("../..", import.meta.url));
+const workflowsDir = join(root, ".github/workflows");
+
+/** The reviewed pin: one commit, one version comment, everywhere it is used. */
+const CACHE_PIN = "actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0";
+
+/** Workflows that legitimately restore the MSVC CRT / Windows SDK cache. */
+const CACHE_USERS = ["publish.yml", "warm-toolchain-cache.yml"] as const;
+
+/** The step both of them own, by name. */
+const RESTORE_STEP = "Restore MSVC CRT and Windows SDK";
+
+function cacheUses(workflow: string): string[] {
+	return [...workflow.matchAll(/actions\/cache@\S+(?: # \S+)?/gu)].map(([use]) => use);
+}
+
+test("every actions/cache use is the one reviewed 6.1.0 pin", async () => {
+	for (const file of CACHE_USERS) {
+		const workflow = await readText(join(workflowsDir, file));
+		const uses = cacheUses(workflow);
+		assert.equal(uses.length, 1, `${file} must use actions/cache exactly once`);
+		assert.equal(uses[0], CACHE_PIN, `${file} drifted off the reviewed pin`);
+	}
+});
+
+test("the workflow carrying every asserted check context does not use actions/cache", async () => {
+	const workflow = await readText(join(workflowsDir, "test.yml"));
+	// test/ci/test-workflow-topology.test.ts asserts both required contexts and
+	// every per-job timeout budget against this file. A cache action absent from
+	// it cannot move either, whatever the major version does.
+	assert.deepEqual(cacheUses(workflow), []);
+	assert.match(workflow, /^[ \t]+timeout-minutes:/mu, "the topology suite's budgets must still live here");
+});
+
+test("both cache users restore the same entry with only inputs this major still accepts", async () => {
+	const restores = new Map<string, Record<string, string>>();
+	for (const file of CACHE_USERS) {
+		const workflow = await readText(join(workflowsDir, file));
+		const owning = jobBlocks(workflow).filter(([, block]) => block.includes("actions/cache@"));
+		assert.equal(owning.length, 1, `${file} must confine actions/cache to one job`);
+		const [jobName, block] = owning[0] as [string, string];
+
+		// A two-major jump must not outlive its hang detector: the job that pays
+		// the restore cost still declares its own wall-clock cap.
+		assert.match(
+			block,
+			/^[ \t]+timeout-minutes: (?:\d+|\$\{\{ matrix\.timeout_minutes \}\})$/mu,
+			`${file}:${jobName} lost its per-job timeout budget`,
+		);
+
+		const step = namedStep(jobSteps(block), RESTORE_STEP);
+		assert.ok(step.includes(CACHE_PIN), `${file}:${jobName} restores through something other than the pin`);
+		const inputs = Object.fromEntries(
+			[
+				...step.matchAll(
+					/^[ \t]+(path|key|restore-keys|save-always|lookup-only|fail-on-cache-miss|enableCrossOsArchive): (.+)$/gmu,
+				),
+			].map(([, name, value]) => [name as string, (value as string).trim()]),
+		);
+		// v5 dropped `save-always`; keeping the reviewed pair means the bump cannot
+		// have quietly carried a retired input into a major that ignores it.
+		assert.deepEqual(
+			Object.keys(inputs).sort(),
+			["key", "path"],
+			`${file} passes an input beyond the two this pin was reviewed with`,
+		);
+		restores.set(file, inputs);
+	}
+
+	// The warming workflow exists only to fill the entry the publishing workflow
+	// reads. A key or path that disagrees warms a cache nothing ever hits.
+	assert.deepEqual(
+		restores.get("publish.yml"),
+		restores.get("warm-toolchain-cache.yml"),
+		"the warming job and the publishing job restore different entries",
+	);
+});

--- a/test/unit/pi-0.83.0-dbos-replay-probe.test.ts
+++ b/test/unit/pi-0.83.0-dbos-replay-probe.test.ts
@@ -18,38 +18,31 @@
  * which is precisely what a new process sees. A re-executed side effect here is
  * a failure, not a flake — every callback counter is exact.
  *
- * The kill boundary is also a serialization boundary, and which one matters.
- * DBOS 4.24.16 persists step output with `DBOSJSON`, which is SuperJSON, not
- * `JSON`. A checkpoint here is a `WorkflowSerializableValue`, so most of what
- * SuperJSON adds — `Date`, `Map`, `Set`, `BigInt` — cannot reach one anyway.
- * The difference that survives that narrowing is an `undefined` property, which
- * the type does permit: SuperJSON keeps the key, `JSON` drops it.
+ * The kill boundary is also a serialization boundary, and this probe crosses the
+ * real one. DBOS 4.24.16 persists step output with `DBOSJSON`: a `superjson`
+ * serialization wrapped in a JSON envelope branded with an explicit
+ * `__dbos_serializer` marker. `dbosPersistedCopy` below is that encoding,
+ * transcribed from `node_modules/@dbos-inc/dbos-sdk/dist/src/serialization.js`,
+ * and every checkpoint the mirror carries across the modelled kill is written and
+ * read back through it — so a payload the SDK could not persist fails here rather
+ * than quietly changing shape in a new process.
  *
- * The mirror crosses by `structuredClone`, and the boundary test below verifies
- * exactly that — `structuredClone` keeps the key — and nothing more. It does not
- * execute SuperJSON, so it cannot detect the stand-in and the real serializer
- * diverging. Saying otherwise would overstate it.
+ * It is transcribed rather than imported because the SDK does not list
+ * `./dist/src/serialization` in its `exports` map, so a deep import of
+ * `DBOSJSON` fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`. `superjson` itself is
+ * imported rather than reached through hoisting: the root workspace declares it
+ * at the 1.13.3 the SDK resolves. Two guards keep the transcription from going
+ * stale — the SDK version is pinned at the one it was taken against, and the
+ * marker constants are read back out of the installed serializer — so a bump
+ * that moves either fails here instead of leaving a stale copy running.
  *
- * That the two agree today is a recorded measurement, not an assumption, taken
- * against the `superjson` build DBOS depends on and reproducible with:
- *
- *   node -e "const sj=require('superjson').default??require('superjson');
- *     const v={settled:true,cancelled:undefined};
- *     console.log(Object.hasOwn(sj.parse(sj.stringify(v)),'cancelled'),
- *                 Object.hasOwn(structuredClone(v),'cancelled'),
- *                 Object.hasOwn(JSON.parse(JSON.stringify(v)),'cancelled'))"
- *   // -> true true false
- *
- * It is recorded rather than asserted because the SDK does not expose
- * `DBOSJSON` through its `exports` map — a deep import fails with
- * `ERR_PACKAGE_PATH_NOT_EXPORTED` — and this repository does not depend on
- * `superjson`, so reaching it from a test would rest on hoisting. Re-run the
- * line above when the SDK moves.
- *
- * What the test does buy is the direction that would otherwise be easy to get
- * wrong: a plain `JSON.parse(JSON.stringify(...))` handoff drops a key real
- * persistence keeps, which would make the probe stricter than the thing it
- * models while still not exercising the serializer that thing uses.
+ * Which serializer runs is not cosmetic. A checkpoint is a
+ * `WorkflowSerializableValue`, so most of what SuperJSON adds — `Date`, `Map`,
+ * `Set`, `BigInt` — cannot reach one. The difference that survives that
+ * narrowing is an `undefined` property, which the type does permit: SuperJSON
+ * keeps the key, plain `JSON` drops it. A `JSON.parse(JSON.stringify(...))`
+ * handoff would therefore be stricter than the persistence it models, and the
+ * boundary test below fails if the handoff is narrowed to one.
  *
  * Still not covered, and out of scope for a dependency gate: a live
  * Postgres-backed replay across two real processes, and a parent killed *after*
@@ -61,6 +54,9 @@
  */
 
 import assert from "node:assert/strict";
+import { join } from "node:path";
+import superjson from "superjson";
+import type { SuperJSONResult } from "superjson/dist/types.js";
 import { Type } from "typebox";
 import { test } from "vitest";
 import { workflow } from "../../packages/workflows/src/authoring/workflow.js";
@@ -73,35 +69,94 @@ import type {
 } from "../../packages/workflows/src/durable/types.js";
 import { run } from "../../packages/workflows/src/engine/run.js";
 import { createStore } from "../../packages/workflows/src/shared/store.js";
+import type { WorkflowSerializableValue } from "../../packages/workflows/src/shared/types.js";
+import { moduleDir, readJson, readText } from "../helpers/runtime.js";
 import { createMockSdk } from "./durable-dbos-backend-helpers.js";
 
 type MockSdk = ReturnType<typeof createMockSdk>;
 
+/** The SDK version this file's `DBOSJSON` transcription was taken against. */
+const MEASURED_DBOS_SDK_VERSION = "4.24.16";
+
+const dbosSdkDir = join(moduleDir(import.meta.url), "../../node_modules/@dbos-inc/dbos-sdk");
+
+/**
+ * The envelope `DBOSJSON` brands its SuperJSON writes with, so a reader can tell
+ * them from the legacy format. Both constants are read back out of the installed
+ * serializer by the boundary test, so a bump that renames either fails there.
+ */
+const DBOS_SERIALIZER_MARKER_KEY = "__dbos_serializer";
+const DBOS_SERIALIZER_MARKER_VALUE = "superjson";
+
+function isDbosBrandedSuperjsonRecord(value: unknown): value is SuperJSONResult {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		DBOS_SERIALIZER_MARKER_KEY in value &&
+		value[DBOS_SERIALIZER_MARKER_KEY] === DBOS_SERIALIZER_MARKER_VALUE &&
+		"json" in value
+	);
+}
+
+/** `DBOSJSON.stringify`, transcribed: SuperJSON, branded, then plain JSON. */
+function dbosStringify(value: WorkflowSerializableValue): string {
+	return JSON.stringify({
+		...superjson.serialize(value),
+		[DBOS_SERIALIZER_MARKER_KEY]: DBOS_SERIALIZER_MARKER_VALUE,
+	});
+}
+
+/** `DBOSJSON.parse`, transcribed, on the branded path this file always writes. */
+function dbosParse(text: string): WorkflowSerializableValue {
+	const parsed: unknown = JSON.parse(text);
+	assert.ok(isDbosBrandedSuperjsonRecord(parsed), "a DBOSJSON write must carry the SuperJSON marker");
+	return superjson.deserialize<WorkflowSerializableValue>(parsed);
+}
+
+/** One `DBOSJSON` write, and the read the next process performs against it. */
+function dbosPersistedCopy(value: WorkflowSerializableValue): WorkflowSerializableValue {
+	return dbosParse(dbosStringify(value));
+}
+
 /**
  * Everything the SDK had committed at the moment of the kill, and nothing else.
  *
- * Step outputs cross by `structuredClone`, the stand-in for the SuperJSON
- * encoding DBOS persists them with; see the header for why it stands in and
- * what that leaves uncovered. The boundary test below pins the value shapes the
- * two agree on, so this cannot be narrowed to plain JSON without failing.
+ * Step outputs cross through `DBOSJSON` — the serializer DBOS persists them
+ * with — rather than through a clone, so a checkpoint the SDK could not write
+ * fails here instead of surviving a boundary production would not let it cross.
  */
 function committedState(sdk: MockSdk): MockSdk {
 	const persisted = createMockSdk();
 	for (const [key, value] of sdk.state.workflows) persisted.state.workflows.set(key, { ...value });
-	for (const [key, value] of sdk.state.steps) persisted.state.steps.set(key, structuredClone(value));
+	for (const [key, value] of sdk.state.steps) persisted.state.steps.set(key, dbosPersistedCopy(value));
 	return persisted;
 }
 
-test("the modelled kill boundary carries an explicitly-undefined checkpoint property", () => {
-	// What this verifies is `structuredClone`'s behaviour, not SuperJSON's: it
-	// executes no serializer, and the header records the measurement showing the
-	// two agree on this key today, with the line to re-run when the SDK moves.
-	//
-	// Its job is to stop the handoff being narrowed to a JSON round trip, which
-	// drops the key and would make the probe stricter than the persistence it
-	// models.
+test("the modelled kill boundary is the DBOS serializer, and it keeps an explicitly-undefined property", async () => {
+	// The transcription's two anchors. Pin the SDK version it was taken against,
+	// and read the marker constants back out of the installed serializer, so a
+	// bump that changes either fails here rather than leaving this file writing
+	// an envelope DBOS no longer reads.
+	const sdkManifest = await readJson<{ version: string }>(join(dbosSdkDir, "package.json"));
+	assert.equal(sdkManifest.version, MEASURED_DBOS_SDK_VERSION);
+
+	const installedSerializer = await readText(join(dbosSdkDir, "dist/src/serialization.js"));
+	assert.ok(
+		installedSerializer.includes(`SERIALIZER_MARKER_KEY = '${DBOS_SERIALIZER_MARKER_KEY}'`),
+		`the installed serializer no longer brands with ${DBOS_SERIALIZER_MARKER_KEY}`,
+	);
+	assert.ok(
+		installedSerializer.includes(`SERIALIZER_MARKER_VALUE = '${DBOS_SERIALIZER_MARKER_VALUE}'`),
+		`the installed serializer no longer brands with ${DBOS_SERIALIZER_MARKER_VALUE}`,
+	);
+
+	// The handoff really runs SuperJSON: the encoded text carries DBOS's brand,
+	// which a clone or a JSON round trip cannot produce.
+	const checkpoint: WorkflowSerializableValue = { settled: true, cancelled: undefined };
+	assert.ok(isDbosBrandedSuperjsonRecord(JSON.parse(dbosStringify(checkpoint))));
+
 	const sdk = createMockSdk();
-	sdk.state.steps.set("run:checkpoint:probe", { settled: true, cancelled: undefined });
+	sdk.state.steps.set("run:checkpoint:probe", checkpoint);
 
 	const carried = committedState(sdk).state.steps.get("run:checkpoint:probe") as Record<string, unknown>;
 
@@ -110,6 +165,11 @@ test("the modelled kill boundary carries an explicitly-undefined checkpoint prop
 		Object.hasOwn(carried, "cancelled"),
 		"an explicitly-undefined checkpoint property must survive the kill boundary",
 	);
+
+	// And the direction that would be easy to get wrong: plain JSON drops that
+	// key, so narrowing the handoff to a JSON round trip makes the probe stricter
+	// than the persistence it models.
+	assert.equal(Object.hasOwn(JSON.parse(JSON.stringify(checkpoint)) as object, "cancelled"), false);
 });
 
 function deferred(): { promise: Promise<void>; resolve: () => void } {

--- a/test/unit/pi-0.83.0-dbos-replay-probe.test.ts
+++ b/test/unit/pi-0.83.0-dbos-replay-probe.test.ts
@@ -18,13 +18,22 @@
  * which is precisely what a new process sees. A re-executed side effect here is
  * a failure, not a flake — every callback counter is exact.
  *
- * The kill boundary is also a serialization boundary. A DBOS checkpoint is
- * written to Postgres and read back by the next process, so `committedState`
- * carries step outputs across it by JSON round trip and asserts the value
- * survives one. `structuredClone` would have carried a `Date`, a `Map` or an
- * `undefined` property into the resumed run that real persistence drops or
- * rewrites, which is the shape of SDK serialization regression a mirror-based
- * gate would otherwise sleep through.
+ * The kill boundary is also a serialization boundary, and which one matters.
+ * DBOS 4.24.16 persists step output with `DBOSJSON`, which is SuperJSON, not
+ * `JSON`. A checkpoint here is a `WorkflowSerializableValue`, so most of what
+ * SuperJSON adds — `Date`, `Map`, `Set`, `BigInt` — cannot reach one anyway.
+ * The difference that survives that narrowing is an `undefined` property, which
+ * the type does permit: SuperJSON keeps the key, `JSON` drops it.
+ *
+ * The mirror crosses by `structuredClone`, which agrees with SuperJSON there —
+ * measured against `superjson` itself, not assumed, and pinned by the boundary
+ * test below. A plain `JSON.parse(JSON.stringify(...))` handoff would be wrong
+ * in the direction that looks safe: it would drop a key real persistence keeps,
+ * making the probe stricter than the thing it models while still not exercising
+ * the serializer that thing uses. The SDK does not expose `DBOSJSON` through
+ * its `exports` map and this repository does not depend on `superjson`, so the
+ * stand-in is what is reachable; SuperJSON's own encoding is therefore not
+ * covered here.
  *
  * Still not covered, and out of scope for a dependency gate: a live
  * Postgres-backed replay across two real processes, and a parent killed *after*
@@ -55,21 +64,36 @@ type MockSdk = ReturnType<typeof createMockSdk>;
 /**
  * Everything the SDK had committed at the moment of the kill, and nothing else.
  *
- * Step outputs cross by JSON round trip because that is what DBOS does with
- * them. The equality assertion makes a payload the SDK could not actually
- * persist a failure here rather than a value that silently changes shape in a
- * new process.
+ * Step outputs cross by `structuredClone`, the stand-in for the SuperJSON
+ * encoding DBOS persists them with; see the header for why it stands in and
+ * what that leaves uncovered. The boundary test below pins the value shapes the
+ * two agree on, so this cannot be narrowed to plain JSON without failing.
  */
 function committedState(sdk: MockSdk): MockSdk {
 	const persisted = createMockSdk();
 	for (const [key, value] of sdk.state.workflows) persisted.state.workflows.set(key, { ...value });
-	for (const [key, value] of sdk.state.steps) {
-		const serialized: unknown = JSON.parse(JSON.stringify(value ?? null));
-		assert.deepEqual(serialized, value ?? null, `checkpoint ${key} does not survive a DBOS serialization round trip`);
-		persisted.state.steps.set(key, serialized);
-	}
+	for (const [key, value] of sdk.state.steps) persisted.state.steps.set(key, structuredClone(value));
 	return persisted;
 }
+
+test("the modelled kill boundary keeps the key SuperJSON keeps and JSON drops", () => {
+	// A checkpoint is a `WorkflowSerializableValue`, so an `undefined` property is
+	// the one shape where DBOS's SuperJSON encoding and plain `JSON` disagree —
+	// measured against `superjson` itself, which keeps the key, as
+	// `structuredClone` does and `JSON.parse(JSON.stringify(...))` does not.
+	// This is what stops the handoff being narrowed to a JSON round trip, which
+	// would make the probe stricter than the persistence it models.
+	const sdk = createMockSdk();
+	sdk.state.steps.set("run:checkpoint:probe", { settled: true, cancelled: undefined });
+
+	const carried = committedState(sdk).state.steps.get("run:checkpoint:probe") as Record<string, unknown>;
+
+	assert.equal(carried.settled, true);
+	assert.ok(
+		Object.hasOwn(carried, "cancelled"),
+		"an explicitly-undefined checkpoint property must survive the kill boundary",
+	);
+});
 
 function deferred(): { promise: Promise<void>; resolve: () => void } {
 	let resolve = (): void => {};

--- a/test/unit/pi-0.83.0-dbos-replay-probe.test.ts
+++ b/test/unit/pi-0.83.0-dbos-replay-probe.test.ts
@@ -18,12 +18,21 @@
  * which is precisely what a new process sees. A re-executed side effect here is
  * a failure, not a flake — every callback counter is exact.
  *
- * Not covered, deliberately: a parent killed *after* one nested child boundary
- * completed and while a later one is in flight. Resuming that shape from a fresh
- * DBOS mirror fails to reconstruct the completed child subtree. It is unrelated
- * to this bump — the same shape resumes cleanly on `InMemoryDurableBackend`, and
- * this sync changes nothing under `packages/workflows/src` — so it belongs to
- * the durable layer that owns it rather than to a dependency gate.
+ * The kill boundary is also a serialization boundary. A DBOS checkpoint is
+ * written to Postgres and read back by the next process, so `committedState`
+ * carries step outputs across it by JSON round trip and asserts the value
+ * survives one. `structuredClone` would have carried a `Date`, a `Map` or an
+ * `undefined` property into the resumed run that real persistence drops or
+ * rewrites, which is the shape of SDK serialization regression a mirror-based
+ * gate would otherwise sleep through.
+ *
+ * Still not covered, and out of scope for a dependency gate: a live
+ * Postgres-backed replay across two real processes, and a parent killed *after*
+ * one nested child boundary completed while a later one is in flight. Resuming
+ * that second shape from a fresh DBOS mirror fails to reconstruct the completed
+ * child subtree. It is unrelated to this bump — the same shape resumes cleanly
+ * on `InMemoryDurableBackend`, and this sync changes nothing under
+ * `packages/workflows/src` — so it belongs to the durable layer that owns it.
  */
 
 import assert from "node:assert/strict";
@@ -43,11 +52,22 @@ import { createMockSdk } from "./durable-dbos-backend-helpers.js";
 
 type MockSdk = ReturnType<typeof createMockSdk>;
 
-/** Everything the SDK had committed at the moment of the kill, and nothing else. */
+/**
+ * Everything the SDK had committed at the moment of the kill, and nothing else.
+ *
+ * Step outputs cross by JSON round trip because that is what DBOS does with
+ * them. The equality assertion makes a payload the SDK could not actually
+ * persist a failure here rather than a value that silently changes shape in a
+ * new process.
+ */
 function committedState(sdk: MockSdk): MockSdk {
 	const persisted = createMockSdk();
 	for (const [key, value] of sdk.state.workflows) persisted.state.workflows.set(key, { ...value });
-	for (const [key, value] of sdk.state.steps) persisted.state.steps.set(key, structuredClone(value));
+	for (const [key, value] of sdk.state.steps) {
+		const serialized: unknown = JSON.parse(JSON.stringify(value ?? null));
+		assert.deepEqual(serialized, value ?? null, `checkpoint ${key} does not survive a DBOS serialization round trip`);
+		persisted.state.steps.set(key, serialized);
+	}
 	return persisted;
 }
 

--- a/test/unit/pi-0.83.0-dbos-replay-probe.test.ts
+++ b/test/unit/pi-0.83.0-dbos-replay-probe.test.ts
@@ -25,15 +25,31 @@
  * The difference that survives that narrowing is an `undefined` property, which
  * the type does permit: SuperJSON keeps the key, `JSON` drops it.
  *
- * The mirror crosses by `structuredClone`, which agrees with SuperJSON there —
- * measured against `superjson` itself, not assumed, and pinned by the boundary
- * test below. A plain `JSON.parse(JSON.stringify(...))` handoff would be wrong
- * in the direction that looks safe: it would drop a key real persistence keeps,
- * making the probe stricter than the thing it models while still not exercising
- * the serializer that thing uses. The SDK does not expose `DBOSJSON` through
- * its `exports` map and this repository does not depend on `superjson`, so the
- * stand-in is what is reachable; SuperJSON's own encoding is therefore not
- * covered here.
+ * The mirror crosses by `structuredClone`, and the boundary test below verifies
+ * exactly that — `structuredClone` keeps the key — and nothing more. It does not
+ * execute SuperJSON, so it cannot detect the stand-in and the real serializer
+ * diverging. Saying otherwise would overstate it.
+ *
+ * That the two agree today is a recorded measurement, not an assumption, taken
+ * against the `superjson` build DBOS depends on and reproducible with:
+ *
+ *   node -e "const sj=require('superjson').default??require('superjson');
+ *     const v={settled:true,cancelled:undefined};
+ *     console.log(Object.hasOwn(sj.parse(sj.stringify(v)),'cancelled'),
+ *                 Object.hasOwn(structuredClone(v),'cancelled'),
+ *                 Object.hasOwn(JSON.parse(JSON.stringify(v)),'cancelled'))"
+ *   // -> true true false
+ *
+ * It is recorded rather than asserted because the SDK does not expose
+ * `DBOSJSON` through its `exports` map — a deep import fails with
+ * `ERR_PACKAGE_PATH_NOT_EXPORTED` — and this repository does not depend on
+ * `superjson`, so reaching it from a test would rest on hoisting. Re-run the
+ * line above when the SDK moves.
+ *
+ * What the test does buy is the direction that would otherwise be easy to get
+ * wrong: a plain `JSON.parse(JSON.stringify(...))` handoff drops a key real
+ * persistence keeps, which would make the probe stricter than the thing it
+ * models while still not exercising the serializer that thing uses.
  *
  * Still not covered, and out of scope for a dependency gate: a live
  * Postgres-backed replay across two real processes, and a parent killed *after*
@@ -76,13 +92,14 @@ function committedState(sdk: MockSdk): MockSdk {
 	return persisted;
 }
 
-test("the modelled kill boundary keeps the key SuperJSON keeps and JSON drops", () => {
-	// A checkpoint is a `WorkflowSerializableValue`, so an `undefined` property is
-	// the one shape where DBOS's SuperJSON encoding and plain `JSON` disagree —
-	// measured against `superjson` itself, which keeps the key, as
-	// `structuredClone` does and `JSON.parse(JSON.stringify(...))` does not.
-	// This is what stops the handoff being narrowed to a JSON round trip, which
-	// would make the probe stricter than the persistence it models.
+test("the modelled kill boundary carries an explicitly-undefined checkpoint property", () => {
+	// What this verifies is `structuredClone`'s behaviour, not SuperJSON's: it
+	// executes no serializer, and the header records the measurement showing the
+	// two agree on this key today, with the line to re-run when the SDK moves.
+	//
+	// Its job is to stop the handoff being narrowed to a JSON round trip, which
+	// drops the key and would make the probe stricter than the persistence it
+	// models.
 	const sdk = createMockSdk();
 	sdk.state.steps.set("run:checkpoint:probe", { settled: true, cancelled: undefined });
 

--- a/test/unit/pi-0.83.0-dbos-replay-probe.test.ts
+++ b/test/unit/pi-0.83.0-dbos-replay-probe.test.ts
@@ -1,0 +1,386 @@
+/**
+ * P4 gate for the `@dbos-inc/dbos-sdk` 4.23.6 -> 4.24.16 bump (design D2).
+ *
+ * Thirteen minors across the SDK that backs workflow durability. The API surface
+ * is not the risk; replay and hydration are. The three required parts:
+ *
+ *  1. a workflow with at least two `ctx.tool` checkpoints, killed mid-run and
+ *     resumed, replays every completed tool result from its checkpoint without
+ *     re-invoking the callback;
+ *  2. hydration validation on resume covers the acyclic-topology check for a
+ *     bounded loop that materializes distinct per-iteration nodes;
+ *  3. a nested child workflow survives a parent resume with stable per-iteration
+ *     identity and call order.
+ *
+ * "Killed mid-run" is modelled the way the rest of this suite models it: only
+ * state the SDK had already committed is carried into a second
+ * `DbosDurableBackend` with its own executor id and an empty in-memory mirror,
+ * which is precisely what a new process sees. A re-executed side effect here is
+ * a failure, not a flake — every callback counter is exact.
+ *
+ * Not covered, deliberately: a parent killed *after* one nested child boundary
+ * completed and while a later one is in flight. Resuming that shape from a fresh
+ * DBOS mirror fails to reconstruct the completed child subtree. It is unrelated
+ * to this bump — the same shape resumes cleanly on `InMemoryDurableBackend`, and
+ * this sync changes nothing under `packages/workflows/src` — so it belongs to
+ * the durable layer that owns it rather than to a dependency gate.
+ */
+
+import assert from "node:assert/strict";
+import { Type } from "typebox";
+import { test } from "vitest";
+import { workflow } from "../../packages/workflows/src/authoring/workflow.js";
+import { DbosDurableBackend } from "../../packages/workflows/src/durable/dbos-backend.js";
+import { directChildTopologyError } from "../../packages/workflows/src/durable/stage-topology-validation.js";
+import type {
+	DurableStageCheckpoint,
+	DurableStageRunTopology,
+	DurableToolCheckpoint,
+} from "../../packages/workflows/src/durable/types.js";
+import { run } from "../../packages/workflows/src/engine/run.js";
+import { createStore } from "../../packages/workflows/src/shared/store.js";
+import { createMockSdk } from "./durable-dbos-backend-helpers.js";
+
+type MockSdk = ReturnType<typeof createMockSdk>;
+
+/** Everything the SDK had committed at the moment of the kill, and nothing else. */
+function committedState(sdk: MockSdk): MockSdk {
+	const persisted = createMockSdk();
+	for (const [key, value] of sdk.state.workflows) persisted.state.workflows.set(key, { ...value });
+	for (const [key, value] of sdk.state.steps) persisted.state.steps.set(key, structuredClone(value));
+	return persisted;
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve = (): void => {};
+	const promise = new Promise<void>((settle) => {
+		resolve = settle;
+	});
+	return { promise, resolve };
+}
+
+const completeAdapter = { complete: { complete: async (text: string): Promise<string> => text } };
+
+test("two completed tool checkpoints replay from DBOS after a mid-run kill without re-invoking the callback", async () => {
+	const sdk = createMockSdk();
+	const firstBackend = new DbosDurableBackend(sdk, { executorId: "killed-process" });
+	const runId = "dbos-replay-two-tools";
+	const calls = { first: 0, second: 0, third: 0 };
+	const thirdStarted = deferred();
+	const thirdGate = deferred();
+
+	const definition = workflow({
+		name: "two-tool-replay",
+		description: "",
+		inputs: {},
+		outputs: { value: Type.String() },
+		run: async (ctx) => {
+			const first = await ctx.tool("first-effect", { step: 1 }, async () => {
+				calls.first += 1;
+				return "first-output";
+			});
+			const second = await ctx.tool("second-effect", { step: 2 }, async () => {
+				calls.second += 1;
+				return "second-output";
+			});
+			const third = await ctx.tool("third-effect", { step: 3 }, async () => {
+				calls.third += 1;
+				thirdStarted.resolve();
+				await thirdGate.promise;
+				return "third-output";
+			});
+			return { value: `${first}/${second}/${third}` };
+		},
+	});
+
+	const controller = new AbortController();
+	const killedRun = run(
+		definition,
+		{},
+		{
+			runId,
+			store: createStore(),
+			durableBackend: firstBackend,
+			signal: controller.signal,
+			adapters: completeAdapter,
+		},
+	);
+	await thirdStarted.promise;
+	await firstBackend.flush();
+	const persistedSdk = committedState(sdk);
+	controller.abort(new Error("process killed mid-run"));
+	thirdGate.resolve();
+	await killedRun;
+
+	assert.deepEqual(calls, { first: 1, second: 1, third: 1 }, "the killed process must have run each effect once");
+
+	const resumedBackend = new DbosDurableBackend(persistedSdk, { executorId: "resumed-process" });
+	assert.equal(resumedBackend.listCheckpoints(runId).length, 0, "a fresh backend starts with an empty mirror");
+	await resumedBackend.hydrateWorkflow(runId);
+
+	const toolCheckpoints = resumedBackend
+		.listCheckpoints(runId)
+		.filter((checkpoint): checkpoint is DurableToolCheckpoint => checkpoint.kind === "tool")
+		.filter((checkpoint) => checkpoint.name.endsWith("-effect"));
+	assert.deepEqual(
+		toolCheckpoints.map((checkpoint) => checkpoint.name).sort(),
+		["first-effect", "second-effect"],
+		"only the two completed tools may have reached DBOS",
+	);
+
+	const resumed = await run(
+		definition,
+		{},
+		{ runId, store: createStore(), durableBackend: resumedBackend, adapters: completeAdapter },
+	);
+
+	assert.equal(resumed.status, "completed");
+	assert.equal(resumed.result?.value, "first-output/second-output/third-output");
+	assert.deepEqual(
+		calls,
+		{ first: 1, second: 1, third: 2 },
+		"a completed tool re-executed its side effect instead of replaying its checkpoint",
+	);
+});
+
+/** The tool nodes a child run contributes, which its stages legitimately name as parents. */
+function childToolNodeIds(backend: DbosDurableBackend, runId: string, childRunId: string): Set<string> {
+	return new Set(
+		backend
+			.listCheckpoints(runId)
+			.filter((checkpoint): checkpoint is DurableToolCheckpoint => checkpoint.kind === "tool")
+			.filter((checkpoint) => checkpoint.topology?.run?.runId === childRunId)
+			.map((checkpoint) => checkpoint.topology?.nodeId ?? ""),
+	);
+}
+
+interface BoundaryRecord {
+	readonly replayScope: string;
+	readonly child: DurableStageRunTopology;
+	readonly stageId: string;
+	readonly name: string;
+}
+
+function boundaryStarts(backend: DbosDurableBackend, runId: string): BoundaryRecord[] {
+	return backend
+		.listCheckpoints(runId)
+		.filter((checkpoint): checkpoint is DurableStageCheckpoint => checkpoint.kind === "stage")
+		.flatMap((checkpoint) => {
+			const boundary = checkpoint.topology?.boundary;
+			if (boundary === undefined || boundary.event !== "start") return [];
+			return [
+				{
+					replayScope: boundary.replayScope,
+					child: boundary.child,
+					stageId: checkpoint.topology?.stageId ?? "",
+					name: checkpoint.name,
+				},
+			];
+		});
+}
+
+function loopWorkflows(calls: { child: number; tool: number }, iterations: number) {
+	const child = workflow({
+		name: "bounded-loop-child",
+		description: "",
+		inputs: { index: Type.Number() },
+		outputs: { value: Type.String() },
+		run: async (ctx) => {
+			calls.child += 1;
+			const effect = await ctx.tool("iteration-effect", { index: ctx.inputs.index }, async () => {
+				calls.tool += 1;
+				return `effect-${ctx.inputs.index}`;
+			});
+			const staged = await ctx.stage(`iteration-stage-${ctx.inputs.index}`).complete(`stage-${ctx.inputs.index}`);
+			return { value: `${effect}:${staged}` };
+		},
+	});
+	const parent = workflow({
+		name: "bounded-loop-parent",
+		description: "",
+		inputs: {},
+		outputs: { value: Type.String() },
+		run: async (ctx) => {
+			const parts: string[] = [];
+			// A bounded loop that materializes a distinct node set per iteration:
+			// each pass gets its own boundary stage, child run, and tool node.
+			for (let index = 0; index < iterations; index += 1) {
+				const iteration = await ctx.workflow(child, { inputs: { index }, stageName: `iteration-${index}` });
+				if (iteration.exited) throw new Error("child exited");
+				parts.push(iteration.outputs.value);
+			}
+			return { value: parts.join(",") };
+		},
+	});
+	return { child, parent };
+}
+
+test("hydration validates the acyclic topology of a bounded loop's per-iteration nodes", async () => {
+	const sdk = createMockSdk();
+	const backend = new DbosDurableBackend(sdk, { executorId: "loop-process" });
+	const runId = "dbos-replay-bounded-loop";
+	const calls = { child: 0, tool: 0 };
+	const { parent } = loopWorkflows(calls, 3);
+
+	const completed = await run(
+		parent,
+		{},
+		{ runId, store: createStore(), durableBackend: backend, adapters: completeAdapter },
+	);
+	assert.equal(completed.status, "completed", completed.error);
+	assert.deepEqual(calls, { child: 3, tool: 3 }, "each iteration must run its child and its effect exactly once");
+	await backend.flush();
+
+	const hydrated = new DbosDurableBackend(committedState(sdk), { executorId: "loop-hydrating-process" });
+	await hydrated.hydrateWorkflow(runId);
+	assert.equal(hydrated.isWorkflowLoadable(runId), true, "hydration rejected a valid bounded-loop topology");
+
+	const boundaries = boundaryStarts(hydrated, runId);
+	assert.deepEqual(
+		boundaries.map((boundary) => boundary.name),
+		["iteration-0", "iteration-1", "iteration-2"],
+	);
+	assert.equal(new Set(boundaries.map((b) => b.stageId)).size, 3, "iterations must materialize distinct nodes");
+	assert.equal(
+		new Set(boundaries.map((b) => b.child.runId)).size,
+		3,
+		"iterations must materialize distinct child runs",
+	);
+
+	const stages = hydrated
+		.listCheckpoints(runId)
+		.filter((checkpoint): checkpoint is DurableStageCheckpoint => checkpoint.kind === "stage");
+
+	for (const boundary of boundaries) {
+		assert.equal(
+			directChildTopologyError(
+				stages,
+				boundary.replayScope,
+				boundary.child,
+				true,
+				childToolNodeIds(hydrated, runId, boundary.child.runId),
+			),
+			undefined,
+			`${boundary.name} failed the hydration topology check`,
+		);
+	}
+
+	// The same check, over the same hydrated records, with one iteration's stage
+	// made its own ancestor. Without this the assertions above would also pass
+	// against a validator that had stopped looking for cycles.
+	const scoped = boundaries[1] as BoundaryRecord;
+	const cyclic = stages.map((stage) => {
+		if (stage.topology?.run?.runId !== scoped.child.runId || stage.topology.boundary !== undefined) return stage;
+		return { ...stage, topology: { ...stage.topology, parentIds: [stage.topology.stageId] } };
+	});
+	assert.match(
+		directChildTopologyError(
+			cyclic,
+			scoped.replayScope,
+			scoped.child,
+			true,
+			childToolNodeIds(hydrated, runId, scoped.child.runId),
+		) ?? "",
+		/cycle/u,
+	);
+});
+
+test("a nested child workflow survives a parent resume with stable per-iteration identity and call order", async () => {
+	const sdk = createMockSdk();
+	const firstBackend = new DbosDurableBackend(sdk, { executorId: "loop-killed-process" });
+	const runId = "dbos-replay-nested-resume";
+	const calls = { child: 0, tool: 0 };
+	const order: string[] = [];
+	const firstIterationStarted = deferred();
+	const firstIterationGate = deferred();
+
+	const child = workflow({
+		name: "nested-resume-child",
+		description: "",
+		inputs: { index: Type.Number() },
+		outputs: { value: Type.String() },
+		run: async (ctx) => {
+			calls.child += 1;
+			const effect = await ctx.tool("iteration-effect", { index: ctx.inputs.index }, async () => {
+				calls.tool += 1;
+				order.push(`effect-${ctx.inputs.index}`);
+				if (ctx.inputs.index === 0) {
+					firstIterationStarted.resolve();
+					await firstIterationGate.promise;
+				}
+				return `effect-${ctx.inputs.index}`;
+			});
+			const staged = await ctx.stage(`iteration-stage-${ctx.inputs.index}`).complete(effect);
+			return { value: staged };
+		},
+	});
+	const parent = workflow({
+		name: "nested-resume-parent",
+		description: "",
+		inputs: {},
+		outputs: { value: Type.String() },
+		run: async (ctx) => {
+			const parts: string[] = [];
+			for (let index = 0; index < 3; index += 1) {
+				const iteration = await ctx.workflow(child, { inputs: { index }, stageName: `iteration-${index}` });
+				if (iteration.exited) throw new Error("child exited");
+				parts.push(iteration.outputs.value);
+			}
+			return { value: parts.join(",") };
+		},
+	});
+
+	const controller = new AbortController();
+	const killedStore = createStore();
+	const killedRun = run(
+		parent,
+		{},
+		{ runId, store: killedStore, durableBackend: firstBackend, signal: controller.signal, adapters: completeAdapter },
+	);
+	await firstIterationStarted.promise;
+	await firstBackend.flush();
+	const persistedSdk = committedState(sdk);
+	const killedBoundaries = boundaryStarts(firstBackend, runId);
+	controller.abort(new Error("parent killed inside its first nested child"));
+	firstIterationGate.resolve();
+	await killedRun;
+
+	assert.deepEqual(order, ["effect-0"], "the killed parent must have reached exactly one iteration");
+
+	const resumedBackend = new DbosDurableBackend(persistedSdk, { executorId: "loop-resumed-process" });
+	await resumedBackend.hydrateWorkflow(runId);
+	const resumedStore = createStore();
+	const resumed = await run(
+		parent,
+		{},
+		{ runId, store: resumedStore, durableBackend: resumedBackend, adapters: completeAdapter },
+	);
+
+	assert.equal(resumed.status, "completed", resumed.error);
+	assert.equal(resumed.result?.value, "effect-0,effect-1,effect-2");
+	// The interrupted first iteration re-runs in the new process, then the loop
+	// continues in its own order. Order is the loop's order, not a race.
+	assert.deepEqual(order, ["effect-0", "effect-0", "effect-1", "effect-2"]);
+	assert.deepEqual(calls, { child: 4, tool: 4 }, "only the interrupted iteration may run a second time");
+
+	const resumedBoundaries = boundaryStarts(resumedBackend, runId);
+	assert.deepEqual(
+		resumedBoundaries.map((boundary) => boundary.name),
+		["iteration-0", "iteration-1", "iteration-2"],
+	);
+	// Per-iteration identity is stable across the kill: the boundary stage id and
+	// the child run id each iteration owned before the kill are the ones it owns
+	// after it.
+	for (const before of killedBoundaries) {
+		const after = resumedBoundaries.find((boundary) => boundary.name === before.name);
+		assert.ok(after, `${before.name} lost its boundary across the resume`);
+		assert.equal(after.stageId, before.stageId, `${before.name} changed boundary identity across the resume`);
+		assert.equal(
+			after.child.runId,
+			before.child.runId,
+			`${before.name} changed child run identity across the resume`,
+		);
+		assert.equal(after.child.parentRunId, runId);
+		assert.equal(after.child.rootRunId, runId);
+	}
+});

--- a/test/unit/pi-0.83.0-inherited-surface-probes.test.ts
+++ b/test/unit/pi-0.83.0-inherited-surface-probes.test.ts
@@ -1,0 +1,222 @@
+/**
+ * P4 probes for the three adapted upstream fixes whose blast radius is a path
+ * that already worked: context-file discovery (`cced6a21`), RPC bash dispatch
+ * (`5d548ae9`) and resource metadata retention across a reload (`66eead65`).
+ *
+ * `packages/coding-agent/test/pi-0.83.0-direct-fixes.test.ts` already asserts
+ * each fix against a hand-built fixture. These probe the same behaviour one
+ * level out, where a regression would actually be felt: a worktree produced by
+ * real `git worktree add` rather than a synthetic `.git` layout, an RPC bash
+ * command with no extension handler installed, and package-sourced resources
+ * read back after the reload that discovered them.
+ */
+
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, test } from "vitest";
+import { DefaultResourceLoader } from "../../packages/coding-agent/src/core/resource-loader.js";
+import { loadProjectContextFiles } from "../../packages/coding-agent/src/core/resource-loader-context-files.js";
+import { createRpcCommandHandler } from "../../packages/coding-agent/src/modes/rpc/rpc-command-handler.js";
+import { createGitEnvironment } from "../../packages/coding-agent/src/utils/git-env.js";
+import { createHarness } from "../../packages/coding-agent/test/suite/harness.js";
+import { spawnSyncCollect } from "../helpers/runtime.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+	for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+function temporaryDirectory(prefix: string): string {
+	const directory = mkdtempSync(join(tmpdir(), prefix));
+	temporaryDirectories.push(directory);
+	return directory;
+}
+
+/**
+ * Run git against an explicit checkout.
+ *
+ * `createGitEnvironment` strips the repository-local variables a hook exports;
+ * this suite itself runs inside a linked worktree, so an inherited `GIT_DIR`
+ * would silently redirect the fixture commands at *this* repository.
+ */
+function git(cwd: string, ...args: string[]): void {
+	const result = spawnSyncCollect(["git", ...args], {
+		cwd,
+		env: createGitEnvironment({
+			GIT_AUTHOR_NAME: "Probe",
+			GIT_AUTHOR_EMAIL: "probe@example.invalid",
+			GIT_COMMITTER_NAME: "Probe",
+			GIT_COMMITTER_EMAIL: "probe@example.invalid",
+			GIT_CONFIG_GLOBAL: join(cwd, ".gitconfig-absent"),
+			GIT_CONFIG_SYSTEM: join(cwd, ".gitconfig-absent"),
+		}),
+	});
+	assert.equal(result.exitCode, 0, `git ${args.join(" ")} failed: ${result.stderr.toString()}`);
+}
+
+test("a real linked worktree nested under its own main repository loads each context file once", () => {
+	const root = temporaryDirectory("atomic-real-worktree-");
+	const repository = join(root, "repo");
+	mkdirSync(repository, { recursive: true });
+	git(repository, "init", "--initial-branch=main");
+	writeFileSync(join(repository, "AGENTS.md"), "main checkout instructions");
+	git(repository, "add", "AGENTS.md");
+	git(repository, "commit", "-m", "seed");
+	// Nested *inside* the main checkout: the layout where the ancestor walk used
+	// to find the main repository's own copy on the way up and load it twice.
+	git(repository, "worktree", "add", "-b", "feature", "nested-worktree");
+	const worktree = join(repository, "nested-worktree");
+	writeFileSync(join(worktree, "AGENTS.md"), "worktree instructions");
+	const agentDir = join(root, "agent");
+	mkdirSync(agentDir, { recursive: true });
+
+	const files = loadProjectContextFiles({ cwd: worktree, agentDir });
+
+	assert.deepEqual(
+		files.map((file) => file.content),
+		["worktree instructions"],
+	);
+	assert.equal(new Set(files.map((file) => file.path)).size, files.length, "a context file was listed twice");
+});
+
+test("a plain subdirectory of a real repository still inherits the repository context file", () => {
+	const root = temporaryDirectory("atomic-real-repo-");
+	const repository = join(root, "repo");
+	const nested = join(repository, "packages", "thing");
+	mkdirSync(nested, { recursive: true });
+	git(repository, "init", "--initial-branch=main");
+	writeFileSync(join(repository, "AGENTS.md"), "repository instructions");
+	git(repository, "add", "AGENTS.md");
+	git(repository, "commit", "-m", "seed");
+	const agentDir = join(root, "agent");
+	mkdirSync(agentDir, { recursive: true });
+
+	const files = loadProjectContextFiles({ cwd: nested, agentDir });
+
+	// The guard must only suppress the *duplicate* main-checkout copy; ordinary
+	// ancestor inheritance is the path that already worked.
+	assert.deepEqual(
+		files.map((file) => file.content),
+		["repository instructions"],
+	);
+});
+
+test("RPC bash reaches a user_bash handler and still runs a real command without one", async () => {
+	const intercepted: string[] = [];
+	const harness = await createHarness({
+		extensionFactories: [
+			(pi) => {
+				pi.on("user_bash", async (event) => {
+					intercepted.push(event.command);
+					if (!event.command.startsWith("handled")) return undefined;
+					return { result: { output: "from handler", exitCode: 0, cancelled: false, truncated: false } };
+				});
+			},
+		],
+	});
+	await harness.session.bindExtensions({ shutdownHandler: () => {} });
+	try {
+		const handle = createRpcCommandHandler({
+			runtimeHost: { session: harness.session, services: { agentDir: harness.tempDir } } as never,
+			getSession: () => harness.session,
+			rebindSession: async () => {},
+			output: () => {},
+		});
+
+		const handled = await handle({ id: "rpc-handled", type: "bash", command: "handled command" });
+		// A handler that declines must not swallow the command: the real executor
+		// still runs it, which is the path that worked before the fix.
+		const declined = await handle({ id: "rpc-declined", type: "bash", command: "echo not-handled" });
+
+		assert.deepEqual(intercepted, ["handled command", "echo not-handled"]);
+		assert.deepEqual((handled as { data: { output: string; exitCode: number } }).data, {
+			output: "from handler",
+			exitCode: 0,
+			cancelled: false,
+			truncated: false,
+		});
+		const declinedData = (declined as { data: { output: string; exitCode: number } }).data;
+		assert.equal(declinedData.exitCode, 0);
+		assert.match(declinedData.output, /not-handled/u);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+/** A theme file the real loader accepts, derived from the shipped dark theme. */
+function writeProbeTheme(path: string, name: string): void {
+	const source = fileURLToPath(
+		new URL("../../packages/coding-agent/src/modes/interactive/theme/dark.json", import.meta.url),
+	);
+	const theme = JSON.parse(readFileSync(source, "utf8")) as { name: string };
+	writeFileSync(path, JSON.stringify({ ...theme, name }));
+}
+
+test("skills, prompts and themes keep their package source after a reload and a later extendResources", async () => {
+	const root = temporaryDirectory("atomic-reload-metadata-");
+	const agentDir = join(root, "agent");
+	const cwd = join(root, "project");
+	mkdirSync(agentDir, { recursive: true });
+	mkdirSync(cwd, { recursive: true });
+
+	const packageDir = join(root, "probe-package");
+	mkdirSync(join(packageDir, "skills", "packaged-skill"), { recursive: true });
+	mkdirSync(join(packageDir, "prompts"), { recursive: true });
+	mkdirSync(join(packageDir, "themes"), { recursive: true });
+	writeFileSync(
+		join(packageDir, "package.json"),
+		JSON.stringify({
+			name: "probe-package",
+			pi: { skills: ["./skills"], prompts: ["./prompts"], themes: ["./themes"] },
+		}),
+	);
+	writeFileSync(
+		join(packageDir, "skills", "packaged-skill", "SKILL.md"),
+		"---\nname: packaged-skill\ndescription: Packaged\n---\nContent",
+	);
+	writeFileSync(join(packageDir, "prompts", "packaged-prompt.md"), "---\ndescription: Packaged\n---\nContent");
+	writeProbeTheme(join(packageDir, "themes", "packaged-theme.json"), "packaged-theme");
+
+	// A later extendResources pass, from an unrelated directory: before the fix
+	// this second pass ran without the reload's metadata and every packaged
+	// resource fell back to a plain local source.
+	const extraSkillDir = join(root, "extra-skills", "extra-skill");
+	mkdirSync(extraSkillDir, { recursive: true });
+	writeFileSync(join(extraSkillDir, "SKILL.md"), "---\nname: extra-skill\ndescription: Extra\n---\nContent");
+
+	const loader = new DefaultResourceLoader({ cwd, agentDir, builtinPackagePaths: [packageDir] });
+	await loader.reload();
+
+	const packagedSourceInfo = () => ({
+		skill: loader.getSkills().skills.find((skill) => skill.name === "packaged-skill")?.sourceInfo,
+		prompt: loader.getPrompts().prompts.find((prompt) => prompt.name === "packaged-prompt")?.sourceInfo,
+		theme: loader.getThemes().themes.find((theme) => theme.name === "packaged-theme")?.sourceInfo,
+	});
+
+	const afterReload = packagedSourceInfo();
+	for (const [kind, sourceInfo] of Object.entries(afterReload)) {
+		assert.ok(sourceInfo, `${kind} was not discovered from the package`);
+		assert.equal(sourceInfo.origin, "package", `${kind} lost its package origin at reload`);
+		assert.equal(sourceInfo.source, packageDir, `${kind} lost its package source at reload`);
+	}
+
+	await loader.extendResources({
+		skillPaths: [
+			{
+				path: extraSkillDir,
+				metadata: { source: "extension:extra", scope: "temporary", origin: "top-level", baseDir: extraSkillDir },
+			},
+		],
+	});
+
+	assert.deepEqual(packagedSourceInfo(), afterReload, "extendResources dropped the reload's package metadata");
+	assert.equal(
+		loader.getSkills().skills.find((skill) => skill.name === "extra-skill")?.sourceInfo?.source,
+		"extension:extra",
+		"the extending pass lost its own metadata",
+	);
+});

--- a/test/unit/pi-0.83.0-oauth-refresh-window-probe.test.ts
+++ b/test/unit/pi-0.83.0-oauth-refresh-window-probe.test.ts
@@ -1,0 +1,142 @@
+/**
+ * P4 probe — the inherited shorter OAuth refresh window (upstream pi #7168).
+ *
+ * pi-ai now refreshes a stored OAuth credential that has under five minutes of
+ * validity left, rather than waiting for it to expire. That widens the window in
+ * which *every* concurrent Atomic session — subagents, workflow stages, RPC
+ * children — decides at the same moment that the shared credential needs
+ * refreshing. The stated risk (R2) is that the widened window amplifies into a
+ * refresh storm: one refresh per session instead of one refresh per credential.
+ *
+ * The suppression lives on Atomic's side of the seam. `AuthStorage.modify` takes
+ * the cross-process `auth.json` lock, and pi-ai re-checks expiry inside that
+ * lock; each session here therefore gets its own `AuthStorage` over one shared
+ * file, which is exactly what separate sessions have.
+ */
+
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Credential, Provider } from "@earendil-works/pi-ai";
+import { createModels } from "@earendil-works/pi-ai";
+import { afterEach, test } from "vitest";
+import { AuthStorage } from "../../packages/coding-agent/src/core/auth-storage.js";
+
+/** Enough concurrency to storm, small enough to stay well inside the budget. */
+const CONCURRENT_SESSIONS = 6;
+const PROVIDER_ID = "refresh-window-probe";
+const FIVE_MINUTES_MS = 5 * 60 * 1000;
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+	for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+function sharedAuthFile(): string {
+	const directory = mkdtempSync(join(tmpdir(), "atomic-refresh-window-"));
+	temporaryDirectories.push(directory);
+	return join(directory, "auth.json");
+}
+
+interface RefreshProbe {
+	readonly authPath: string;
+	readonly refreshes: () => number;
+	readonly sessions: ReadonlyArray<ReturnType<typeof createModels>>;
+}
+
+async function createRefreshProbe(remainingValidityMs: number): Promise<RefreshProbe> {
+	const authPath = sharedAuthFile();
+	const seed = AuthStorage.create(authPath);
+	await seed.modify(PROVIDER_ID, async () => ({
+		type: "oauth",
+		access: "stored-access",
+		refresh: "stored-refresh",
+		expires: Date.now() + remainingValidityMs,
+	}));
+
+	let refreshes = 0;
+	const provider = (): Provider => ({
+		id: PROVIDER_ID,
+		name: "Refresh Window Probe",
+		auth: {
+			oauth: {
+				name: "OAuth",
+				login: async () => {
+					throw new Error("the probe never logs in");
+				},
+				refresh: async (credential: Credential & { type: "oauth" }) => {
+					refreshes += 1;
+					// Hold the lock long enough that a second refresher would have to be
+					// a real concurrency failure rather than a scheduling accident.
+					await new Promise((resolve) => setTimeout(resolve, 25));
+					return { ...credential, access: "rotated-access", expires: Date.now() + 60 * 60 * 1000 };
+				},
+				toAuth: async (credential: Credential & { type: "oauth" }) => ({ apiKey: credential.access }),
+			},
+		},
+		getModels: () => [],
+		stream: () => {
+			throw new Error("the probe never streams");
+		},
+		streamSimple: () => {
+			throw new Error("the probe never streams");
+		},
+	});
+
+	const sessions = Array.from({ length: CONCURRENT_SESSIONS }, () => {
+		const models = createModels({ credentials: AuthStorage.create(authPath) });
+		models.setProvider(provider());
+		return models;
+	});
+
+	return { authPath, refreshes: () => refreshes, sessions };
+}
+
+test("concurrent sessions inside the five-minute window refresh the shared credential once", async () => {
+	// Still valid, but inside the window: this credential would not have been
+	// refreshed at all before the change, so it is the case the change created.
+	const probe = await createRefreshProbe(FIVE_MINUTES_MS - 60_000);
+
+	const resolved = await Promise.all(probe.sessions.map((models) => models.getAuth(PROVIDER_ID)));
+
+	assert.equal(probe.refreshes(), 1, `${CONCURRENT_SESSIONS} sessions produced ${probe.refreshes()} refreshes`);
+	assert.deepEqual(
+		resolved.map((result) => result?.auth),
+		Array.from({ length: CONCURRENT_SESSIONS }, () => ({ apiKey: "rotated-access" })),
+		"every session must observe the one rotated credential",
+	);
+
+	const persisted = await AuthStorage.create(probe.authPath).read(PROVIDER_ID);
+	assert.equal(persisted?.type, "oauth");
+	assert.equal((persisted as Credential & { type: "oauth" }).access, "rotated-access");
+});
+
+test("a credential outside the window is not refreshed by any concurrent session", async () => {
+	// The path that already worked: a comfortably valid credential must not be
+	// touched, or the shorter window would mean a refresh on every resolution.
+	const probe = await createRefreshProbe(FIVE_MINUTES_MS + 60 * 60 * 1000);
+
+	const resolved = await Promise.all(probe.sessions.map((models) => models.getAuth(PROVIDER_ID)));
+
+	assert.equal(probe.refreshes(), 0);
+	assert.deepEqual(
+		resolved.map((result) => result?.auth),
+		Array.from({ length: CONCURRENT_SESSIONS }, () => ({ apiKey: "stored-access" })),
+	);
+});
+
+test("a session that arrives after the rotation reuses it instead of refreshing again", async () => {
+	const probe = await createRefreshProbe(FIVE_MINUTES_MS - 60_000);
+
+	await Promise.all(probe.sessions.map((models) => models.getAuth(PROVIDER_ID)));
+	// A late session — the next subagent, the next workflow stage — reads the
+	// rotated credential from the shared file and must find nothing to do.
+	const late = createModels({ credentials: AuthStorage.create(probe.authPath) });
+	late.setProvider(probe.sessions[0]!.getProviders()[0]!);
+	const resolved = await late.getAuth(PROVIDER_ID);
+
+	assert.equal(probe.refreshes(), 1);
+	assert.deepEqual(resolved?.auth, { apiKey: "rotated-access" });
+});

--- a/test/unit/pi-0.83.0-pending-stop-reason-probes.test.ts
+++ b/test/unit/pi-0.83.0-pending-stop-reason-probes.test.ts
@@ -1,0 +1,239 @@
+/**
+ * P4 probe — the inherited `pending` streaming stop reason (upstream
+ * `f9a49869`).
+ *
+ * `pending` is not a terminal reason a provider delivers: pi-ai raises an error
+ * when a stream *ends* on it. It is the reason every in-flight partial carries,
+ * so it crosses Atomic's surfaces on every single turn — `message_start` and
+ * each `message_update` carry `stopReason: "pending"`, and only `message_end`
+ * carries the terminal reason. The first test below measures that rather than
+ * assuming it, so the rest of the file cannot quietly stop covering the real
+ * shape.
+ *
+ * Four consumers must therefore tolerate the whole `StopReason` union, `pending`
+ * included: the isolated engine protocol, the RPC message projection, branch
+ * summaries and Verbatim Compaction. Each is driven with every member of the
+ * union; an unhandled variant would throw rather than fail an assertion, so the
+ * probes also pin the outcome each reason produces.
+ */
+
+import assert from "node:assert/strict";
+import { PassThrough } from "node:stream";
+import type { StreamFn } from "@earendil-works/pi-agent-core";
+import type { AssistantMessage, Model, StopReason } from "@earendil-works/pi-ai/compat";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai/compat";
+import { test } from "vitest";
+import { generateBranchSummary } from "../../packages/coding-agent/src/core/compaction/branch-summarization.js";
+import { planDeletedLineRanges } from "../../packages/coding-agent/src/core/compaction/range-planner.js";
+import {
+	INTERACTIVE_ENGINE_PROTOCOL_VERSION,
+	parseInteractiveEngineCommand,
+	serializeInteractiveEngineFrame,
+} from "../../packages/coding-agent/src/modes/interactive-engine/protocol.js";
+import { attachJsonlLineReader, serializeJsonLine } from "../../packages/coding-agent/src/modes/rpc/jsonl.js";
+import type { RpcEvent } from "../../packages/coding-agent/src/modes/rpc/rpc-types.js";
+import { createHarness } from "../../packages/coding-agent/test/suite/harness.js";
+import { borrowed, PARAMETERS, region, scriptedStream, testModel } from "./compaction-rung-support.js";
+
+/**
+ * Every member of the union. Declared as a total `Record<StopReason, true>` so a
+ * variant added by a future pi-ai release fails `tsc` here rather than quietly
+ * going unprobed.
+ */
+const STOP_REASON_COVERAGE = {
+	pending: true,
+	stop: true,
+	length: true,
+	toolUse: true,
+	error: true,
+	aborted: true,
+} satisfies Record<StopReason, true>;
+
+const ALL_STOP_REASONS = Object.keys(STOP_REASON_COVERAGE) as StopReason[];
+
+function assistantWith(stopReason: StopReason): AssistantMessage {
+	return { ...fauxAssistantMessage("body text", { stopReason }), timestamp: 1 };
+}
+
+/** Replay session events through the exact JSONL projection RPC mode writes. */
+async function projectThroughRpcWire(events: readonly RpcEvent[]): Promise<RpcEvent[]> {
+	const stream = new PassThrough();
+	const received: RpcEvent[] = [];
+	const drained = new Promise<void>((resolve) => {
+		attachJsonlLineReader(stream, (line) => received.push(JSON.parse(line) as RpcEvent), { onDrained: resolve });
+	});
+	for (const event of events) stream.write(serializeJsonLine(event));
+	stream.end();
+	await drained;
+	return received;
+}
+
+test("every streaming partial that crosses a session surface carries the pending stop reason", async () => {
+	const harness = await createHarness();
+	try {
+		harness.setResponses([fauxAssistantMessage("done", { stopReason: "stop" })]);
+		await harness.session.prompt("hi");
+
+		const assistantReasons = harness.events
+			.filter(
+				(event): event is Extract<RpcEvent, { type: "message_start" | "message_update" | "message_end" }> =>
+					(event.type === "message_start" || event.type === "message_update" || event.type === "message_end") &&
+					event.message.role === "assistant",
+			)
+			.map((event) => ({ type: event.type, stopReason: (event.message as AssistantMessage).stopReason }));
+
+		assert.ok(assistantReasons.length >= 3, "the turn must produce a start, at least one update, and an end");
+		const partials = assistantReasons.filter((entry) => entry.type !== "message_end");
+		assert.ok(partials.length >= 2, "expected streaming partials before the terminal message");
+		for (const partial of partials) {
+			assert.equal(partial.stopReason, "pending", `${partial.type} must carry the pending partial reason`);
+		}
+		assert.equal(assistantReasons.at(-1)?.stopReason, "stop", "only the terminal message carries the mapped reason");
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test("the RPC message projection round-trips every stop reason, pending included", async () => {
+	const events: RpcEvent[] = ALL_STOP_REASONS.map((stopReason) => ({
+		type: "message_end",
+		message: assistantWith(stopReason),
+	}));
+
+	const received = await projectThroughRpcWire(events);
+
+	assert.equal(received.length, ALL_STOP_REASONS.length);
+	assert.deepEqual(
+		received.map((event) => ((event as { message: AssistantMessage }).message satisfies AssistantMessage).stopReason),
+		ALL_STOP_REASONS,
+	);
+});
+
+test("a whole pending-carrying turn survives the RPC projection unchanged", async () => {
+	const harness = await createHarness();
+	try {
+		harness.setResponses([fauxAssistantMessage("done", { stopReason: "stop" })]);
+		await harness.session.prompt("hi");
+
+		const received = await projectThroughRpcWire(harness.events);
+
+		assert.deepEqual(
+			received.map((event) => event.type),
+			harness.events.map((event) => event.type),
+		);
+		assert.deepEqual(received, JSON.parse(JSON.stringify(harness.events)) as RpcEvent[]);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test("the isolated engine protocol carries a pending message frame at protocol version 2", () => {
+	assert.equal(INTERACTIVE_ENGINE_PROTOCOL_VERSION, 2);
+
+	for (const stopReason of ALL_STOP_REASONS) {
+		const message = JSON.parse(JSON.stringify(assistantWith(stopReason))) as Record<string, unknown>;
+		const frame = serializeInteractiveEngineFrame({
+			type: "engine_message_render",
+			componentId: `component-${stopReason}`,
+			requestId: 1,
+			width: 80,
+			message: message as never,
+			expanded: false,
+			outputPad: 1,
+		});
+
+		const parsed = parseInteractiveEngineCommand(frame.trimEnd());
+
+		assert.ok(parsed, `the engine dropped the ${stopReason} frame instead of parsing it`);
+		assert.equal(parsed.type, "engine_message_render");
+		assert.equal(
+			(parsed as Extract<typeof parsed, { type: "engine_message_render" }>).message.stopReason,
+			stopReason,
+			`the ${stopReason} frame lost its stop reason across the engine boundary`,
+		);
+	}
+});
+
+/** A branch-summary stream that answers with one scripted assistant message. */
+function summaryStream(stopReason: StopReason): StreamFn {
+	return ((model: Model<string>) => ({
+		result: async (): Promise<AssistantMessage> => ({
+			...assistantWith(stopReason),
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+		}),
+	})) as unknown as StreamFn;
+}
+
+test("branch summarization classifies every stop reason without an unhandled variant", async () => {
+	const entries = [
+		{
+			id: "e1",
+			type: "message" as const,
+			parentId: null,
+			timestamp: new Date(1).toISOString(),
+			message: { role: "user" as const, content: "summarize this branch", timestamp: 1 },
+		},
+	];
+
+	for (const stopReason of ALL_STOP_REASONS) {
+		const result = await generateBranchSummary(
+			entries as never,
+			{
+				model: testModel(),
+				apiKey: "probe-key",
+				signal: new AbortController().signal,
+				streamFn: summaryStream(stopReason),
+			} as never,
+		);
+
+		if (stopReason === "aborted") {
+			assert.deepEqual(result, { aborted: true }, "an aborted summary stays an abort");
+			continue;
+		}
+		if (stopReason === "error") {
+			assert.ok(result.error, "an errored summary stays an error");
+			continue;
+		}
+		// Everything else — pending included — is a completed summary, which is
+		// what a terminal reason produced before the raw-stop-reason batch.
+		assert.equal(result.error, undefined, `${stopReason} must not become a summarization failure`);
+		assert.equal(result.aborted, undefined, `${stopReason} must not be reported as an abort`);
+		assert.match(result.summary ?? "", /body text/u, `${stopReason} lost the summary text`);
+	}
+});
+
+test("the compaction range planner classifies every stop reason without an unhandled variant", async () => {
+	for (const stopReason of ALL_STOP_REASONS) {
+		const stream = scriptedStream({ default: [{ text: "5,12\n", stopReason }] });
+		const plan = () =>
+			planDeletedLineRanges(region(40), PARAMETERS, borrowed(testModel(), "high"), 20, {
+				streamFn: stream.streamFn,
+			});
+
+		if (stopReason === "aborted") {
+			await assert.rejects(plan, /Compaction cancelled/u, "an aborted plan stays a cancellation");
+			continue;
+		}
+
+		const outcome = await plan();
+		if (stopReason === "error") {
+			assert.equal(outcome.kind, "providerError");
+			continue;
+		}
+		// `pending`, `stop` and `toolUse` all parse the ranges; `length` takes the
+		// truncation-recovery path. None may throw, and none may lose the range.
+		assert.ok(
+			outcome.kind === "ranked" || outcome.kind === "recovered",
+			`${stopReason} produced ${outcome.kind} instead of usable ranges`,
+		);
+		assert.deepEqual(
+			(outcome.ranges as ReadonlyArray<{ start: number; end: number }>).map((range) => ({
+				start: Number(range.start),
+				end: Number(range.end),
+			})),
+			[{ start: 5, end: 12 }],
+		);
+	}
+});

--- a/test/unit/pi-0.83.0-stop-reason-probes.test.ts
+++ b/test/unit/pi-0.83.0-stop-reason-probes.test.ts
@@ -1,0 +1,233 @@
+/**
+ * P4 probe — the inherited raw-stop-reason batch (upstream `926eb15c`,
+ * `637737ca`, `23cb385b`, `5a53f086`, `e5ef8d06`, `fe1c9b6d`).
+ *
+ * Upstream now surfaces an *unmapped* terminal reason as a provider error
+ * instead of a successful stop. That is the change this repository inherits and
+ * does not own. The risk it carries is the opposite direction: a raw reason that
+ * previously mapped to a successful stop must still map to one. A probe that
+ * only asserted the new error would pass just as happily if every provider had
+ * started erroring on `end_turn`.
+ *
+ * So each case drives the real pi-ai stream over a canned provider response and
+ * asserts the *mapped* reason and the absence of an error message. The final
+ * case in each family asserts the inherited behaviour itself, which is also what
+ * proves the success cases are discriminating rather than vacuous.
+ */
+
+import assert from "node:assert/strict";
+import { stream as streamAnthropicMessages } from "@earendil-works/pi-ai/api/anthropic-messages";
+import { stream as streamGoogleGenerativeAi } from "@earendil-works/pi-ai/api/google-generative-ai";
+import { stream as streamOpenAiCompletions } from "@earendil-works/pi-ai/api/openai-completions";
+import type { Api, AssistantMessage, Context, Model, StopReason } from "@earendil-works/pi-ai/compat";
+import { afterEach, test, vi } from "vitest";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+const CONTEXT: Context = {
+	systemPrompt: "",
+	messages: [{ role: "user", content: [{ type: "text", text: "hi" }], timestamp: 0 }],
+};
+
+function model<TApi extends Api>(api: TApi, baseUrl: string): Model<TApi> {
+	return {
+		id: `${api}-probe`,
+		name: `${api} probe`,
+		provider: "stop-reason-probe",
+		api,
+		baseUrl,
+		contextWindow: 10_000,
+		maxTokens: 1_000,
+		input: ["text"],
+		output: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	} as unknown as Model<TApi>;
+}
+
+function sseResponse(frames: string[]): Response {
+	return new Response(frames.join(""), { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
+/** Answer every request in one case with the same canned provider body. */
+function respondWith(body: () => Response): void {
+	vi.spyOn(globalThis, "fetch").mockImplementation(async () => body());
+}
+
+function anthropicBody(rawStopReason: string, withToolCall = false): Response {
+	const content = withToolCall
+		? [
+				{ type: "content_block_start", index: 0, content_block: { type: "tool_use", id: "t1", name: "read" } },
+				{ type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: "{}" } },
+				{ type: "content_block_stop", index: 0 },
+			]
+		: [
+				{ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+				{ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } },
+				{ type: "content_block_stop", index: 0 },
+			];
+	const events = [
+		{
+			type: "message_start",
+			message: {
+				id: "msg",
+				type: "message",
+				role: "assistant",
+				content: [],
+				model: "probe",
+				stop_reason: null,
+				stop_sequence: null,
+				usage: { input_tokens: 1, output_tokens: 1 },
+			},
+		},
+		...content,
+		{
+			type: "message_delta",
+			delta: { stop_reason: rawStopReason, stop_sequence: null },
+			usage: { output_tokens: 1 },
+		},
+		{ type: "message_stop" },
+	];
+	return sseResponse(events.map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`));
+}
+
+function openAiCompletionsBody(rawFinishReason: string, withToolCall = false): Response {
+	const first = withToolCall
+		? {
+				id: "1",
+				choices: [
+					{
+						index: 0,
+						delta: {
+							role: "assistant",
+							tool_calls: [
+								{ index: 0, id: "t1", type: "function", function: { name: "read", arguments: "{}" } },
+							],
+						},
+						finish_reason: null,
+					},
+				],
+			}
+		: { id: "1", choices: [{ index: 0, delta: { role: "assistant", content: "ok" }, finish_reason: null }] };
+	const last = {
+		id: "1",
+		choices: [{ index: 0, delta: {}, finish_reason: rawFinishReason }],
+		usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+	};
+	return sseResponse([...[first, last].map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`), "data: [DONE]\n\n"]);
+}
+
+function googleBody(rawFinishReason: string): Response {
+	const chunks = [
+		{ candidates: [{ index: 0, content: { parts: [{ text: "ok" }] } }] },
+		{
+			candidates: [{ index: 0, content: { parts: [] }, finishReason: rawFinishReason }],
+			usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 },
+		},
+	];
+	return sseResponse(chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`));
+}
+
+/**
+ * Raw terminal reasons that reached a *successful* stop before the batch, with
+ * the mapped reason each one must still produce. `pause_turn` and
+ * `stop_sequence` are the load-bearing rows: they are the reasons a mapper is
+ * most likely to drop into its new unmapped-is-an-error default.
+ */
+const ANTHROPIC_SUCCESSES: ReadonlyArray<readonly [string, StopReason, boolean]> = [
+	["end_turn", "stop", false],
+	["max_tokens", "length", false],
+	["pause_turn", "stop", false],
+	["stop_sequence", "stop", false],
+	["tool_use", "toolUse", true],
+];
+
+const OPENAI_COMPLETIONS_SUCCESSES: ReadonlyArray<readonly [string, StopReason, boolean]> = [
+	["stop", "stop", false],
+	["end", "stop", false],
+	["length", "length", false],
+	["tool_calls", "toolUse", true],
+	["function_call", "toolUse", true],
+];
+
+const GOOGLE_SUCCESSES: ReadonlyArray<readonly [string, StopReason]> = [
+	["STOP", "stop"],
+	["MAX_TOKENS", "length"],
+];
+
+function assertSucceeded(message: AssistantMessage, expected: StopReason, label: string): void {
+	assert.equal(message.stopReason, expected, `${label} must still map to ${expected}`);
+	assert.equal(message.errorMessage, undefined, `${label} must not carry a provider error message`);
+}
+
+test("anthropic-messages terminal reasons that succeeded before still succeed", async () => {
+	for (const [raw, expected, withToolCall] of ANTHROPIC_SUCCESSES) {
+		respondWith(() => anthropicBody(raw, withToolCall));
+		const result = await streamAnthropicMessages(model("anthropic-messages", "https://anthropic.probe"), CONTEXT, {
+			apiKey: "probe-key",
+		}).result();
+		assertSucceeded(result, expected, `anthropic ${raw}`);
+		vi.restoreAllMocks();
+	}
+});
+
+test("an unmapped anthropic-messages reason is a provider error, not a silent stop", async () => {
+	respondWith(() => anthropicBody("reason_invented_after_this_release"));
+	const result = await streamAnthropicMessages(model("anthropic-messages", "https://anthropic.probe"), CONTEXT, {
+		apiKey: "probe-key",
+	}).result();
+	assert.equal(result.stopReason, "error");
+	assert.match(result.errorMessage ?? "", /reason_invented_after_this_release/u);
+});
+
+test("openai-completions finish reasons that succeeded before still succeed", async () => {
+	for (const [raw, expected, withToolCall] of OPENAI_COMPLETIONS_SUCCESSES) {
+		respondWith(() => openAiCompletionsBody(raw, withToolCall));
+		const result = await streamOpenAiCompletions(model("openai-completions", "https://openai.probe/v1"), CONTEXT, {
+			apiKey: "probe-key",
+		}).result();
+		assertSucceeded(result, expected, `openai-completions ${raw}`);
+		vi.restoreAllMocks();
+	}
+});
+
+test("an unmapped openai-completions finish reason is a provider error", async () => {
+	respondWith(() => openAiCompletionsBody("finish_reason_invented_after_this_release"));
+	const result = await streamOpenAiCompletions(model("openai-completions", "https://openai.probe/v1"), CONTEXT, {
+		apiKey: "probe-key",
+	}).result();
+	assert.equal(result.stopReason, "error");
+	assert.match(result.errorMessage ?? "", /finish_reason_invented_after_this_release/u);
+});
+
+test("google-generative-ai finish reasons that succeeded before still succeed", async () => {
+	for (const [raw, expected] of GOOGLE_SUCCESSES) {
+		respondWith(() => googleBody(raw));
+		const result = await streamGoogleGenerativeAi(
+			model("google-generative-ai", "https://google.probe/v1beta"),
+			CONTEXT,
+			{ apiKey: "probe-key" },
+		).result();
+		assertSucceeded(result, expected, `google ${raw}`);
+		vi.restoreAllMocks();
+	}
+});
+
+/**
+ * The Google mapper reaches a terminal state for a safety block and reports it
+ * as an error. That is the pre-existing shape, not the new batch — asserting it
+ * here keeps the success rows above from being read as "google never errors".
+ */
+test("a google safety block stays a provider error with the raw reason attached", async () => {
+	respondWith(() => googleBody("SAFETY"));
+	const result = await streamGoogleGenerativeAi(
+		model("google-generative-ai", "https://google.probe/v1beta"),
+		CONTEXT,
+		{
+			apiKey: "probe-key",
+		},
+	).result();
+	assert.equal(result.stopReason, "error");
+	assert.match(result.errorMessage ?? "", /SAFETY/u);
+});


### PR DESCRIPTION
Every probe here also covers the path that already worked. A probe asserting
only the new behaviour would pass just as happily against a build that had
broken every previously successful stop, which is the risk this layer exists
to bound.

Raw stop reasons (926eb15c and its five siblings): unmapped terminal reasons
now surface as provider errors. Each provider family is driven over the real
pi-ai stream with a canned response, once per raw reason that used to reach a
successful stop - end_turn, max_tokens, pause_turn, stop_sequence, tool_use,
stop, end, length, tool_calls, function_call, STOP, MAX_TOKENS - and once with
a reason no mapper knows. The last case is what proves the others discriminate.

The pending stop reason (f9a49869) is not a reason a provider delivers: pi-ai
raises when a stream ends on it. It is what every in-flight partial carries, so
it crosses Atomic on every turn. That is measured rather than assumed, then the
whole StopReason union is driven through the four consumers the design names -
the isolated-engine protocol at version 2, the RPC JSONL projection, branch
summaries, and the Verbatim Compaction planner. The union is declared as a total
Record<StopReason, true>, so a variant added upstream fails tsc here instead of
going unprobed.

The three adapted fixes are probed one level out from their unit fixtures: a
worktree built by real `git worktree add` nested inside its own checkout, an RPC
bash command with a handler that intercepts and one that declines - the decline
must still run real bash - and package-sourced skills, prompts and themes read
back after a later extendResources. Each fails when its fix is defeated.

The shorter OAuth refresh window (pi #7168) is probed for the storm it could
amplify into: six concurrent sessions over one shared auth.json refresh a
credential inside the window exactly once, a credential outside it not at all,
and a session arriving after the rotation finds nothing to do.

Two dependency gates. actions/cache 6.1.0 is pinned by contract in test/ci,
where the strongest available statement is structural - every asserted check
context and timeout budget lives in test.yml, which uses no cache action - and
the full ci-contracts suite is green. The DBOS SDK bump gets the three required
replay parts: two tool checkpoints replaying after a mid-run kill without
re-invoking their callbacks, hydration's acyclic-topology check over a bounded
loop's per-iteration nodes with a deliberately cyclic counterpart to show the
check is live, and a nested child surviving a parent resume with stable
per-iteration identity and call order.

One shape is documented as deliberately uncovered in that file: a parent killed
after one nested child boundary completed and while a later one is in flight
does not resume from a fresh DBOS mirror. The same shape resumes cleanly on
InMemoryDurableBackend and this sync changes nothing under packages/workflows,
so it belongs to the durable layer rather than to a dependency gate.

Nothing needed fixing: all 22 probes pass against the tree as ported.

Assistant-model: Claude Opus 5
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788120455&installation_model_id=10562&pr_number=2109&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2109&signature=6b5dd4a44915ca9eadc515c6314a4932ae781857fda9a2916ef865a3af950b9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ports pi 0.83.0 behavior, updates runtime and CI dependencies, adds guarded `atomic auth` credential-print commands, and expands regression coverage for streaming, OAuth refreshes, worktrees, resource reloads, cache configuration, and DBOS replay.

A focused credential-print test showed that an ambiguous bearer-token request can refresh and persist OAuth credentials for multiple matching providers before returning the ambiguity error. This changes credentials for providers the caller did not select, so the change should not merge until that side effect is removed.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until ambiguous credential export requests stop changing unselected providers' stored OAuth credentials.

The reproduced failure is deterministic in a focused test and affects persisted authentication state: a request that exits as ambiguous can still rotate credentials for more than one provider.

**Files Needing Attention:** packages/coding-agent/src/cli/credential-print.ts, especially the candidate-resolution loop and the ambiguity check after credential resolution.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a P1 finding proof for the focused ambiguous OAuth refresh scenario and referenced the corresponding review comment for details.
- T-Rex produced a second P1 finding proof and referenced its review comment.
- T-Rex ran the credential-print-ambiguous-oauth-refresh.test.ts test via Vitest in packages/coding-agent, and Vitest reported exit code 0 with 1 test passed.
- T-Rex registered the artifacts for the validation proof in the trex-artifacts repository and linked them to the proof.

<a href="https://app.greptile.com/trex/runs/16867949/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **actions/cache probe ignores unknown action inputs while claiming to reject them**

   - **Bug**
     - `test/ci/actions-cache-bump-contract.test.ts:75-88` says the reviewed cache step may pass only `key` and `path`, but the extraction regex at line 78 matches only a fixed allowlist of known input names. An arbitrary input such as `unsupported-future-cache-input: true` is omitted from `inputs`, so the subsequent key-set assertion still sees exactly `["key", "path"]` and passes. The targeted workflow mutation was executed and the CI test remained green.
   - **Cause**
     - The test parses only recognized input names before asserting the resulting set, instead of parsing all YAML input keys in the cache step and then asserting the allowed set.
   - **Fix**
     - Parse every direct key under the cache step's `with:` block (preferably using the repository's YAML parser/helper), then assert the complete key set equals `["key", "path"]`. Retain a mutation test for an unknown input to ensure this negative path fails.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. `packages/coding-agent/src/cli/credential-print.ts`, line 569-640 ([link](https://github.com/bastani-inc/atomic/blob/8d19608ea3da1f431288aa2b2dccd83076705991/packages/coding-agent/src/cli/credential-print.ts#L569-L640)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Ambiguous exports rotate unselected OAuth credentials**

   When `print-bearer-token` is run without `--provider`, this loop invokes the mutating `getAuth()` path for every matching OAuth provider before checking whether more than one credential is available. If multiple credentials are inside the refresh window, each may be refreshed and persisted before the command exits with `ProviderAmbiguous` and emits no token. Reject ambiguity before performing refreshes, or use a non-mutating probe to determine eligibility first.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Focused ambiguous OAuth refresh Vitest source](https://app.greptile.com/trex/artifacts/5f99ac8c-e382-4b41-afaa-7e8609238b92)**

   - Captured the authored ModelRuntime-compatible test with two stale OAuth providers, refresh/persistence tracking, and ambiguity/no-secret assertions; takeaway: the test directly exercises the hypothesized side-effect path.

   **[Focused ambiguous OAuth refresh Vitest execution](https://app.greptile.com/trex/artifacts/c1227080-5ac6-4165-bdb1-22796f18d168)**

   - Captured output from the focused Vitest command run in the coding-agent package, which exited 0 with one passing test; takeaway: execution verifies both refresh/persistence side effects precede exit-3 ambiguity.

   <a href="https://app.greptile.com/trex/runs/16867949/artifacts?artifact=5f99ac8c-e382-4b41-afaa-7e8609238b92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/coding-agent/src/cli/credential-print.ts
   Line: 569-640

   Comment:
   **Ambiguous exports rotate unselected OAuth credentials**

   When `print-bearer-token` is run without `--provider`, this loop invokes the mutating `getAuth()` path for every matching OAuth provider before checking whether more than one credential is available. If multiple credentials are inside the refresh window, each may be refreshed and persisted before the command exits with `ProviderAmbiguous` and emits no token. Reject ambiguity before performing refreshes, or use a non-mutating probe to determine eligibility first.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>


3. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Ambiguous bearer-token export refreshes multiple OAuth credentials before rejecting the request**

   - **Bug**
     - When two eligible OAuth providers offer the same model and both need refresh for the requested minimum validity, the credential-print loop calls `getAuth()` for both providers. Their refresh paths can persist rotated credentials; only afterward does the method detect two collected values and throw `ProviderAmbiguous` with exit code 3. No credential is emitted, but both credential records may be mutated.
   - **Cause**
     - `resolveCredentialForPrint` iterates every eligible model and calls the mutating `ModelRuntime.getAuth()` at lines 569-609 before the ambiguity check at lines 635-640.
   - **Fix**
     - Determine and reject provider ambiguity before invoking mutating credential resolution, or introduce/use a non-mutating runtime probe that can establish whether candidates can satisfy the requested OAuth validity without refreshing or persisting credentials.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/src/cli/credential-print.ts:569-640
**Ambiguous exports rotate unselected OAuth credentials**

When `print-bearer-token` is run without `--provider`, this loop invokes the mutating `getAuth()` path for every matching OAuth provider before checking whether more than one credential is available. If multiple credentials are inside the refresh window, each may be refreshed and persisted before the command exits with `ProviderAmbiguous` and emits no token. Reject ambiguity before performing refreshes, or use a non-mutating probe to determine eligibility first.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (15): Last reviewed commit: ["test: cross the DBOS serializer at the m..."](https://github.com/bastani-inc/atomic/commit/8d19608ea3da1f431288aa2b2dccd83076705991) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49193960)</sub>

<!-- /greptile_comment -->