### PR TITLE
fix: repair main check under biome 2.5.6

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
 	"linter": {
 		"enabled": true,
 		"rules": {

--- a/packages/coding-agent/src/cli/credential-print.ts
+++ b/packages/coding-agent/src/cli/credential-print.ts
@@ -387,7 +387,8 @@ const CREDENTIAL_SHAPES: readonly RegExp[] = [
  * Field names whose value is the credential, however opaque that value looks.
  * `x-api-key` is the case shape-matching cannot reach: the value is just bytes.
  */
-const CREDENTIAL_FIELD_NAME = String.raw`(?:x-)?(?:api[-_]?key|apikey|auth(?:orization)?|access[-_]?token|refresh[-_]?token|id[-_]?token|client[-_]?secret|secret[-_]?key|private[-_]?key|session[-_]?key|password|passwd|token|secret|key)`;
+const CREDENTIAL_FIELD_NAME =
+	"(?:x-)?(?:api[-_]?key|apikey|auth(?:orization)?|access[-_]?token|refresh[-_]?token|id[-_]?token|client[-_]?secret|secret[-_]?key|private[-_]?key|session[-_]?key|password|passwd|token|secret|key)";
 
 /**
  * Auth schemes that stand between the field name and the value it introduces.
@@ -397,7 +398,7 @@ const CREDENTIAL_FIELD_NAME = String.raw`(?:x-)?(?:api[-_]?key|apikey|auth(?:ori
  * pass depends on, that pass can no longer reach the token either. An opaque
  * `Authorization: Bearer <token>` then survives both passes.
  */
-const CREDENTIAL_AUTH_SCHEME = String.raw`(?:Bearer|Basic|Digest|Token|ApiKey|OAuth)`;
+const CREDENTIAL_AUTH_SCHEME = "(?:Bearer|Basic|Digest|Token|ApiKey|OAuth)";
 
 const CREDENTIAL_CONTEXTS: readonly RegExp[] = [
 	// Header or YAML-ish: `x-api-key: abc123`, to end of line, and the scheme


### PR DESCRIPTION
## Summary

#2116 (biome 2.5.5 → 2.5.6) went green in CI before `credential-print.ts` landed on main, so the merged combination was never checked. Biome 2.5.6's new `noUselessStringRaw` rule flags that file's two escape-free `String.raw` patterns, and `npm run check` now fails on main.

- Replace the two `String.raw` template patterns with plain string literals (byte-identical regex sources; all 53 credential-redaction tests pass unchanged).
- `biome migrate`: bump `biome.json` schema to 2.5.6.

## Verification

- `npm run check` green (biome + typecheck + shrinkwrap)
- full unit suite green via pre-commit hook

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788154344&installation_model_id=10562&pr_number=2118&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2118&signature=3c20999323454f399d431becb0454632e7b7abf5550ee284d239a6e328c4b0ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the Biome schema reference to 2.5.6 and replaces two raw template literals with equivalent quoted strings in the credential-redaction patterns.

The potential credential-redaction regression was disproved by exercising the focused credential-print suite and comparing the former and current literal forms across API-key, JSON, query-string, Bearer, and Basic credential contexts. The literals have identical runtime values and redact every exercised credential value.

## T-Rex validation blocked

Evidence upload was blocked because the environment did not provide an artifact-upload tool or endpoint. The executed comparison script and test logs are available only as repository-local files and cannot be attached as uploaded artifacts.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised credential-redaction behavior and the limited configuration update.

No defects remain: the only meaningful failure hypothesis was directly contradicted by focused credential-print tests and old-versus-new runtime comparisons.

**Files Needing Attention:** No additional files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Checked whether the completed credential-redaction validation evidence could be uploaded and found no artifact-upload endpoint in the environment.
- Observed that the available tools can read, edit, search the filesystem and execute commands, but there is no artifact-upload command, so repository-local validation scripts and logs remain unuploaded.

<a href="https://app.greptile.com/trex/runs/16873105/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: repair main check under biome 2.5.6"](https://github.com/bastani-inc/atomic/commit/e310ae7a7a7a89835faaf019ea88ffc5916fa7ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49289156)</sub>

<!-- /greptile_comment -->