### PR TITLE
fix(natives): harden WASI loader fallback and flavor selection

### DIFF
--- a/packages/natives/native/index.js
+++ b/packages/natives/native/index.js
@@ -523,47 +523,163 @@ function requireNative() {
   }
 }
 
-nativeBinding = requireNative()
+function createLoadErrorChain(errors) {
+  return errors.reduce((previous, current) => {
+    let message
+    try {
+      message =
+        current && typeof current.message === 'string'
+          ? current.message
+          : String(current)
+    } catch {
+      message = 'Unknown error'
+    }
+    const error = new Error(message)
+    error.cause = previous
+    return error
+  }, null)
+}
 
 // NAPI_RS_FORCE_WASI is a tri-state flag:
 //   unset / any other value → native binding preferred, WASI is only a fallback
-//   'true'                   → force WASI fallback even if native loaded
-//   'error'                  → force WASI and throw if no WASI binding is found
+//   'true'                   → prefer WASI, but retain native as a lazy fallback
+//   'error'                  → require WASI without initializing a native fallback
 // Treating any non-empty string as truthy (the historical behavior) meant
 // NAPI_RS_FORCE_WASI=false, NAPI_RS_FORCE_WASI=0, etc. inadvertently triggered
 // the WASI path, causing ENOENT for packages shipped without a .wasi.cjs file.
+//
+// NAPI_RS_WASI_FLAVOR selects one exact generated flavor and implies strict
+// WASI loading. It never crosses into another flavor or falls back to native.
+const __napiWasiFlavors = ["wasm32-wasi"]
+const __napiWasiFlavor = process.env.NAPI_RS_WASI_FLAVOR
+const __napiWasiFlavorRequested =
+  typeof __napiWasiFlavor === 'string' && __napiWasiFlavor.length > 0
+if (
+  __napiWasiFlavorRequested &&
+  __napiWasiFlavors.indexOf(__napiWasiFlavor) === -1
+) {
+  throw new Error(
+    'Unsupported WASI flavor "' +
+      __napiWasiFlavor +
+      '". Available flavors: ' +
+      __napiWasiFlavors.join(', '),
+  )
+}
+const forceWasiError = process.env.NAPI_RS_FORCE_WASI === 'error'
 const forceWasi =
-  process.env.NAPI_RS_FORCE_WASI === 'true' || process.env.NAPI_RS_FORCE_WASI === 'error'
+  process.env.NAPI_RS_FORCE_WASI === 'true' ||
+  forceWasiError ||
+  __napiWasiFlavorRequested
+
+if (!forceWasi) {
+  nativeBinding = requireNative()
+}
 
 if (!nativeBinding || forceWasi) {
   let wasiBinding = null
-  let wasiBindingError = null
-  try {
-    wasiBinding = require('./atomic_natives.wasi.cjs')
-    nativeBinding = wasiBinding
-  } catch (err) {
-    if (forceWasi) {
-      wasiBindingError = err
-    }
-  }
-  if (!nativeBinding || forceWasi) {
+  let wasiBindingLoaded = false
+  const wasiBindingErrors = []
+  const __napiWasiResolveCandidate = (specifier, isPackage, localArtifacts) => {
     try {
-      wasiBinding = require('@bastani/atomic-natives-wasm32-wasi')
-      nativeBinding = wasiBinding
-    } catch (err) {
-      if (forceWasi) {
-        if (!wasiBindingError) {
-          wasiBindingError = err
-        } else {
-          wasiBindingError.cause = err
-        }
-        loadErrors.push(err)
+      require.resolve(specifier)
+    } catch (resolveError) {
+      if (!resolveError || resolveError.code !== 'MODULE_NOT_FOUND') {
+        throw resolveError
       }
+      if (isPackage) {
+        try {
+          require.resolve(specifier + '/package.json')
+        } catch (packageError) {
+          if (packageError && packageError.code === 'MODULE_NOT_FOUND') {
+            return resolveError
+          }
+          // An exports restriction proves the package exists even when its
+          // package.json is not public. Preserve the root resolution failure.
+          throw resolveError
+        }
+        // The package exists but its main/export target is broken.
+        throw resolveError
+      }
+      return resolveError
+    }
+    if (localArtifacts) {
+      let artifactError = null
+      for (let i = 0; i < localArtifacts.length; i++) {
+        try {
+          require.resolve(localArtifacts[i])
+          return null
+        } catch (resolveError) {
+          if (!resolveError || resolveError.code !== 'MODULE_NOT_FOUND') {
+            throw resolveError
+          }
+          artifactError = resolveError
+        }
+      }
+      return artifactError
+    }
+    return null
+  }
+  if (!wasiBindingLoaded && (!__napiWasiFlavorRequested || __napiWasiFlavor === "wasm32-wasi")) {
+    let candidateError = null
+    let candidateFailed = false
+    try {
+      candidateError = __napiWasiResolveCandidate('./atomic_natives.wasi.cjs', false, ["./atomic_natives.wasm32-wasi.debug.wasm","./atomic_natives.wasm32-wasi.wasm"])
+      candidateFailed = candidateError !== null
+      if (!candidateFailed) {
+        wasiBinding = require('./atomic_natives.wasi.cjs')
+        nativeBinding = wasiBinding
+        wasiBindingLoaded = true
+      }
+    } catch (err) {
+      candidateError = err
+      candidateFailed = true
+    }
+    if (candidateFailed) {
+      wasiBindingErrors.push(candidateError)
+      loadErrors.push(candidateError)
     }
   }
-  if (process.env.NAPI_RS_FORCE_WASI === 'error' && !wasiBinding) {
-    const error = new Error('WASI binding not found and NAPI_RS_FORCE_WASI is set to error')
-    error.cause = wasiBindingError
+  if (!wasiBindingLoaded && (!__napiWasiFlavorRequested || __napiWasiFlavor === "wasm32-wasi")) {
+    let candidateError = null
+    let candidateFailed = false
+    try {
+      candidateError = __napiWasiResolveCandidate('@bastani/atomic-natives-wasm32-wasi', true, undefined)
+      candidateFailed = candidateError !== null
+      if (!candidateFailed) {
+        if (process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          const bindingPackageVersion = require('@bastani/atomic-natives-wasm32-wasi/package.json').version
+          if (bindingPackageVersion !== '0.0.0') {
+            throw new Error(`WASI binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          }
+        }
+        wasiBinding = require('@bastani/atomic-natives-wasm32-wasi')
+        nativeBinding = wasiBinding
+        wasiBindingLoaded = true
+      }
+    } catch (err) {
+      candidateError = err
+      candidateFailed = true
+    }
+    if (candidateFailed) {
+      wasiBindingErrors.push(candidateError)
+      loadErrors.push(candidateError)
+    }
+  }
+  if (
+    !wasiBindingLoaded &&
+    forceWasi &&
+    !forceWasiError &&
+    !__napiWasiFlavorRequested
+  ) {
+    nativeBinding = requireNative()
+  }
+  if ((forceWasiError || __napiWasiFlavorRequested) && !wasiBindingLoaded) {
+    const error = new Error(
+      __napiWasiFlavorRequested
+        ? 'WASI binding for flavor "' + __napiWasiFlavor + '" not found'
+        : 'WASI binding not found and NAPI_RS_FORCE_WASI is set to error',
+    )
+    error.cause = createLoadErrorChain(wasiBindingErrors)
     throw error
   }
 }
@@ -577,10 +693,7 @@ if (!nativeBinding) {
     )
     // assign instead of the `new Error(message, { cause })` options form,
     // which Node < 16.9 silently ignores
-    error.cause = loadErrors.reduce((err, cur) => {
-      cur.cause = err
-      return cur
-    })
+    error.cause = createLoadErrorChain(loadErrors)
     throw error
   }
   throw new Error(`Failed to load native binding`)


### PR DESCRIPTION
## Summary

Reworks the generated napi-rs JS loader in `packages/natives/native/index.js` so WASI binding loading is resilient, flavor-aware, and never mutates or drops load errors.

## Changes

- `NAPI_RS_FORCE_WASI=true` now prefers WASI but retains native as a lazy fallback; `error` remains strict and throws when no WASI binding is found.
- Added `NAPI_RS_WASI_FLAVOR` support: selects one exact generated WASI flavor, implies strict WASI loading, and never crosses flavors or falls back to native. Unsupported flavors throw with the available list.
- Each WASI candidate (local `atomic_natives.wasi.cjs` plus its `.wasm` artifacts, and the `@bastani/atomic-natives-wasm32-wasi` package) is resolved before being required, so missing artifacts are recorded as load errors instead of thrown; genuine package-export breakage still surfaces.
- `NAPI_RS_ENFORCE_VERSION_CHECK` now validates the WASI binding package version.
- Error cause chains are built defensively via `createLoadErrorChain`, replacing the reduce that mutated original errors and threw on an empty error list.

## Notes

- Pre-commit hooks (`npm run check`, `npm run test:unit`) passed on commit and push.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788155473&installation_model_id=10562&pr_number=2119&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2119&signature=62b5ef54ea8e30bfc91eb2bfd2084746bc8947819b7a86fec2ee7ba734b0ab0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change hardens WASI/native fallback selection, validates WASI package versions, and preserves underlying load errors when building error chains.

A release compatibility failure remains in `packages/natives/native/index.js`: the release version stamper leaves the WASI package-version guard at `0.0.0`. As a result, users who enable package-version enforcement cannot load the correctly versioned published WASI package.

The generated-loader overwrite concern was disproved: rebuilding the native output from an empty generated directory reproduced the loader byte-for-byte with the WASI selection, fallback, version validation, and error-chain behavior intact.

<h3>Confidence Score: 4/5</h3>

Do not merge until the WASI version guard is included in release version stamping.

The release path was exercised with a correctly versioned mock WASI package before and after running the real version stamper. The loader continued to expect `0.0.0` after stamping and rejected the package. The separate concern that native regeneration removes the hardening was disproved by a clean regeneration and byte-for-byte comparison.

**Files Needing Attention:** `scripts/bump-version.ts` needs to stamp the WASI package-version comparison and its corresponding error message; `packages/natives/native/index.js` contains the affected generated guard.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced proof for a posted P1 finding and linked artifacts including the isolated WASI version-stamp repro harness and the pre- and post-release WASI loader rejection logs.
- T-Rex rebuilt packages/natives/native from an empty generated-output directory in a detached worktree, verified that the regenerated index.js had all WASI hardening markers and that the diff against HEAD was empty, and confirmed a fresh Node process with an unsupported WASI flavor produced the expected strict rejection.
- T-Rex produced proof for a second posted P1 finding.
- T-Rex analyzed the bump-version logic and identified the mismatch caused by the bump script not mapping to the native WASI comparison path, supported by shell-script evidence and runtime logs.
- T-Rex performed a clean WASI-regeneration check in a fresh worktree, verified exit code 0, no diff against HEAD, confirmed the runtime rejection for unsupported WASI flavor, and inspected the relevant index.js region to confirm markers remained intact.

<a href="https://app.greptile.com/trex/runs/16873919/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Release stamping omits the WASI package version guard**

   - **Bug**
     - At `packages/natives/native/index.js:651`, the WASI fallback compares the installed WASI package to the literal `0.0.0`. The executed release-stamping path leaves that comparison and its error text unchanged when stamping version `1.2.3`. With `NAPI_RS_ENFORCE_VERSION_CHECK=1`, a loader using a correctly versioned `@bastani/atomic-natives-wasm32-wasi@1.2.3` rejects it.
   - **Cause**
     - `bumpNativeIndex` in `scripts/bump-version.ts` only replaces comparisons whose text is `bindingPackageVersion !== '…' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK`. The WASI block guards the comparison in an outer `if`, so it does not match either replacement expression.
   - **Fix**
     - Update `bumpNativeIndex` to also replace the WASI comparison and its `WASI binding package version mismatch, expected …` error text (or use a pattern that safely stamps both generated native and WASI version-check forms). Add a fixture test containing the WASI form.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/natives/native/index.js:651-652
**Release stamping omits the WASI package version guard**

The release version stamper only recognizes native checks where `bindingPackageVersion !== '…'` is immediately followed by `&& process.env.NAPI_RS_ENFORCE_VERSION_CHECK`. This WASI check is nested under the environment condition instead, so both its expected-version literal and error text remain `0.0.0` after a release bump. Consequently, when `NAPI_RS_ENFORCE_VERSION_CHECK=1`, a published loader rejects the correctly versioned `@bastani/atomic-natives-wasm32-wasi` package. Extend the stamping logic to cover this WASI form and add a release-fixture test for it.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(natives): harden WASI loader fallbac..."](https://github.com/bastani-inc/atomic/commit/0f02f78366023329e4ec3730eef95eb781d7a251) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49290556)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->