### PR TITLE
Prerelease 0.9.11-alpha.9 changelog

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.11-alpha.9] - 2026-08-01
+
 ### Breaking Changes
 
 - Adopted pi 0.83.0 (`@earendil-works/pi-agent-core`, `@earendil-works/pi-ai`, `@earendil-works/pi-tui` at `^0.83.0`), which moves the bundled TypeBox to 1.3.7. TypeBox 1.3.7 **removes seven deprecated APIs**. Atomic inherits the removal exactly as upstream shipped it and does not provide a compatibility shim, so an extension, skill, workflow, or MCP schema that still calls one of these will now fail to compile and to run. Atomic's own sources use none of them; the migration below is for package authors. TypeBox 1.3.7 also fixes compiled validation of nullable array tool arguments, and — because `typebox` is pinned to a single hoisted `1.3.7` node — an Atomic-defined tool schema and a pi-defined one now validate identically in the same process.

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.11-alpha.9] - 2026-08-01
+
 ### Fixed
 
 - Declared `handlesCtrlC` on the `/mcp` panel, the `/mcp setup` panel, and the MCP OAuth panel. In isolated interactive sessions the terminal host now closes an undeclared remote `ctx.ui.custom()` component on the first Ctrl+C, which would have bypassed each panel's own Ctrl+C handler along with its cancel and cleanup work. The declaration keeps that handler running.

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.11-alpha.9] - 2026-08-01
+
 ### Fixed
 
 - Fixed startup artifact cleanup escaping isolated agent directories. When the host provides a non-default session directory (for example an isolated programmatic `agentDir` used by tests and embedders), the global artifact scan now stays inside that sessions root; the real global and legacy `~/.pi` sessions roots are only scanned when no host-provided root is available ([#2070](https://github.com/bastani-inc/atomic/issues/2070)).

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.11-alpha.9] - 2026-08-01
+
 ### Added
 
 - Added per-node cancellation to `ctx.tool`. Every callback now receives a `WorkflowToolContext` (`{ signal }`) derived from a per-invocation `AbortController` combined with the run signal, so a run abort still cascades to every node while one node can be aborted alone. All retries of a call share that one signal, and existing zero-argument callbacks keep compiling and running unchanged. `WorkflowToolContext` is exported from the authoring surface ([#2078](https://github.com/bastani-inc/atomic/issues/2078)).


### PR DESCRIPTION
## Summary

Release-notes PR for prerelease **0.9.11-alpha.9** (base: `main`).

- Moves each package's `[Unreleased]` notes under a new `## [0.9.11-alpha.9] - 2026-08-01` section:
  - `packages/coding-agent/CHANGELOG.md`
  - `packages/mcp/CHANGELOG.md`
  - `packages/subagents/CHANGELOG.md`
  - `packages/workflows/CHANGELOG.md`
- Changelog-only diff; no version bumps. All package manifests, lockfile workspace entries, and Cargo manifests remain at the `0.0.0` placeholder per the versionless release-base flow.
- Version stamping happens later on the detached `Release 0.9.11-alpha.9` commit via `scripts/cut-release.ts` after this PR merges.

## Validation

- prek pre-commit hooks: `npm run check` (biome + typecheck + shrinkwrap) and `npm run test:unit` passed.
- Verified changelog-only diff against `origin/main` and `0.0.0` placeholders across all manifests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788160995&installation_model_id=10562&pr_number=2125&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2125&signature=1405c32ae50828e2c893cecb7e7a6b3800c453d9320b6756dd006e16750d848d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the 0.9.11-alpha.9 release section to each package changelog containing pending notes.

- Moves coding-agent breaking-change notes under the new release heading.
- Moves MCP and subagent fixes under the new release heading.
- Moves workflow cancellation additions under the new release heading.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it only adds consistent release headings to the changelogs with pending entries.

The headings match existing changelog conventions and the release-note parser, and no package with pending notes was omitted.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/CHANGELOG.md | Adds a correctly formatted 0.9.11-alpha.9 heading above the pending breaking-change notes. |
| packages/mcp/CHANGELOG.md | Adds a correctly formatted 0.9.11-alpha.9 heading above the pending MCP fix. |
| packages/subagents/CHANGELOG.md | Adds a correctly formatted 0.9.11-alpha.9 heading above the pending cleanup fix. |
| packages/workflows/CHANGELOG.md | Adds a correctly formatted 0.9.11-alpha.9 heading above the pending workflow feature notes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): record 0.9.11-alpha.9 p..."](https://github.com/bastani-inc/atomic/commit/5cb44ec87a335f7cfdad4de16a5f6b669c1537e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49297476)</sub>

<!-- /greptile_comment -->