### PR TITLE
fix(release): skip nested node_modules entries when stamping package-lock.json

### DIFF
--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -384,7 +384,12 @@ async function bumpNpmLock(filePath: string, version: string): Promise<void> {
 	const lock = (await Bun.file(fullPath).json()) as { packages?: Record<string, NpmLockEntry> };
 	let changed = 0;
 	for (const [entryPath, entry] of Object.entries(lock.packages ?? {})) {
-		if (!entryPath.startsWith("packages/") || entry.version === undefined) continue;
+		// Only direct workspace entries are stamped. A nested install under a
+		// workspace path (packages/*/node_modules/*) is a third-party package;
+		// stamping it desynchronizes the lock and `npm ci` refuses the tagged
+		// release commit.
+		if (!entryPath.startsWith("packages/") || entryPath.includes("/node_modules/")) continue;
+		if (entry.version === undefined) continue;
 		entry.version = version;
 		changed += 1;
 		for (const section of FIRST_PARTY_DEPENDENCY_SECTIONS) {

--- a/test/unit/bump-version-script.test.ts
+++ b/test/unit/bump-version-script.test.ts
@@ -130,6 +130,14 @@ if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHE
 			},
 			"packages/beta": { name: "@fixture/beta", version: "0.1.0" },
 			"packages/natives": { name: "@bastani/atomic-natives", version: "0.1.0" },
+			// A nested third-party install under a workspace path -- the production
+			// shape (@napi-rs/cli under packages/natives/node_modules) that a bare
+			// `packages/` prefix check mistakes for a workspace entry.
+			"packages/natives/node_modules/nested-tool": {
+				version: "3.8.1",
+				resolved: "https://registry.npmjs.org/nested-tool/-/nested-tool-3.8.1.tgz",
+				dependencies: { "third-party": "9.9.9" },
+			},
 		},
 	});
 
@@ -197,6 +205,14 @@ describe("scripts/bump-version.ts", () => {
 			// rewriting either would invalidate the lock rather than stamp it.
 			assert.equal(lock.packages["packages/alpha"]?.dependencies?.["third-party"], "9.9.9");
 			assert.equal(lock.packages["node_modules/third-party"]?.version, "9.9.9");
+			// A nested node_modules entry under a workspace path is third-party,
+			// not a workspace entry: stamping it desynchronizes the lock and makes
+			// `npm ci` refuse the tagged release commit.
+			assert.equal(lock.packages["packages/natives/node_modules/nested-tool"]?.version, "3.8.1");
+			assert.equal(
+				lock.packages["packages/natives/node_modules/nested-tool"]?.dependencies?.["third-party"],
+				"9.9.9",
+			);
 			assert.equal(lock.packages["node_modules/@fixture/alpha"]?.link, true);
 			assert.equal(lock.packages["node_modules/@fixture/alpha"]?.version, undefined);
 			assert.match(result.stdout, /package-lock\.json: 3 workspace entries → 1\.2\.3-alpha\.1/u);


### PR DESCRIPTION
## Summary

`scripts/bump-version.ts` stamped every `package-lock.json` entry whose path starts with `packages/`, which also matched nested third-party installs like `packages/natives/node_modules/@napi-rs/cli` (introduced by the @napi-rs/cli 3.7.4 → 3.8.1 bump in #2112). The stamp rewrote their versions to the release version, desynchronizing the lockfile so `npm ci` refused the tagged release commit and every [Publish 0.9.11-alpha.9 build job failed](https://github.com/bastani-inc/atomic/actions/runs/30690152942).

## Changes

- `scripts/bump-version.ts`: skip lock entries whose path contains `/node_modules/`, stamping only direct workspace entries.
- `test/unit/bump-version-script.test.ts`: fixture now includes a nested `packages/*/node_modules/*` entry reproducing the production shape; asserts its version and dependency pins stay untouched.

## Notes

- The fixed stamper was also verified against the real repository lockfile.
- The `0.9.11-alpha.9` changelog section is already merged on `main`; no changelog edits here.
- Retagging/republishing `0.9.11-alpha.9` is handled separately, not in this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788191623&installation_model_id=10562&pr_number=2126&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2126&signature=4ee095afa71821f735efa99ceb0a6b659280078aa9143ea50bded6522c86dc92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change prevents release stamping from rewriting nested third-party `node_modules` entries in `package-lock.json`, while continuing to update direct workspace entries and first-party dependency ranges.

The nested lockfile-stamping failure path was exercised with a temporary workspace fixture and disproved: the release command completed successfully, updated the direct workspace entry to the requested version, and preserved the nested third-party package version and dependency pins.

<h3>Confidence Score: 5/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex recorded the pre-capture workspace state, capturing the direct workspace entry at 0.1.0 and the nested third-party entry at 1.2.3 with its original pins.
- T-Rex performed the capture and observed the post-capture state, where package-lock.json shows 1 workspace entry before and 2.3.4 after, the direct entry is 2.3.4, and the nested third-party entry remained unchanged.
- T-Rex completed the general contract validation with all assertions passing and no blocking cause encountered.

<a href="https://app.greptile.com/trex/runs/16897766/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(release): skip nested node\_modules e..."](https://github.com/bastani-inc/atomic/commit/747d0e76738dca3c9cc293f2c2d01ee08333378f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49339160)</sub>

<!-- /greptile_comment -->