### PR TITLE
test(unit): deflake interactive-engine abort-lifetime under load

### DIFF
--- a/test/unit/interactive-engine-abort-lifetime.test.ts
+++ b/test/unit/interactive-engine-abort-lifetime.test.ts
@@ -1,10 +1,29 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "vitest";
 import { RpcClient } from "../../packages/coding-agent/src/modes/rpc/rpc-client.ts";
-import { bunExecutable, moduleDir, sleep } from "../helpers/runtime.js";
+import { bunExecutable, moduleDir, sleep, spawnSyncCollect } from "../helpers/runtime.js";
 
 const serialTest = process.platform === "win32" ? test.sequential.skip : test.sequential;
+/** Real Bun CLI startup, engine binding, signal handling, and bounded process-tree teardown. */
+const REAL_CLI_ENGINE_TIMEOUT_MS = 30_000;
+/** SIGSTOP delivery is asynchronous; allow a loaded kernel to report the child stopped. */
+const ENGINE_STOP_CONFIRMATION_TIMEOUT_MS = 5_000;
+const ENGINE_STOP_STATE_POLL_MS = 20;
+
+async function waitUntilProcessStopped(pid: number, timeoutMs: number): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	let lastState = "unknown";
+	while (Date.now() < deadline) {
+		const result = spawnSyncCollect(["ps", "-o", "state=", "-p", String(pid)]);
+		lastState = result.stdout.toString("utf8").trim() || `ps exit ${result.exitCode}`;
+		if (lastState.startsWith("T")) return;
+		await sleep(ENGINE_STOP_STATE_POLL_MS);
+	}
+	throw new Error(`engine child ${pid} did not stop within ${timeoutMs} ms (last state: ${lastState})`);
+}
 
 /**
  * Escape's contract is an unbounded cooperative wait. `abort` used to fall under
@@ -15,11 +34,12 @@ const serialTest = process.platform === "win32" ? test.sequential.skip : test.se
  * Failure detection is unaffected: the request still rejects on child exit,
  * transport failure, generation replacement, and explicit stop.
  */
-function makeClient(requestTimeoutMs: number): RpcClient {
+function makeClient(agentDir: string, requestTimeoutMs: number): RpcClient {
 	return new RpcClient({
 		cliPath: join(moduleDir(import.meta.url), "../../packages/coding-agent/src/cli.ts"),
 		cwd: join(moduleDir(import.meta.url), "../.."),
 		runtimeExecutable: bunExecutable(),
+		env: { ATOMIC_CODING_AGENT_DIR: agentDir },
 		provider: "isolation-fixture",
 		model: "blocking-model",
 		requestTimeoutMs,
@@ -41,57 +61,76 @@ function makeClient(requestTimeoutMs: number): RpcClient {
 serialTest(
 	"a pending abort outlives the generic request deadline and rejects only on stop",
 	async () => {
-		const client = makeClient(60);
-		await client.start();
-		// start() already waited for engine_ready, so the pid is recorded by now.
-		const enginePid = client.getEnginePid();
-		assert.ok(enginePid, "engine child never reported its pid");
-		let resumed = false;
-		// A SIGSTOPped child cannot answer a stop request, and a failed assertion
-		// between here and the resume below would leak it: frozen, unkillable by the
-		// client, and still holding this process's stdio pipes — the same leak class
-		// that hung the Windows job. Teardown is unconditional for that reason.
-		const resume = (): void => {
-			if (resumed) return;
-			resumed = true;
-			try {
-				process.kill(enginePid, "SIGCONT");
-			} catch {
-				// Already gone: nothing to resume, and stop() below is idempotent.
-			}
-		};
+		// Startup touches the trust store after engine_ready; an ambient agent dir
+		// lets parallel real-CLI tests turn that short critical section into ELOCKED.
+		const agentDir = mkdtempSync(join(tmpdir(), "atomic-abort-lifetime-"));
+		const client = makeClient(agentDir, 60);
 		try {
-			// Freeze the child so it can never answer the cooperative abort.
-			process.kill(enginePid, "SIGSTOP");
-			let settled: "resolved" | "rejected" | undefined;
-			let rejection: Error | undefined;
-			const abort = client.abort().then(
-				() => {
-					settled = "resolved";
-				},
-				(error: Error) => {
-					settled = "rejected";
-					rejection = error;
-				},
-			);
+			await client.start();
+			// engine_ready intentionally precedes session binding. Wait for bound so
+			// startup has finished before this test freezes the RPC loop.
+			await client.waitForInteractiveEngineBound();
 
-			// Well past the configured deadline; a timed request would already be dead.
-			await sleep(400);
-			assert.equal(settled, undefined, "the cooperative abort must not time out");
+			// The real child owns the RPC loop and reports its own process.pid.
+			const enginePid = client.getEnginePid();
+			assert.ok(enginePid, "engine child never reported its pid");
+			let resumed = false;
+			// A SIGSTOPped child cannot answer a stop request, and a failed assertion
+			// between here and the resume below would leak it: frozen, unkillable by the
+			// client, and still holding this process's stdio pipes — the same leak class
+			// that hung the Windows job. Teardown is unconditional for that reason.
+			const resume = (): void => {
+				if (resumed) return;
+				resumed = true;
+				try {
+					process.kill(enginePid, "SIGCONT");
+				} catch {
+					// Already gone: nothing to resume, and stop() below is idempotent.
+				}
+			};
+			try {
+				// Freeze the child so it can never answer the cooperative abort.
+				process.kill(enginePid, "SIGSTOP");
+				await waitUntilProcessStopped(enginePid, ENGINE_STOP_CONFIRMATION_TIMEOUT_MS);
+				let settled: "resolved" | "rejected" | undefined;
+				let rejection: Error | undefined;
+				const abort = client.abort().then(
+					() => {
+						settled = "resolved";
+					},
+					(error: Error) => {
+						settled = "rejected";
+						rejection = error;
+					},
+				);
 
-			// An ordinary short command still honours the deadline, proving the timer is
-			// live and only `abort` is exempt.
-			await assert.rejects(() => client.getState(), /Timeout waiting for response to get_state/);
+				// Well past the configured deadline; a timed request would already be dead.
+				await sleep(400);
+				assert.equal(
+					settled,
+					undefined,
+					`the cooperative abort must not time out (rejection: ${rejection?.message ?? "none"})`,
+				);
 
-			resume();
-			await client.stop();
-			await abort;
-			assert.equal(settled, "rejected", "explicit stop must settle the pending abort");
-			assert.match(rejection?.message ?? "", /Agent process stopped/);
+				// An ordinary short command still honours the deadline, proving the timer is
+				// live and only `abort` is exempt.
+				await assert.rejects(() => client.getState(), /Timeout waiting for response to get_state/);
+
+				// Arm termination while the child is frozen; resuming first lets its queued
+				// abort response race ahead of the explicit stop on a loaded host.
+				const stop = client.stop();
+				resume();
+				await stop;
+				await abort;
+				assert.equal(settled, "rejected", "explicit stop must settle the pending abort");
+				assert.match(rejection?.message ?? "", /Agent process stopped/);
+			} finally {
+				resume();
+			}
 		} finally {
-			resume();
 			await client.stop().catch(() => {});
+			rmSync(agentDir, { recursive: true, force: true });
 		}
 	},
-	30_000,
+	REAL_CLI_ENGINE_TIMEOUT_MS,
 );


### PR DESCRIPTION
## Summary

Deflakes `test/unit/interactive-engine-abort-lifetime.test.ts`, which failed rarely on loaded machines (observed once during the pre-push run for #2126). Stress reproduction (12 concurrent copies + 12 CPU burners) surfaced three distinct races; all are fixed test-only per the AGENTS.md load-sensitivity policy — no skip, no serialization, headroom via named constants.

## Root causes and fixes

1. **`ELOCKED` child exit (the observed flake).** The spawned real CLI child used the shared `~/.atomic/agent` directory, and `engine_ready` precedes trust/session startup, so agent-dir lock contention made an already-ready child exit with code 1; terminal drain then legitimately rejected the pending abort. Captured rejection: `Agent process exited (code=1 signal=null)` with `ELOCKED: Lock file is already being held` on stderr. → The test now runs against a unique temp `ATOMIC_CODING_AGENT_DIR` and waits for engine binding before freezing the child.
2. **Unconfirmed SIGSTOP (latent, opposite polarity).** `kill(pid, "SIGSTOP")` only posts the signal; under load the child could answer the abort before the kernel froze it, flipping the same assertion to `resolved`. → The test now confirms observed process state `T` via `ps` under a named bounded wait (`ENGINE_STOP_CONFIRMATION_TIMEOUT_MS`) before sending the abort.
3. **Resume-before-stop (latent).** Sending SIGCONT before arming `stop()` let the child's queued abort response beat the explicit stop. → The test now arms `stop()` while the child is frozen, then resumes it.

## Changes

- Hermetic temp agent dir with unconditional cleanup; wait for `engine_bound` before freezing
- `waitUntilProcessStopped` polls `ps` state until `T` before the abort is sent
- `client.stop()` armed while frozen, then SIGCONT
- The previously silent assertion now includes `rejection?.message`, so a future failure names its own cause
- Structural 30 s timeout named `REAL_CLI_ENGINE_TIMEOUT_MS`; `test.sequential` and the win32 skip preserved

## Notes

Validation: 1/1 in isolation; **144/144 across 12 consecutive stress rounds** with the fix applied (same setup that reproduced the flake at ~1/131 before); `npm run check` green. What the test proves — abort exempt from the generic request deadline, ordinary requests still timing out, explicit stop settling the pending abort — is unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788194980&installation_model_id=10562&pr_number=2127&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2127&signature=fb72a4cde499f231b8328302ea3aadf8de1a706819abfb79cc587f58a332ae14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes the interactive-engine abort-lifetime test more deterministic by isolating its agent directory, waiting for engine binding and confirmed suspension, and ensuring the child is resumed before cleanup.

The real CLI scenario completed successfully in 12 concurrent focused executions. Each run verified that abort remains pending beyond the ordinary request deadline, a normal state request still times out, explicit stop settles the pending abort, and teardown leaves no stopped child process or temporary agent directory.

<h3>Confidence Score: 5/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused interactive-engine abort-lifetime Vitest test in three rounds of four concurrent real CLI executions, to exercise the updated abort timeout, SIGSTOP/SIGCONT ordering, explicit stop behavior, and the cleanup path.
- All 12 runs reported 1 passed (1) and each round showed stopped\_related\_children=none, with the final RESULT: PASS.
- Validated the teardown cleanup: the baseline temporary-agent-directory count was zero and no validation-created directory remained, consistent with the PASS outcome.
- Noted a runtime caveat: Bun was at version 1.3.10, below the repository's declared \>=1.3.14, which is focused test evidence rather than release-compatible verification.
- Artifacts, including shell-script artifacts and a test log, were prepared to enable independent validation of the runs and teardown.

<a href="https://app.greptile.com/trex/runs/16900782/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["test(unit): deflake interactive-engine a..."](https://github.com/bastani-inc/atomic/commit/6b3b5504635391ade2752cd8d9f553d02a304a0f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49346835)</sub>

<!-- /greptile_comment -->