### PR TITLE
chore(models): update agent defaults to GPT-5.6 Luna

### DIFF
--- a/packages/subagents/agents/code-simplifier.md
+++ b/packages/subagents/agents/code-simplifier.md
@@ -8,8 +8,8 @@ description: |
   - Production-quality refinement of a working draft ("ugly but working CSV parser").
   - Code that has gotten messy after several iterations.
 tools: read, edit, write, search, find, ls, bash, todo
-model: openai-codex/gpt-5.6-sol:medium
-fallbackModels: github-copilot/gpt-5.6-sol:medium, openai/gpt-5.6-sol:medium, anthropic/claude-opus-5:low, github-copilot/claude-opus-5:low, openai-codex/gpt-5.5:medium, github-copilot/gpt-5.5:medium, openai/gpt-5.5:medium, anthropic/claude-fable-5:low, github-copilot/claude-fable-5:low, anthropic/claude-opus-4-8:medium, github-copilot/claude-opus-4.8:medium, xai/grok-4.5:high, zai/glm-5.2:high, zai-coding-cn/glm-5.2:high, openrouter/openai/gpt-5.6-sol:medium, openrouter/anthropic/claude-opus-5:low, openrouter/openai/gpt-5.5:medium, openrouter/anthropic/claude-fable-5:low, openrouter/anthropic/claude-opus-4-8:medium, openrouter/x-ai/grok-4.5, openrouter/z-ai/glm-5.2:xhigh
+model: openai-codex/gpt-5.6-luna:max
+fallbackModels: github-copilot/gpt-5.6-luna:max, openai/gpt-5.6-luna:max, anthropic/claude-opus-5:low, github-copilot/claude-opus-5:low, openai-codex/gpt-5.5:medium, github-copilot/gpt-5.5:medium, openai/gpt-5.5:medium, anthropic/claude-fable-5:low, github-copilot/claude-fable-5:low, anthropic/claude-opus-4-8:medium, github-copilot/claude-opus-4.8:medium, xai/grok-4.5:high, zai/glm-5.2:high, zai-coding-cn/glm-5.2:high, openrouter/openai/gpt-5.6-luna:max, openrouter/anthropic/claude-opus-5:low, openrouter/openai/gpt-5.5:medium, openrouter/anthropic/claude-fable-5:low, openrouter/anthropic/claude-opus-4-8:medium, openrouter/x-ai/grok-4.5, openrouter/z-ai/glm-5.2:xhigh
 skills: tdd, playwright-cli, tmux
 ---
 

--- a/packages/subagents/agents/codebase-analyzer.md
+++ b/packages/subagents/agents/codebase-analyzer.md
@@ -2,8 +2,8 @@
 name: codebase-analyzer
 description: Analyzes codebase implementation details. Call the codebase-analyzer agent when you need to find detailed information about specific components.
 tools: read, search, find, ls, todo
-model: openai-codex/gpt-5.6-sol:medium
-fallbackModels: github-copilot/gpt-5.6-sol:medium, openai/gpt-5.6-sol:medium, anthropic/claude-opus-5:low, github-copilot/claude-opus-5:low, openai-codex/gpt-5.5:medium, github-copilot/gpt-5.5:medium, openai/gpt-5.5:medium, anthropic/claude-fable-5:low, github-copilot/claude-fable-5:low, anthropic/claude-opus-4-8:medium, github-copilot/claude-opus-4.8:medium, xai/grok-4.5:high, zai/glm-5.2:high, zai-coding-cn/glm-5.2:high, openrouter/openai/gpt-5.6-sol:medium, openrouter/anthropic/claude-opus-5:low, openrouter/openai/gpt-5.5:medium, openrouter/anthropic/claude-fable-5:low, openrouter/anthropic/claude-opus-4-8:medium, openrouter/x-ai/grok-4.5, openrouter/z-ai/glm-5.2:xhigh
+model: openai-codex/gpt-5.6-luna:max
+fallbackModels: github-copilot/gpt-5.6-luna:max, openai/gpt-5.6-luna:max, anthropic/claude-opus-5:low, github-copilot/claude-opus-5:low, openai-codex/gpt-5.5:medium, github-copilot/gpt-5.5:medium, openai/gpt-5.5:medium, anthropic/claude-fable-5:low, github-copilot/claude-fable-5:low, anthropic/claude-opus-4-8:medium, github-copilot/claude-opus-4.8:medium, xai/grok-4.5:high, zai/glm-5.2:high, zai-coding-cn/glm-5.2:high, openrouter/openai/gpt-5.6-luna:max, openrouter/anthropic/claude-opus-5:low, openrouter/openai/gpt-5.5:medium, openrouter/anthropic/claude-fable-5:low, openrouter/anthropic/claude-opus-4-8:medium, openrouter/x-ai/grok-4.5, openrouter/z-ai/glm-5.2:xhigh
 skills: tdd, playwright-cli, tmux
 ---
 

--- a/packages/subagents/agents/codebase-locator.md
+++ b/packages/subagents/agents/codebase-locator.md
@@ -2,8 +2,8 @@
 name: codebase-locator
 description: Locates files, directories, and components relevant to a feature or task. Basically a "super search/find/ls tool."
 tools: read, search, find, ls
-model: openai-codex/gpt-5.6-terra:high
-fallbackModels: github-copilot/gpt-5.6-terra:high, openai/gpt-5.6-terra:high, anthropic/claude-opus-5:low, github-copilot/claude-opus-5:low, openai-codex/gpt-5.5:low, github-copilot/gpt-5.5:low, openai/gpt-5.5:low, anthropic/claude-opus-4-8:low, github-copilot/claude-opus-4.8:low, xai/grok-4.5:high, zai/glm-5.2:high, zai-coding-cn/glm-5.2:high, openrouter/openai/gpt-5.6-terra:high, openrouter/anthropic/claude-opus-5:low, openrouter/openai/gpt-5.5:low, openrouter/anthropic/claude-opus-4-8:low, openrouter/x-ai/grok-4.5, openrouter/z-ai/glm-5.2:xhigh
+model: openai-codex/gpt-5.6-luna:max
+fallbackModels: github-copilot/gpt-5.6-luna:max, openai/gpt-5.6-luna:max, anthropic/claude-opus-5:low, github-copilot/claude-opus-5:low, openai-codex/gpt-5.5:low, github-copilot/gpt-5.5:low, openai/gpt-5.5:low, anthropic/claude-opus-4-8:low, github-copilot/claude-opus-4.8:low, xai/grok-4.5:high, zai/glm-5.2:high, zai-coding-cn/glm-5.2:high, openrouter/openai/gpt-5.6-luna:max, openrouter/anthropic/claude-opus-5:low, openrouter/openai/gpt-5.5:low, openrouter/anthropic/claude-opus-4-8:low, openrouter/x-ai/grok-4.5, openrouter/z-ai/glm-5.2:xhigh
 ---
 
 ## Role and goal

--- a/packages/subagents/agents/codebase-online-researcher.md
+++ b/packages/subagents/agents/codebase-online-researcher.md
@@ -2,8 +2,8 @@
 name: codebase-online-researcher
 description: Online research for up-to-date documentation and library-source knowledge. Use when you need authoritative external information — official docs, ecosystem context, version-specific behavior, GitHub permalinks into open-source libraries, or video tutorials.
 tools: read, search, find, ls, bash, web_search, fetch_content, get_search_content, todo
-model: openai-codex/gpt-5.6-sol:medium
-fallbackModels: github-copilot/gpt-5.6-sol:medium, openai/gpt-5.6-sol:medium, anthropic/claude-opus-5:low, github-copilot/claude-opus-5:low, openai-codex/gpt-5.5:medium, github-copilot/gpt-5.5:medium, openai/gpt-5.5:medium, anthropic/claude-fable-5:low, github-copilot/claude-fable-5:low, anthropic/claude-opus-4-8:medium, github-copilot/claude-opus-4.8:medium, xai/grok-4.5:high, zai/glm-5.2:high, zai-coding-cn/glm-5.2:high, openrouter/openai/gpt-5.6-sol:medium, openrouter/anthropic/claude-opus-5:low, openrouter/openai/gpt-5.5:medium, openrouter/anthropic/claude-fable-5:low, openrouter/anthropic/claude-opus-4-8:medium, openrouter/x-ai/grok-4.5, openrouter/z-ai/glm-5.2:xhigh
+model: openai-codex/gpt-5.6-luna:max
+fallbackModels: github-copilot/gpt-5.6-luna:max, openai/gpt-5.6-luna:max, anthropic/claude-opus-5:low, github-copilot/claude-opus-5:low, openai-codex/gpt-5.5:medium, github-copilot/gpt-5.5:medium, openai/gpt-5.5:medium, anthropic/claude-fable-5:low, github-copilot/claude-fable-5:low, anthropic/claude-opus-4-8:medium, github-copilot/claude-opus-4.8:medium, xai/grok-4.5:high, zai/glm-5.2:high, zai-coding-cn/glm-5.2:high, openrouter/openai/gpt-5.6-luna:max, openrouter/anthropic/claude-opus-5:low, openrouter/openai/gpt-5.5:medium, openrouter/anthropic/claude-fable-5:low, openrouter/anthropic/claude-opus-4-8:medium, openrouter/x-ai/grok-4.5, openrouter/z-ai/glm-5.2:xhigh
 skills: playwright-cli
 ---
 

--- a/packages/subagents/agents/codebase-pattern-finder.md
+++ b/packages/subagents/agents/codebase-pattern-finder.md
@@ -2,8 +2,8 @@
 name: codebase-pattern-finder
 description: Find similar implementations, usage examples, or existing patterns in the codebase that can be modeled after.
 tools: read, search, find, ls
-model: openai-codex/gpt-5.6-terra:high
-fallbackModels: github-copilot/gpt-5.6-terra:high, openai/gpt-5.6-terra:high, anthropic/claude-opus-5:low, github-copilot/claude-opus-5:low, openai-codex/gpt-5.5:low, github-copilot/gpt-5.5:low, openai/gpt-5.5:low, anthropic/claude-opus-4-8:low, github-copilot/claude-opus-4.8:low, xai/grok-4.5:high, zai/glm-5.2:high, zai-coding-cn/glm-5.2:high, openrouter/openai/gpt-5.6-terra:high, openrouter/anthropic/claude-opus-5:low, openrouter/openai/gpt-5.5:low, openrouter/anthropic/claude-opus-4-8:low, openrouter/x-ai/grok-4.5, openrouter/z-ai/glm-5.2:xhigh
+model: openai-codex/gpt-5.6-luna:max
+fallbackModels: github-copilot/gpt-5.6-luna:max, openai/gpt-5.6-luna:max, anthropic/claude-opus-5:low, github-copilot/claude-opus-5:low, openai-codex/gpt-5.5:low, github-copilot/gpt-5.5:low, openai/gpt-5.5:low, anthropic/claude-opus-4-8:low, github-copilot/claude-opus-4.8:low, xai/grok-4.5:high, zai/glm-5.2:high, zai-coding-cn/glm-5.2:high, openrouter/openai/gpt-5.6-luna:max, openrouter/anthropic/claude-opus-5:low, openrouter/openai/gpt-5.5:low, openrouter/anthropic/claude-opus-4-8:low, openrouter/x-ai/grok-4.5, openrouter/z-ai/glm-5.2:xhigh
 ---
 
 ## Role and goal

--- a/packages/subagents/agents/codebase-research-analyzer.md
+++ b/packages/subagents/agents/codebase-research-analyzer.md
@@ -2,8 +2,8 @@
 name: codebase-research-analyzer
 description: Analyzes local research documents to extract high-value insights, decisions, and technical details while filtering out noise. Use this when you want to deep dive on a research topic or understand the rationale behind decisions.
 tools: read, search, find, ls, todo
-model: openai-codex/gpt-5.6-sol:medium
-fallbackModels: github-copilot/gpt-5.6-sol:medium, openai/gpt-5.6-sol:medium, anthropic/claude-opus-5:low, github-copilot/claude-opus-5:low, openai-codex/gpt-5.5:medium, github-copilot/gpt-5.5:medium, openai/gpt-5.5:medium, anthropic/claude-fable-5:low, github-copilot/claude-fable-5:low, anthropic/claude-opus-4-8:medium, github-copilot/claude-opus-4.8:medium, xai/grok-4.5:high, zai/glm-5.2:high, zai-coding-cn/glm-5.2:high, openrouter/openai/gpt-5.6-sol:medium, openrouter/anthropic/claude-opus-5:low, openrouter/openai/gpt-5.5:medium, openrouter/anthropic/claude-fable-5:low, openrouter/anthropic/claude-opus-4-8:medium, openrouter/x-ai/grok-4.5, openrouter/z-ai/glm-5.2:xhigh
+model: openai-codex/gpt-5.6-luna:max
+fallbackModels: github-copilot/gpt-5.6-luna:max, openai/gpt-5.6-luna:max, anthropic/claude-opus-5:low, github-copilot/claude-opus-5:low, openai-codex/gpt-5.5:medium, github-copilot/gpt-5.5:medium, openai/gpt-5.5:medium, anthropic/claude-fable-5:low, github-copilot/claude-fable-5:low, anthropic/claude-opus-4-8:medium, github-copilot/claude-opus-4.8:medium, xai/grok-4.5:high, zai/glm-5.2:high, zai-coding-cn/glm-5.2:high, openrouter/openai/gpt-5.6-luna:max, openrouter/anthropic/claude-opus-5:low, openrouter/openai/gpt-5.5:medium, openrouter/anthropic/claude-fable-5:low, openrouter/anthropic/claude-opus-4-8:medium, openrouter/x-ai/grok-4.5, openrouter/z-ai/glm-5.2:xhigh
 ---
 
 ## Role and goal

--- a/packages/subagents/agents/codebase-research-locator.md
+++ b/packages/subagents/agents/codebase-research-locator.md
@@ -2,8 +2,8 @@
 name: codebase-research-locator
 description: Discovers local research documents that are relevant to the current research task.
 tools: read, search, find, ls
-model: openai-codex/gpt-5.6-terra:high
-fallbackModels: github-copilot/gpt-5.6-terra:high, openai/gpt-5.6-terra:high, anthropic/claude-opus-5:low, github-copilot/claude-opus-5:low, openai-codex/gpt-5.5:low, github-copilot/gpt-5.5:low, openai/gpt-5.5:low, anthropic/claude-opus-4-8:low, github-copilot/claude-opus-4.8:low, xai/grok-4.5:high, zai/glm-5.2:high, zai-coding-cn/glm-5.2:high, openrouter/openai/gpt-5.6-terra:high, openrouter/anthropic/claude-opus-5:low, openrouter/openai/gpt-5.5:low, openrouter/anthropic/claude-opus-4-8:low, openrouter/x-ai/grok-4.5, openrouter/z-ai/glm-5.2:xhigh
+model: openai-codex/gpt-5.6-luna:max
+fallbackModels: github-copilot/gpt-5.6-luna:max, openai/gpt-5.6-luna:max, anthropic/claude-opus-5:low, github-copilot/claude-opus-5:low, openai-codex/gpt-5.5:low, github-copilot/gpt-5.5:low, openai/gpt-5.5:low, anthropic/claude-opus-4-8:low, github-copilot/claude-opus-4.8:low, xai/grok-4.5:high, zai/glm-5.2:high, zai-coding-cn/glm-5.2:high, openrouter/openai/gpt-5.6-luna:max, openrouter/anthropic/claude-opus-5:low, openrouter/openai/gpt-5.5:low, openrouter/anthropic/claude-opus-4-8:low, openrouter/x-ai/grok-4.5, openrouter/z-ai/glm-5.2:xhigh
 ---
 
 ## Role and goal

--- a/packages/subagents/agents/worker.md
+++ b/packages/subagents/agents/worker.md
@@ -5,8 +5,8 @@ systemPromptMode: replace
 inheritProjectContext: true
 inheritSkills: false
 tools: read, edit, write, search, find, ls, bash, web_search, fetch_content, get_search_content, intercom, contact_supervisor, todo
-model: openai-codex/gpt-5.6-sol:medium
-fallbackModels: github-copilot/gpt-5.6-sol:medium, openai/gpt-5.6-sol:medium, anthropic/claude-opus-5:low, github-copilot/claude-opus-5:low, openai-codex/gpt-5.5:medium, github-copilot/gpt-5.5:medium, openai/gpt-5.5:medium, anthropic/claude-fable-5:low, github-copilot/claude-fable-5:low, anthropic/claude-opus-4-8:medium, github-copilot/claude-opus-4.8:medium, xai/grok-4.5:high, zai/glm-5.2:high, zai-coding-cn/glm-5.2:high, openrouter/openai/gpt-5.6-sol:medium, openrouter/anthropic/claude-opus-5:low, openrouter/openai/gpt-5.5:medium, openrouter/anthropic/claude-fable-5:low, openrouter/anthropic/claude-opus-4-8:medium, openrouter/x-ai/grok-4.5, openrouter/z-ai/glm-5.2:xhigh
+model: openai-codex/gpt-5.6-luna:max
+fallbackModels: github-copilot/gpt-5.6-luna:max, openai/gpt-5.6-luna:max, anthropic/claude-opus-5:low, github-copilot/claude-opus-5:low, openai-codex/gpt-5.5:medium, github-copilot/gpt-5.5:medium, openai/gpt-5.5:medium, anthropic/claude-fable-5:low, github-copilot/claude-fable-5:low, anthropic/claude-opus-4-8:medium, github-copilot/claude-opus-4.8:medium, xai/grok-4.5:high, zai/glm-5.2:high, zai-coding-cn/glm-5.2:high, openrouter/openai/gpt-5.6-luna:max, openrouter/anthropic/claude-opus-5:low, openrouter/openai/gpt-5.5:medium, openrouter/anthropic/claude-fable-5:low, openrouter/anthropic/claude-opus-4-8:medium, openrouter/x-ai/grok-4.5, openrouter/z-ai/glm-5.2:xhigh
 skills: tdd, playwright-cli, tmux
 defaultContext: fork
 defaultProgress: true

--- a/packages/workflows/builtin/ralph-models.ts
+++ b/packages/workflows/builtin/ralph-models.ts
@@ -48,10 +48,10 @@ export const promptEngineerModelConfig = {
 };
 
 export const researchModelConfig = {
-    model: "openai-codex/gpt-5.6-sol:medium",
+    model: "openai-codex/gpt-5.6-luna:max",
     fallbackModels: [
-      "github-copilot/gpt-5.6-sol:medium",
-      "openai/gpt-5.6-sol:medium",
+      "github-copilot/gpt-5.6-luna:max",
+      "openai/gpt-5.6-luna:max",
       "anthropic/claude-opus-5:low",
       "github-copilot/claude-opus-5:low",
       "anthropic/claude-fable-5:low",
@@ -64,7 +64,7 @@ export const researchModelConfig = {
       "xai/grok-4.5:high",
       "zai/glm-5.2:high",
       "zai-coding-cn/glm-5.2:high",
-      "openrouter/openai/gpt-5.6-sol:medium",
+      "openrouter/openai/gpt-5.6-luna:max",
       "openrouter/anthropic/claude-opus-5:low",
       "openrouter/openai/gpt-5.5:medium",
       "openrouter/anthropic/claude-fable-5:low",


### PR DESCRIPTION
## Summary

Update built-in agent and Ralph workflow model defaults to GPT-5.6 Luna.

## Changes

- Replace GPT-5.6 Sol and Terra defaults with `openai-codex/gpt-5.6-luna:max`.
- Align direct-provider and OpenRouter fallback entries with the Luna model.
- Preserve existing fallback ordering and role-specific quality levels.

## Notes

- Pre-commit hooks passed.
- `npm run check` passed.
- `npm run test:unit` passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788209730&installation_model_id=10562&pr_number=2131&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2131&signature=3b7800fdbceed03b136ea8d8dcb516b7536276421373d1a8ff8c301a47cf169a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change moves builtin subagents and Ralph research routing to GPT-5.6 Luna at maximum reasoning while retaining the established fallback families.

Two documentation issues need correction before release: `packages/subagents/CHANGELOG.md` does not record the builtin model-default change, and `packages/workflows/builtin/ralph-models.ts` still describes Ralph research as using the retired GPT-5.5-medium/Fable-low policy while `packages/workflows/CHANGELOG.md` omits the routing change. Executed checks confirmed both mismatches.

<h3>Confidence Score: 4/5</h3>

Do not merge until the user-facing model-routing documentation is aligned with the new defaults.

The model configuration change is functional, but two verified documentation defects leave users and maintainers without an accurate release record and Ralph policy rationale.

**Files Needing Attention:** `packages/subagents/CHANGELOG.md`, `packages/workflows/builtin/ralph-models.ts`, and `packages/workflows/CHANGELOG.md`.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the P2 finding by running the narrow changelog validation script and the parent-vs-current docs lookup, confirming the Luna release note was missing.
- Repeated the validation with a script importing Ralph's configured research model and checking its comment and changelog; reviewed the parent revision policy and Unreleased changelog state, and re-ran validation after the GPT-5.6 Luna model update.
- Observed a subsequent P2 finding proof was produced, but no artifacts were attached.
- Ran the general contract validation and observed that before capture the default was GPT-5.6 Sol with no Luna change to document, and after capture the default became GPT-5.6 Luna max with Unreleased empty; the script exited 0, confirming the omission.
- Validated changes to the research primary and changelog: the code now shows GPT-5.6 Luna max as primary, and the Unreleased section remains empty, aligning with project conventions.

<a href="https://app.greptile.com/trex/runs/16914381/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `packages/workflows/builtin/ralph-models.ts`, line 7 ([link](https://github.com/bastani-inc/atomic/blob/4fc873493ee6187547fb8442c504e8745ca86fc9/packages/workflows/builtin/ralph-models.ts#L7)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Ralph research policy describes the retired model tier**

   `researchModelConfig` now selects `openai-codex/gpt-5.6-luna:max`, but this policy comment says research remains on GPT-5.5 medium/Fable low for performance-per-dollar. Update the rationale to describe the Luna-max policy and add an Unreleased workflow changelog entry, so Ralph's documented routing matches what users receive.

   **Context Used:** AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))
   
   <details><summary><strong>Artifacts</strong></summary><br />
   
   **[Validation script that imports Ralph's configured research model and checks its comment and changelog](https://app.greptile.com/trex/artifacts/1b6aede9-71e6-4a78-bec6-8295fe7cd67c)**
   
   - The executed Bun validation source compares the changed configuration with its parent revision and parses the Unreleased section, showing the focused checks used to establish the defect.
   
   **[Parent revision model policy and Unreleased changelog state](https://app.greptile.com/trex/artifacts/26e49c3e-1bbc-46e2-8357-0c6deca6fad0)**
   
   - The captured parent-revision command output shows GPT-5.6 Sol medium as the previous research primary, the already-present old rationale, and an empty Unreleased section.
   
   **[Executed validation after the GPT-5.6 Luna model update](https://app.greptile.com/trex/artifacts/b6ba9106-c92c-4210-bae9-628bd4919248)**
   
   - The captured Bun run imports the changed config as GPT-5.6 Luna max and reports both the stale rationale and missing Unreleased documentation, confirming the defect.
   
   <a href="https://app.greptile.com/trex/runs/16914381/artifacts?artifact=1b6aede9-71e6-4a78-bec6-8295fe7cd67c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>
   
   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: packages/workflows/builtin/ralph-models.ts
   Line: 7
   
   Comment:
   **Ralph research policy describes the retired model tier**
   
   `researchModelConfig` now selects `openai-codex/gpt-5.6-luna:max`, but this policy comment says research remains on GPT-5.5 medium/Fable low for performance-per-dollar. Update the rationale to describe the Luna-max policy and add an Unreleased workflow changelog entry, so Ralph's documented routing matches what users receive.
   
   **Context Used:** AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

2. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Builtin GPT-5.6 Luna default change lacks an Unreleased release note**

   - **Bug**
     - The checked-out commit changes the code-simplifier's shipped primary model and mirrored fallback models, but leaves `packages/subagents/CHANGELOG.md` Unreleased empty. Users therefore cannot discover the default-model and reasoning-level behavior change in the package release notes.
   - **Cause**
     - Commit `4fc87349` modifies builtin agent frontmatter without adding the corresponding `### Changed` entry to the subagents changelog.
   - **Fix**
     - Add a concise `### Changed` entry under `packages/subagents/CHANGELOG.md` → `## [Unreleased]` describing the code-simplifier (and, if intended, the other affected builtin agents) move to GPT-5.6 Luna `:max` and its provider-mirror fallbacks.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


3. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Ralph research model change leaves stale rationale and no Unreleased release note**

   - **Bug**
     - `researchModelConfig` now executes with `openai-codex/gpt-5.6-luna:max`, but the immediately adjacent policy text still says research remains on GPT-5.5 medium/Fable low for performance-per-dollar. The package changelog's Unreleased section is empty even though this is a shipped built-in workflow routing/default change.
   - **Cause**
     - Commit `4fc87349` changed only research-model primary and mirror entries; it did not update the surrounding rationale or `packages/workflows/CHANGELOG.md`.
   - **Fix**
     - Revise `packages/workflows/builtin/ralph-models.ts:7` to explain the Luna-max research policy (including the retained fallback tiers, if intended), and add a concise `### Changed` entry beneath `packages/workflows/CHANGELOG.md`'s Unreleased heading documenting the Ralph research-primary change.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/subagents/agents/code-simplifier.md:11-12
**Builtin Luna default lacks release notes**

The shipped `code-simplifier` primary model and provider-mirror fallbacks now route to GPT-5.6 Luna at `:max`, but `packages/subagents/CHANGELOG.md` still has an empty Unreleased section. Add a Changed entry covering this builtin-agent routing and reasoning-level change so users can discover the new default before release.

### Issue 2
packages/workflows/builtin/ralph-models.ts:7
**Ralph research policy describes the retired model tier**

`researchModelConfig` now selects `openai-codex/gpt-5.6-luna:max`, but this policy comment says research remains on GPT-5.5 medium/Fable low for performance-per-dollar. Update the rationale to describe the Luna-max policy and add an Unreleased workflow changelog entry, so Ralph's documented routing matches what users receive.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(models): update agent defaults to ..."](https://github.com/bastani-inc/atomic/commit/4fc873493ee6187547fb8442c504e8745ca86fc9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49377868)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->