### PR TITLE
docs(changelog): prepare 0.9.11-alpha.10 release notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.11-alpha.10] - 2026-08-01
+
 ### Fixed
 
 - Fixed an isolated interactive-engine exit after an admitted tool call leaving that session permanently pending and unusable on resume. Reopening an inactive session now derives explicit error results for unanswered `toolUse` calls without rewriting its append-only JSONL, so the transcript can render, compact, and accept another prompt while preserving that the interrupted command's side effects are unknown. Unexpected-restart notices now also retain the bounded exit kind, code, or signal that triggered recovery while excluding child stderr.


### PR DESCRIPTION
## Summary

Prepares the changelog for the `0.9.11-alpha.10` prerelease. The entries that had accumulated under `## [Unreleased]` now sit under a dated `## [0.9.11-alpha.10]` section.

## Release-base invariant

The diff is changelog-only. Every package manifest, the lockfile, the Cargo manifests/lock, and the generated version files stay at the `0.0.0` versionless placeholder. `scripts/cut-release.ts` remains the only thing that stamps the real version, and only on the detached `Release 0.9.11-alpha.10` commit created after this PR merges.

- `packages/coding-agent/CHANGELOG.md` — the only changed file
- No already-released section was touched

## Notes covered by this prerelease

- Session recovery after an interactive-engine exit during an admitted tool call
- Anthropic subscription login on Bun-hosted Linux sessions
- `/model` refresh stalls for existing authenticated users
- `/logout` timing out after the credential was already deleted

## Validation

- `bun run vitest --run --project unit test/unit/changelog.test.ts test/unit/package-metadata.test.ts` — 14 passed
- `bun run vitest --run --project ci test/ci/release-publisher-contracts.test.ts` — 2 passed
- prek pre-commit and pre-push hooks: `npm run check` and `npm run test:unit` passed

No tag, merge, or publication was performed in this stage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788210106&installation_model_id=10562&pr_number=2132&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2132&signature=50ba8fae03167e445994bb2fb986732e6e886f167b81530b7a6df8ac9d85d71b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prepares the coding-agent changelog for the `0.9.11-alpha.10` prerelease by moving four accumulated fixes out of `Unreleased` into a dated release section.

The release contract was exercised against both revisions: before the change, four fixes were under `Unreleased`; after the change, `Unreleased` is empty, `0.9.11-alpha.10` is dated `2026-08-01`, contains those four fixes, retains `0.9.11-alpha.9`, and parses as prerelease revision 10. The applicable changelog tests passed.

<h3>Confidence Score: 5/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the release-contract validation script to check the change between before HEAD^ and after HEAD; both runs completed with exit code 0.
- Compared the baseline changelog contract result with the PR changelog contract result to confirm the PR reflects the intended changes.
- Executed the existing changelog tests using the specified test command; the run exited 0 with three passing tests.
- Compiled and prepared artifacts that capture the script sources and the baseline/PR results and the test outcome for reviewer inspection.

<a href="https://app.greptile.com/trex/runs/16914719/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.11-alpha.10..."](https://github.com/bastani-inc/atomic/commit/56c7607142feda5e9e3693d8e2f1d31fd9f6a22e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49378442)</sub>

<!-- /greptile_comment -->