### PR TITLE
fix(subagents): render detached completion notices with the standard notification UI

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed detached foreground subagent completion notifications rendering as an unstyled dump of the full child output. They now use the same structured, collapsed notification UI as background completions while preserving the distinct detached-task wording, and persisted notifications with custom labels remain parseable.
+
 ## [0.9.11-alpha.10] - 2026-08-01
 
 ### Fixed

--- a/packages/subagents/src/extension/notification-content.ts
+++ b/packages/subagents/src/extension/notification-content.ts
@@ -1,10 +1,6 @@
 import type { SubagentNotifyDetails } from "../runs/background/notify.ts";
 
-const HEADER_PREFIXES = [
-	["Background task completed: **", "completed"],
-	["Background task failed: **", "failed"],
-	["Background task paused: **", "paused"],
-] as const;
+const HEADER_STATUSES = ["completed", "failed", "paused"] as const;
 
 function isHeaderLineTerminator(character: string): boolean {
 	return character === "\r" || character === "\u2028" || character === "\u2029";
@@ -15,10 +11,19 @@ function isWhitespace(character: string | undefined): boolean {
 }
 
 function parseHeader(header: string): Pick<SubagentNotifyDetails, "agent" | "status" | "taskInfo"> | undefined {
-	const matchedPrefix = HEADER_PREFIXES.find(([prefix]) => header.startsWith(prefix));
-	if (!matchedPrefix) return undefined;
-	const [prefix, status] = matchedPrefix;
-	const suffix = header.slice(prefix.length);
+	let markerIndex = -1;
+	let status: SubagentNotifyDetails["status"] | undefined;
+	for (const candidateStatus of HEADER_STATUSES) {
+		const candidateMarker = ` ${candidateStatus}: **`;
+		const candidateIndex = header.indexOf(candidateMarker);
+		if (candidateIndex < 1 || (markerIndex >= 0 && candidateIndex >= markerIndex)) continue;
+		markerIndex = candidateIndex;
+		status = candidateStatus;
+	}
+	if (markerIndex < 1 || !status) return undefined;
+	const label = header.slice(0, markerIndex);
+	if (label !== label.trim() || [...label].some(isHeaderLineTerminator)) return undefined;
+	const suffix = header.slice(markerIndex + ` ${status}: **`.length);
 
 	if (suffix.endsWith("**")) {
 		const agent = suffix.slice(0, -2);

--- a/packages/subagents/src/runs/background/notify.ts
+++ b/packages/subagents/src/runs/background/notify.ts
@@ -198,8 +198,8 @@ export default function registerSubagentNotify(pi: ExtensionAPI): () => void {
 
 		const taskInfo =
 			result.taskIndex !== undefined && result.totalTasks !== undefined
-				? ` (${result.taskIndex + 1}/${result.totalTasks})`
-				: "";
+				? `(${result.taskIndex + 1}/${result.totalTasks})`
+				: undefined;
 
 		const sessionLine = result.shareUrl
 			? `Session: ${result.shareUrl}`
@@ -214,8 +214,23 @@ export default function registerSubagentNotify(pi: ExtensionAPI): () => void {
 			typeof result.noticeLabel === "string" && result.noticeLabel.trim()
 				? result.noticeLabel.trim()
 				: "Background task";
+		let sessionLabel: string | undefined;
+		let sessionValue: string | undefined;
+		if (sessionLine) {
+			const separator = sessionLine.indexOf(":");
+			sessionLabel = sessionLine.slice(0, separator).toLowerCase();
+			sessionValue = sessionLine.slice(separator + 1).trim();
+		}
+		const details: SubagentNotifyDetails = {
+			agent,
+			status,
+			...(taskInfo ? { taskInfo } : {}),
+			resultPreview: displaySummary,
+			...(result.durationMs !== undefined ? { durationMs: result.durationMs } : {}),
+			...(sessionLabel && sessionValue ? { sessionLabel, sessionValue } : {}),
+		};
 		const content = [
-			`${noticeLabel} ${status}: **${agent}**${taskInfo}`,
+			`${noticeLabel} ${status}: **${agent}**${taskInfo ? ` ${taskInfo}` : ""}`,
 			"",
 			displaySummary,
 			sessionLine ? "" : undefined,
@@ -224,10 +239,11 @@ export default function registerSubagentNotify(pi: ExtensionAPI): () => void {
 			.filter((line) => line !== undefined)
 			.join("\n");
 
-		const terminalMessage = {
+		const terminalMessage: TerminalPreludeMessage = {
 			customType: "subagent-notify",
 			content,
 			display: true,
+			details,
 		};
 		const deliveryOptions = { triggerTurn: true, stageAdmissionKey: `subagent:${key}` } as const;
 		const succeed = (): void => {

--- a/test/unit/subagents-detached-foreground-notify.test.ts
+++ b/test/unit/subagents-detached-foreground-notify.test.ts
@@ -1,12 +1,27 @@
 import assert from "node:assert/strict";
+import { getKeybindings, setKeybindings } from "@earendil-works/pi-tui";
 import { test } from "vitest";
-import registerSubagentNotify from "../../packages/subagents/src/runs/background/notify.js";
+import { KeybindingsManager } from "../../packages/coding-agent/src/core/keybindings.ts";
+import { initTheme, theme } from "../../packages/coding-agent/src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../../packages/coding-agent/src/utils/ansi.ts";
+import { renderSubagentNotification } from "../../packages/subagents/src/extension/index.ts";
+import registerSubagentNotify, {
+	type SubagentNotifyDetails,
+} from "../../packages/subagents/src/runs/background/notify.js";
 import { notifyDetachedForegroundChildExit } from "../../packages/subagents/src/runs/foreground/subagent-executor-status.js";
 import type { SingleResult } from "../../packages/subagents/src/shared/types.js";
 
+type SentNotification = {
+	customType: string;
+	content: string;
+	details?: SubagentNotifyDetails;
+};
+
+const originalKeybindings = getKeybindings();
+
 function createHarness() {
 	const listeners = new Map<string, Set<(data: unknown) => void>>();
-	const sent: { customType: string; content: string }[] = [];
+	const sent: SentNotification[] = [];
 	const pi = {
 		events: {
 			on(event: string, handler: (data: unknown) => void) {
@@ -19,7 +34,7 @@ function createHarness() {
 				for (const handler of listeners.get(event) ?? []) handler(payload);
 			},
 		},
-		sendMessage(message: { customType: string; content: string }) {
+		sendMessage(message: SentNotification) {
 			sent.push(message);
 		},
 	};
@@ -32,10 +47,15 @@ function makeResult(overrides: Partial<SingleResult> = {}): SingleResult {
 		task: "audit",
 		exitCode: 0,
 		usage: {} as SingleResult["usage"],
-		finalOutput: "Findings report content",
+		finalOutput: "Findings report content\nAdditional detail",
 		sessionFile: "/tmp/sessions/child-0.jsonl",
+		progressSummary: { toolCount: 2, tokens: 10, durationMs: 1250 },
 		...overrides,
 	};
+}
+
+function renderNotification(message: SentNotification): string {
+	return stripAnsi(renderSubagentNotification(message, { expanded: false }, theme).render(120).join("\n"));
 }
 
 test("detached foreground child exit delivers a completion notice to the parent session", () => {
@@ -57,7 +77,75 @@ test("detached foreground child exit delivers a completion notice to the parent 
 	assert.match(message.content, /^Detached subagent task completed: \*\*codebase-analyzer\*\* \(2\/4\)/);
 	assert.match(message.content, /Findings report content/);
 	assert.match(message.content, /Session file: \/tmp\/sessions\/child-0\.jsonl/);
+	assert.deepEqual(message.details, {
+		agent: "codebase-analyzer",
+		status: "completed",
+		taskInfo: "(2/4)",
+		resultPreview: "Findings report content\nAdditional detail",
+		durationMs: 1250,
+		sessionLabel: "session file",
+		sessionValue: "/tmp/sessions/child-0.jsonl",
+	});
 	unregister();
+});
+
+test("detached foreground completion notices render like background notifications for every status", () => {
+	initTheme("dark");
+	setKeybindings(new KeybindingsManager());
+	try {
+		for (const status of ["completed", "failed", "paused"] as const) {
+			const harness = createHarness();
+			const unregister = registerSubagentNotify(harness.pi as never);
+			const result =
+				status === "failed"
+					? makeResult({ exitCode: 1, error: "boom" })
+					: status === "paused"
+						? makeResult({ interrupted: true })
+						: makeResult();
+			const summary = status === "failed" ? `boom\n\nOutput:\n${result.finalOutput}` : result.finalOutput!;
+
+			notifyDetachedForegroundChildExit({
+				pi: harness.pi as never,
+				runId: `run-render-${status}`,
+				mode: "parallel",
+				index: 1,
+				totalTasks: 4,
+				result,
+			});
+			const detached = harness.sent[0]!;
+			const backgroundSuccess = status === "completed";
+			harness.pi.events.emit("subagent:async-complete", {
+				id: `background-render-${status}`,
+				agent: result.agent,
+				success: backgroundSuccess,
+				summary,
+				exitCode: status === "failed" ? 1 : 0,
+				...(status === "paused" ? { state: "paused" } : {}),
+				timestamp: Date.now(),
+				durationMs: result.progressSummary?.durationMs,
+				sessionFile: result.sessionFile,
+				taskIndex: 1,
+				totalTasks: 4,
+			});
+			const background = harness.sent[1]!;
+			const detachedRendered = renderNotification(detached);
+			const backgroundRendered = renderNotification(background);
+
+			assert.equal(detachedRendered, backgroundRendered, `${status} detached output uses the standard renderer`);
+			assert.notEqual(
+				detachedRendered,
+				detached.content,
+				`${status} detached output is not the raw notification body`,
+			);
+			assert.match(detachedRendered, /[✓✗■] codebase-analyzer (completed|failed|paused)/);
+			assert.match(detachedRendered, /⎿ {2}(Findings report content|boom)/);
+			assert.match(detachedRendered, /ctrl\+o full notification/);
+			assert.doesNotMatch(detachedRendered, /Additional detail/);
+			unregister();
+		}
+	} finally {
+		setKeybindings(originalKeybindings);
+	}
 });
 
 test("detached foreground completion notices dedupe per run and child index", () => {

--- a/test/unit/subagents-notification-content.test.ts
+++ b/test/unit/subagents-notification-content.test.ts
@@ -48,6 +48,25 @@ describe("subagent notification content parsing", () => {
 		});
 	});
 
+	test("parses a detached notice label with a known status", () => {
+		assert.deepEqual(parseSubagentNotifyContent("Detached subagent task completed: **worker**\n\nresult"), {
+			agent: "worker",
+			status: "completed",
+			resultPreview: "result",
+		});
+	});
+
+	test("rejects unrelated content with an invalid notification shape", () => {
+		for (const content of [
+			"Detached subagent task unknown: **worker**\n\nresult",
+			"Detached subagent task completed **worker**\n\nresult",
+			"Detached subagent task completed: **worker\n\nresult",
+			"The worker completed the task and reported a result.",
+		]) {
+			assert.equal(parseSubagentNotifyContent(content), undefined, content);
+		}
+	});
+
 	test("rejects malformed notification headers", () => {
 		for (const content of [
 			"Background task completed: ****\n\nresult",


### PR DESCRIPTION
## Summary

Detached foreground subagent completions were rendering as an unstyled dump of the entire child output instead of the collapsed, styled notification that ordinary background completions get.

The renderer never got structured data, so it re-parsed its own formatted header string — and the parser only recognized the literal prefix `Background task completed/failed/paused: **`. A detached notice says `Detached subagent task completed: **agent**`, so `parseSubagentNotifyContent` returned `undefined` and `renderSubagentNotification` fell through to `new Text(content, 0, 0)`: the raw notification body, full subagent output included, unstyled and never collapsed.

**Before** (rendered verbatim):

```
Detached subagent task completed: **codebase-analyzer**

line one
line two

Session file: /tmp/s/c.jsonl
```

**After** (collapsed, identical to the background equivalent):

```
✓ codebase-analyzer completed · 1s
  ⎿  line one
  ctrl+o full notification
  session file: /tmp/s/c.jsonl
```

## Is the detached notification redundant?

**No.** The user asked whether this notice duplicates the background result-delivery notification. It does not, and the two dedupe namespaces (`foreground-detach-<runId>-<index>` vs `completion-notify-<hash>`) cannot both fire for one run:

- `RESULTS_DIR/<id>.json` is written only by `packages/subagents/src/runs/background/subagent-runner-finalize.ts:104`.
- That runner is spawned only from `async-execution-common.ts:99`, and `resultPath`/`nestedResultsPath` are supplied at exactly two call sites: `async-execution-single.ts:184` and `async-execution-chain.ts:395`.
- `packages/subagents/src/runs/foreground/` contains zero references to `RESULTS_DIR`, `resultPath`, or `nestedResultsPath`; `foreground/execution-attempt.ts` spawns pi directly with no result path.

A detached foreground child therefore never writes a result file, so `result-delivery-processor.ts:276` has no input for it and cannot double-notify. No dedupe was needed.

## Changes

- **`packages/subagents/src/runs/background/notify.ts`** — attach a typed `SubagentNotifyDetails` object (`agent`, `status`, `taskInfo`, `resultPreview`, `durationMs`, `sessionLabel`, `sessionValue`) to the emitted `subagent-notify` message so the renderer no longer depends on re-parsing its own formatted string. The `content` string is unchanged in shape; the header keeps its distinct `Detached subagent task …` wording.
- **`packages/subagents/src/extension/notification-content.ts`** — generalize the string parser from three hardcoded `Background task …` prefixes to any notice label followed by one of the three known statuses and the `: **agent**` form. Kept as a backward-compatible fallback for notifications already persisted in existing sessions. Guards reject an empty label, an untrimmed label, and a label containing a line terminator, so unrelated prose still does not parse. Task-info and session-line parsing behavior is unchanged.
- **`packages/coding-agent/CHANGELOG.md`** — entry under `## [Unreleased]` → `### Fixed`.

Scope is the rendering path only: `packages/subagents/src/extension/index.ts` is untouched.

## Tests

New:
- `test/unit/subagents-detached-foreground-notify.test.ts` → `detached foreground completion notices render like background notifications for every status` — drives the real production path (`notifyDetachedForegroundChildExit` → `registerSubagentNotify` → `renderSubagentNotification`) with the real dark theme and a real `KeybindingsManager`, and for completed/failed/paused asserts the detached render equals the background render, differs from the raw `content` (i.e. never reaches the `new Text(content, 0, 0)` branch), shows the status icon and bold agent, shows the single-line `⎿` preview plus the `ctrl+o full notification` hint, and collapses the second preview line away.
- `test/unit/subagents-notification-content.test.ts` → `parses a detached notice label with a known status` and `rejects unrelated content with an invalid notification shape`.

Updated:
- `test/unit/subagents-detached-foreground-notify.test.ts` → the existing delivery test gains a `deepEqual` on the full `details` object; the shared `makeResult` fixture is widened (multi-line `finalOutput`, `progressSummary.durationMs`) so collapsing and duration can be asserted. No test name was deleted or renamed and every original assertion survives.

The pre-existing suite asserted only the raw `content` string, which is exactly why this regression stayed green.

## Verification

- `npm run check` — exit 0 (biome: 2345 files, no fixes; `tsc --noEmit` clean; shrinkwrap up to date).
- `npm run test:unit` — exit 0, 609 files, 5684 passed / 2 skipped.
- `subagents-detached-foreground-notify.test.ts` (5), `subagents-notification-content.test.ts` (7), `subagents-completion-notification.test.ts`, and `expandable-extension-renderers.test.ts` (6) all green.
- Three independent reviewers reproduced the result: byte-identical `stripAnsi` output between detached and background across three statuses and eight payload shapes in both collapsed and expanded mode; a 23-input differential against the `origin/main` parser showing every previously-accepted input still parses byte-identically; and a replay of real persisted session entries (which carry no `details`) confirming the backward-compatible parser fallback renders them styled.

## Reviewer notes (non-blocking)

- Background notifications now also render a duration segment (`✓ agent completed · (2/4) · 1s`), because `details` carries `durationMs` and the old string parser could never recover it. The renderer already supported the field. This follows from the requirement that detached output match background output on duration, but it is a small user-visible change to a surface the bug report did not name.
- The three new parser label guards (empty label, untrimmed label, line terminator in label) are correct but are not pinned by a committed negative test input.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788235974&installation_model_id=10562&pr_number=2133&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2133&signature=eebaddb2cbf0a0b287972afce10b3ad011e7781078fde11a1d1ee56c284b002a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes detached foreground subagent completion notices use the same collapsed notification presentation as background completions, while retaining detached-task wording and preserving custom-label parsing for persisted notices.

A focused runtime check exercised completed, failed, and paused detached completions through the notification pipeline and renderer. The rendered output retained task, duration, session, and preview details, remained collapsed, and did not fall back to displaying the raw child output. The suspected raw-rendering regression was disproved by `bun test trex-artifacts/pr-2133-detached-notification-renderer.test.ts --timeout 30000`, which passed for all three terminal states.

<h3>Confidence Score: 5/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran bun test trex-artifacts/pr-2133-detached-notification-renderer.test.ts --timeout 30000 and observed that results were delivered through the standard collapsed notification renderer with structured task, duration, session, and preview details rather than raw child output.
- The test exited cleanly with code 0 and one passing test, and the captured output clearly contrasts raw messages with the collapsed rendered notifications.

<a href="https://app.greptile.com/trex/runs/16935849/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(subagents): render detached completi..."](https://github.com/bastani-inc/atomic/commit/462f55c1560f1700034d300606c95be0ed59e92b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49423929)</sub>

<!-- /greptile_comment -->