### PR TITLE
fix(workflows): remove background widget run cap and expire quit cards

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+
+- Removed the four-workflow display cap from the BACKGROUND widget so every qualifying top-level run is rendered.
+
+### Fixed
+
+- Quit workflow cards now expire from the BACKGROUND widget after the same recent-run window as finished cards while remaining resumable and discoverable through workflow status.
 
 ## [0.9.11-alpha.10] - 2026-08-01
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Fixed
 
-- Quit workflow cards now expire from the BACKGROUND widget after the same recent-run window as finished cards while remaining resumable and discoverable through workflow status.
+- Quit workflow cards now expire from the BACKGROUND widget after the same recent-run window as finished cards while remaining resumable and discoverable through workflow status; the header count now matches the rendered cards after expiry.
 
 ## [0.9.11-alpha.10] - 2026-08-01
 

--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -117,7 +117,7 @@ Named workflow runs execute in the background. By default, after launch expect a
 
 For a request with several implementation items, do not turn list order into one serial workflow by default. Triage dependencies first, then launch independent items as a bounded wave of separate top-level runs; see [Task queues and software factories](#task-queues-and-software-factories).
 
-While a workflow is running, the visible below-editor `BACKGROUND` panel advances its elapsed label every second from the moment the run starts; it does not require opening or switching to the orchestrator. Updates repaint the existing mounted panel in place, paused timers stay frozen, and terminal cards retain their short recent-run expiry.
+While a workflow is running, the visible below-editor `BACKGROUND` panel advances its elapsed label every second from the moment the run starts; it does not require opening or switching to the orchestrator. Updates repaint the existing mounted panel in place, paused timers stay frozen, the panel renders every qualifying top-level run, and terminal or quit cards retain their short recent-run expiry. Quit cards remain resumable and discoverable with `/workflow status` after they leave the panel.
 
 ### Or hand-write the TypeScript
 

--- a/packages/workflows/src/shared/store-run-methods.ts
+++ b/packages/workflows/src/shared/store-run-methods.ts
@@ -179,6 +179,7 @@ export function createRunStoreMethods(context: StoreContext): RunStoreMethods {
 			if (!run) return false;
 			if (TERMINAL_STATUSES.has(run.status)) return false;
 			const wasPaused = run.status === "paused";
+			const enteringQuit = metadata?.exitReason === "quit" && run.exitReason !== "quit";
 			if (!wasPaused) {
 				run.status = "paused";
 				run.pausedAt = pausedAt ?? Date.now();
@@ -186,6 +187,7 @@ export function createRunStoreMethods(context: StoreContext): RunStoreMethods {
 			}
 			if (metadata?.resumable !== undefined) run.resumable = metadata.resumable;
 			if (metadata?.exitReason !== undefined) run.exitReason = metadata.exitReason;
+			if (enteringQuit) run.quitAt = Date.now();
 			if (wasPaused && metadata === undefined) return false;
 			context.bumpAndNotify();
 			return true;
@@ -201,6 +203,7 @@ export function createRunStoreMethods(context: StoreContext): RunStoreMethods {
 			run.pausedDurationMs = accumulatePausedDurationMs(run.pausedDurationMs, run.pausedAt, resumedTs);
 			run.resumedAt = resumedTs;
 			run.pausedAt = undefined;
+			delete run.quitAt;
 			delete run.exitReason;
 			context.bumpAndNotify();
 			return true;

--- a/packages/workflows/src/shared/store-types.ts
+++ b/packages/workflows/src/shared/store-types.ts
@@ -282,6 +282,8 @@ export interface RunSnapshot {
 	pausedDurationMs?: number;
 	/** Timestamp set when a controlled pause begins; cleared on resume. */
 	pausedAt?: number;
+	/** Timestamp when the run entered resumable quit state; display-only expiry marker. */
+	quitAt?: number;
 	/** Timestamp recorded on the most recent resume from a paused state. */
 	resumedAt?: number;
 	result?: WorkflowOutputValues;

--- a/packages/workflows/src/tui/widget.ts
+++ b/packages/workflows/src/tui/widget.ts
@@ -386,7 +386,7 @@ export function buildThemedWidgetLines(
 	const display = selectDisplayRuns(snap, now);
 	if (display.length === 0) return [];
 
-	const counts = countRuns(topLevelWorkflowRuns(snap.runs), snap.runs);
+	const displayCounts = countRuns(display, snap.runs);
 	// Active + recently-ended dominate the badge counts so a finished run
 	// visually persists for a beat before dropping off.
 	const visibleCounts: RunCounts = {
@@ -400,7 +400,7 @@ export function buildThemedWidgetLines(
 		blocked: display.filter((r) => effectiveRunStatus(r) === "blocked").length,
 		failed: display.filter((r) => r.endedAt !== undefined && ["failed", "killed"].includes(effectiveRunStatus(r)))
 			.length,
-		awaiting: counts.awaiting,
+		awaiting: displayCounts.awaiting,
 	};
 
 	const themed = piTheme !== undefined;
@@ -411,7 +411,7 @@ export function buildThemedWidgetLines(
 		return [themed ? themedCollapsed(visibleCounts, graphTheme) : plainCollapsed(visibleCounts)];
 	}
 
-	const total = counts.active + counts.paused + counts.quit + counts.done + counts.blocked + counts.failed;
+	const total = display.length;
 	const subtitle = `${total} run${total === 1 ? "" : "s"}`;
 
 	const badgeList = countBadges(visibleCounts, graphTheme);

--- a/packages/workflows/src/tui/widget.ts
+++ b/packages/workflows/src/tui/widget.ts
@@ -39,7 +39,6 @@ import type { PiTheme } from "./store-widget-installer.js";
 // ---------------------------------------------------------------------------
 
 const SHORT_ID_LEN = 6;
-const MAX_VISIBLE_RUNS = 4;
 export const RECENT_ENDED_WINDOW_MS = 30_000;
 const COLLAPSED_BREAKPOINT_COLS = 80;
 
@@ -62,16 +61,28 @@ export function formatDuration(ms: number): string {
 // Run classification + selection
 // ---------------------------------------------------------------------------
 
+function isQuitRun(run: RunSnapshot): boolean {
+	return run.endedAt === undefined && run.status === "paused" && run.exitReason === "quit";
+}
+
 function isActive(run: RunSnapshot): boolean {
-	return run.endedAt === undefined;
+	return run.endedAt === undefined && !isQuitRun(run);
 }
 
 function recentlyEnded(run: RunSnapshot, now: number): boolean {
 	return run.endedAt !== undefined && now - run.endedAt <= RECENT_ENDED_WINDOW_MS;
 }
 
-function isQuitRun(run: RunSnapshot): boolean {
-	return run.endedAt === undefined && run.status === "paused" && run.exitReason === "quit";
+/**
+ * Returns the timestamp from which a quit card's display-only expiry is measured.
+ * Older snapshots do not have `quitAt`, so retain the bounded legacy fallbacks.
+ */
+function quitExpiryTimestamp(run: RunSnapshot): number {
+	return run.quitAt ?? run.pausedAt ?? run.startedAt;
+}
+
+function recentlyQuit(run: RunSnapshot, now: number): boolean {
+	return isQuitRun(run) && now - quitExpiryTimestamp(run) <= RECENT_ENDED_WINDOW_MS;
 }
 
 interface RunCounts {
@@ -123,7 +134,7 @@ function countRuns(runs: readonly RunSnapshot[], allRuns: readonly RunSnapshot[]
 /**
  * Returns the next wall-clock boundary that can change the visible widget.
  * Running elapsed labels tick on exact one-second boundaries; paused runs stay
- * frozen. Recently ended cards retain their independent one-shot expiry.
+ * frozen. Recently ended and quit cards retain their independent one-shot expiry.
  * Reactive-widget updates the existing mounted component in place, so these
  * ticks repaint the visible panel without disposing or remounting it.
  */
@@ -131,9 +142,14 @@ export function nextWidgetRefreshDelayMs(snap: StoreSnapshot, now = Date.now()):
 	const display = selectDisplayRuns(snap, now);
 	if (display.length === 0) return undefined;
 
-	const delays: number[] = display
-		.filter((run) => run.endedAt !== undefined)
-		.map((run) => Math.max(1, run.endedAt! + RECENT_ENDED_WINDOW_MS - now + 1));
+	const delays: number[] = [];
+	for (const run of display) {
+		if (run.endedAt !== undefined) {
+			delays.push(Math.max(1, run.endedAt + RECENT_ENDED_WINDOW_MS - now + 1));
+		} else if (isQuitRun(run)) {
+			delays.push(Math.max(1, quitExpiryTimestamp(run) + RECENT_ENDED_WINDOW_MS - now + 1));
+		}
+	}
 	for (const run of display) {
 		if (run.endedAt !== undefined || effectiveRunStatus(run) !== "running" || run.pausedAt !== undefined) continue;
 		const remainder = elapsedRunMs(run, now) % 1_000;
@@ -150,11 +166,10 @@ function selectDisplayRuns(snap: StoreSnapshot, now: number): RunSnapshot[] {
 	// rule `statusRuns`/the `status` action already apply.
 	const all = topLevelWorkflowRuns(snap.runs);
 	const active = all.filter((r) => isActive(r));
-	const recent = all.filter((r) => recentlyEnded(r, now));
+	const recent = all.filter((r) => recentlyEnded(r, now) || recentlyQuit(r, now));
 	// Most recently started first within each bucket; active runs precede recent.
 	const sort = (xs: RunSnapshot[]) => [...xs].sort((a, b) => (b.startedAt ?? 0) - (a.startedAt ?? 0));
-	const ordered = [...sort(active), ...sort(recent)];
-	return ordered.slice(0, MAX_VISIBLE_RUNS);
+	return [...sort(active), ...sort(recent)];
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/store.test.ts
+++ b/test/unit/store.test.ts
@@ -280,6 +280,32 @@ describe("store run pausing", () => {
 		assert.equal(run.resumedAt, 16_000);
 		assert.equal(run.pausedDurationMs, 10_000);
 	});
+	test("records quit time separately from paused time and clears it on resume", () => {
+		const originalNow = Date.now;
+		let now = 10_000;
+		Date.now = () => now;
+		try {
+			const s = createStore();
+			s.recordRunStart({ ...makeRun("quit"), startedAt: 1_000 });
+			const pausedAt = now;
+			assert.equal(s.recordRunPaused("quit", pausedAt), true);
+
+			now += 5_000;
+			const quitAt = now;
+			assert.equal(s.recordRunPaused("quit", undefined, { exitReason: "quit", resumable: true }), true);
+			let run = s.snapshot().runs[0]!;
+			assert.equal(run.pausedAt, pausedAt);
+			assert.equal(run.quitAt, quitAt);
+			assert.equal(run.endedAt, undefined);
+
+			assert.equal(s.recordRunResumed("quit", now + 1_000), true);
+			run = s.snapshot().runs[0]!;
+			assert.equal(run.quitAt, undefined);
+			assert.equal(run.exitReason, undefined);
+		} finally {
+			Date.now = originalNow;
+		}
+	});
 
 	test("recordRunEnd excludes paused time from final duration", () => {
 		const originalNow = Date.now;

--- a/test/unit/widget-rendering.test.ts
+++ b/test/unit/widget-rendering.test.ts
@@ -15,6 +15,8 @@
 
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
+import { statusRuns } from "../../packages/workflows/src/runs/background/status.js";
+import { createStore } from "../../packages/workflows/src/shared/store.js";
 import type { RunSnapshot, StageSnapshot, StoreSnapshot } from "../../packages/workflows/src/shared/store-types.js";
 import { hexToAnsi } from "../../packages/workflows/src/tui/color-utils.js";
 import { deriveGraphTheme } from "../../packages/workflows/src/tui/graph-theme.js";
@@ -140,6 +142,48 @@ describe("renderWidgetLines — standard form", () => {
 		assert.ok(lines[0]!.includes("BACKGROUND  1 run  1 quit"));
 		assert.ok(joined.includes("quit · resumable via /workflow resume"));
 	});
+	test("quit card expires from the widget after the recent window while status stays resumable", () => {
+		const originalNow = Date.now;
+		let now = 1_000_000;
+		Date.now = () => now;
+		try {
+			const store = createStore();
+			const runId = "quit-after-pause";
+			store.recordRunStart(makeRun(runId, "resume-me-later", "running", [], now - RECENT_ENDED_WINDOW_MS * 3));
+			const pausedAt = now - RECENT_ENDED_WINDOW_MS * 2;
+			assert.equal(store.recordRunPaused(runId, pausedAt), true);
+
+			now += RECENT_ENDED_WINDOW_MS / 6;
+			const quitAt = now;
+			assert.equal(store.recordRunPaused(runId, undefined, { exitReason: "quit", resumable: true }), true);
+
+			const quitRun = store.snapshot().runs[0]!;
+			assert.equal(quitRun.status, "paused");
+			assert.equal(quitRun.endedAt, undefined);
+			assert.equal(quitRun.pausedAt, pausedAt, "quitting must not repurpose pausedAt");
+			assert.equal(quitRun.quitAt, quitAt, "expiry must start when the run is quit");
+			assert.equal(quitRun.resumable, true);
+			assert.ok(
+				renderWidgetLines(store.snapshot(), 120)
+					.map(stripAnsi)
+					.join("\n")
+					.includes("quit · resumable via /workflow resume"),
+				"a newly quit run should render immediately",
+			);
+
+			now = quitAt + RECENT_ENDED_WINDOW_MS + 1;
+			assert.deepEqual(renderWidgetLines(store.snapshot(), 120), [], "expired quit card should disappear");
+
+			const status = statusRuns({ store });
+			assert.deepEqual(
+				status.map((entry) => [entry.runId, entry.status]),
+				[[runId, "paused"]],
+			);
+			assert.equal(store.snapshot().runs[0]!.resumable, true, "expiry must not change resumability");
+		} finally {
+			Date.now = originalNow;
+		}
+	});
 
 	test("running run shows chain mode when multi-stage", () => {
 		const run = makeRun("xyz000aaaa", "deep-research", "running", [
@@ -187,6 +231,20 @@ describe("renderWidgetLines — standard form", () => {
 		const wfTwoIdx = lines.findIndex((l) => l.includes("wf-two"));
 		const wfOneIdx = lines.findIndex((l) => l.includes("wf-one"));
 		assert.ok(wfTwoIdx < wfOneIdx, "most recently started run renders first");
+	});
+	test("more than four concurrent runs all render without truncation", () => {
+		const now = Date.now();
+		const runs = Array.from({ length: 6 }, (_, index) =>
+			makeRun(`run-${index}-abcdef`, `wf-${index}`, "running", [], now - (6 - index) * 100),
+		);
+		const lines = renderWidgetLines(makeSnap(runs), 120).map(stripAnsi);
+		const joined = lines.join("\n");
+
+		assert.ok(lines[0]!.includes("6 runs"));
+		for (let index = 0; index < runs.length; index++) {
+			assert.ok(joined.includes(`wf-${index}`), `workflow ${index} should render`);
+		}
+		assert.equal(lines.filter((line) => line.includes("single")).length, 6);
 	});
 
 	test("hides nested child workflow runs, showing only the top-level run", () => {
@@ -269,6 +327,24 @@ describe("renderWidgetLines — standard form", () => {
 		assert.ok(header.includes("❚❚ 1 paused"), "paused badge");
 		assert.ok(header.includes("✓ 1 complete"), "completed badge");
 		assert.ok(header.includes("✗ 1 failed"), "failed badge");
+	});
+	test("expired quit runs do not contribute quit badges after their cards disappear", () => {
+		const now = 1_000_000;
+		const active = makeRun("active-run", "still-running", "running", [], now - 1_000);
+		const expiredQuit = makeRun("expired-quit", "already-quit", "paused", [], now - RECENT_ENDED_WINDOW_MS * 2);
+		expiredQuit.pausedAt = now - RECENT_ENDED_WINDOW_MS * 2;
+		expiredQuit.quitAt = now - RECENT_ENDED_WINDOW_MS - 1;
+		expiredQuit.exitReason = "quit";
+		expiredQuit.resumable = true;
+		const snap = makeSnap([active, expiredQuit]);
+
+		const wide = renderWidgetLines(snap, 120).map(stripAnsi);
+		assert.ok(wide.join("\n").includes("still-running"));
+		assert.ok(!wide[0]!.includes("quit"), "wide quit badge must match rendered cards");
+
+		const collapsed = renderWidgetLines(snap, 60).map(stripAnsi);
+		assert.ok(collapsed[0]!.includes("1 background"));
+		assert.ok(!collapsed[0]!.includes("quit"), "collapsed quit badge must match rendered cards");
 	});
 
 	test("ctx.exit blocked remains distinct from completed exit statuses", () => {
@@ -359,6 +435,20 @@ describe("renderWidgetLines — standard form", () => {
 
 		const ended = makeRun("r2xxxxxx", "wf-d", "completed", [], now - 20_000, now - 10_000);
 		assert.equal(nextWidgetRefreshDelayMs(makeSnap([offsetActive, ended]), now), 750);
+	});
+	test("quit runs schedule the expiry repaint from quitAt", () => {
+		const now = 1_000_000;
+		const quitAt = now - RECENT_ENDED_WINDOW_MS / 6;
+		const quit = makeRun("quit-refresh", "wf-quit", "paused", [], now - RECENT_ENDED_WINDOW_MS * 2);
+		quit.pausedAt = now - RECENT_ENDED_WINDOW_MS * 2;
+		quit.quitAt = quitAt;
+		quit.exitReason = "quit";
+		quit.resumable = true;
+
+		assert.equal(
+			nextWidgetRefreshDelayMs(makeSnap([quit]), now),
+			RECENT_ENDED_WINDOW_MS - RECENT_ENDED_WINDOW_MS / 6 + 1,
+		);
 	});
 
 	test("standard panel scales to the provided terminal width", () => {

--- a/test/unit/widget-rendering.test.ts
+++ b/test/unit/widget-rendering.test.ts
@@ -328,7 +328,7 @@ describe("renderWidgetLines — standard form", () => {
 		assert.ok(header.includes("✓ 1 complete"), "completed badge");
 		assert.ok(header.includes("✗ 1 failed"), "failed badge");
 	});
-	test("expired quit runs do not contribute quit badges after their cards disappear", () => {
+	test("expired quit runs do not contribute counts after their cards disappear", () => {
 		const now = 1_000_000;
 		const active = makeRun("active-run", "still-running", "running", [], now - 1_000);
 		const expiredQuit = makeRun("expired-quit", "already-quit", "paused", [], now - RECENT_ENDED_WINDOW_MS * 2);
@@ -340,6 +340,7 @@ describe("renderWidgetLines — standard form", () => {
 
 		const wide = renderWidgetLines(snap, 120).map(stripAnsi);
 		assert.ok(wide.join("\n").includes("still-running"));
+		assert.ok(wide[0]!.includes("BACKGROUND  1 run"), "wide header total must match its single rendered card");
 		assert.ok(!wide[0]!.includes("quit"), "wide quit badge must match rendered cards");
 
 		const collapsed = renderWidgetLines(snap, 60).map(stripAnsi);


### PR DESCRIPTION
## Summary

Two linked fixes to the workflows `BACKGROUND` widget in `packages/workflows/src/tui/widget.ts`.

The panel truncated to four runs, and quit runs never expired. Those two facts compounded: a quit run has no `endedAt`, so `isActive` reported it as active forever, it never became `recentlyEnded`, and it never dropped off. Quit cards accumulated without bound and, under the four-run cap, crowded live runs off the panel. The cap made the leak visible; the leak made the cap bite.

## Changes

**Removed the display cap.** `MAX_VISIBLE_RUNS` and its `ordered.slice(0, MAX_VISIBLE_RUNS)` in `selectDisplayRuns` are deleted rather than raised, so every qualifying top-level run renders. There was no overflow or "+N more" affordance to clean up.

**Quit cards expire on the finished-run rule.** Quit runs are resumable, so expiry must not make them look terminal — stamping `endedAt` would change `isActive`, the counts, and every other consumer of run state. Instead the run is expired from the *display* against the existing `RECENT_ENDED_WINDOW_MS` window:

- `isQuitRun` moves above `isActive`, and `isActive` now excludes quit runs.
- A new `recentlyQuit` measures the window from `quitAt`, a display-only timestamp added to `RunSnapshot` and set in `recordRunPaused` when a run first enters quit state. `pausedAt` was unsuitable: a run can be paused long before it is quit, which would expire the card early or immediately. `quitAt` is cleared on resume.
- `quitExpiryTimestamp` falls back to `pausedAt` then `startedAt` so snapshots written before this change still expire rather than pinning forever.

**Repaint scheduling.** `nextWidgetRefreshDelayMs` previously scheduled expiry repaints only for runs with `endedAt`. It now schedules the quit expiry the same way, so a quit card leaves the screen on time instead of lingering until some unrelated event repaints the widget.

**Badges match cards.** `countRuns` ran over all top-level runs, so a `N quit` badge would keep counting quit runs whose cards had already expired. Counts and the `N runs` subtitle now derive from the display set.

### Before / after, six runs of which two were quit

Before: the four newest runs rendered; the two oldest were silently dropped, and both quit cards stayed forever, so over time the quit pair permanently occupied half the panel while live runs went unseen. After: all six render; roughly 30 s after each quit, that card disappears on a scheduled repaint and the panel settles to the four live runs with a header reading `4 runs`.

## Discoverability

An expired quit card does not make the run unreachable. `statusRuns` and the `workflow` `status` action read `snap.runs`, which this change does not touch, and `resumable` is untouched — asserted directly in `quit card expires from the widget after the recent window while status stays resumable`.

## Tests

Extended the existing suites; no parallel ones. Time-dependent assertions derive from the exported `RECENT_ENDED_WINDOW_MS` rather than hardcoding 30000.

`test/unit/widget-rendering.test.ts`
- `more than four concurrent runs all render without truncation`
- `quit card expires from the widget after the recent window while status stays resumable`
- `expired quit runs do not contribute counts after their cards disappear` — covers the wide and collapsed forms across the 80-column breakpoint
- `quit runs schedule the expiry repaint from quitAt`

`test/unit/store.test.ts`
- `records quit time separately from paused time and clears it on resume`

## Verification

`npm run check` and `npm run test:unit` both passed as pre-push hooks on this branch: 609 test files, 5686 passed, 2 skipped, zero failures.

## Known non-blocking observations

Recorded by review as P3 observations, not defects, and left unfixed to keep the change scoped:

1. **Panel height is now unbounded above the 80-column breakpoint.** This is the requested behavior — the cap was to be deleted, not raised — but it is a real consequence: a probe with 40 concurrent runs produced a 121-line below-editor panel. The collapsed form below 80 columns stays a single line. Worth a look if run counts get large in practice.
2. **A retried quit does not restart the expiry window.** `publishLocalQuit` can run twice without an intervening resume: once with `resumable: false` when the durable write is refused, then again on the retry that upgrades the record. The `enteringQuit` guard is false on that second call, so `quitAt` keeps the first quit's timestamp; if the retry lands more than one window later, the card does not reappear even though the run has just become resumable. The run stays discoverable through `status` throughout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788237278&installation_model_id=10562&pr_number=2134&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2134&signature=37b0c4cf950b298052215174983c48304b05fd1ba2eab3c5eaa3d6a133040239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change removes expired quit workflow runs from BACKGROUND widget cards, totals, and badges while preserving active workflow cards and their attention indicators.

The widget expiry boundary was exercised with an expired quit run alongside an active run awaiting input at wide and collapsed widths. The resulting widget showed one active card, `BACKGROUND  1 run` in wide mode, and `1 background · 1 ●` in collapsed mode, with no stale quit card or quit count. The focused widget-rendering suite passed all 29 tests.

<h3>Confidence Score: 5/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran a deterministic TypeScript boundary harness with one expired quit workflow run and one active workflow at 120-column and 60-column widths, then compared the harness output to verify the widget renders only the active workflow and shows the expected background badges.
- I executed the Vitest unit test suite for widget rendering and all 29 focused tests passed.
- I implemented code changes to exclude quit runs from display via selectDisplayRuns and to derive wide/collapsed totals and badges from the display set via buildThemedWidgetLines.
- I verified that awaiting behavior is preserved: countRuns(display, snap.runs) continues to show the active run with its needs-attention badge while expired quit runs are omitted.
- I uploaded artifact references documenting the changes and their verification for review.

<a href="https://app.greptile.com/trex/runs/16936639/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(workflows): align widget header coun..."](https://github.com/bastani-inc/atomic/commit/6d81007cd0dca54e109391e5a23d1d1e26f733af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49426044)</sub>

<!-- /greptile_comment -->