### PR TITLE
feat(release): add first-class musl/Alpine Linux support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,7 +71,7 @@ jobs:
           echo "npm-tag=$npm_tag" >> "$GITHUB_OUTPUT"
 
   native-artifacts:
-    name: Native ${{ matrix.platform }} ${{ matrix.arch }}
+    name: Native ${{ matrix.slug }}
     needs: integrity
     runs-on: ${{ matrix.runner }}
     # Job caps are hang detectors, sized per leg from the last eight releases.
@@ -84,14 +84,22 @@ jobs:
       fail-fast: false
       matrix:
         # timeout_minutes caps the job; build_timeout_minutes caps the compile step.
+        # `slug` is the napi platform id: it names the .node file, the npm leaf, and
+        # this leg's artifact, so two legs that share platform+arch (glibc and musl
+        # Linux) can never collide on an artifact name.
         include:
-          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: linux, arch: x64, target: x86_64-unknown-linux-gnu, timeout_minutes: 7, build_timeout_minutes: 5 }
-          - { runner: blacksmith-4vcpu-ubuntu-2404-arm, platform: linux, arch: arm64, target: aarch64-unknown-linux-gnu, timeout_minutes: 8, build_timeout_minutes: 5 }
+          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: linux, arch: x64, slug: linux-x64-gnu, target: x86_64-unknown-linux-gnu, timeout_minutes: 7, build_timeout_minutes: 5 }
+          - { runner: blacksmith-4vcpu-ubuntu-2404-arm, platform: linux, arch: arm64, slug: linux-arm64-gnu, target: aarch64-unknown-linux-gnu, timeout_minutes: 8, build_timeout_minutes: 5 }
+          # musl legs reuse the same zig toolchain; @napi-rs/cli adds
+          # `-C target-feature=-crt-static` for a musl ABI, which is what keeps the
+          # produced .node a dlopen-able shared object instead of a static-CRT blob.
+          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: linux, arch: x64, slug: linux-x64-musl, target: x86_64-unknown-linux-musl, timeout_minutes: 7, build_timeout_minutes: 5 }
+          - { runner: blacksmith-4vcpu-ubuntu-2404-arm, platform: linux, arch: arm64, slug: linux-arm64-musl, target: aarch64-unknown-linux-musl, timeout_minutes: 8, build_timeout_minutes: 5 }
           # Blacksmith macOS is Apple Silicon only, so darwin x64 stays GitHub-hosted.
-          - { runner: macos-26-intel, platform: darwin, arch: x64, target: x86_64-apple-darwin, timeout_minutes: 9, build_timeout_minutes: 8 }
-          - { runner: blacksmith-6vcpu-macos-26, platform: darwin, arch: arm64, target: aarch64-apple-darwin, timeout_minutes: 5, build_timeout_minutes: 5 }
-          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: win32, arch: x64, target: x86_64-pc-windows-msvc, timeout_minutes: 10, build_timeout_minutes: 5 }
-          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: win32, arch: arm64, target: aarch64-pc-windows-msvc, timeout_minutes: 10, build_timeout_minutes: 5 }
+          - { runner: macos-26-intel, platform: darwin, arch: x64, slug: darwin-x64, target: x86_64-apple-darwin, timeout_minutes: 9, build_timeout_minutes: 8 }
+          - { runner: blacksmith-6vcpu-macos-26, platform: darwin, arch: arm64, slug: darwin-arm64, target: aarch64-apple-darwin, timeout_minutes: 5, build_timeout_minutes: 5 }
+          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: win32, arch: x64, slug: win32-x64-msvc, target: x86_64-pc-windows-msvc, timeout_minutes: 10, build_timeout_minutes: 5 }
+          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: win32, arch: arm64, slug: win32-arm64-msvc, target: aarch64-pc-windows-msvc, timeout_minutes: 10, build_timeout_minutes: 5 }
     steps:
       # Sticky disks are Blacksmith-Linux-only; elsewhere this action stalls ~78s
       # before falling back to a normal clone.
@@ -111,8 +119,8 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
-      # rustup needs the bare target; Linux's napi build separately receives the
-      # glibc-suffixed target consumed by cargo-zigbuild.
+      # rustup needs the bare target; only the glibc Linux legs separately receive
+      # the glibc-suffixed target consumed by cargo-zigbuild.
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         timeout-minutes: 4
         with:
@@ -131,10 +139,13 @@ jobs:
         shell: bash
         env:
           BARE_TARGET: ${{ matrix.target }}
-          TARGET_PLATFORM: ${{ matrix.platform }}
         run: |
+          # Only a glibc triple gets the floor suffix. build-native.ts routes
+          # `<triple>.<major>.<minor>` straight to cargo-zigbuild's glibc pinning;
+          # a musl triple must stay bare so it falls through to napi's
+          # --cross-compile path, which is what applies -crt-static.
           build_target="$BARE_TARGET"
-          [[ "$TARGET_PLATFORM" != linux ]] || build_target="${BARE_TARGET}.${GLIBC_FLOOR}"
+          [[ "$BARE_TARGET" != *-unknown-linux-gnu ]] || build_target="${BARE_TARGET}.${GLIBC_FLOOR}"
           echo "build-target=$build_target" >> "$GITHUB_OUTPUT"
       - name: Set baseline x64 CPU flags
         if: matrix.arch == 'x64'
@@ -143,7 +154,7 @@ jobs:
       # Community Zig mirrors have stalled two releases (795.9s and 437.6s).
       # setup-zig applies no per-mirror deadline, so bound it and retry once on a
       # re-shuffled mirror list: a stall now costs at most 4 minutes and fails loudly.
-      - name: Setup zig for portable Linux GNU builds
+      - name: Setup zig for portable Linux builds
         id: zig
         if: matrix.platform == 'linux'
         continue-on-error: true
@@ -166,7 +177,7 @@ jobs:
           use-cache: false
       # Unversioned taiki-e tools resolve to @latest, floating the build toolchain
       # of a provenance-signed artifact with no diff.
-      - name: Install cargo-zigbuild for portable Linux GNU builds
+      - name: Install cargo-zigbuild for portable Linux builds
         if: matrix.platform == 'linux'
         timeout-minutes: 3
         uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2.85.5
@@ -218,7 +229,7 @@ jobs:
         run: bun run --cwd packages/natives build
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: atomic-natives-${{ matrix.platform }}-${{ matrix.arch }}
+          name: atomic-natives-${{ matrix.slug }}
           path: packages/natives/native/*.node
           if-no-files-found: error
           retention-days: 14
@@ -314,9 +325,76 @@ jobs:
           if ($output -match "Failed to load extension") { exit 1 }
           if ($status -ne 0 -and $output -notmatch "No models available|No model selected|No API key found") { exit $status }
 
+  # The one leg that proves musl at runtime rather than at link time. Docker is the
+  # only way to reach a musl userspace from a Blacksmith Ubuntu runner, and the
+  # native binding is downloaded rather than rebuilt so this job costs an archive
+  # build instead of a second zig cross-compile.
+  alpine-binary-smoke:
+    name: Smoke Alpine musl binary
+    needs: [integrity, native-artifacts]
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 12
+    steps:
+      - uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1.1
+        with:
+          ref: ${{ env.SOURCE_REF }}
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+      - name: Download musl native binding
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: atomic-natives-linux-x64-musl
+          path: packages/natives/native
+      - name: Build Linux x64 musl archive
+        run: ./scripts/build-binaries.sh --skip-deps --platform linux-x64-musl
+      - name: Smoke musl release archive on Alpine
+        shell: bash
+        run: |
+          set -euo pipefail
+          smoke="$RUNNER_TEMP/atomic-alpine-smoke"
+          rm -rf "$smoke"
+          mkdir -p "$smoke"
+          tar -xzf packages/coding-agent/binaries/atomic-linux-x64-musl.tar.gz -C "$smoke"
+          cat > "$smoke/smoke.sh" <<'SMOKE'
+          set -eu
+          apk add --no-cache libgcc libstdc++
+          atomic=/smoke/atomic/atomic
+          "$atomic" --version
+          mkdir -p /tmp/atomic-alpine-cwd
+          cd /tmp/atomic-alpine-cwd
+          set +e
+          output=$(printf '' | "$atomic" --no-session 2>&1)
+          status=$?
+          set -e
+          echo "$output"
+          if echo "$output" | grep -q 'Failed to load extension'; then exit 1; fi
+          if [ "$status" -ne 0 ] && ! echo "$output" | grep -Eq 'No models available|No model selected|No API key found'; then
+            exit "$status"
+          fi
+          SMOKE
+          docker run --rm -v "$smoke:/smoke" alpine:3.22 /bin/sh /smoke/smoke.sh
+      - name: Load the musl native binding under musl libc
+        shell: bash
+        run: |
+          set -euo pipefail
+          smoke="$RUNNER_TEMP/atomic-alpine-smoke"
+          # `atomic` catches a failed binding load and degrades to the JS search
+          # paths, so starting is not proof the addon dlopen'd. Require it here.
+          docker run --rm -v "$smoke:/smoke" node:22-alpine node -e '
+            const binding = require("/smoke/atomic/node_modules/@bastani/atomic-natives");
+            for (const name of ["glob", "grep"]) {
+              if (typeof binding[name] !== "function") throw new Error(`musl binding is missing ${name}()`);
+            }
+            console.log("musl native binding loaded:", Object.keys(binding).length, "exports");'
+
   build:
     name: Build release payload
-    needs: [integrity, native-artifacts, linux-binary-smoke, windows-binary-smoke]
+    needs: [integrity, native-artifacts, linux-binary-smoke, windows-binary-smoke, alpine-binary-smoke]
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:
@@ -372,7 +450,7 @@ jobs:
             }
             for (const pkg of [atomic, natives]) for (const deps of [pkg.dependencies, pkg.optionalDependencies, pkg.peerDependencies]) for (const [name, range] of Object.entries(deps ?? {})) if (String(range).startsWith("workspace:")) failures.push(`workspace range: ${name}`);
             for (const path of [atomic.main, atomic.types, atomic.bin?.atomic, "dist/builtin", "dist/builtin/workflows/package.json", "dist/builtin/subagents/package.json", "dist/builtin/mcp/package.json", "dist/builtin/web-access/package.json", "dist/builtin/intercom/package.json"]) if (!path || !existsSync(`packages/coding-agent/${path}`)) failures.push(`missing ${path}`);
-            for (const native of ["darwin-arm64","darwin-x64","linux-arm64-gnu","linux-x64-gnu","win32-arm64-msvc","win32-x64-msvc"]) if (!existsSync(`packages/natives/native/atomic_natives.${native}.node`)) failures.push(`missing native ${native}`);
+            for (const native of ["darwin-arm64","darwin-x64","linux-arm64-gnu","linux-arm64-musl","linux-x64-gnu","linux-x64-musl","win32-arm64-msvc","win32-x64-msvc"]) if (!existsSync(`packages/natives/native/atomic_natives.${native}.node`)) failures.push(`missing native ${native}`);
             if (failures.length) throw new Error(failures.join("\n"));'
           rm -rf release-assets npm-packages
           mkdir release-assets npm-packages
@@ -381,12 +459,12 @@ jobs:
           test -s release-assets/RELEASE_NOTES.md || echo "Release $VERSION" > release-assets/RELEASE_NOTES.md
           (cd release-assets && sha256sum atomic-*.tar.gz atomic-*.zip > SHA256SUMS)
           for dir in packages/natives/npm/* packages/natives packages/coding-agent; do npm pack "./$dir" --pack-destination npm-packages; done
-          test "$(find npm-packages -name '*.tgz' -type f | wc -l | tr -d ' ')" = 8
+          test "$(find npm-packages -name '*.tgz' -type f | wc -l | tr -d ' ')" = 10
           bun -e '
-            const expected = new Set(["@bastani/atomic-natives-darwin-arm64","@bastani/atomic-natives-darwin-x64","@bastani/atomic-natives-linux-arm64-gnu","@bastani/atomic-natives-linux-x64-gnu","@bastani/atomic-natives-win32-arm64-msvc","@bastani/atomic-natives-win32-x64-msvc"]);
+            const expected = new Set(["@bastani/atomic-natives-darwin-arm64","@bastani/atomic-natives-darwin-x64","@bastani/atomic-natives-linux-arm64-gnu","@bastani/atomic-natives-linux-arm64-musl","@bastani/atomic-natives-linux-x64-gnu","@bastani/atomic-natives-linux-x64-musl","@bastani/atomic-natives-win32-arm64-msvc","@bastani/atomic-natives-win32-x64-msvc"]);
             const root = await Bun.file("packages/natives/package.json").json();
             const actual = Object.keys(root.optionalDependencies ?? {});
-            if (actual.length !== 6 || actual.some((name) => !expected.has(name) || root.optionalDependencies[name] !== process.env.VERSION)) throw new Error("native optionalDependencies must be the six exact-version platform packages");'
+            if (actual.length !== 8 || actual.some((name) => !expected.has(name) || root.optionalDependencies[name] !== process.env.VERSION)) throw new Error("native optionalDependencies must be the eight exact-version platform packages");'
       - name: Upload release payload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -421,7 +499,7 @@ jobs:
           existing=$(gh release view "$RELEASE_TAG" --json isDraft --jq .isDraft 2>/dev/null || true)
           [[ "$existing" != false ]] || { echo "GitHub Release $RELEASE_TAG is already published. Refusing to mutate a public release." >&2; exit 1; }
           [[ "$existing" != true ]] || gh release delete "$RELEASE_TAG" --yes
-          assets=(atomic-darwin-arm64.tar.gz atomic-darwin-x64.tar.gz atomic-linux-x64.tar.gz atomic-linux-arm64.tar.gz atomic-windows-x64.zip atomic-windows-arm64.zip SHA256SUMS)
+          assets=(atomic-darwin-arm64.tar.gz atomic-darwin-x64.tar.gz atomic-linux-x64.tar.gz atomic-linux-arm64.tar.gz atomic-linux-x64-musl.tar.gz atomic-linux-arm64-musl.tar.gz atomic-windows-x64.zip atomic-windows-arm64.zip SHA256SUMS)
           gh release create "$RELEASE_TAG" --verify-tag --draft --title "$RELEASE_TAG" --notes-file RELEASE_NOTES.md "${assets[@]}"
           expected=$(printf '%s\n' "${assets[@]}" | sort)
           actual=$(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name' | sort)
@@ -462,8 +540,8 @@ jobs:
             [[ "$version" == "$VERSION" ]] || { echo "$name has version $version, expected $VERSION" >&2; exit 1; }
             tarballs[$name]="$file"
           done
-          packages=(@bastani/atomic-natives-darwin-arm64 @bastani/atomic-natives-darwin-x64 @bastani/atomic-natives-linux-arm64-gnu @bastani/atomic-natives-linux-x64-gnu @bastani/atomic-natives-win32-arm64-msvc @bastani/atomic-natives-win32-x64-msvc @bastani/atomic-natives @bastani/atomic)
-          [[ "${#tarballs[@]}" -eq "${#packages[@]}" ]] || { echo "Expected exactly eight npm packages" >&2; exit 1; }
+          packages=(@bastani/atomic-natives-darwin-arm64 @bastani/atomic-natives-darwin-x64 @bastani/atomic-natives-linux-arm64-gnu @bastani/atomic-natives-linux-arm64-musl @bastani/atomic-natives-linux-x64-gnu @bastani/atomic-natives-linux-x64-musl @bastani/atomic-natives-win32-arm64-msvc @bastani/atomic-natives-win32-x64-msvc @bastani/atomic-natives @bastani/atomic)
+          [[ "${#tarballs[@]}" -eq "${#packages[@]}" ]] || { echo "Expected exactly ten npm packages" >&2; exit 1; }
           for name in "${packages[@]}"; do
             [[ -n "${tarballs[$name]:-}" ]] || { echo "Missing package $name" >&2; exit 1; }
             if npm view "$name@$VERSION" version --registry https://registry.npmjs.org >/dev/null 2>&1; then

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -16,9 +16,9 @@ Pull request / selected branch push
 Release tag push (`0.9.10` or `0.9.10-alpha.1`)
 └─ publish.yml
    ├─ integrity: tag package version = tag and tag commit subject = `Release <tag>`
-   ├─ native-artifacts: six-platform NAPI matrix
-   ├─ linux-binary-smoke + windows-binary-smoke
-   ├─ build: shrinkwrap/package validation, six archives, eight npm tarballs,
+   ├─ native-artifacts: eight-platform NAPI matrix
+   ├─ linux-binary-smoke + windows-binary-smoke + alpine-binary-smoke
+   ├─ build: shrinkwrap/package validation, eight archives, ten npm tarballs,
    │  release notes, and SHA256SUMS
    ├─ stage-github-release: create a verified draft and refuse to change a
    │  published release
@@ -156,16 +156,18 @@ The native job always rebuilds and uploads one artifact for each shipped `@basta
 
 | Platform | Runner | Explicit rustup target |
 | --- | --- | --- |
-| Linux x64 | `blacksmith-4vcpu-ubuntu-2404` | `x86_64-unknown-linux-gnu` |
-| Linux arm64 | `blacksmith-4vcpu-ubuntu-2404-arm` | `aarch64-unknown-linux-gnu` |
+| Linux x64 (GNU) | `blacksmith-4vcpu-ubuntu-2404` | `x86_64-unknown-linux-gnu` |
+| Linux arm64 (GNU) | `blacksmith-4vcpu-ubuntu-2404-arm` | `aarch64-unknown-linux-gnu` |
+| Linux x64 (musl) | `blacksmith-4vcpu-ubuntu-2404` | `x86_64-unknown-linux-musl` |
+| Linux arm64 (musl) | `blacksmith-4vcpu-ubuntu-2404-arm` | `aarch64-unknown-linux-musl` |
 | macOS x64 | `macos-26-intel` | `x86_64-apple-darwin` |
 | macOS arm64 | `blacksmith-6vcpu-macos-26` | `aarch64-apple-darwin` |
 | Windows x64 | `blacksmith-4vcpu-ubuntu-2404` | `x86_64-pc-windows-msvc` |
 | Windows arm64 | `blacksmith-4vcpu-ubuntu-2404` | `aarch64-pc-windows-msvc` |
 
-The old publisher built both Linux GNU bindings directly on Ubuntu 24.04, so its shipped cdylibs could acquire that runner's newer glibc symbol floor. The new pipeline fixes that portability bug: workflow-level `GLIBC_FLOOR=2.17` leaves rustup on each bare Linux target but passes `x86_64-unknown-linux-gnu.2.17` or `aarch64-unknown-linux-gnu.2.17` to `packages/natives/scripts/build-native.ts`. That script invokes cargo-zigbuild and copies the cdylib from Cargo's bare-target output directory, explicitly handling the bare-vs-glibc-suffixed target split. Windows targets use LLVM and cargo-xwin. Darwin x64 and arm64 build on real Intel and Apple Silicon macOS runners. The matrix has `fail-fast: false`, names artifacts with platform and architecture, and never downloads native artifacts from another run.
+The old publisher built both Linux GNU bindings directly on Ubuntu 24.04, so its shipped cdylibs could acquire that runner's newer glibc symbol floor. The new pipeline fixes that portability bug: workflow-level `GLIBC_FLOOR=2.17` leaves rustup on each bare Linux target but passes `x86_64-unknown-linux-gnu.2.17` or `aarch64-unknown-linux-gnu.2.17` to `packages/natives/scripts/build-native.ts`. Only GNU Linux targets receive that suffix; musl targets stay bare and use NAPI-RS's `--cross-compile` path. That script invokes cargo-zigbuild for GNU builds and copies the cdylib from Cargo's bare-target output directory, explicitly handling the bare-vs-glibc-suffixed target split. Windows targets use LLVM and cargo-xwin. Darwin x64 and arm64 build on real Intel and Apple Silicon macOS runners. The matrix has `fail-fast: false`, names artifacts with distinct platform/libc slugs, and never downloads native artifacts from another run.
 
-The build job downloads the six same-run bindings, generates the six platform npm packages, and populates the root native package's exact-version optional dependencies without publishing during preparation.
+The build job downloads the eight same-run bindings, generates the eight platform npm packages, and populates the root native package's exact-version optional dependencies without publishing during preparation.
 
 ### Dependency-fetch bounds in the native matrix
 
@@ -295,17 +297,19 @@ pins are supply-chain hygiene, not a fix for this incident.
 
 Linux and Windows x64 each run `scripts/build-binaries.sh` for their platform, extract the resulting archive, check required bundled files, run `--version`, and start `--no-session` from a clean temporary directory. Expected no-model/no-key exits are accepted; extension-load failures and unexpected exits fail the job.
 
+The `alpine-binary-smoke` job downloads the x64 musl binding, builds `atomic-linux-x64-musl.tar.gz`, and runs it in an `alpine:3.22` Docker container. The container installs `libgcc` and `libstdc++`, runs `--version` and the clean-cwd `--no-session` smoke, and rejects extension-load failures. A separate `node:22-alpine` container directly requires the extracted native package and checks its search exports. This currently exercises the x64 archive; the native matrix builds and publishes both musl architectures.
+
 ### Release payload
 
 After native and smoke jobs pass, `build`:
 
 1. Installs with `npm ci --ignore-scripts` and runs `npm run check:shrinkwrap`.
 2. Generates native platform package directories and the native root manifest.
-3. Runs `scripts/build-binaries.sh --skip-install` for all six archives.
-4. Validates package identity, versions, public/private metadata, binary entrypoint, workspace dependency ranges, build outputs, six native modules, and six exact-version native optional dependencies.
-5. Packs exactly eight npm tarballs.
+3. Runs `scripts/build-binaries.sh --skip-install` for all eight archives.
+4. Validates package identity, versions, public/private metadata, binary entrypoint, workspace dependency ranges, build outputs, eight native modules, and eight exact-version native optional dependencies.
+5. Packs exactly ten npm tarballs.
 6. Extracts release notes from `packages/coding-agent/CHANGELOG.md`.
-7. Creates `SHA256SUMS` for the six binary archives.
+7. Creates `SHA256SUMS` for the eight binary archives.
 8. Uploads the npm tarballs and GitHub Release assets as one same-run artifact.
 
 GitHub Release assets are:
@@ -314,6 +318,8 @@ GitHub Release assets are:
 - `atomic-darwin-x64.tar.gz`
 - `atomic-linux-x64.tar.gz`
 - `atomic-linux-arm64.tar.gz`
+- `atomic-linux-x64-musl.tar.gz`
+- `atomic-linux-arm64-musl.tar.gz`
 - `atomic-windows-x64.zip`
 - `atomic-windows-arm64.zip`
 - `SHA256SUMS`
@@ -326,16 +332,18 @@ After npm succeeds, `publish-github-release` changes the draft to public and set
 
 ## npm publication
 
-The npm job uses environment `npm-publish` with only `contents: read` and `id-token: write`. It upgrades to an npm version that supports trusted publishing and publishes with provenance. Configure the npm trusted publisher for workflow filename `publish.yml` and environment `npm-publish` on all eight package names:
+The npm job uses environment `npm-publish` with only `contents: read` and `id-token: write`. It upgrades to an npm version that supports trusted publishing and publishes with provenance. Configure the npm trusted publisher for workflow filename `publish.yml` and environment `npm-publish` on all ten package names:
 
 1. `@bastani/atomic-natives-darwin-arm64`
 2. `@bastani/atomic-natives-darwin-x64`
 3. `@bastani/atomic-natives-linux-arm64-gnu`
-4. `@bastani/atomic-natives-linux-x64-gnu`
-5. `@bastani/atomic-natives-win32-arm64-msvc`
-6. `@bastani/atomic-natives-win32-x64-msvc`
-7. `@bastani/atomic-natives`
-8. `@bastani/atomic`
+4. `@bastani/atomic-natives-linux-arm64-musl`
+5. `@bastani/atomic-natives-linux-x64-gnu`
+6. `@bastani/atomic-natives-linux-x64-musl`
+7. `@bastani/atomic-natives-win32-arm64-msvc`
+8. `@bastani/atomic-natives-win32-x64-msvc`
+9. `@bastani/atomic-natives`
+10. `@bastani/atomic`
 
 That order publishes native leaves first, then the native root, then the coding agent. A package version already present in the registry is logged and skipped, making recovery idempotent. Stable versions use `latest`; alpha versions use `next`. No static npm credential is configured.
 
@@ -358,4 +366,4 @@ Repository-wide workflow permissions are read-only. Only draft staging, undrafti
 3. From a clean checkout, run `bun run scripts/cut-release.ts <version> --base <base> --push`.
 4. Inspect the single `Publish <version>` push run. Do not start a duplicate manual run during normal publication.
 5. If recovery is required, manually dispatch `publish.yml` with the original `tag`; set `source_ref` to the exact recovery ref whose package version still matches that tag.
-6. Confirm all eight npm packages and the public GitHub Release exist with the expected dist-tag and assets.
+6. Confirm all ten npm packages and the public GitHub Release exist with the expected dist-tag and assets.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Fixed detached foreground subagent completion notifications rendering as an unstyled dump of the full child output. They now use the same structured, collapsed notification UI as background completions while preserving the distinct detached-task wording, and persisted notifications with custom labels remain parseable.
 - Fixed workflow-stage re-attach status falling back to `Working...` while context compaction is still active; the active compaction reason now survives host remounts so manual compaction, threshold auto-compaction, and overflow recovery retain their factual status labels.
 
+### Added
+
+- Added first-class Alpine/musl Linux support for x64 and arm64, including native search and PTY bindings and the `atomic-linux-x64-musl.tar.gz` and `atomic-linux-arm64-musl.tar.gz` release archives. The musl archives omit the clipboard native binding and glibc-linked `@embedded-postgres/*` binaries: Atomic falls back to Linux clipboard commands/OSC52, while durable Alpine workflows require external Postgres via `DBOS_SYSTEM_DATABASE_URL` or Docker; otherwise the existing loud non-durable in-memory fallback applies.
+
 ## [0.9.11-alpha.10] - 2026-08-01
 
 ### Fixed

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -79,7 +79,7 @@ atomic
 
 Then just talk to Atomic. By default, Atomic gives the model six coding tools: `read`, `write`, `edit`, `bash`, `find`, and `search`. The model uses these to fulfill your requests. `read`, `search`, `write`, and successful `edit` calls emit session-scoped hashline anchors (`[path#TAG]` plus `LINE:text`) so the model can make stale-safe line edits; see [docs/tools.md](docs/tools.md). Add capabilities via [skills](#skills), [prompt templates](#prompt-templates), [extensions](#extensions), or [Atomic packages](#atomic-packages).
 
-**Platform notes:** [Windows](docs/windows.md) | [Termux (Android)](docs/termux.md) | [tmux](docs/tmux.md) | [Terminal setup](docs/terminal-setup.md) | [Shell aliases](docs/shell-aliases.md)
+**Platform notes:** [Windows](docs/windows.md) | [Alpine/musl Linux](docs/index.md#alpine-and-musl-linux-archives) | [Termux (Android)](docs/termux.md) | [tmux](docs/tmux.md) | [Terminal setup](docs/terminal-setup.md) | [Shell aliases](docs/shell-aliases.md)
 
 ---
 

--- a/packages/coding-agent/docs/index.md
+++ b/packages/coding-agent/docs/index.md
@@ -33,6 +33,16 @@ Atomic does not require package install scripts. If you want to disable dependen
 
 Or download an `atomic-*` archive from the Atomic GitHub Release for your platform.
 
+### Alpine and musl Linux archives
+
+Alpine Linux x64 and arm64 users can download `atomic-linux-x64-musl.tar.gz` or `atomic-linux-arm64-musl.tar.gz`. These archives include native search and PTY bindings. Install the required runtime libraries before running an archive:
+
+```bash
+apk add --no-cache libgcc libstdc++
+```
+
+The musl archives deliberately omit a clipboard native binding because `@mariozechner/clipboard` 0.3.9 publishes metadata-only musl stubs without a `.node` payload; Atomic uses Linux clipboard commands and OSC52 fallback instead. They also omit `@embedded-postgres/*` binary packages because those packages are glibc-linked. Durable workflows on Alpine therefore require external Postgres via `DBOS_SYSTEM_DATABASE_URL` or Docker; without a durable backend, Atomic uses a loud non-durable in-memory fallback.
+
 Then run it in a project directory:
 
 ```bash

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -34,7 +34,7 @@ Atomic does not require package install scripts. If you want to disable dependen
 
 ### Alpine and musl Linux archives
 
-For Alpine Linux, use `atomic-linux-x64-musl.tar.gz` on x64 or `atomic-linux-arm64-musl.tar.gz` on arm64. These archives provide native search and PTY bindings. Install their runtime libraries with `apk add --no-cache libgcc libstdc++`, then see the [Alpine and musl Linux archive notes](/#alpine-and-musl-linux-archives) for the clipboard fallback and external Postgres or Docker requirement for durable workflows.
+For Alpine Linux, use `atomic-linux-x64-musl.tar.gz` on x64 or `atomic-linux-arm64-musl.tar.gz` on arm64. These archives provide native search and PTY bindings. Install their runtime libraries with `apk add --no-cache libgcc libstdc++`, then see the [Alpine and musl Linux archive notes](/index#alpine-and-musl-linux-archives) for the clipboard fallback and external Postgres or Docker requirement for durable workflows.
 
 Then start Atomic in the project directory you want it to work on:
 

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -32,6 +32,10 @@ bun add -g @bastani/atomic
 
 Atomic does not require package install scripts. If you want to disable dependency lifecycle scripts during the Atomic install, you can add `--ignore-scripts` to the install command.
 
+### Alpine and musl Linux archives
+
+For Alpine Linux, use `atomic-linux-x64-musl.tar.gz` on x64 or `atomic-linux-arm64-musl.tar.gz` on arm64. These archives provide native search and PTY bindings. Install their runtime libraries with `apk add --no-cache libgcc libstdc++`, then see the [Alpine and musl Linux archive notes](/#alpine-and-musl-linux-archives) for the clipboard fallback and external Postgres or Docker requirement for durable workflows.
+
 Then start Atomic in the project directory you want it to work on:
 
 ```bash

--- a/packages/coding-agent/docs/termux.md
+++ b/packages/coding-agent/docs/termux.md
@@ -2,6 +2,8 @@
 
 Atomic runs on Android via [Termux](https://termux.dev/), a terminal emulator and Linux environment for Android.
 
+Termux uses Android's bionic libc, not Alpine's musl libc. Atomic's Alpine musl archives target x64 and arm64 musl Linux only; they are not Termux packages and do not provide an Android target. Android ARM64 still has no Atomic native target, so musl support does not change Termux's native-addon limitations.
+
 ## Prerequisites
 
 1. Install [Termux](https://github.com/termux/termux-app#installation) from GitHub or F-Droid (not Google Play, that version is deprecated)
@@ -101,7 +103,7 @@ termux-camera-photo out.jpg   # Take photo
 ## Limitations
 
 - **No image clipboard**: Termux clipboard API only supports text
-- **No native binaries**: Some optional native dependencies (like the clipboard module) are unavailable on Android ARM64 and are skipped during installation
+- **No Atomic native target on Android ARM64**: Termux uses Android's bionic libc rather than Alpine's musl libc, so Alpine musl archives are not usable as Termux targets; optional native dependencies such as the clipboard module are unavailable and skipped during installation
 - **Storage access**: To access files in `/storage/emulated/0` (Downloads, etc.), run `termux-setup-storage` once to grant permissions
 
 ## Troubleshooting

--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -3211,7 +3211,9 @@ Validation uses the final retained transcript for a repeated stage replay key, s
 
 ### Configuring DBOS/Postgres
 
-DBOS/Postgres durability requires no setup on supported local platforms. To use an existing Postgres database, set `DBOS_SYSTEM_DATABASE_URL` before starting Atomic; otherwise Atomic provisions embedded Postgres (with drop-privilege support when running as root on Linux), with Docker as a platform fallback. The DBOS SDK ships with `@bastani/atomic`. If no durable backend can be provisioned, workflows run on a process-local in-memory backend with a loud non-durable warning — never on the legacy per-workflow file store under `~/.atomic/workflow-durable` — and cross-process resume is unavailable until Postgres provisioning is fixed.
+**Alpine/musl archives.** Musl release archives deliberately omit `@embedded-postgres/*` binary packages because the available packages are glibc-linked and cannot run on musl. Durable workflows on Alpine must use external Postgres by setting `DBOS_SYSTEM_DATABASE_URL` or use Docker. If neither is available, Atomic falls back to a process-local in-memory backend with a loud non-durable warning; state does not survive process exit and cross-process resume is unavailable.
+
+DBOS/Postgres durability requires no setup on supported local platforms. To use an existing Postgres database, set `DBOS_SYSTEM_DATABASE_URL` before starting Atomic; otherwise Atomic provisions embedded Postgres where a compatible platform package exists (with drop-privilege support when running as root on Linux), with Docker as a platform fallback. The DBOS SDK ships with `@bastani/atomic`. If no durable backend can be provisioned, workflows run on a process-local in-memory backend with a loud non-durable warning — never on the legacy per-workflow file store under `~/.atomic/workflow-durable` — and cross-process resume is unavailable until Postgres provisioning is fixed.
 
 ```bash
 export DBOS_SYSTEM_DATABASE_URL="postgresql://user:password@localhost:5432/atomic_dbos_sys"

--- a/packages/coding-agent/npm-shrinkwrap.json
+++ b/packages/coding-agent/npm-shrinkwrap.json
@@ -522,7 +522,9 @@
 				"@bastani/atomic-natives-darwin-arm64": "0.0.0",
 				"@bastani/atomic-natives-darwin-x64": "0.0.0",
 				"@bastani/atomic-natives-linux-arm64-gnu": "0.0.0",
+				"@bastani/atomic-natives-linux-arm64-musl": "0.0.0",
 				"@bastani/atomic-natives-linux-x64-gnu": "0.0.0",
+				"@bastani/atomic-natives-linux-x64-musl": "0.0.0",
 				"@bastani/atomic-natives-win32-arm64-msvc": "0.0.0",
 				"@bastani/atomic-natives-win32-x64-msvc": "0.0.0"
 			},
@@ -570,6 +572,21 @@
 			],
 			"optional": true
 		},
+		"node_modules/@bastani/atomic-natives-linux-arm64-musl": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/@bastani/atomic-natives-linux-arm64-musl/-/atomic-natives-linux-arm64-musl-0.0.0.tgz",
+			"license": "MIT",
+			"os": [
+				"linux"
+			],
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"optional": true
+		},
 		"node_modules/@bastani/atomic-natives-linux-x64-gnu": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/@bastani/atomic-natives-linux-x64-gnu/-/atomic-natives-linux-x64-gnu-0.0.0.tgz",
@@ -582,6 +599,21 @@
 			],
 			"libc": [
 				"glibc"
+			],
+			"optional": true
+		},
+		"node_modules/@bastani/atomic-natives-linux-x64-musl": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/@bastani/atomic-natives-linux-x64-musl/-/atomic-natives-linux-x64-musl-0.0.0.tgz",
+			"license": "MIT",
+			"os": [
+				"linux"
+			],
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"optional": true
 		},

--- a/packages/coding-agent/scripts/copy-clipboard-native-bindings.ts
+++ b/packages/coding-agent/scripts/copy-clipboard-native-bindings.ts
@@ -44,6 +44,20 @@ export const CLIPBOARD_NATIVE_TARGETS = {
 	},
 } satisfies Record<string, ClipboardNativeTarget>;
 
+/**
+ * Release platforms that deliberately ship without a clipboard binding.
+ *
+ * `@mariozechner/clipboard@0.3.9` declares `@mariozechner/clipboard-linux-x64-musl` and
+ * `-linux-arm64-musl` as optional dependencies, but both are published as metadata-only stubs:
+ * their tarballs contain `package.json` (and, for x64, a README) and no `.node` payload at all,
+ * while the glibc leaf ships a 627 KB binding. There is nothing to copy, so the musl archives
+ * ship the wrapper without a binding and `loadClipboardNative()` returns null — the same
+ * degradation a headless Linux box without DISPLAY already takes.
+ *
+ * Delete an entry here the moment upstream publishes a real musl binding.
+ */
+export const CLIPBOARD_PLATFORMS_WITHOUT_BINDING: readonly string[] = ["linux-x64-musl", "linux-arm64-musl"];
+
 function packagePath(nodeModulesRoot: string, packageName: string): string {
 	return join(nodeModulesRoot, ...packageName.split("/"));
 }
@@ -73,6 +87,7 @@ export function copyClipboardNativeBindings(options: CopyClipboardNativeBindings
 	}
 
 	for (const platform of options.platforms) {
+		if (CLIPBOARD_PLATFORMS_WITHOUT_BINDING.includes(platform)) continue;
 		const target = CLIPBOARD_NATIVE_TARGETS[platform as keyof typeof CLIPBOARD_NATIVE_TARGETS];
 		if (!target) throw new Error(`Unsupported clipboard target: ${platform}`);
 		const sourcePackage = packagePath(options.sourceNodeModules, target.packageName);

--- a/packages/coding-agent/scripts/copy-clipboard-native-bindings.ts
+++ b/packages/coding-agent/scripts/copy-clipboard-native-bindings.ts
@@ -54,7 +54,8 @@ export const CLIPBOARD_NATIVE_TARGETS = {
  * ship the wrapper without a binding and `loadClipboardNative()` returns null — the same
  * degradation a headless Linux box without DISPLAY already takes.
  *
- * Delete an entry here the moment upstream publishes a real musl binding.
+ * `packages/coding-agent/test/clipboard-native-packaging.test.ts` fails when an excluded package
+ * gains a `.node` payload, so the exclusion cannot silently outlive its upstream justification.
  */
 export const CLIPBOARD_PLATFORMS_WITHOUT_BINDING: readonly string[] = ["linux-x64-musl", "linux-arm64-musl"];
 

--- a/packages/coding-agent/scripts/stage-clipboard-native-bindings.ts
+++ b/packages/coding-agent/scripts/stage-clipboard-native-bindings.ts
@@ -6,11 +6,15 @@ import { CLIPBOARD_NATIVE_TARGETS } from "./copy-clipboard-native-bindings.js";
 interface StageClipboardNativePackagesOptions {
 	readonly destination: string;
 	readonly version: string;
+	readonly packageNames?: readonly string[];
 	readonly bunExecutable?: string;
 }
 
-export function clipboardNativePackageSpecs(version: string): string[] {
-	return Object.values(CLIPBOARD_NATIVE_TARGETS).map((target) => `${target.packageName}@${version}`);
+export function clipboardNativePackageSpecs(
+	version: string,
+	packageNames: readonly string[] = Object.values(CLIPBOARD_NATIVE_TARGETS).map((target) => target.packageName),
+): string[] {
+	return packageNames.map((packageName) => `${packageName}@${version}`);
 }
 
 export function stageClipboardNativePackages(options: StageClipboardNativePackagesOptions): void {
@@ -25,6 +29,7 @@ export function stageClipboardNativePackages(options: StageClipboardNativePackag
 		join(destination, "package.json"),
 		`${JSON.stringify({ name: "atomic-clipboard-native-stage", private: true }, null, 2)}\n`,
 	);
+	const packageNames = options.packageNames ?? Object.values(CLIPBOARD_NATIVE_TARGETS).map((target) => target.packageName);
 	const result = spawnSync(
 		options.bunExecutable ?? "bun",
 		[
@@ -34,7 +39,7 @@ export function stageClipboardNativePackages(options: StageClipboardNativePackag
 			"*",
 			"--cpu",
 			"*",
-			...clipboardNativePackageSpecs(options.version),
+			...clipboardNativePackageSpecs(options.version, packageNames),
 		],
 		{
 			cwd: destination,

--- a/packages/coding-agent/test/clipboard-native-packaging.test.ts
+++ b/packages/coding-agent/test/clipboard-native-packaging.test.ts
@@ -1,9 +1,13 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { CLIPBOARD_NATIVE_TARGETS, copyClipboardNativeBindings } from "../scripts/copy-clipboard-native-bindings.ts";
+import {
+	CLIPBOARD_NATIVE_TARGETS,
+	CLIPBOARD_PLATFORMS_WITHOUT_BINDING,
+	copyClipboardNativeBindings,
+} from "../scripts/copy-clipboard-native-bindings.ts";
 import { stageClipboardNativePackages } from "../scripts/stage-clipboard-native-bindings.ts";
 
 const tempDirs: string[] = [];
@@ -44,6 +48,24 @@ describe("standalone clipboard native packaging", () => {
 			const copied = join(destinationNodeModules, "@mariozechner", "clipboard", target.bindingName);
 			expect(readFileSync(copied, "utf-8")).toBe(`binding:${target.packageName}`);
 		}
+	});
+	it("skips the metadata-only musl leaves instead of sending them to the strict copier", () => {
+		const root = mkdtempSync(join(tmpdir(), "atomic-clipboard-musl-packaging-"));
+		tempDirs.push(root);
+		const sourceNodeModules = join(root, "source");
+		const destinationNodeModules = join(root, "destination");
+		writePackage(sourceNodeModules, "@mariozechner/clipboard", "0.3.9");
+		writePackage(destinationNodeModules, "@mariozechner/clipboard", "0.3.9");
+
+		expect(CLIPBOARD_PLATFORMS_WITHOUT_BINDING).toEqual(["linux-x64-musl", "linux-arm64-musl"]);
+		expect(() =>
+			copyClipboardNativeBindings({
+				sourceNodeModules,
+				destinationNodeModules,
+				platforms: CLIPBOARD_PLATFORMS_WITHOUT_BINDING,
+			}),
+		).not.toThrow();
+		expect(readdirSync(join(destinationNodeModules, "@mariozechner", "clipboard"))).toEqual(["package.json"]);
 	});
 
 	it("rejects a native package version that differs from the generic wrapper", () => {

--- a/packages/coding-agent/test/clipboard-native-packaging.test.ts
+++ b/packages/coding-agent/test/clipboard-native-packaging.test.ts
@@ -12,6 +12,57 @@ import { stageClipboardNativePackages } from "../scripts/stage-clipboard-native-
 
 const tempDirs: string[] = [];
 
+// Missing musl leaves require a real Bun package staging install; this structural network cost exceeds the suite default.
+interface ClipboardWrapperMetadata {
+	readonly version: string;
+	readonly optionalDependencies?: Readonly<Record<string, string>>;
+}
+
+interface MissingClipboardLeaf {
+	readonly platform: string;
+	readonly packageName: string;
+}
+
+const REAL_CLIPBOARD_STALENESS_GUARD_TIMEOUT_MS = 180_000;
+
+function clipboardPackageDirectory(nodeModulesRoot: string, packageName: string): string {
+	return join(nodeModulesRoot, ...packageName.split("/"));
+}
+
+function nativeBindingFiles(packageDirectory: string): string[] {
+	const nativeFiles: string[] = [];
+	for (const entry of readdirSync(packageDirectory, { withFileTypes: true })) {
+		const entryPath = join(packageDirectory, entry.name);
+		if (entry.isDirectory()) {
+			nativeFiles.push(...nativeBindingFiles(entryPath));
+		} else if (entry.isFile() && entry.name.endsWith(".node")) {
+			nativeFiles.push(entryPath);
+		}
+	}
+	return nativeFiles;
+}
+
+function muslClipboardRemediation(platform: string): string {
+	return (
+		`Upstream now ships a real musl binding for ${platform}; remove ${platform} from ` +
+		"CLIPBOARD_PLATFORMS_WITHOUT_BINDING and add it to CLIPBOARD_NATIVE_TARGETS in " +
+		"packages/coding-agent/scripts/copy-clipboard-native-bindings.ts."
+	);
+}
+
+function readClipboardWrapperMetadata(repoRoot: string): ClipboardWrapperMetadata {
+	const packageJsonPath = join(repoRoot, "node_modules", "@mariozechner", "clipboard", "package.json");
+	if (!existsSync(packageJsonPath)) {
+		throw new Error(`Clipboard wrapper metadata is missing: ${packageJsonPath}`);
+	}
+	try {
+		return JSON.parse(readFileSync(packageJsonPath, "utf-8")) as ClipboardWrapperMetadata;
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : String(error);
+		throw new Error(`Clipboard wrapper metadata could not be inspected: ${detail}`);
+	}
+}
+
 function writePackage(root: string, packageName: string, version: string, bindingName?: string): void {
 	const packageDir = join(root, ...packageName.split("/"));
 	mkdirSync(packageDir, { recursive: true });
@@ -67,6 +118,97 @@ describe("standalone clipboard native packaging", () => {
 		).not.toThrow();
 		expect(readdirSync(join(destinationNodeModules, "@mariozechner", "clipboard"))).toEqual(["package.json"]);
 	});
+	it(
+		"fails loudly if an excluded musl leaf gains a native binding",
+		() => {
+			const repoRoot = resolve(import.meta.dirname, "..", "..", "..");
+			const wrapperMetadata = readClipboardWrapperMetadata(repoRoot);
+			if (!wrapperMetadata.version.trim()) {
+				throw new Error("Clipboard wrapper metadata has no version; the staleness guard cannot be evaluated");
+			}
+			const optionalDependencies = wrapperMetadata.optionalDependencies;
+			if (!optionalDependencies) {
+				throw new Error("Clipboard wrapper has no optionalDependencies; the staleness guard cannot be evaluated");
+			}
+
+			const rootNodeModules = join(repoRoot, "node_modules");
+			const packageDirectories = new Map<string, string>();
+			const missingLeaves: MissingClipboardLeaf[] = [];
+			for (const platform of CLIPBOARD_PLATFORMS_WITHOUT_BINDING) {
+				const packageName = `@mariozechner/clipboard-${platform}`;
+				const declaredVersion = optionalDependencies[packageName];
+				if (!declaredVersion) {
+					throw new Error(
+						`Clipboard wrapper no longer declares ${packageName}; the musl staleness guard cannot be evaluated`,
+					);
+				}
+				if (declaredVersion !== wrapperMetadata.version) {
+					throw new Error(
+						`Clipboard wrapper declares ${packageName}@${declaredVersion}, not its own version ${wrapperMetadata.version}; the musl staleness guard cannot be evaluated`,
+					);
+				}
+
+				const packageDirectory = clipboardPackageDirectory(rootNodeModules, packageName);
+				if (existsSync(packageDirectory)) {
+					packageDirectories.set(platform, packageDirectory);
+				} else {
+					missingLeaves.push({ platform, packageName });
+				}
+			}
+
+			if (missingLeaves.length > 0) {
+				const stagingRoot = mkdtempSync(join(tmpdir(), "atomic-clipboard-musl-guard-"));
+				tempDirs.push(stagingRoot);
+				try {
+					stageClipboardNativePackages({
+						destination: stagingRoot,
+						version: wrapperMetadata.version,
+						packageNames: missingLeaves.map(({ packageName }) => packageName),
+					});
+				} catch (error) {
+					const detail = error instanceof Error ? error.message : String(error);
+					const platforms = missingLeaves.map(({ platform }) => platform).join(", ");
+					throw new Error(`Clipboard musl staleness guard could not inspect ${platforms}: ${detail}`);
+				}
+
+				const stagedNodeModules = join(stagingRoot, "node_modules");
+				for (const { platform, packageName } of missingLeaves) {
+					const packageDirectory = clipboardPackageDirectory(stagedNodeModules, packageName);
+					if (!existsSync(packageDirectory)) {
+						throw new Error(
+							`Clipboard musl staleness guard could not inspect ${platform}: staged package ${packageName} is missing`,
+						);
+					}
+					packageDirectories.set(platform, packageDirectory);
+				}
+			}
+
+			for (const platform of CLIPBOARD_PLATFORMS_WITHOUT_BINDING) {
+				const packageDirectory = packageDirectories.get(platform);
+				if (!packageDirectory) {
+					throw new Error(
+						`Clipboard musl staleness guard could not inspect ${platform}: package path is unavailable`,
+					);
+				}
+				if (!existsSync(join(packageDirectory, "package.json"))) {
+					throw new Error(
+						`Clipboard musl staleness guard could not inspect ${platform}: package metadata is missing`,
+					);
+				}
+				let nativeFiles: string[];
+				try {
+					nativeFiles = nativeBindingFiles(packageDirectory);
+				} catch (error) {
+					const detail = error instanceof Error ? error.message : String(error);
+					throw new Error(`Clipboard musl staleness guard could not inspect ${platform}: ${detail}`);
+				}
+				if (nativeFiles.length > 0) {
+					throw new Error(`${muslClipboardRemediation(platform)} Found: ${nativeFiles.join(", ")}`);
+				}
+			}
+		},
+		REAL_CLIPBOARD_STALENESS_GUARD_TIMEOUT_MS,
+	);
 
 	it("rejects a native package version that differs from the generic wrapper", () => {
 		const root = mkdtempSync(join(tmpdir(), "atomic-clipboard-version-"));

--- a/packages/coding-agent/test/clipboard-native-packaging.test.ts
+++ b/packages/coding-agent/test/clipboard-native-packaging.test.ts
@@ -12,7 +12,6 @@ import { stageClipboardNativePackages } from "../scripts/stage-clipboard-native-
 
 const tempDirs: string[] = [];
 
-// Missing musl leaves require a real Bun package staging install; this structural network cost exceeds the suite default.
 interface ClipboardWrapperMetadata {
 	readonly version: string;
 	readonly optionalDependencies?: Readonly<Record<string, string>>;
@@ -23,6 +22,7 @@ interface MissingClipboardLeaf {
 	readonly packageName: string;
 }
 
+// Missing musl leaves require a real Bun package staging install; this structural network cost exceeds the suite default.
 const REAL_CLIPBOARD_STALENESS_GUARD_TIMEOUT_MS = 180_000;
 
 function clipboardPackageDirectory(nodeModulesRoot: string, packageName: string): string {

--- a/packages/natives/package.json
+++ b/packages/natives/package.json
@@ -42,7 +42,9 @@
       "x86_64-unknown-linux-gnu",
       "aarch64-unknown-linux-gnu",
       "aarch64-apple-darwin",
-      "aarch64-pc-windows-msvc"
+      "aarch64-pc-windows-msvc",
+      "x86_64-unknown-linux-musl",
+      "aarch64-unknown-linux-musl"
     ]
   },
   "files": [

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -8,4 +8,6 @@ targets = [
 	"aarch64-pc-windows-msvc",
 	"x86_64-apple-darwin",
 	"aarch64-apple-darwin",
+	"x86_64-unknown-linux-musl",
+	"aarch64-unknown-linux-musl",
 ]

--- a/scripts/build-binaries.sh
+++ b/scripts/build-binaries.sh
@@ -11,7 +11,8 @@
 #   --skip-install       Reuse dependencies installed by the caller
 #   --skip-package-build Reuse packages/coding-agent/dist built by the caller
 #   --platform <name>    Build only for specified platform
-#                        (darwin-arm64, darwin-x64, linux-x64, linux-arm64, windows-x64, windows-arm64)
+#                        (darwin-arm64, darwin-x64, linux-x64, linux-arm64,
+#                         linux-x64-musl, linux-arm64-musl, windows-x64, windows-arm64)
 #
 # Output:
 #   packages/coding-agent/binaries/
@@ -19,6 +20,8 @@
 #     atomic-darwin-x64.tar.gz
 #     atomic-linux-x64.tar.gz
 #     atomic-linux-arm64.tar.gz
+#     atomic-linux-x64-musl.tar.gz
+#     atomic-linux-arm64-musl.tar.gz
 #     atomic-windows-x64.zip
 #     atomic-windows-arm64.zip
 
@@ -71,11 +74,11 @@ done
 
 if [[ -n "$PLATFORM" ]]; then
     case "$PLATFORM" in
-        darwin-arm64|darwin-x64|linux-x64|linux-arm64|windows-x64|windows-arm64)
+        darwin-arm64|darwin-x64|linux-x64|linux-arm64|linux-x64-musl|linux-arm64-musl|windows-x64|windows-arm64)
             ;;
         *)
             echo "Invalid platform: $PLATFORM"
-            echo "Valid platforms: darwin-arm64, darwin-x64, linux-x64, linux-arm64, windows-x64, windows-arm64"
+            echo "Valid platforms: darwin-arm64, darwin-x64, linux-x64, linux-arm64, linux-x64-musl, linux-arm64-musl, windows-x64, windows-arm64"
             exit 1
             ;;
     esac
@@ -97,7 +100,7 @@ if [[ "$SKIP_DEPS" == "false" ]]; then
     # because none of these are meant to run on this host.
     natives_version="$(node -p 'require("./packages/natives/package.json").version')"
     natives_targets=()
-    for natives_platform in darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu win32-x64-msvc win32-arm64-msvc; do
+    for natives_platform in darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu linux-x64-musl linux-arm64-musl win32-x64-msvc win32-arm64-msvc; do
         natives_targets+=("@bastani/atomic-natives-${natives_platform}@${natives_version}")
     done
     # A versionless release base pins every manifest at the 0.0.0 placeholder, and
@@ -158,7 +161,7 @@ mkdir -p binaries
 if [[ -n "$PLATFORM" ]]; then
     PLATFORMS=("$PLATFORM")
 else
-    PLATFORMS=(darwin-arm64 darwin-x64 linux-x64 linux-arm64 windows-x64 windows-arm64)
+    PLATFORMS=(darwin-arm64 darwin-x64 linux-x64 linux-arm64 linux-x64-musl linux-arm64-musl windows-x64 windows-arm64)
 fi
 
 shared_app_dir="binaries/.app"
@@ -206,6 +209,8 @@ atomic_native_filename() {
         darwin-x64) echo "atomic_natives.darwin-x64.node" ;;
         linux-x64) echo "atomic_natives.linux-x64-gnu.node" ;;
         linux-arm64) echo "atomic_natives.linux-arm64-gnu.node" ;;
+        linux-x64-musl) echo "atomic_natives.linux-x64-musl.node" ;;
+        linux-arm64-musl) echo "atomic_natives.linux-arm64-musl.node" ;;
         windows-x64) echo "atomic_natives.win32-x64-msvc.node" ;;
         windows-arm64) echo "atomic_natives.win32-arm64-msvc.node" ;;
         *) echo "Unknown platform: $1" >&2; return 1 ;;
@@ -244,6 +249,11 @@ for platform in "${PLATFORMS[@]}"; do
     fi
 
     cp -r "$runtime_deps_dir" "binaries/$platform/node_modules"
+    if [[ "$platform" == linux-*-musl ]]; then
+        # The embedded-postgres wrapper remains useful for its Docker/in-memory fallback,
+        # but its optional @embedded-postgres/* packages contain glibc binaries only.
+        rm -rf "binaries/$platform/node_modules/@embedded-postgres"
+    fi
     rm -rf "binaries/$platform/node_modules/@bastani/atomic-natives/npm"
     find "binaries/$platform/node_modules/@bastani/atomic-natives" -maxdepth 1 -type f -name 'atomic_natives.*.node' -delete
     atomic_native="$(atomic_native_filename "$platform")"

--- a/scripts/generate-coding-agent-shrinkwrap.mjs
+++ b/scripts/generate-coding-agent-shrinkwrap.mjs
@@ -150,6 +150,8 @@ function platformDescriptorFromNapiTarget(packageJson, target) {
 		"aarch64-apple-darwin": { suffix: "darwin-arm64", os: ["darwin"], cpu: ["arm64"] },
 		"x86_64-unknown-linux-gnu": { suffix: "linux-x64-gnu", os: ["linux"], cpu: ["x64"], libc: ["glibc"] },
 		"aarch64-unknown-linux-gnu": { suffix: "linux-arm64-gnu", os: ["linux"], cpu: ["arm64"], libc: ["glibc"] },
+		"x86_64-unknown-linux-musl": { suffix: "linux-x64-musl", os: ["linux"], cpu: ["x64"], libc: ["musl"] },
+		"aarch64-unknown-linux-musl": { suffix: "linux-arm64-musl", os: ["linux"], cpu: ["arm64"], libc: ["musl"] },
 	};
 	const mapping = mappings[target];
 	if (!mapping) {

--- a/test/ci/ci-workflow-contracts.test.ts
+++ b/test/ci/ci-workflow-contracts.test.ts
@@ -182,6 +182,7 @@ test("publish graph stages a draft before npm and undrafts last", async () => {
 		"native-artifacts",
 		"linux-binary-smoke",
 		"windows-binary-smoke",
+		"alpine-binary-smoke",
 		"build",
 		"stage-github-release",
 		"publish-npm",
@@ -192,7 +193,7 @@ test("publish graph stages a draft before npm and undrafts last", async () => {
 	}
 	assert.match(
 		jobBlock(workflow, "build", "stage-github-release"),
-		/needs: \[integrity, native-artifacts, linux-binary-smoke, windows-binary-smoke\]/,
+		/needs: \[integrity, native-artifacts, linux-binary-smoke, windows-binary-smoke, alpine-binary-smoke\]/,
 	);
 	const stage = jobBlock(workflow, "stage-github-release", "publish-npm");
 	assert.match(stage, /needs: \[integrity, build\]/);
@@ -229,7 +230,7 @@ test("publish permissions, timeouts, runners, and OIDC are least privilege", asy
 		assert.match(writeJob, /GH_REPO: \$\{\{ github\.repository \}\}/);
 		assert.doesNotMatch(writeJob, /id-token: write|npm publish/);
 	}
-	assert.equal([...workflow.matchAll(/^ {4}timeout-minutes:/gmu)].length, 9);
+	assert.equal([...workflow.matchAll(/^ {4}timeout-minutes:/gmu)].length, 10);
 	assert.match(workflow, /blacksmith-4vcpu-ubuntu-2404-arm/);
 	assert.match(workflow, /macos-26-intel/);
 	assert.match(workflow, /blacksmith-6vcpu-macos-26/);
@@ -243,13 +244,19 @@ test("native release matrix pins all shipped targets and the Linux glibc floor",
 		"x86_64-unknown-linux-gnu",
 		"aarch64-unknown-linux-gnu",
 		"x86_64-apple-darwin",
+		"x86_64-unknown-linux-musl",
+		"aarch64-unknown-linux-musl",
 		"aarch64-apple-darwin",
 		"x86_64-pc-windows-msvc",
 		"aarch64-pc-windows-msvc",
 	])
 		assert.match(native, new RegExp(target));
 	assert.match(workflow.slice(0, workflow.indexOf("jobs:")), /GLIBC_FLOOR: "2\.17"/);
-	assert.match(native, /build_target="\$\{BARE_TARGET\}\.\$\{GLIBC_FLOOR\}"/);
+	assert.match(
+		native,
+		/\[\[ "\$BARE_TARGET" != \*-unknown-linux-gnu \]\] \|\| build_target="\$\{BARE_TARGET\}\.\$\{GLIBC_FLOOR\}"/u,
+	);
+	assert.doesNotMatch(native, /linux-musl[^\n]*GLIBC_FLOOR/u);
 	assert.match(native, /toolchain: 1\.97\.0/);
 	assert.match(workflow.slice(0, workflow.indexOf("jobs:")), /RUSTUP_TOOLCHAIN: "1\.97\.0"/);
 	assert.match(native, /NATIVE_TARGET: \$\{\{ matrix\.platform == 'darwin' && matrix\.target \|\| '' \}\}/);
@@ -257,7 +264,7 @@ test("native release matrix pins all shipped targets and the Linux glibc floor",
 	assert.match(native, /cargo-zigbuild/);
 	assert.match(native, /RUSTFLAGS=-C target-cpu=x86-64-v2/);
 	assert.match(native, /fail-fast: false/);
-	assert.match(native, /name: atomic-natives-\$\{\{ matrix\.platform \}\}-\$\{\{ matrix\.arch \}\}/);
+	assert.match(native, /name: atomic-natives-\$\{\{ matrix\.slug \}\}/u);
 	assert.match(native, /macos-26-intel/);
 	assert.match(native, /blacksmith-6vcpu-macos-26/);
 	assert.doesNotMatch(native, /run-id:|github-token:|artifact_lookup/iu);
@@ -271,6 +278,17 @@ test("native release matrix pins all shipped targets and the Linux glibc floor",
 	);
 });
 
+test("Alpine smoke consumes the x64 musl artifact and installs its runtime libraries", async () => {
+	const workflow = await readText(publishPath);
+	const alpine = jobBlock(workflow, "alpine-binary-smoke", "build");
+	assert.match(alpine, /needs: \[integrity, native-artifacts\]/u);
+	assert.match(alpine, /name: atomic-natives-linux-x64-musl/u);
+	assert.match(alpine, /atomic-linux-x64-musl\.tar\.gz/u);
+	assert.match(alpine, /apk add --no-cache libgcc libstdc\+\+/u);
+	assert.match(alpine, /node:22-alpine/u);
+	assert.match(alpine, /require\("\/smoke\/atomic\/node_modules\/@bastani\/atomic-natives"\)/u);
+});
+
 test("release build retains Atomic native, smoke, shrinkwrap, metadata, and asset contracts", async () => {
 	const workflow = await readText(publishPath);
 	assert.match(workflow, /"win32-arm64-msvc"/);
@@ -279,8 +297,10 @@ test("release build retains Atomic native, smoke, shrinkwrap, metadata, and asse
 	assert.match(workflow, /Build Linux x64 archive[\s\S]*--platform linux-x64/);
 	assert.match(workflow, /Build Windows x64 archive[\s\S]*--platform windows-x64/);
 	assert.match(workflow, /Failed to load extension/);
-	assert.match(workflow, /native optionalDependencies must be the six exact-version platform packages/);
-	assert.match(workflow, /test .* = 8/);
+	assert.match(workflow, /native optionalDependencies must be the eight exact-version platform packages/u);
+	assert.match(workflow, /test .* = 10/u);
+	assert.match(workflow, /Build Linux x64 musl archive[\s\S]*--platform linux-x64-musl/u);
+	assert.match(workflow, /apk add --no-cache libgcc libstdc\+\+/u);
 	assert.doesNotMatch(
 		workflow,
 		/Release-base-ref|Release-base-sha|RELEASE_BASE_REFS|deterministic release tree|create-event binding/iu,
@@ -396,7 +416,7 @@ test("sticky-disk checkout stays on Blacksmith Linux runners", async () => {
 	}
 	const publish = await readText(publishPath);
 	const testWorkflow = await readText(testPath);
-	assert.doesNotMatch(jobBlock(publish, "windows-binary-smoke", "build"), /useblacksmith/u);
+	assert.doesNotMatch(jobBlock(publish, "windows-binary-smoke", "alpine-binary-smoke"), /useblacksmith/u);
 	// Every cross-platform job in test.yml now checks out for itself, so each one
 	// must keep the Linux/non-Linux checkout pair.
 	const crossPlatformJobs = ["suites", "agent-suite", "release-archive"] as const;
@@ -449,6 +469,8 @@ test("each native leg declares its own measured job and compile budget", async (
 		...native.matchAll(/platform: (\w+), arch: (\w+),[^}]*timeout_minutes: (\d+), build_timeout_minutes: (\d+)/gu),
 	].map(([, platform, arch, job, build]) => `${platform} ${arch} ${job}/${build}`);
 	assert.deepEqual(legs, [
+		"linux x64 7/5",
+		"linux arm64 8/5",
 		"linux x64 7/5",
 		"linux arm64 8/5",
 		"darwin x64 9/8",

--- a/test/ci/release-publisher-contracts.test.ts
+++ b/test/ci/release-publisher-contracts.test.ts
@@ -19,7 +19,9 @@ const nativePackageNames = [
 	"@bastani/atomic-natives-darwin-arm64",
 	"@bastani/atomic-natives-darwin-x64",
 	"@bastani/atomic-natives-linux-arm64-gnu",
+	"@bastani/atomic-natives-linux-arm64-musl",
 	"@bastani/atomic-natives-linux-x64-gnu",
+	"@bastani/atomic-natives-linux-x64-musl",
 	"@bastani/atomic-natives-win32-arm64-msvc",
 	"@bastani/atomic-natives-win32-x64-msvc",
 ] as const;
@@ -28,12 +30,14 @@ const nativeBinaryNames = [
 	"atomic_natives.darwin-arm64.node",
 	"atomic_natives.darwin-x64.node",
 	"atomic_natives.linux-arm64-gnu.node",
+	"atomic_natives.linux-arm64-musl.node",
 	"atomic_natives.linux-x64-gnu.node",
+	"atomic_natives.linux-x64-musl.node",
 	"atomic_natives.win32-arm64-msvc.node",
 	"atomic_natives.win32-x64-msvc.node",
 ] as const;
 
-test("prepared native root tarball contains all six exact-version optional dependencies", async () => {
+test("prepared native root tarball contains all eight exact-version optional dependencies", async () => {
 	const stage = mkdtempSync(join(tmpdir(), "atomic-native-release-contract-"));
 	const nativeDir = join(stage, "native");
 	const outputDir = join(stage, "packed");
@@ -102,7 +106,8 @@ test("publish pipeline prepares exact native package set and publishes in depend
 	const workflow = await readText(`${root}/.github/workflows/publish.yml`);
 	const expectedOrder = [...nativePackageNames, "@bastani/atomic-natives", "@bastani/atomic"].join(" ");
 	assert.match(workflow, /prepublish:native -- --skip-optional-publish/u);
-	assert.match(workflow, /Expected exactly eight npm packages/u);
+	assert.match(workflow, /Expected exactly ten npm packages/u);
+	assert.match(workflow, /atomic-linux-x64-musl\.tar\.gz.*atomic-linux-arm64-musl\.tar\.gz/u);
 	assert.ok(
 		workflow.includes(`packages=(${expectedOrder})`),
 		"npm packages must publish native leaves, native root, then coding agent",

--- a/test/ci/release-recovery-contracts.test.ts
+++ b/test/ci/release-recovery-contracts.test.ts
@@ -25,7 +25,8 @@ test("integrity always verifies the tag while recovery builds the selected sourc
 	for (const [name, next] of [
 		["native-artifacts", "linux-binary-smoke"],
 		["linux-binary-smoke", "windows-binary-smoke"],
-		["windows-binary-smoke", "build"],
+		["windows-binary-smoke", "alpine-binary-smoke"],
+		["alpine-binary-smoke", "build"],
 		["build", "stage-github-release"],
 	] as const) {
 		const job = jobBlock(workflow, name, next);

--- a/test/unit/build-binaries-platform-packaging.test.ts
+++ b/test/unit/build-binaries-platform-packaging.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "vitest";
+
+const root = fileURLToPath(new URL("../..", import.meta.url));
+const buildScriptPath = join(root, "scripts/build-binaries.sh");
+
+test("musl archive staging removes embedded-postgres binary leaves", () => {
+	const buildScript = readFileSync(buildScriptPath, "utf8");
+	const stagingBlock = buildScript.slice(
+		buildScript.indexOf('cp -r "$runtime_deps_dir" "binaries/$platform/node_modules"'),
+		buildScript.indexOf('atomic_native="$(atomic_native_filename "$platform")'),
+	);
+
+	assert.match(stagingBlock, /if \[\[ "\$platform" == linux-\*-musl \]\]; then/u);
+	assert.match(stagingBlock, /rm -rf "binaries\/\$platform\/node_modules\/@embedded-postgres"/u);
+	assert.doesNotMatch(stagingBlock, /rm -rf "binaries\/\$platform\/node_modules\/embedded-postgres"/u);
+
+	const syntax = spawnSync("bash", ["-n", buildScriptPath], { encoding: "utf8" });
+	assert.equal(syntax.status, 0, syntax.stderr);
+});

--- a/test/unit/build-native-portability.test.ts
+++ b/test/unit/build-native-portability.test.ts
@@ -55,6 +55,37 @@ unixTest("glibc-suffixed Linux targets use cargo-zigbuild and copy from the bare
 	}
 });
 
+unixTest("musl targets use NAPI-RS cross compilation without a glibc floor suffix", () => {
+	const stage = mkdtempSync(join(tmpdir(), "atomic-musl-cross-contract-"));
+	const bin = join(stage, "bin");
+	const args = join(stage, "bunx-args.txt");
+
+	try {
+		mkdirSync(bin);
+		const bunx = join(bin, "bunx");
+		writeFileSync(bunx, `#!/usr/bin/env bash\nprintf '%s\\n' "$*" > "$BUNX_ARGS_FILE"\n`);
+		chmodSync(bunx, 0o755);
+		const result = spawnSyncCollect([bunExecutable(), script], {
+			cwd: root,
+			env: {
+				...process.env,
+				PATH: `${bin}${delimiter}${process.env.PATH ?? ""}`,
+				CROSS_TARGET: "x86_64-unknown-linux-musl",
+				BUNX_ARGS_FILE: args,
+			},
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+
+		assert.equal(result.exitCode, 0, result.stderr.toString());
+		const invoked = readFileSync(args, "utf8");
+		assert.match(invoked, /napi build .*--target x86_64-unknown-linux-musl --cross-compile/u);
+		assert.doesNotMatch(invoked, /x86_64-unknown-linux-musl\.2\.17/u);
+	} finally {
+		rmSync(stage, { recursive: true, force: true });
+	}
+});
+
 unixTest("explicit Darwin targets stay native and do not request cross compilation", () => {
 	const stage = mkdtempSync(join(tmpdir(), "atomic-darwin-native-contract-"));
 	const bin = join(stage, "bin");

--- a/test/unit/bump-version-script.test.ts
+++ b/test/unit/bump-version-script.test.ts
@@ -10,6 +10,7 @@ interface VersionedPackageJson {
 	version: string;
 	private?: boolean;
 	dependencies?: Record<string, string>;
+	optionalDependencies?: Record<string, string>;
 }
 
 interface NpmLockEntry {
@@ -73,6 +74,7 @@ function createFixtureRoot(): string {
 		name: "@fixture/alpha",
 		version: "0.1.0",
 		private: true,
+		optionalDependencies: { "@bastani/atomic-natives-linux-x64-musl": "0.1.0" },
 	});
 	writeJson(join(root, "packages", "beta", "package.json"), {
 		name: "@fixture/beta",
@@ -126,7 +128,10 @@ if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHE
 				name: "@fixture/alpha",
 				version: "0.1.0",
 				dependencies: { "@bastani/atomic-natives": "0.1.0", "third-party": "9.9.9" },
-				optionalDependencies: { "@bastani/atomic-natives-linux-x64-gnu": "0.1.0" },
+				optionalDependencies: {
+					"@bastani/atomic-natives-linux-x64-gnu": "0.1.0",
+					"@bastani/atomic-natives-linux-x64-musl": "0.1.0",
+				},
 			},
 			"packages/beta": { name: "@fixture/beta", version: "0.1.0" },
 			"packages/natives": { name: "@bastani/atomic-natives", version: "0.1.0" },
@@ -168,7 +173,12 @@ describe("scripts/bump-version.ts", () => {
 			const rootPackageJson = readJson(join(root, "package.json"));
 			assert.equal(rootPackageJson.version, "1.2.3-alpha.1");
 			assert.equal(rootPackageJson.dependencies?.["@bastani/atomic-natives"], "1.2.3-alpha.1");
-			assert.equal(readJson(join(root, "packages", "alpha", "package.json")).version, "1.2.3-alpha.1");
+			const alphaPackageJson = readJson(join(root, "packages", "alpha", "package.json"));
+			assert.equal(alphaPackageJson.version, "1.2.3-alpha.1");
+			assert.equal(
+				alphaPackageJson.optionalDependencies?.["@bastani/atomic-natives-linux-x64-musl"],
+				"1.2.3-alpha.1",
+			);
 			assert.equal(readJson(join(root, "packages", "beta", "package.json")).version, "1.2.3-alpha.1");
 			assert.match(readFileSync(join(root, "Cargo.toml"), "utf8"), /version = "1\.2\.3-alpha\.1"/);
 			assert.match(
@@ -196,6 +206,10 @@ describe("scripts/bump-version.ts", () => {
 			assert.equal(lock.packages["packages/natives"]?.version, "1.2.3-alpha.1");
 			// First-party ranges inside a workspace entry move with it, in every
 			// section, including the platform-suffixed native packages.
+			assert.equal(
+				lock.packages["packages/alpha"]?.optionalDependencies?.["@bastani/atomic-natives-linux-x64-musl"],
+				"1.2.3-alpha.1",
+			);
 			assert.equal(lock.packages["packages/alpha"]?.dependencies?.["@bastani/atomic-natives"], "1.2.3-alpha.1");
 			assert.equal(
 				lock.packages["packages/alpha"]?.optionalDependencies?.["@bastani/atomic-natives-linux-x64-gnu"],

--- a/test/unit/package-metadata.test.ts
+++ b/test/unit/package-metadata.test.ts
@@ -242,6 +242,8 @@ describe("package metadata", () => {
 			"aarch64-unknown-linux-gnu",
 			"aarch64-apple-darwin",
 			"aarch64-pc-windows-msvc",
+			"x86_64-unknown-linux-musl",
+			"aarch64-unknown-linux-musl",
 		]);
 		assert.ok(nativesPackageJson.files.includes("native/index.js"));
 		assert.ok(nativesPackageJson.files.includes("native/index.d.ts"));

--- a/test/unit/shrinkwrap-atomic-natives.test.ts
+++ b/test/unit/shrinkwrap-atomic-natives.test.ts
@@ -24,7 +24,9 @@ const expectedNativeOptionalPackages = [
 	"@bastani/atomic-natives-darwin-arm64",
 	"@bastani/atomic-natives-darwin-x64",
 	"@bastani/atomic-natives-linux-arm64-gnu",
+	"@bastani/atomic-natives-linux-arm64-musl",
 	"@bastani/atomic-natives-linux-x64-gnu",
+	"@bastani/atomic-natives-linux-x64-musl",
 	"@bastani/atomic-natives-win32-arm64-msvc",
 	"@bastani/atomic-natives-win32-x64-msvc",
 ];
@@ -59,7 +61,11 @@ function assertDeterministicNativeEntries(shrinkwrap: Shrinkwrap, expectedVersio
 		assert.ok(entry.os?.length, `${packageName} should declare supported OS`);
 		assert.ok(entry.cpu?.length, `${packageName} should declare supported CPU`);
 		if (packageName.includes("linux")) {
-			assert.deepEqual(entry.libc, ["glibc"], `${packageName} should constrain the GNU build to glibc`);
+			assert.deepEqual(
+				entry.libc,
+				[packageName.includes("-musl") ? "musl" : "glibc"],
+				`${packageName} should constrain its libc ABI`,
+			);
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Adds first-class musl (Alpine / musl-libc Linux) support to Atomic, end to end: native N-API addon targets, npm platform leaves, release archives, and an Alpine runtime proof in CI.

- **Native targets**: `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` added to `packages/natives/package.json` (`napi.targets`) and `rust-toolchain.toml`. `@napi-rs/cli` supplies `-C target-feature=-crt-static` for a musl ABI, so the produced `.node` is a dlopen-able shared object; no manual RUSTFLAGS are needed.
- **npm leaves**: `@bastani/atomic-natives-linux-x64-musl` and `-linux-arm64-musl`, with `libc: ["musl"]` descriptors generated by `scripts/generate-coding-agent-shrinkwrap.mjs` and reflected in the regenerated `packages/coding-agent/npm-shrinkwrap.json`.
- **Release archives**: `atomic-linux-x64-musl.tar.gz` and `atomic-linux-arm64-musl.tar.gz`, built by `scripts/build-binaries.sh` (Bun targets `bun-linux-x64-musl` / `bun-linux-arm64-musl`) and uploaded by `publish.yml`.
- **`GLIBC_FLOOR` suffixing narrowed** to `*-unknown-linux-gnu`. A musl triple must stay bare so it falls through to napi's cross-compile path rather than cargo-zigbuild's glibc pinning.
- **Matrix `slug` field**: each native leg now carries the napi platform id, so the glibc and musl legs that share `platform`+`arch` can no longer collide on an uploaded artifact name.

## Deliberate exclusions (documented, not shipped broken)

Two components genuinely cannot support musl today. Both are excluded on purpose and the limitation is documented rather than papered over.

- **Clipboard binding.** `@mariozechner/clipboard@0.3.9` publishes `-linux-x64-musl` and `-linux-arm64-musl` as metadata-only stubs with no `.node` payload (the glibc leaf ships a 627 KB binding). The musl archives ship the wrapper without a binding; `loadClipboardNative()` returns null and Atomic falls back to Linux clipboard commands and OSC52 — the same degradation a headless Linux box already takes. A staleness guard test fails loudly if an excluded leaf ever gains a real `.node`, and fails rather than passing when it cannot inspect the packages at all.
- **`embedded-postgres`.** It has no musl packages and its x64/arm64 binaries are glibc-linked. `scripts/build-binaries.sh` now deletes `@embedded-postgres/*` from musl archive staging; the wrapper stays for its Docker/in-memory fallback. Durable workflows on Alpine need external Postgres via `DBOS_SYSTEM_DATABASE_URL` or Docker; otherwise the existing loud non-durable in-memory fallback applies.

No other musl loader branches (`arm-musleabihf`, `loong64`, `riscv64`) were added — there is no evidence supporting them. Termux is unchanged: it uses Android's bionic libc, and `docs/termux.md` now says so explicitly so musl archives are not mistaken for an Android target.

## Alpine runtime verification in CI

A new `alpine-binary-smoke` job (Docker, `timeout-minutes: 12`) gates `build`:

1. Runs the built `atomic-linux-x64-musl.tar.gz` under `alpine:3.22` with `apk add --no-cache libgcc libstdc++`.
2. Separately `require()`s the musl `.node` under `node:22-alpine` and asserts real exports. Atomic catches a failed binding load and degrades to JS search paths, so a clean start is not proof the addon loaded — that is asserted directly.

## Pinned lists and the tests that pin them

Every hardcoded platform list that must agree was updated together with its contract test:

| Updated list | Pinning test |
| --- | --- |
| `publish.yml` native-file existence check, expected npm leaf set (6 → 8), `gh release create` asset list, npm `packages=(…)` (8 → 10) | `test/ci/release-publisher-contracts.test.ts`, `test/ci/ci-workflow-contracts.test.ts`, `test/ci/release-recovery-contracts.test.ts` |
| `packages/natives/package.json` `napi.targets`, `rust-toolchain.toml` | `test/unit/build-native-portability.test.ts`, `test/unit/package-metadata.test.ts` |
| `scripts/generate-coding-agent-shrinkwrap.mjs` descriptors, `npm-shrinkwrap.json` | `test/unit/shrinkwrap-atomic-natives.test.ts` |
| `scripts/bump-version.ts` (needed no change — it walks `optionalDependencies` generically) | `test/unit/bump-version-script.test.ts`, extended to cover a musl leaf |
| `scripts/build-binaries.sh` platform list, native filename map, musl `@embedded-postgres` removal | new `test/unit/build-binaries-platform-packaging.test.ts` |
| clipboard exclusion list | `packages/coding-agent/test/clipboard-native-packaging.test.ts` |

## Docs and changelog

`packages/coding-agent/docs/index.md` gains an "Alpine and musl Linux archives" section stating the `apk` prerequisite and both limitations; `README.md`, `docs/quickstart.md`, and `docs/workflows.md` link to it; `docs/termux.md` is corrected; `docs/ci.md` documents the new job. A `### Added` entry was appended under `## [Unreleased]` in `packages/coding-agent/CHANGELOG.md`. No released section was modified and no version was bumped — the release base stays versionless at `0.0.0`.

## Verification

Cross-build proof (cargo-zigbuild 0.22.3, rustc 1.97.0, zig 0.16.0, both arches, isolated target dirs):

```
ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, stripped
0x0000000000000001 (NEEDED)  Shared library: [libc.so]
```

Negative control without the CRT flag: `warning: dropping unsupported crate type cdylib`, no `.so` produced — which is why napi supplying that flag is load-bearing.

Suites, all at the branch head:

- `npm run check` — Biome (2346 files), `tsc --noEmit`, shrinkwrap check. Pass.
- `npm run test:unit` — 610 files, 5684 passed, 1 skipped.
- `npm run test:ci-contracts` — 5 files, 38 tests. Pass (re-run at branch head: 38/38).
- `npm run test --workspace=@bastani/atomic` — 376 files, 3020 passed, 4 skipped.
- Musl tarball inspection — `embedded-postgres` wrapper present, no `@embedded-postgres/*` leaves, exactly one `atomic_natives.linux-x64-musl.node`.

## Known limits of this change

- **Alpine runtime execution is CI-only.** Docker is unavailable on the authoring machine, so `alpine-binary-smoke` is proven by construction and by the contract tests; its first real execution is the next tagged publish.
- **The clipboard staleness guard reaches the network** when the musl leaves are absent, which is every non-Linux host. That is the direct consequence of requiring it to fail loudly rather than pass vacuously when it cannot determine the answer. Deliberate trade, flagged here.
- Non-blocking review notes (all P3, left as-is): `test/unit/build-binaries-platform-packaging.test.ts` spawns `bash -n` without a Windows guard (verified safe — `.gitattributes` pins `*.sh` to LF and Git Bash is on PATH on the Windows runner; the cost is only a less legible message on a hypothetical ENOENT), and the native-leg budget assertion in `ci-workflow-contracts.test.ts` fingerprints legs by `platform`+`arch`, so a musl leg now renders identically to its glibc twin. Other assertions in the same file pin `slug` and all eight rustup triples, so nothing is unguarded.
- `.cargo/config.toml` target-scoped musl rustflags were deliberately not added; no shipped path reaches a musl triple through direct Cargo.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788252609&installation_model_id=10562&pr_number=2137&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2137&signature=a71ac099f51b1ff0bdeeb35a551197eda3f340d00c40abc00dac2a2e3931d03c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds first-class x64 and arm64 musl Linux support for native bindings, npm packages, standalone archives, release publication, and user documentation.

The musl build path was exercised for both architectures: each invoked N-API-RS cross-compilation with the bare musl target, and the generated loader selected its matching musl native package. Focused native-package, archive-staging, and release-workflow contract tests also passed. These checks disprove missing musl target routing, incorrect libc-specific loader selection, and incorrect release-package or asset enumeration.

### T-Rex validation blocked
A real Alpine archive and addon smoke could not run because the `docker` tool is missing. The uploaded evidence also lacks the required artifact labels, so the container-runtime evidence cannot be presented as a fully labeled proof.

<h3>Confidence Score: 5/5</h3>

Safe to merge; no blocking failure remains.

The musl target routing, libc-specific native loader behavior, package metadata, archive staging, and release workflow contracts were exercised successfully. Alpine container execution could not be performed because Docker is unavailable, but no defect was reproduced.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I verified the pre-change state: the parent musl-support commit had no musl N-API target.
- I executed the temporary validation script to drive the musl build-native.ts for x86\_64-unknown-linux-musl and aarch64-unknown-linux-musl with a stubbed bunx, and observed real invocations and successful wrapper loading after the change.
- I validated the N-API-RS loader under simulated musl Linux x64 and arm64 conditions and confirmed the correct @bastani/atomic-natives-linux-\*-musl packages were selected.
- I ran the focused unit and CI release-contract suites; 3 unit files with 6 tests and 2 CI files with 24 tests passed.
- I attempted the Alpine container smoke test but Docker is unavailable in this environment.

<a href="https://app.greptile.com/trex/runs/16948732/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["docs(quickstart): point musl notes at th..."](https://github.com/bastani-inc/atomic/commit/d9490dbe105fc8eab7154a85aa49208c328d16bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49446295)</sub>

<!-- /greptile_comment -->