### PR TITLE
fix(interactive): drop the tool-output expansion status line

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Removed the four-workflow display cap from the BACKGROUND widget so every qualifying top-level run is rendered.
 - Moved durable workflow run artifacts—including goal ledgers, Ralph implementation notes, QA evidence video paths, and worktree task outputs—from per-invocation OS temp directories to the run-scoped durable root under the Atomic config directory (`~/.atomic/workflows/runs/<runId>/`, overridable with `ATOMIC_WORKFLOW_ARTIFACT_DIR`), so they survive OS temp purges and follow state-aware retention.
+- Toggling tool-output expansion (`ctrl+o`) no longer prints a `Tool output: expanded` / `Tool output: collapsed` status line. The chat re-renders in the new state, which is the same information without the extra line.
 
 ### Fixed
 

--- a/packages/coding-agent/src/modes/interactive/interactive-editor-actions.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-editor-actions.ts
@@ -77,7 +77,8 @@ InteractiveModeBase.prototype.setToolsExpanded = function (this: InteractiveMode
 			child.setExpanded(expanded);
 		}
 	}
-	this.showStatus(`Tool output: ${expanded ? "expanded" : "collapsed"}`);
+	// The rendered chat is the feedback; a status line restating it only adds noise.
+	this.ui.requestRender();
 };
 
 InteractiveModeBase.prototype.toggleThinkingBlockVisibility = function (this: InteractiveModeBase): void {

--- a/packages/coding-agent/test/interactive-mode-status-basic.suite.ts
+++ b/packages/coding-agent/test/interactive-mode-status-basic.suite.ts
@@ -60,7 +60,7 @@ describe("InteractiveMode.showStatus", () => {
 });
 
 describe("InteractiveMode.setToolsExpanded", () => {
-	test("applies expansion state to the active header and chat entries", () => {
+	test("applies expansion state to the active header and chat entries without a status line", () => {
 		const header = { setExpanded: vi.fn() };
 		const chatChild = { setExpanded: vi.fn() };
 		const fakeThis: any = {
@@ -77,7 +77,8 @@ describe("InteractiveMode.setToolsExpanded", () => {
 		expect(fakeThis.toolOutputExpanded).toBe(true);
 		expect(header.setExpanded).toHaveBeenCalledWith(true);
 		expect(chatChild.setExpanded).toHaveBeenCalledWith(true);
-		expect(fakeThis.showStatus).toHaveBeenCalledWith("Tool output: expanded");
+		expect(fakeThis.showStatus).not.toHaveBeenCalled();
+		expect(fakeThis.ui.requestRender).toHaveBeenCalled();
 	});
 });
 

--- a/packages/coding-agent/test/pi-0.83.0-direct-fixes.test.ts
+++ b/packages/coding-agent/test/pi-0.83.0-direct-fixes.test.ts
@@ -79,8 +79,9 @@ describe("Pi 0.83.0 direct coding-agent parity", () => {
 		expect(context.selectedIndex).toBe(2);
 	});
 
-	it("0d008b74: reports the new tool-output expansion state on the status line", () => {
+	it("0d008b74: applies tool-output expansion without emitting a status line", () => {
 		const statuses: string[] = [];
+		let renders = 0;
 		const setToolsExpanded = Reflect.get(InteractiveModeBase.prototype, "setToolsExpanded") as (
 			this: object,
 			expanded: boolean,
@@ -90,13 +91,23 @@ describe("Pi 0.83.0 direct coding-agent parity", () => {
 			customHeader: undefined,
 			builtInHeader: undefined,
 			chatContainer: { children: [] as unknown[] },
+			ui: {
+				requestRender: () => {
+					renders += 1;
+				},
+			},
 			showStatus: (message: string) => statuses.push(message),
 		};
 
 		setToolsExpanded.call(context, true);
+		expect(context.toolOutputExpanded).toBe(true);
 		setToolsExpanded.call(context, false);
+		expect(context.toolOutputExpanded).toBe(false);
 
-		expect(statuses).toEqual(["Tool output: expanded", "Tool output: collapsed"]);
+		// Atomic drops upstream's `Tool output: expanded/collapsed` status: the toggle is
+		// already visible in the chat, so the line was pure noise. The re-render is not.
+		expect(statuses).toEqual([]);
+		expect(renders).toBe(2);
 	});
 
 	it("c2275d67: does not subscribe from a startup rebind the session switch superseded", async () => {


### PR DESCRIPTION
## What

`ctrl+o` printed `Tool output: expanded` / `Tool output: collapsed` to the status line on every toggle. The chat re-renders in the new state on the same keystroke, so the line restated what the user could already see, and it consumed two rows of scrollback (spacer + text) each time.

Both strings are gone. The toggle now only re-renders.

## The one thing that is not a pure deletion

`showStatus()` was also the only caller of `ui.requestRender()` on this path — no caller of `setToolsExpanded` renders afterwards. Deleting the line outright would have left `ctrl+o` without a repaint, so the render request stays and only the message goes:

```ts
-	this.showStatus(`Tool output: ${expanded ? "expanded" : "collapsed"}`);
+	// The rendered chat is the feedback; a status line restating it only adds noise.
+	this.ui.requestRender();
```

## Tests

Two tests asserted the message. Both now assert its absence:

- `test/interactive-mode-status-basic.suite.ts` — `showStatus` is not called; `requestRender` is.
- `test/pi-0.83.0-direct-fixes.test.ts` — this is an upstream-parity test for pi `0d008b74`, which introduced the status line. It now records the deliberate divergence, and additionally pins the repaint count so a later edit cannot silently drop it.

`npm run check` and `npm run test:unit` pass (pre-commit hooks ran both).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788289314&installation_model_id=10562&pr_number=2142&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2142&signature=525083453fb2a3aea815ddcc56cf4c4849ec5bfd202e7866a7c136a01a6a0534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change removes the redundant tool-output expansion status line while preserving the immediate repaint that makes the changed expansion state visible. The expansion toggle was exercised through both transitions: the header and tool output changed between collapsed and expanded, each toggle requested one repaint, and no status text was emitted. The focused interactive regression suite passed all 28 tests.

<h3>Confidence Score: 5/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted the requested verification and noted that local artifact references were not uploaded.
- T-Rex ran the tool-output-expansion-review script and the focused regression test suite, both finishing with exit code 0 and reporting successful results.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(interactive): drop the tool-output e..."](https://github.com/bastani-inc/atomic/commit/724d4dc8442218258eb6b56ef9ef114365d51fe9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49499865)</sub>

<!-- /greptile_comment -->