### PR TITLE
test(workflows): separate viewport-scoped from graph-scoped read budgets

### DIFF
--- a/test/unit/overlay-graph-perf.test.ts
+++ b/test/unit/overlay-graph-perf.test.ts
@@ -203,12 +203,23 @@ function renderPairGraph(count: number): { composed: number; edges: number; card
 	}
 }
 
-function viewportReadBudgets(view: InstrumentedGraphView): {
-	bands: number;
-	displayStages: number;
-	edges: number;
-	layout: number;
-	paintedCards: number;
+/**
+ * Per-frame read budgets, in two kinds — the distinction matters.
+ *
+ * `viewportScoped` entries are this change's actual claim: they stay flat as the
+ * graph grows, because the band walk and card placement stop at the viewport.
+ * A 400-stage chain and a 100,000-stage chain both paint the same few cards.
+ *
+ * `graphScoped` entries deliberately scale with the graph and are NOT viewport
+ * bounds. The render examines every edge for a cheap four-comparison bounds test
+ * before plotting only the visible ones, and the header counts every stage once.
+ * These budgets pin the *shape* of that work — no duplicate walk, no per-card
+ * clone or slice — not its magnitude. A green run here is not evidence that a
+ * frame is viewport-bounded; only the `viewportScoped` entries say that.
+ */
+function perFrameReadBudgets(view: InstrumentedGraphView): {
+	viewportScoped: { bands: number; layout: number; paintedCards: number };
+	graphScoped: { displayStages: number; edges: number };
 } {
 	const geometry = view.renderGeometryForTest();
 	assert.ok(geometry.bands.length > 1, "fixture must contain more than one layout band");
@@ -237,16 +248,20 @@ function viewportReadBudgets(view: InstrumentedGraphView): {
 	}
 
 	return {
-		// Rendering and hit-target recording each perform the same binary search and band walk.
-		bands: 2 * (binarySearchReads + walkedBandReads),
-		// One empty-layout length check, two reads per painted card, and two focused-stage hint reads.
-		layout: 2 * paintedCards + 3,
-		// Display selection checks length once, then the header counts every stage once.
-		// Cards share the same collection and must not clone or scan it.
-		displayStages: 2 * view.layoutForTest().length + 2,
-		// Edge bounds are cheap to test, so one full O(E) edge walk is intentional even though few edges are plotted.
-		edges: 2 * geometry.edges.length + 1,
-		paintedCards,
+		viewportScoped: {
+			// Rendering and hit-target recording each perform the same binary search and band walk.
+			bands: 2 * (binarySearchReads + walkedBandReads),
+			// One empty-layout length check, two reads per painted card, and two focused-stage hint reads.
+			layout: 2 * paintedCards + 3,
+			paintedCards,
+		},
+		graphScoped: {
+			// Display selection checks length once, then the header counts every stage once.
+			// Cards share the same collection and must not clone or scan it.
+			displayStages: 2 * view.layoutForTest().length + 2,
+			// One full O(E) walk is intentional: each edge gets a cheap bounds test before plotting.
+			edges: 2 * geometry.edges.length + 1,
+		},
 	};
 }
 
@@ -272,7 +287,9 @@ describe("GraphView many-stage performance (#2100)", () => {
 				view.composeCalls <= view.bodyRowsForTest(),
 				`composed ${view.composeCalls} rows for a ${view.bodyRowsForTest()}-row body`,
 			);
-			const { paintedCards } = viewportReadBudgets(view);
+			const {
+				viewportScoped: { paintedCards },
+			} = perFrameReadBudgets(view);
 			assert.equal(
 				view.paintedCards,
 				paintedCards,
@@ -294,13 +311,17 @@ describe("GraphView many-stage performance (#2100)", () => {
 			initialFocusedStageId: "s0",
 		});
 		try {
-			const budget = viewportReadBudgets(view);
+			const { viewportScoped } = perFrameReadBudgets(view);
 			view.countRenderReadsForTest();
 			const text = visibleText(view.render(96));
 			const reads = view.renderReadCountsForTest();
 			assert.match(text, /s0\b/);
-			assert.ok(reads.bands.numeric <= budget.bands, `visited ${reads.bands.numeric} layout bands`);
-			assert.equal(view.paintedCards, budget.paintedCards, `painted ${view.paintedCards} cards below the viewport`);
+			assert.ok(reads.bands.numeric <= viewportScoped.bands, `visited ${reads.bands.numeric} layout bands`);
+			assert.equal(
+				view.paintedCards,
+				viewportScoped.paintedCards,
+				`painted ${view.paintedCards} cards below the viewport`,
+			);
 		} finally {
 			view.dispose();
 		}
@@ -499,20 +520,25 @@ describe("GraphView many-stage performance (#2100)", () => {
 		});
 		try {
 			view.render(96);
-			const budget = viewportReadBudgets(view);
+			const { viewportScoped, graphScoped } = perFrameReadBudgets(view);
 			view.countRenderReadsForTest();
 			view.render(96);
 			const reads = view.renderReadCountsForTest();
+			// Viewport-scoped: flat as the graph grows.
 			assert.ok(
-				totalArrayReads(reads.layout) <= budget.layout,
+				totalArrayReads(reads.layout) <= viewportScoped.layout,
 				`read layout ${totalArrayReads(reads.layout)} times`,
 			);
-			assert.ok(reads.bands.numeric <= budget.bands, `visited ${reads.bands.numeric} layout bands`);
+			assert.ok(reads.bands.numeric <= viewportScoped.bands, `visited ${reads.bands.numeric} layout bands`);
+			// Graph-scoped: one pass each, so a duplicate walk or a per-card clone fails.
 			assert.ok(
-				totalArrayReads(reads.displayStages) <= budget.displayStages,
+				totalArrayReads(reads.displayStages) <= graphScoped.displayStages,
 				`read display stages ${totalArrayReads(reads.displayStages)} times`,
 			);
-			assert.ok(totalArrayReads(reads.edges) <= budget.edges, `read edges ${totalArrayReads(reads.edges)} times`);
+			assert.ok(
+				totalArrayReads(reads.edges) <= graphScoped.edges,
+				`read edges ${totalArrayReads(reads.edges)} times`,
+			);
 		} finally {
 			view.dispose();
 		}


### PR DESCRIPTION
Layer 4 of stack #2145. Base is [#2147](https://github.com/bastani-inc/atomic/pull/2147). Test-only.

## Why

`viewportReadBudgets` in `test/unit/overlay-graph-perf.test.ts` returned four numbers, and two of them were not viewport budgets:

| Budget | Formula | 400-stage chain | Scales with |
| --- | --- | ---: | --- |
| `bands` | `2 × (binarySearch + walked)` | 22 | viewport |
| `layout` | `2 × paintedCards + 3` | 7 | viewport |
| `displayStages` | `2 × N + 2` | 802 | whole graph |
| `edges` | `2 × E + 1` | 799 | whole graph |

The first two are [#2143](https://github.com/bastani-inc/atomic/pull/2143)'s actual claim — paint 400 stages or 100,000 and card work stays at 7. The other two deliberately scale with the graph, because the render examines every edge for a cheap four-comparison bounds test before plotting only the visible ones, and the header counts every stage once.

Those two are still worth asserting: they fail on a duplicate edge walk, a per-card display-stage clone, and a per-card layout slice. But they pin the **shape** of that work, not its magnitude. At 100,000 stages the budget is 200,002 and the test passes happily while the scan is the bottleneck.

A comment said this. The name said otherwise, and names win — a future reader sees "viewport read budgets: green" and concludes frames are viewport-bounded.

## The change

Split the return into `viewportScoped` and `graphScoped`, so the distinction shows up at every call site instead of in a doc comment someone has to go find.

No behavior change; every budget keeps its formula. Verified the assertions still bite: a per-card `cachedLayout.slice(ni, ni + 1)` still fails the hit-target budget.

## Verification

| Command | Outcome |
| --- | --- |
| `npm run check` | exit 0 |
| `npm run test:unit` | exit 0 |

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This test-only change separates rendering read budgets that should remain flat for the visible viewport from intentional single-pass reads that scale with graph size. The focused overlay graph performance suite passed all 14 tests, and an executed source-contract check confirmed that `bands`, `layout`, `paintedCards`, `displayStages`, and `edges` are all still returned and asserted in their respective scopes. The potential regression of weakened or lost read-budget coverage was disproved by those checks.

<h3>Confidence Score: 5/5</h3>

Safe to merge; no blocking failure remains.

The focused performance tests passed, and the retained budget fields and their assertion call sites were checked directly.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran npx vitest run --project unit test/unit/overlay-graph-perf.test.ts and observed that the focused file completed successfully with 14 passing tests.
- Ran the authored read-budget source-contract script and observed that all five previously tracked fields remain returned under viewportScoped or graphScoped, with their assertion call sites present.
- The test and contract checks showed that regrouping the helper did not remove or weaken the performance-budget coverage.
- Compared baseline and after-state artifacts for the read-budget feature, including before/after logs and contract outputs, to validate consistency.

<a href="https://app.greptile.com/trex/runs/17016582/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(workflows): separate viewport-scope..."](https://github.com/bastani-inc/atomic/commit/841d39e8c89614077e386f1d094ec7ea02132580) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49579556)</sub>

<!-- /greptile_comment -->