### PR TITLE
test(ci): gate pushes on every suite CI runs, not just the unit suite

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -25,4 +25,11 @@ hooks = [
   # Renamed off the `bun-` prefix with the toolchain: these run under npm now.
   { id = "check", name = "npm run check", entry = "npm run check", language = "system", pass_filenames = false },
   { id = "test-unit", name = "npm run test:unit", entry = "npm run test:unit", language = "system", pass_filenames = false },
+  # Push-only. CI runs all three suites, so a hook that stops at test:unit lets an
+  # integration or contract failure reach CI by default — which is exactly how a
+  # Windows-only line-ending bug and a broken integration fixture both got pushed.
+  # They are cheap next to test:unit (~12 s and ~15 s against ~85 s) but there is no
+  # reason to pay them on every commit, so they gate the push instead.
+  { id = "test-integration", name = "npm run test:integration", entry = "npm run test:integration", language = "system", pass_filenames = false, stages = ["pre-push"] },
+  { id = "test-ci-contracts", name = "npm run test:ci-contracts", entry = "npm run test:ci-contracts", language = "system", pass_filenames = false, stages = ["pre-push"] },
 ]

--- a/test/ci/ci-workflow-contracts.test.ts
+++ b/test/ci/ci-workflow-contracts.test.ts
@@ -564,3 +564,41 @@ test("Blacksmith runners are used everywhere they are supported", async () => {
 	// ubuntu-latest is only ever acceptable on the OIDC publish job.
 	assert.equal(jobBlock(publish, "publish-npm", "publish-github-release").includes("runs-on: ubuntu-latest"), true);
 });
+
+/**
+ * Every suite CI runs must also gate a push.
+ *
+ * The hooks used to stop at `npm run test:unit`, so an integration or contract
+ * failure was invisible locally and reached CI by default. Two did: a
+ * Windows-only line-ending bug in a changelog check, and an integration fixture
+ * broken by a change in the same branch. Neither could fail the suite anyone was
+ * actually running.
+ *
+ * This asserts coverage, not spelling. A hook may run at every stage or only at
+ * `pre-push`; what it may not do is exclude the push, because that is the last
+ * point before CI. `test:all` and `test:scripts` are deliberately out of scope —
+ * the first is a convenience wrapper over suites already covered here, and the
+ * second is not part of the `test` workflow's required checks.
+ */
+test("every CI test suite also gates a push", async () => {
+	const prek = await readText(join(root, "prek.toml"));
+	const manifest = await readJson<{ scripts: Record<string, string> }>(join(root, "package.json"));
+
+	for (const script of ["test:unit", "test:integration", "test:ci-contracts"]) {
+		assert.ok(manifest.scripts[script], `missing script: ${script}`);
+		const hook = new RegExp(String.raw`\{[^}]*entry\s*=\s*"npm run ${script}"[^}]*\}`, "u").exec(prek);
+		assert.ok(
+			hook,
+			`prek.toml declares no hook running \`npm run ${script}\`; a suite CI runs must not be able to fail only in CI`,
+		);
+
+		const stages = /stages\s*=\s*\[([^\]]*)\]/u.exec(hook[0]);
+		if (stages) {
+			assert.match(
+				stages[1] as string,
+				/"pre-push"/u,
+				`the \`${script}\` hook restricts itself to ${stages[1]} and so does not gate a push`,
+			);
+		}
+	}
+});


### PR DESCRIPTION
Layer 5 of stack #2145. Base is [#2148](https://github.com/bastani-inc/atomic/pull/2148). No shipped package behavior changes.

## Why

The hooks stopped at `npm run test:unit`. CI runs three suites, so an integration or contract failure was invisible locally and reached CI by default.

Two did, in this stack:

- A **Windows-only line-ending bug** in the released-changelog check. It compared a CRLF working-tree file against `git show <tag>:<path>`, which emits the blob verbatim with LF. It cannot fail on macOS or Linux, and it is not in the unit suite's blast radius anyway.
- An **integration fixture broken by a change in the same branch**. The animation gate leaves `hasAnimatingStages` false for a run with `stages: []`, so no tick fires and `overlay-entrypoints-animation.test.ts` fails.

Neither could fail the suite anyone was actually running. No amount of care with `test:unit` — and this stack ran it a lot — would have caught either.

## The change

Add `test:integration` and `test:ci-contracts` as `pre-push` hooks.

Push-only on purpose. They are cheap next to the unit suite (~12 s and ~15 s against ~85 s), but there is no reason to pay them on every commit, and the push is the last point before CI.

## The guard

A contract test in `test/ci/ci-workflow-contracts.test.ts` asserts every suite CI runs also gates a push, so the gap cannot silently reopen.

It asserts **coverage, not spelling**: a hook may run at every stage or only at `pre-push`, but it may not exclude the push. Reverting `prek.toml` to its previous shape fails it with:

```
AssertionError: prek.toml declares no hook running `npm run test:integration`;
a suite CI runs must not be able to fail only in CI
```

`test:all` and `test:scripts` are deliberately out of scope — the first wraps suites already covered here, the second is not among the `test` workflow's required checks.

## Verification

| Suite | Result |
| --- | --- |
| `npm run check` | exit 0 |
| `npm run test:unit` | 5836 passed, 2 skipped |
| `npm run test:integration` | 484 passed, 1 skipped |
| `npm run test:ci-contracts` | 39 passed |

This PR's own push was gated by the hooks it adds.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds integration and CI-contract suites to the local pre-push gate and adds a check that the currently listed CI suites have push-eligible hooks.

The suite-coverage check can drift from CI because it maintains its own hardcoded suite inventory. Adding, removing, or renaming a CI-required suite without updating this list can leave that suite out of the local push gate while the contract continues to pass.

## T-Rex validation blocked
A reversible check added a simulated CI-required suite and observed that `npm run test:ci-contracts` still passed with 39 tests, confirming the drift path. The required evidence could not be attached because the Greptile artifact-upload tool was unavailable.

<h3>Confidence Score: 4/5</h3>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
test/ci/ci-workflow-contracts.test.ts:587
**CI suite inventory is duplicated**

The contract hardcodes the three current suite names instead of deriving them from the CI workflow, so adding, removing, or renaming a CI suite without updating this array leaves the push-gate coverage check out of sync and allows a new required suite to remain ungated.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ci): gate pushes on every suite CI ..."](https://github.com/bastani-inc/atomic/commit/ff6f07a65867d7e0a52c7bd2284941e6691064bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49583227)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->