### PR TITLE
fix(web-access): release the full README from bounded truncations

### DIFF
--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed retained GitHub README truncations by copying bounded text into flat strings before storing long-lived results ([#2151](https://github.com/bastani-inc/atomic/issues/2151)).
+
 ## [0.9.11-alpha.1] - 2026-07-20
 
 ### Changed

--- a/packages/web-access/content-tools.ts
+++ b/packages/web-access/content-tools.ts
@@ -44,6 +44,7 @@ export function registerContentTools(pi: ExtensionAPI, deps: RegisterContentTool
 
 		renderCall(args, theme) {
 			const { query } = args as { query?: string };
+			// This status-line preview is built and dropped within the same turn, so a bare slice is sufficient.
 			const display = !query
 				? "(no query)"
 				: query.length > 70 ? query.slice(0, 67) + "..." : query;

--- a/packages/web-access/flat-string.ts
+++ b/packages/web-access/flat-string.ts
@@ -1,0 +1,37 @@
+/**
+ * Truncation that actually releases the untruncated source.
+ *
+ * This local web-access copy mirrors the original helper in
+ * `packages/workflows/src/shared/flat-string.ts`; web-access is a standalone package and
+ * cannot import that workflows module.
+ *
+ * V8 does not copy characters for `String.prototype.slice`. For a flat parent of
+ * 13 characters or more it allocates a **SlicedString**, which is a length, an
+ * offset, and a pointer to the parent. Template interpolation then wraps that in
+ * a **ConsString**, which keeps the same pointer. So the obvious way to bound a
+ * value for storage:
+ *
+ * ```ts
+ * `${JSON.stringify(value).slice(0, 237)}...`
+ * ```
+ *
+ * produces a 240-character string that reports `length === 240` while holding
+ * the entire serialized payload alive. The bound is on what you can read, not on
+ * what you retain. An 8 MiB tool result summarized to 240 characters still costs
+ * 8 MiB for as long as anything keeps the summary.
+ *
+ * That is invisible in every ordinary test: the value is correct, its length is
+ * correct, and equality holds. It only shows up as heap that never comes back.
+ *
+ * `split("").join("")` copies the code units into a fresh flat string with no
+ * parent pointer. It is code-unit exact, including lone surrogates, because
+ * `split("")` splits on UTF-16 code units rather than code points.
+ *
+ * Use this at any truncation whose result outlives the value it came from —
+ * memoized projections, durable checkpoints, catalogs, persisted summaries.
+ * A truncation that is consumed and dropped within the same turn does not need
+ * it, and paying for a copy there is waste.
+ */
+export function flattenTruncatedString(value: string): string {
+	return value.split("").join("");
+}

--- a/packages/web-access/github-api.ts
+++ b/packages/web-access/github-api.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import type { ExtractedContent } from "./extract.js";
+import { flattenTruncatedString } from "./flat-string.js";
 import type { GitHubUrlInfo } from "./github-extract.js";
 
 const MAX_TREE_ENTRIES = 200;
@@ -97,7 +98,7 @@ async function fetchReadmeViaApi(owner: string, repo: string, ref: string): Prom
 				}
 				try {
 					const decoded = Buffer.from(stdout.trim(), "base64").toString("utf-8");
-					resolve(decoded.length > 8192 ? decoded.slice(0, 8192) + "\n\n[README truncated at 8K chars]" : decoded);
+					resolve(decoded.length > 8192 ? flattenTruncatedString(decoded.slice(0, 8192) + "\n\n[README truncated at 8K chars]") : decoded);
 				} catch {
 					resolve(null);
 				}

--- a/packages/web-access/github-extract.ts
+++ b/packages/web-access/github-extract.ts
@@ -3,6 +3,7 @@ import { execFile } from "node:child_process";
 import { extname, join, resolve as resolvePath, sep as pathSep } from "node:path";
 import { activityMonitor } from "./activity.js";
 import type { ExtractedContent } from "./extract.js";
+import { flattenTruncatedString } from "./flat-string.js";
 import { checkGhAvailable, checkRepoSize, fetchViaApi, showGhHint } from "./github-api.js";
 import { BINARY_EXTENSIONS, MAX_INLINE_FILE_CHARS, MAX_TREE_ENTRIES, NOISE_DIRS, loadGitHubConfig, parseGitHubUrl, resetGitHubConfig, type GitHubCloneConfig, type GitHubUrlInfo } from "./github-config.js";
 export { parseGitHubUrl, type GitHubUrlInfo } from "./github-config.js";
@@ -225,14 +226,14 @@ function buildDirListing(rootPath: string, subPath: string): string {
 	return lines.join("\n");
 }
 
-function readReadme(localPath: string): string | null {
+export function readReadme(localPath: string): string | null {
 	const candidates = ["README.md", "readme.md", "README", "README.txt", "README.rst"];
 	for (const name of candidates) {
 		const readmePath = join(localPath, name);
 		if (existsSync(readmePath)) {
 			try {
 				const content = readFileSync(readmePath, "utf-8");
-				return content.length > 8192 ? content.slice(0, 8192) + "\n\n[README truncated at 8K chars]" : content;
+				return content.length > 8192 ? flattenTruncatedString(content.slice(0, 8192) + "\n\n[README truncated at 8K chars]") : content;
 			} catch {
 				continue;
 			}

--- a/test/unit/web-access-flat-string.test.ts
+++ b/test/unit/web-access-flat-string.test.ts
@@ -83,19 +83,27 @@ function readReadmeInFrame(localPath: string): string {
 	return readme;
 }
 
-function externalMemoryAfterCollection(): number {
+/**
+ * Where the README string lives depends on the Node/V8 build: `readFileSync`
+ * with an encoding may hand back a V8 *external* string (counted only in
+ * `external_memory`) or an ordinary in-heap string (counted only in
+ * `heapUsed`), and which one you get varies by version and platform. Probe the
+ * sum of both counters so a pinned parent is visible either way — and so the
+ * positive-control arm still fails loudly if neither counter observes it.
+ */
+function totalMemoryAfterCollection(): number {
 	collect();
 	collect();
-	return v8.getHeapStatistics().external_memory;
+	return process.memoryUsage().heapUsed + v8.getHeapStatistics().external_memory;
 }
 
 function retainedReadme(read: (localPath: string) => string): { retained: number; summary: string } {
 	const localPath = mkdtempSync(join(tmpdir(), "web-access-flat-string-"));
 	try {
 		writeLargeReadme(localPath);
-		const baseline = externalMemoryAfterCollection();
+		const baseline = totalMemoryAfterCollection();
 		const summary = read(localPath);
-		const retained = externalMemoryAfterCollection() - baseline;
+		const retained = totalMemoryAfterCollection() - baseline;
 		// Read the summary after measuring so it is not collected early.
 		assert.equal(summary.length, README_LIMIT + README_SUFFIX.length);
 		return { retained, summary };
@@ -133,7 +141,7 @@ describe("web-access flattenTruncatedString", () => {
 		assert.equal(summary, "r".repeat(README_LIMIT) + README_SUFFIX);
 		assert.ok(
 			retained > RETAINED_PARENT_BYTES,
-			`expected a bare file-backed slice to pin its parent, retained ${retained} external bytes`,
+			`expected a bare file-backed slice to pin its parent, retained ${retained} bytes across heap and external memory`,
 		);
 	});
 
@@ -143,7 +151,7 @@ describe("web-access flattenTruncatedString", () => {
 		// A release can make the signed delta negative when external memory is reclaimed during the measurement.
 		assert.ok(
 			retained < RETAINED_PARENT_BYTES,
-			`expected readReadme to release its README source, retained ${retained} external bytes`,
+			`expected readReadme to release its README source, retained ${retained} bytes across heap and external memory`,
 		);
 	});
 });

--- a/test/unit/web-access-flat-string.test.ts
+++ b/test/unit/web-access-flat-string.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import v8 from "node:v8";
+import vm from "node:vm";
+import { describe, test } from "vitest";
+import { flattenTruncatedString } from "../../packages/web-access/flat-string.js";
+import { readReadme } from "../../packages/web-access/github-extract.js";
+
+/**
+ * Large enough that a retained parent is unmistakable against ordinary test
+ * churn, and built by joining materialized chunks: `"x".repeat(n)` leaves V8 an
+ * unmaterialized rope, which measures as free while held and would make the
+ * positive-control arm pass for the wrong reason.
+ */
+const PARENT_CHUNKS = 16 * 1024;
+const CHUNK = 1024;
+const PARENT_BYTES = PARENT_CHUNKS * CHUNK;
+/** Half a parent: a collected one measures near zero, a pinned one near PARENT_BYTES. */
+const RETAINED_PARENT_BYTES = PARENT_BYTES / 2;
+const SUMMARY_LIMIT = 240;
+const README_LIMIT = 8192;
+const README_SUFFIX = "\n\n[README truncated at 8K chars]";
+
+function resolveCollect(): () => void {
+	const existing = (globalThis as { gc?: () => void }).gc;
+	if (typeof existing === "function") return existing;
+	v8.setFlagsFromString("--expose-gc");
+	try {
+		const exposed = vm.runInNewContext("gc") as () => void;
+		assert.equal(typeof exposed, "function", "expected --expose-gc to expose gc()");
+		return exposed;
+	} finally {
+		v8.setFlagsFromString("--no-expose-gc");
+	}
+}
+
+const collect = resolveCollect();
+
+function heapUsedAfterCollection(): number {
+	collect();
+	collect();
+	return process.memoryUsage().heapUsed;
+}
+
+function materializedParent(character: string): string {
+	return new Array(PARENT_CHUNKS).fill(character.repeat(CHUNK)).join("");
+}
+
+/**
+ * Truncate in its own frame. An interpreter frame keeps every register it held,
+ * so a parent built inline would stay reachable through the measurement.
+ */
+function truncateInFrame(flatten: boolean): string {
+	const parent = materializedParent("p");
+	const sliced = parent.slice(0, SUMMARY_LIMIT);
+	return flatten ? flattenTruncatedString(sliced) : sliced;
+}
+
+function retainedBytesFor(flatten: boolean): { retained: number; summary: string } {
+	const baseline = heapUsedAfterCollection();
+	const summary = truncateInFrame(flatten);
+	const retained = heapUsedAfterCollection() - baseline;
+	// Read the summary after measuring so it is not collected early.
+	assert.equal(summary.length, SUMMARY_LIMIT);
+	return { retained, summary };
+}
+
+function writeLargeReadme(localPath: string): void {
+	const parent = materializedParent("r");
+	writeFileSync(join(localPath, "README.md"), parent, "utf-8");
+}
+
+function readReadmeInFrame(localPath: string): string {
+	const readme = readReadme(localPath);
+	if (readme === null) throw new Error("expected readReadme to find README.md");
+	return readme;
+}
+
+function retainedReadme(): { retained: number; summary: string } {
+	const localPath = mkdtempSync(join(tmpdir(), "web-access-flat-string-"));
+	try {
+		writeLargeReadme(localPath);
+		const baseline = heapUsedAfterCollection();
+		const summary = readReadmeInFrame(localPath);
+		const retained = heapUsedAfterCollection() - baseline;
+		// Read the summary after measuring so it is not collected early.
+		assert.equal(summary.length, README_LIMIT + README_SUFFIX.length);
+		return { retained, summary };
+	} finally {
+		rmSync(localPath, { recursive: true, force: true });
+	}
+}
+
+describe("web-access flattenTruncatedString", () => {
+	test("a bare slice keeps its parent alive — the probe can observe retention", () => {
+		const { retained } = retainedBytesFor(false);
+		assert.ok(
+			retained > RETAINED_PARENT_BYTES,
+			`expected a bare slice to pin its parent, retained ${retained} bytes`,
+		);
+	});
+
+	test("a flattened truncation releases the parent", () => {
+		const { retained } = retainedBytesFor(true);
+		assert.ok(
+			retained < RETAINED_PARENT_BYTES,
+			`expected a flattened truncation to release its parent, retained ${retained} bytes`,
+		);
+	});
+
+	test("flattening is code-unit exact, including lone surrogates", () => {
+		for (const value of ["", "a", "hello world", "héllo ☃", "\uD800", "a\uDC00b", "🙂 mixed \uD83D"]) {
+			assert.equal(flattenTruncatedString(value), value);
+			assert.equal(flattenTruncatedString(value).length, value.length);
+		}
+	});
+
+	test("readReadme returns exact text and releases the README source", () => {
+		const { retained, summary } = retainedReadme();
+		assert.equal(summary, "r".repeat(README_LIMIT) + README_SUFFIX);
+		assert.ok(
+			retained < RETAINED_PARENT_BYTES,
+			`expected readReadme to release its README source, retained ${retained} bytes`,
+		);
+	});
+});

--- a/test/unit/web-access-flat-string.test.ts
+++ b/test/unit/web-access-flat-string.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import v8 from "node:v8";
@@ -72,19 +72,30 @@ function writeLargeReadme(localPath: string): void {
 	writeFileSync(join(localPath, "README.md"), parent, "utf-8");
 }
 
+function readBareReadmeInFrame(localPath: string): string {
+	const content = readFileSync(join(localPath, "README.md"), "utf-8");
+	return content.length > README_LIMIT ? content.slice(0, README_LIMIT) + README_SUFFIX : content;
+}
+
 function readReadmeInFrame(localPath: string): string {
 	const readme = readReadme(localPath);
 	if (readme === null) throw new Error("expected readReadme to find README.md");
 	return readme;
 }
 
-function retainedReadme(): { retained: number; summary: string } {
+function externalMemoryAfterCollection(): number {
+	collect();
+	collect();
+	return v8.getHeapStatistics().external_memory;
+}
+
+function retainedReadme(read: (localPath: string) => string): { retained: number; summary: string } {
 	const localPath = mkdtempSync(join(tmpdir(), "web-access-flat-string-"));
 	try {
 		writeLargeReadme(localPath);
-		const baseline = heapUsedAfterCollection();
-		const summary = readReadmeInFrame(localPath);
-		const retained = heapUsedAfterCollection() - baseline;
+		const baseline = externalMemoryAfterCollection();
+		const summary = read(localPath);
+		const retained = externalMemoryAfterCollection() - baseline;
 		// Read the summary after measuring so it is not collected early.
 		assert.equal(summary.length, README_LIMIT + README_SUFFIX.length);
 		return { retained, summary };
@@ -117,12 +128,22 @@ describe("web-access flattenTruncatedString", () => {
 		}
 	});
 
-	test("readReadme returns exact text and releases the README source", () => {
-		const { retained, summary } = retainedReadme();
+	test("a bare file-backed slice keeps its parent alive — the external probe can observe retention", () => {
+		const { retained, summary } = retainedReadme(readBareReadmeInFrame);
 		assert.equal(summary, "r".repeat(README_LIMIT) + README_SUFFIX);
 		assert.ok(
+			retained > RETAINED_PARENT_BYTES,
+			`expected a bare file-backed slice to pin its parent, retained ${retained} external bytes`,
+		);
+	});
+
+	test("readReadme returns exact text and releases the README source", () => {
+		const { retained, summary } = retainedReadme(readReadmeInFrame);
+		assert.equal(summary, "r".repeat(README_LIMIT) + README_SUFFIX);
+		// A release can make the signed delta negative when external memory is reclaimed during the measurement.
+		assert.ok(
 			retained < RETAINED_PARENT_BYTES,
-			`expected readReadme to release its README source, retained ${retained} bytes`,
+			`expected readReadme to release its README source, retained ${retained} external bytes`,
 		);
 	});
 });


### PR DESCRIPTION
Fixes #2151.

## Problem

V8 does not copy characters for `String.prototype.slice`. For a flat parent of 13 characters or more it allocates a **SlicedString** — a length, an offset, and a pointer to the parent — and template concatenation wraps that in a **ConsString** holding the same pointer. A truncation therefore bounds what you can *read*, not what you *retain*.

Two GitHub README truncations in `packages/web-access` did this to strings that outlive the source they came from:

- `github-extract.ts` `readReadme()` — an 8 KiB summary of a multi-megabyte README pinned the whole file.
- `github-api.ts` `fetchReadmeViaApi()` — the identical shape on the base64-decoded body.

The 8 KiB result then travels into a long-lived `ExtractedContent`, so the full README stayed alive for as long as anything held the summary.

## Change

- **New `packages/web-access/flat-string.ts`** — a 37-line, dependency-free `flattenTruncatedString()` that copies code units into a fresh flat string via `split("").join("")`. It is code-unit exact, lone surrogates included, because `split("")` splits on UTF-16 code units rather than code points. The module is **local to `packages/web-access`**; it deliberately does not import the twin helper in `packages/workflows`, which web-access cannot depend on. The doc comment states when to reach for it and when paying for the copy is waste.
- **Both README truncations wrapped** at `github-extract.ts:236` and `github-api.ts:101`. The `<= 8192` branch still returns the source verbatim — no copy where none is needed. Cut point, suffix, and passthrough behaviour are unchanged.
- **`gemini-web.ts:307` left alone, with the reasoning recorded.** The `File upload failed: … (${text.slice(0, 200)})` throw escapes `runGeminiWebOnce` (reachable only when `options.files` is set) to its sole files-passing caller, `video-extract.ts:235-240`. The catch at `:248-250` runs `shouldRethrow`, which matches only `/^Failed to parse /`, so this message is swallowed and the Error is unreachable at the end of the turn. Nothing retains it, so flattening would buy nothing.
- **One explanatory comment** at `content-tools.ts:47`, above the status-line preview slice, noting that a value built and dropped within the same turn does not need the helper. Every other slice site named in the audit — `content-tools.ts:199,204,214,346`, `index-heavy.ts:114,117,119,132,136,153`, `rsc-extract.ts:329`, `pdf-extract.ts:174` — is byte-for-byte unchanged.
- **CHANGELOG** entry under `[Unreleased] / Fixed`.

## Test

`test/unit/web-access-flat-string.test.ts` (5 arms), modelled on `test/unit/flat-string-truncation.test.ts`.

The point of interest is calibration: a retention probe that measures nothing passes just as happily as one that works. So the suite carries **positive controls**. Arm 1 asserts a bare slice *does* pin its parent, and arm 4 asserts the same for the file-backed path through a real 16 MiB README in a temp dir. If the instrument ever stops observing retention, those two arms fail rather than going quietly green.

Three details the probe depends on:

- The parent is built by joining materialized 1 KiB chunks. `"x".repeat(n)` leaves V8 an unmaterialized rope that measures as free while held, which would make the positive control pass for the wrong reason.
- Truncation happens in its own frame. An interpreter frame keeps every register it held, so a parent built inline stays reachable through the measurement.
- The file-backed arms measure `v8.getHeapStatistics().external_memory`, not `heapUsed`. A large `readFileSync` string is external; a `heapUsed` probe reports a small negative delta and sees nothing at all.

`readReadme` was exported so the real function is under test rather than a copy of its body.

## Validation

- `npm run check` — clean (biome across 2370 files, `tsc --noEmit` silent, shrinkwrap up to date).
- `npm run test:unit` — 623 files, 5835 passed / 2 skipped.
- The push of this branch ran the repository pre-push hooks: `test:unit`, `test:integration`, and `test:ci-contracts` all passed.
- **Mutation-proved, not just green.** Replacing the helper body with `return value;` fails 2 arms; reverting `github-extract.ts:236` to the bare slice fails the file-backed arm with the retention message. The assertions are load-bearing.

## Review notes

Three reviewers approved independently, each running the gates and writing their own probes rather than trusting the implementation's test. One non-blocking P3 remains and is disclosed rather than closed: **`github-api.ts:101` has no persisted regression test**, because exercising `fetchReadmeViaApi` needs the `gh` CLI and network. Two reviewers reproduced its exact base64-decode-then-truncate shape in standalone probes — bare retained 16,777,216 external bytes, flattened retained 0 — so the fix is verified, but only the `readReadme` twin is protected against future regression.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788335724&installation_model_id=10562&pr_number=2153&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2153&signature=1ad8db235f13c46be3162d7724b709693cc46f20413c5aa2c661da781d508cc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change prevents truncated GitHub README summaries from retaining their complete source strings and adds coverage for file-backed README extraction. The local extraction path preserves the expected truncated content and releases the backing source. However, API-backed extraction silently omits sufficiently large READMEs because the encoded `gh` response can exceed the subprocess output buffer before truncation occurs.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until API-backed README extraction retains content for large README responses.

The local file-backed path was verified, but `packages/web-access/github-api.ts` silently converts oversized README subprocess output into an absent README. This causes repository context to differ depending on which extraction path is used.

**Files Needing Attention:** packages/web-access/github-api.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- - Validated the posted P1 finding by reviewing proof 0 and its associated artifacts, including the focused README extraction probe source and the control/oversized/output logs, to confirm both local and API paths were exercised.
- - Noted that a second finding-comment-proof was posted and reviewed for completeness, confirming continued coverage of the P1 finding.
- - Performed general contract validation around oversized README handling by running the readme extraction probe and inspecting the related maxBuffer and flat-string test artifacts to compare local versus API paths.

<a href="https://app.greptile.com/trex/runs/17026356/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **File-backed retention positive-control test is not portable to the supported Node runtime**

   - **Bug**
     - `NODE_OPTIONS=--expose-gc npx vitest run test/unit/web-access-flat-string.test.ts --project unit` fails 1/5 tests on Node v24.18.1: the test expects a bare `readFileSync(..., "utf-8")` slice to retain more than 8 MiB external memory, but measures 0 bytes. The test suite therefore fails even though `readReadme` itself passes its exact-content/release assertion.
   - **Cause**
     - The test assumes Node/V8 represents the UTF-8 file-read string as an externally backed parent retained by a slice. On this runtime, that assumption is false or the backing store is not charged as expected to `external_memory`, so the positive-control threshold is invalid.
   - **Fix**
     - Make the positive control runtime-aware (skip/report inconclusive when it cannot observe retention), or use a deterministic heap/inspector representation test that establishes the runtime string backing behavior before asserting the production release delta.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. `packages/web-access/github-api.ts`, line 93 ([link](https://github.com/bastani-inc/atomic/blob/d9cd92e8d9aee531527de6716c34ed7b0ba1771a/packages/web-access/github-api.ts#L93)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **API fallback silently omits large README files before truncation**

   The API README request leaves `execFile` at its default stdout `maxBuffer`, then treats any subprocess error as an absent README. A 900,096-character README produces a 1,200,128-character base64 payload, which exceeds that buffer: the API result succeeds but has no README, while the local path returns the expected 8K truncated summary. Set an explicit bounded `maxBuffer` for this response, large enough for the accepted encoded README payload, and add a regression case that crosses the current buffer boundary.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Focused local and API README extraction probe source](https://app.greptile.com/trex/artifacts/ff56c64b-8257-4749-bf94-4271c94d7ff3)**

   - This authored harness invokes \`readReadme\` and \`fetchViaApi\` with a spawned mock \`gh\` CLI at control and oversized response sizes, proving the exact API boundary.

   **[Control API README extraction output below the default output buffer](https://app.greptile.com/trex/artifacts/48a0182b-0c26-4e90-adca-fe21ddf39155)**

   - The executed 700,416-character source / 933,888-character base64 response preserved the exact local and API truncated README, establishing the control behavior.

   **[Oversized API README extraction output above the default output buffer](https://app.greptile.com/trex/artifacts/3a1a9010-9b51-4bd3-a5cc-81f5f92e48d5)**

   - The executed 900,096-character source / 1,200,128-character base64 response preserved the local truncation but omitted the API README, proving the defect.

   **[Focused flat-string local README retention test output](https://app.greptile.com/trex/artifacts/232bdce3-cfb5-430e-9199-66a07f2a9a33)**

   - The executed focused Vitest suite passed all five assertions, including exact local README content and released-source retention behavior, showing the local change works.

   <a href="https://app.greptile.com/trex/runs/17026356/artifacts?artifact=ff56c64b-8257-4749-bf94-4271c94d7ff3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/web-access/github-api.ts
   Line: 93

   Comment:
   **API fallback silently omits large README files before truncation**

   The API README request leaves `execFile` at its default stdout `maxBuffer`, then treats any subprocess error as an absent README. A 900,096-character README produces a 1,200,128-character base64 payload, which exceeds that buffer: the API result succeeds but has no README, while the local path returns the expected 8K truncated summary. Set an explicit bounded `maxBuffer` for this response, large enough for the accepted encoded README payload, and add a regression case that crosses the current buffer boundary.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>


3. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **API fallback silently omits large README files before truncation**

   - **Bug**
     - The API README path accepts a 700,416-character README but silently removes a 900,096-character README from the otherwise successful repository result. The latter's base64 response is 1,200,128 characters, exceeding `execFile`'s default stdout buffer. This violates the intended behavior: README content should be truncated to 8K, not discarded because the pre-truncation transport payload is larger.
   - **Cause**
     - `fetchReadmeViaApi` at `packages/web-access/github-api.ts:90-105` configures only `timeout` at line 93. When `gh` stdout exceeds the default `execFile` `maxBuffer`, the callback receives an error and lines 95-97 resolve `null`; the caller then emits the tree-only API result. The new flattening at line 101 is never reached.
   - **Fix**
     - At `packages/web-access/github-api.ts:93`, add an explicit bounded `maxBuffer` appropriate for the accepted encoded README response (and document the chosen limit), then add the oversized API README fixture/harness case as a regression test. Preserve the existing 8K decoded truncation and flat-string copy after decoding.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/web-access/github-api.ts:93
**API fallback silently omits large README files before truncation**

The API README request leaves `execFile` at its default stdout `maxBuffer`, then treats any subprocess error as an absent README. A 900,096-character README produces a 1,200,128-character base64 payload, which exceeds that buffer: the API result succeeds but has no README, while the local path returns the expected 8K truncated summary. Set an explicit bounded `maxBuffer` for this response, large enough for the accepted encoded README payload, and add a regression case that crosses the current buffer boundary.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test(web-access): probe heap and externa..."](https://github.com/bastani-inc/atomic/commit/d9cd92e8d9aee531527de6716c34ed7b0ba1771a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49599529)</sub>

<!-- /greptile_comment -->