### PR TITLE
docs(changelog): prepare 0.9.11-alpha.12 release notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.11-alpha.12] - 2026-08-03
+
 ### Fixed
 
 - Fixed PDF extraction dropping text and streaming `TypeError: Math.sumPrecise is not a function` warnings on Node runtimes that do not implement `Math.sumPrecise`. The `unpdf` dependency was declared as the floating range `^1.6.2`, which resolves to 1.8.0 in a published or global install; that release's bundled PDF.js v6.1 dropped the guarded fallback and calls the builtin unconditionally, so extraction threw per glyph, emitted font-substitution warnings, and silently returned fewer text items. `unpdf` is now exact-pinned to `1.7.0`, the newest release that still ships the fallback, so no install can float to 1.8.0 ([#2141](https://github.com/bastani-inc/atomic/issues/2141)).

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.11-alpha.12] - 2026-08-03
+
 ### Fixed
 
 - Fixed PDF extraction dropping text and streaming `TypeError: Math.sumPrecise is not a function` warnings on Node runtimes that do not implement `Math.sumPrecise`. The `unpdf` dependency was declared as the floating range `^1.6.2`, which resolves to 1.8.0 in a published or global install; that release's bundled PDF.js v6.1 dropped the guarded fallback and calls the builtin unconditionally, so extraction threw per glyph, emitted font-substitution warnings, and silently returned fewer text items. On the reported 17-page arXiv PDF this cost 69 text items and 221 characters. `unpdf` is now exact-pinned to `1.7.0`, the newest release that still ships the fallback, so no install can float to 1.8.0 ([#2141](https://github.com/bastani-inc/atomic/issues/2141)).


### PR DESCRIPTION
## Summary

Prepares release notes for the `0.9.11-alpha.12` prerelease.

Moves the accumulated `[Unreleased]` entries for `coding-agent` and `web-access` under a `## [0.9.11-alpha.12]` heading. The notes cover the `unpdf` exact pin to `1.7.0`, which stops published and global installs floating to `1.8.0` — that release's bundled PDF.js v6.1 dropped the guarded fallback and calls `Math.sumPrecise` unconditionally, so PDF extraction threw per glyph and silently returned fewer text items on runtimes without the builtin.

## Scope

- Changelog-only diff: 2 files, 4 insertions, 0 deletions.
- Every package manifest, lockfile, and Cargo file stays at the `0.0.0` versionless placeholder.
- No version stamping here. `scripts/cut-release.ts` materializes the real version on the detached `Release` commit after this PR merges.

## Validation

- `test/unit/changelog.test.ts` and `test/unit/package-metadata.test.ts` — passed
- `test/ci/release-publisher-contracts.test.ts` — passed
- Pre-commit hooks: `npm run check`, `npm run test:unit` — passed
- Pre-push hooks: `npm run check`, `test:unit`, `test:integration`, `test:ci-contracts` — passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788364918&installation_model_id=10562&pr_number=2157&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2157&signature=56dae3d5546c77508ba05ab01e36125649c0f00e29077ef5ce4001411cf9319d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `0.9.11-alpha.12` headings to the coding-agent and web-access changelogs, placing the documented PDF extraction fixes in the corresponding prerelease section. The changelog and package-metadata contracts passed both before and after the change, confirming that the new headings preserve the repository’s release ordering and metadata expectations.

<h3>Confidence Score: 5/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Unit tests were run against both the pre-change and post-change states, and both runs completed successfully with two files and 22 tests passing.
- New headings were added to packages/coding-agent/CHANGELOG.md:5 and packages/web-access/CHANGELOG.md:7, and these changes satisfy the prerelease parsing, ordering, tagged-section immutability, and workspace release-metadata contracts.
- The contract validation points are shown in test/unit/changelog.test.ts and test/unit/package-metadata.test.ts, including parser/immutability checks at lines 111-155 and 200-255 and the strict release-version metadata checks at lines 16 and 117-127.
- Test-run artifacts were captured to support review, including logs that document the unit test results.

<a href="https://app.greptile.com/trex/runs/17081384/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.11-alpha.12..."](https://github.com/bastani-inc/atomic/commit/cd65497cd68be2e5fdcbf1b409627c67ad9475aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49715360)</sub>

<!-- /greptile_comment -->