### PR TITLE
fix(evals): walk codex -> openai -> openrouter in the main chat

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -65,10 +65,11 @@ Add `--n-attempts <k>` for pass@k-style repeats. Sizing `--n-concurrent`: each t
 
 ### Default (Used for official Atomic Deep SWE run)
 
-Note: The OpenRouter provider can first try making requests to the OpenAI and Anthropic APIs directly and otherwise falls back to OpenRouter.
+Note: the main chat walks a fallback chain. Codex runs go `openai-codex` -> `openai` -> `openrouter`; Anthropic runs go `anthropic` -> `openrouter`. The adapters start the session on the first candidate whose credential is present and write the rest to `settings.fallbackModels` in the sandbox, so the running session advances on rate limits, quota exhaustion, and provider errors.
 
 ```bash
-export OPENROUTER_API_KEY="..."  # fallback for rate limits, relies on OpenAI Codex and Claude Code subscriptions
+export OPENAI_API_KEY="..."      # first fallback for Codex runs
+export OPENROUTER_API_KEY="..."  # last fallback, relies on OpenAI Codex and Claude Code subscriptions
 
 uv run pier run \
   -p deep-swe/tasks \
@@ -136,12 +137,13 @@ uv run pier run \
 
 For GHES use `COPILOT_API_TARGET=api.enterprise.githubcopilot.com`; for GHEC use the tenant-specific GHE Copilot routing host.
 
-### Anthropic subscription with OpenRouter fallback
+### Anthropic subscription with API-key and OpenRouter fallback
 
-Export `ANTHROPIC_OAUTH_TOKEN` to run Anthropic models through the subscription OAuth path. Also export `OPENROUTER_API_KEY` if you want the adapters to fall back to the equivalent `openrouter/anthropic/...` model when the subscription token is unavailable:
+Export `ANTHROPIC_OAUTH_TOKEN` to run Anthropic models through the subscription OAuth path. Atomic cannot tell a subscription apart from an API key — both route through the `anthropic` provider — so `ANTHROPIC_API_KEY` keeps `anthropic` as the primary candidate. Also export `OPENROUTER_API_KEY` if you want a fallback to the equivalent `openrouter/anthropic/...` model when no Anthropic credential is present:
 
 ```bash
 export ANTHROPIC_OAUTH_TOKEN="..."
+export ANTHROPIC_API_KEY="..."   # optional; same `anthropic` provider
 export OPENROUTER_API_KEY="..."  # optional fallback
 
 uv run pier run \
@@ -159,12 +161,13 @@ uv run pier run \
 
 The native Anthropic provider uses dash-form model ids such as `claude-opus-4-8`; when falling back, the adapters translate version suffixes to OpenRouter's matching dot-form slugs such as `openrouter/anthropic/claude-opus-4.8`.
 
-### OpenAI Codex subscription with OpenRouter fallback
+### OpenAI Codex subscription with OpenAI and OpenRouter fallback
 
-For `openai-codex/...` models, Atomic uses OAuth credentials stored in the agent auth file rather than an environment variable. Log in on the host so `~/.atomic/agent/auth.json` (or legacy `~/.pi/agent/auth.json`) contains an `openai-codex` entry. The Pier and Harbor adapters merge valid local entries with Atomic taking precedence over legacy Pi, remove denied providers and providers shadowed by explicit environment credentials, then write the remainder to the sandbox user's `~/.atomic/agent/auth.json` with `0600` permissions. Export `OPENROUTER_API_KEY` if you want missing Codex subscription auth to fall back to the equivalent `openrouter/openai/...` model.
+For `openai-codex/...` models, Atomic uses OAuth credentials stored in the agent auth file rather than an environment variable. Log in on the host so `~/.atomic/agent/auth.json` (or legacy `~/.pi/agent/auth.json`) contains an `openai-codex` entry. The Pier and Harbor adapters merge valid local entries with Atomic taking precedence over legacy Pi, remove denied providers and providers shadowed by explicit environment credentials, then write the remainder to the sandbox user's `~/.atomic/agent/auth.json` with `0600` permissions. Export `OPENAI_API_KEY` and `OPENROUTER_API_KEY` for the `openai` and `openrouter` rungs behind the subscription; each is used only when its key is exported, both as the pre-launch selection when the subscription is missing and as a main-chat `fallbackModels` entry when it is not.
 
 ```bash
-export OPENROUTER_API_KEY="..."  # optional fallback
+export OPENAI_API_KEY="..."      # optional first fallback
+export OPENROUTER_API_KEY="..."  # optional last fallback
 
 uv run pier run \
   -p deep-swe/tasks \

--- a/evals/atomic_harbor.py
+++ b/evals/atomic_harbor.py
@@ -172,6 +172,9 @@ class Atomic(BaseInstalledAgent):
 
     def _has_subscription_auth(self, provider: str) -> bool:
         if provider == "anthropic":
+            # Atomic exposes no way to tell an Anthropic subscription apart from
+            # an API key: both route through the same `anthropic` provider, so
+            # either credential keeps `anthropic` as the primary candidate.
             return bool(
                 self._get_env("ANTHROPIC_API_KEY")
                 or self._get_env("ANTHROPIC_OAUTH_TOKEN")
@@ -185,26 +188,48 @@ class Atomic(BaseInstalledAgent):
     def _openrouter_anthropic_model(model: str) -> str:
         return re.sub(r"-(\d+)-(\d+)$", r"-\1.\2", model)
 
-    def _fallback_model(self, provider: str, model: str) -> tuple[str, str] | None:
-        if not self._get_env("OPENROUTER_API_KEY"):
-            return None
-        if provider == "anthropic":
-            return "openrouter", f"anthropic/{self._openrouter_anthropic_model(model)}"
-        if provider == self._OPENAI_CODEX_PROVIDER:
-            return "openrouter", f"openai/{model}"
-        return None
+    def _model_chain(self, provider: str, model: str) -> list[tuple[str, str]]:
+        """Ordered `(provider, model)` candidates for the requested model.
 
-    def _select_provider_model(self, provider: str, model: str) -> tuple[str, str]:
-        # The Atomic CLI has no top-level subscription->OpenRouter retry flag; its
-        # `fallbackModels` support is scoped to workflow/subagent attempts. For
-        # eval runs we therefore select the OpenRouter mirror before launch only
-        # when the subscription credential is absent, preserving subscription-first
-        # behavior while avoiding a failed primary attempt that cannot recover.
-        if not self._has_subscription_auth(provider):
-            fallback = self._fallback_model(provider, model)
-            if fallback:
-                return fallback
-        return provider, model
+        Codex walks `openai-codex` -> `openai` -> `openrouter`; Anthropic walks
+        `anthropic` -> `openrouter`. A candidate is listed only when its
+        credential is present, so the chain never names a provider the sandbox
+        cannot authenticate.
+        """
+        chain: list[tuple[str, str]] = []
+        if self._has_subscription_auth(provider):
+            chain.append((provider, model))
+        if provider == self._OPENAI_CODEX_PROVIDER:
+            if self._get_env("OPENAI_API_KEY"):
+                chain.append(("openai", model))
+            if self._get_env("OPENROUTER_API_KEY"):
+                chain.append(("openrouter", f"openai/{model}"))
+        elif provider == "anthropic" and self._get_env("OPENROUTER_API_KEY"):
+            chain.append(
+                ("openrouter", f"anthropic/{self._openrouter_anthropic_model(model)}")
+            )
+        return chain or [(provider, model)]
+
+    @staticmethod
+    def _fallback_settings_command(chain: list[tuple[str, str]]) -> str:
+        """Seed main-chat `settings.fallbackModels` with the chain after the primary.
+
+        Atomic only starts a session on a model it can authenticate, so the
+        first credentialed candidate is selected before launch. The rest become
+        `fallbackModels`, which main-chat turns walk on rate limits, quota
+        exhaustion, and provider errors.
+        """
+        fallback_models = [
+            f"{candidate_provider}/{candidate_model}"
+            for candidate_provider, candidate_model in chain[1:]
+        ]
+        if not fallback_models:
+            return ""
+        settings = json.dumps({"fallbackModels": fallback_models}, indent=2)
+        return (
+            f"printf '%s\\n' {shlex.quote(settings)} "
+            '> "$HOME/.atomic/agent/settings.json"; '
+        )
 
     async def _provision_subscription_auth(
         self,
@@ -215,6 +240,8 @@ class Atomic(BaseInstalledAgent):
         auth_data = self._load_provider_auths()
         if env is None:
             keys = list(self._PROVIDER_AUTH_ENV_KEYS.get(provider, ()))
+            if provider == self._OPENAI_CODEX_PROVIDER:
+                keys.append("OPENAI_API_KEY")
             if provider in {"anthropic", self._OPENAI_CODEX_PROVIDER}:
                 keys.append("OPENROUTER_API_KEY")
             environment_keys = {
@@ -315,7 +342,8 @@ class Atomic(BaseInstalledAgent):
             raise ValueError("Model name must be in the format provider/model_name")
 
         requested_provider, requested_model = self.model_name.split("/", 1)
-        provider, model = self._select_provider_model(requested_provider, requested_model)
+        chain = self._model_chain(requested_provider, requested_model)
+        provider, model = chain[0]
 
         env: dict[str, str] = {}
         provider_env_keys: dict[str, tuple[str, ...]] = {
@@ -339,9 +367,14 @@ class Atomic(BaseInstalledAgent):
             "openrouter": ("OPENROUTER_API_KEY",),
             "xai": ("XAI_API_KEY",),
         }
-        keys = list(provider_env_keys.get(provider, ()))
-        if requested_provider in {"anthropic", self._OPENAI_CODEX_PROVIDER}:
-            keys.append("OPENROUTER_API_KEY")
+        # Forward credentials for every provider in the fallback chain, not just
+        # the selected one: a main-chat fallback attempt needs its own key
+        # inside the sandbox.
+        keys = [
+            key
+            for candidate_provider, _ in chain
+            for key in provider_env_keys.get(candidate_provider, ())
+        ]
 
         for key in keys:
             val = self._get_env(key)
@@ -370,6 +403,7 @@ class Atomic(BaseInstalledAgent):
             command=(
                 f"rm -rf {session_dir} {log_session_dir} && mkdir -p {session_dir} && "
                 f"{self._agent_state_setup_command()}"
+                f"{self._fallback_settings_command(chain)}"
                 f"{self._session_sync_trap_command(session_dir, log_session_dir)}"
                 f"{atomic_runtime_environment_command()} && "
                 f"atomic --print --mode json --session-dir {session_dir} "

--- a/evals/atomic_harbor.py
+++ b/evals/atomic_harbor.py
@@ -218,6 +218,13 @@ class Atomic(BaseInstalledAgent):
         first credentialed candidate is selected before launch. The rest become
         `fallbackModels`, which main-chat turns walk on rate limits, quota
         exhaustion, and provider errors.
+
+        The adapter owns this file. Each trial provisions a fresh sandbox agent
+        directory, and nothing else in the image writes `settings.json`, so a
+        whole-document write has nothing to preserve. Atomic's own writes go the
+        other way safely: `persistScopedSettings` re-reads the file and replaces
+        only the fields it modified, so a `defaultModel` write during the run
+        does not drop these entries.
         """
         fallback_models = [
             f"{candidate_provider}/{candidate_model}"

--- a/evals/atomic_pier.py
+++ b/evals/atomic_pier.py
@@ -341,6 +341,9 @@ class Atomic(BaseInstalledAgent):
 
     def _has_subscription_auth(self, provider: str) -> bool:
         if provider == "anthropic":
+            # Atomic exposes no way to tell an Anthropic subscription apart from
+            # an API key: both route through the same `anthropic` provider, so
+            # either credential keeps `anthropic` as the primary candidate.
             return bool(
                 self._get_env("ANTHROPIC_API_KEY")
                 or self._get_env("ANTHROPIC_OAUTH_TOKEN")
@@ -354,26 +357,48 @@ class Atomic(BaseInstalledAgent):
     def _openrouter_anthropic_model(model: str) -> str:
         return re.sub(r"-(\d+)-(\d+)$", r"-\1.\2", model)
 
-    def _fallback_model(self, provider: str, model: str) -> tuple[str, str] | None:
-        if not self._get_env("OPENROUTER_API_KEY"):
-            return None
-        if provider == "anthropic":
-            return "openrouter", f"anthropic/{self._openrouter_anthropic_model(model)}"
-        if provider == self._OPENAI_CODEX_PROVIDER:
-            return "openrouter", f"openai/{model}"
-        return None
+    def _model_chain(self, provider: str, model: str) -> list[tuple[str, str]]:
+        """Ordered `(provider, model)` candidates for the requested model.
 
-    def _select_provider_model(self, provider: str, model: str) -> tuple[str, str]:
-        # The Atomic CLI has no top-level subscription->OpenRouter retry flag; its
-        # `fallbackModels` support is scoped to workflow/subagent attempts. For
-        # eval runs we therefore select the OpenRouter mirror before launch only
-        # when the subscription credential is absent, preserving subscription-first
-        # behavior while avoiding a failed primary attempt that cannot recover.
-        if not self._has_subscription_auth(provider):
-            fallback = self._fallback_model(provider, model)
-            if fallback:
-                return fallback
-        return provider, model
+        Codex walks `openai-codex` -> `openai` -> `openrouter`; Anthropic walks
+        `anthropic` -> `openrouter`. A candidate is listed only when its
+        credential is present, so the chain never names a provider the sandbox
+        cannot authenticate.
+        """
+        chain: list[tuple[str, str]] = []
+        if self._has_subscription_auth(provider):
+            chain.append((provider, model))
+        if provider == self._OPENAI_CODEX_PROVIDER:
+            if self._get_env("OPENAI_API_KEY"):
+                chain.append(("openai", model))
+            if self._get_env("OPENROUTER_API_KEY"):
+                chain.append(("openrouter", f"openai/{model}"))
+        elif provider == "anthropic" and self._get_env("OPENROUTER_API_KEY"):
+            chain.append(
+                ("openrouter", f"anthropic/{self._openrouter_anthropic_model(model)}")
+            )
+        return chain or [(provider, model)]
+
+    @staticmethod
+    def _fallback_settings_command(chain: list[tuple[str, str]]) -> str:
+        """Seed main-chat `settings.fallbackModels` with the chain after the primary.
+
+        Atomic only starts a session on a model it can authenticate, so the
+        first credentialed candidate is selected before launch. The rest become
+        `fallbackModels`, which main-chat turns walk on rate limits, quota
+        exhaustion, and provider errors.
+        """
+        fallback_models = [
+            f"{candidate_provider}/{candidate_model}"
+            for candidate_provider, candidate_model in chain[1:]
+        ]
+        if not fallback_models:
+            return ""
+        settings = json.dumps({"fallbackModels": fallback_models}, indent=2)
+        return (
+            f"printf '%s\\n' {shlex.quote(settings)} "
+            '> "$HOME/.atomic/agent/settings.json"; '
+        )
 
     async def _provision_subscription_auth(
         self,
@@ -384,6 +409,8 @@ class Atomic(BaseInstalledAgent):
         auth_data = self._load_provider_auths()
         if env is None:
             keys = list(self._PROVIDER_AUTH_ENV_KEYS.get(provider, ()))
+            if provider == self._OPENAI_CODEX_PROVIDER:
+                keys.append("OPENAI_API_KEY")
             if provider in {"anthropic", self._OPENAI_CODEX_PROVIDER}:
                 keys.append("OPENROUTER_API_KEY")
             environment_keys = {
@@ -483,10 +510,9 @@ class Atomic(BaseInstalledAgent):
             raise ValueError("Model name must be in the format provider/model_name")
 
         requested_provider, requested_model = self.model_name.split("/", 1)
-        provider, model = self._select_provider_model(
-            requested_provider,
-            requested_model,
-        )
+        chain = self._model_chain(requested_provider, requested_model)
+        provider, model = chain[0]
+        fallback_settings_command = self._fallback_settings_command(chain)
         # Forward credentials for every Atomic-supported provider, not just the
         # top-level Pier --model provider: nested workflow/subagent model
         # assignments can select other providers (e.g. kimi-coding under an
@@ -527,6 +553,7 @@ class Atomic(BaseInstalledAgent):
         command = (
             f"rm -rf {session_dir} {log_session_dir} && mkdir -p {session_dir} && "
             f"{self._agent_state_setup_command()}"
+            f"{fallback_settings_command}"
             f"{self._session_sync_trap_command(session_dir, log_session_dir)}"
             f"{copilot_config_command}"
             f"{atomic_runtime_environment_command()} && "

--- a/evals/atomic_pier.py
+++ b/evals/atomic_pier.py
@@ -387,6 +387,13 @@ class Atomic(BaseInstalledAgent):
         first credentialed candidate is selected before launch. The rest become
         `fallbackModels`, which main-chat turns walk on rate limits, quota
         exhaustion, and provider errors.
+
+        The adapter owns this file. Each trial provisions a fresh sandbox agent
+        directory, and nothing else in the image writes `settings.json`, so a
+        whole-document write has nothing to preserve. Atomic's own writes go the
+        other way safely: `persistScopedSettings` re-reads the file and replaces
+        only the fields it modified, so a `defaultModel` write during the run
+        does not drop these entries.
         """
         fallback_models = [
             f"{candidate_provider}/{candidate_model}"

--- a/evals/tests/test_model_fallback.py
+++ b/evals/tests/test_model_fallback.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from atomic_pier import Atomic
+
+_CREDENTIAL_KEYS = (
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_OAUTH_TOKEN",
+    "OPENAI_API_KEY",
+    "OPENROUTER_API_KEY",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_host_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Host credentials must not leak into the chain under test."""
+    for key in _CREDENTIAL_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _agent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    env: dict[str, str] | None = None,
+    subscriptions: dict[str, dict[str, object]] | None = None,
+) -> Atomic:
+    auth_path = tmp_path / "auth.json"
+    if subscriptions:
+        auth_path.write_text(json.dumps(subscriptions), encoding="utf-8")
+    monkeypatch.setattr(Atomic, "_auth_config_paths", staticmethod(lambda: (auth_path,)))
+    return Atomic(logs_dir=tmp_path / "logs", extra_env=env or {})
+
+
+def _codex_subscription() -> dict[str, dict[str, object]]:
+    return {"openai-codex": {"type": "oauth", "access": "codex-token"}}
+
+
+def test_codex_subscription_leads_openai_then_openrouter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    agent = _agent(
+        tmp_path,
+        monkeypatch,
+        env={"OPENAI_API_KEY": "sk-openai", "OPENROUTER_API_KEY": "sk-or"},
+        subscriptions=_codex_subscription(),
+    )
+
+    assert agent._model_chain("openai-codex", "gpt-5.6-sol") == [
+        ("openai-codex", "gpt-5.6-sol"),
+        ("openai", "gpt-5.6-sol"),
+        ("openrouter", "openai/gpt-5.6-sol"),
+    ]
+
+
+def test_missing_codex_subscription_starts_on_openai(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    agent = _agent(
+        tmp_path,
+        monkeypatch,
+        env={"OPENAI_API_KEY": "sk-openai", "OPENROUTER_API_KEY": "sk-or"},
+    )
+
+    assert agent._model_chain("openai-codex", "gpt-5.6-sol") == [
+        ("openai", "gpt-5.6-sol"),
+        ("openrouter", "openai/gpt-5.6-sol"),
+    ]
+
+
+def test_codex_falls_all_the_way_to_openrouter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    agent = _agent(tmp_path, monkeypatch, env={"OPENROUTER_API_KEY": "sk-or"})
+
+    assert agent._model_chain("openai-codex", "gpt-5.6-sol") == [
+        ("openrouter", "openai/gpt-5.6-sol")
+    ]
+
+
+def test_disallowed_codex_subscription_is_not_a_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text(json.dumps(_codex_subscription()), encoding="utf-8")
+    monkeypatch.setattr(Atomic, "_auth_config_paths", staticmethod(lambda: (auth_path,)))
+    agent = Atomic(
+        logs_dir=tmp_path / "logs",
+        extra_env={"OPENAI_API_KEY": "sk-openai"},
+        disallowed_subscriptions="openai-codex",
+    )
+
+    assert agent._model_chain("openai-codex", "gpt-5.6-sol") == [
+        ("openai", "gpt-5.6-sol")
+    ]
+
+
+@pytest.mark.parametrize(
+    "env",
+    [
+        {"ANTHROPIC_OAUTH_TOKEN": "oauth", "OPENROUTER_API_KEY": "sk-or"},
+        {"ANTHROPIC_API_KEY": "sk-ant", "OPENROUTER_API_KEY": "sk-or"},
+    ],
+)
+def test_anthropic_credential_leads_openrouter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, env: dict[str, str]
+) -> None:
+    # Atomic cannot tell an Anthropic subscription from an API key: either
+    # credential keeps `anthropic` primary, with OpenRouter behind it.
+    agent = _agent(tmp_path, monkeypatch, env=env)
+
+    assert agent._model_chain("anthropic", "claude-opus-4-8") == [
+        ("anthropic", "claude-opus-4-8"),
+        ("openrouter", "anthropic/claude-opus-4.8"),
+    ]
+
+
+def test_anthropic_without_credentials_starts_on_openrouter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    agent = _agent(tmp_path, monkeypatch, env={"OPENROUTER_API_KEY": "sk-or"})
+
+    assert agent._model_chain("anthropic", "claude-opus-4-8") == [
+        ("openrouter", "anthropic/claude-opus-4.8")
+    ]
+
+
+def test_requested_model_survives_when_no_fallback_is_configured(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    agent = _agent(tmp_path, monkeypatch)
+
+    assert agent._model_chain("openai-codex", "gpt-5.6-sol") == [
+        ("openai-codex", "gpt-5.6-sol")
+    ]
+
+
+def test_settings_command_writes_fallback_models_after_the_primary(
+    tmp_path: Path,
+) -> None:
+    command = Atomic._fallback_settings_command(
+        [
+            ("openai-codex", "gpt-5.6-sol"),
+            ("openai", "gpt-5.6-sol"),
+            ("openrouter", "openai/gpt-5.6-sol"),
+        ]
+    )
+
+    home = tmp_path / "home"
+    agent_dir = home / ".atomic" / "agent"
+    agent_dir.mkdir(parents=True)
+    subprocess.run(
+        ["/bin/bash", "-c", f"set -euo pipefail; {command}"],
+        env={"HOME": str(home), "PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        check=True,
+    )
+
+    settings = json.loads((agent_dir / "settings.json").read_text(encoding="utf-8"))
+    assert settings == {
+        "fallbackModels": ["openai/gpt-5.6-sol", "openrouter/openai/gpt-5.6-sol"]
+    }
+
+
+def test_settings_command_is_empty_without_fallbacks() -> None:
+    assert Atomic._fallback_settings_command([("anthropic", "claude-opus-4-8")]) == ""


### PR DESCRIPTION
## Summary

The eval adapters mirrored a missing subscription straight to OpenRouter, skipping a plain OpenAI API key even when one was exported. The choice was also made once before launch, so a rate limit mid-run had nowhere to go.

Both adapters now build an ordered candidate chain and hand the tail to the main chat:

- Codex: `openai-codex` → `openai` → `openrouter`
- Anthropic: `anthropic` → `openrouter`

A candidate is listed only when its credential is present. The first candidate becomes `--provider/--model`, because Atomic only starts a session on a model it can authenticate. The rest are written to `settings.fallbackModels` in the sandbox agent directory, which main-chat turns walk on rate limits, quota exhaustion, and provider errors.

Atomic cannot tell an Anthropic subscription from an API key — both route through the `anthropic` provider — so either credential keeps `anthropic` primary and OpenRouter stays behind it. Workflow definitions already declare their own `fallbackModels` and are untouched.

## Changes

- `evals/atomic_pier.py`, `evals/atomic_harbor.py`: `_model_chain` replaces `_fallback_model`/`_select_provider_model`; `_fallback_settings_command` seeds `settings.fallbackModels`; Harbor forwards credentials for every provider in the chain instead of the selected one alone.
- `evals/tests/test_model_fallback.py`: new — chain order per credential set, disallowed subscriptions, the Anthropic dot-form OpenRouter slug, and the settings file the seed command actually writes (run through bash).
- `evals/README.md`: documents the chain and the `OPENAI_API_KEY` rung.

## Test plan

- `uv run pytest tests` in `evals/` — 23 passed
- `uv run --group dev basedpyright atomic_pier.py atomic_harbor.py tests/test_model_fallback.py` — 0 errors

No package changelog entry: eval harness scripts are repository infrastructure, not shipped package behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788374761&installation_model_id=10562&pr_number=2164&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2164&signature=b6638d89f2b2c03fe7ac529739f69fdfcb4af9974934f9057c273e717652a4a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds credential-aware model fallback chains to Pier and Harbor eval runs. Codex runs can move from subscription authentication to OpenAI and then OpenRouter; Anthropic runs can move from Anthropic to OpenRouter. The adapters seed the remaining authenticated models into Atomic’s main-chat fallback settings and forward the credentials required by those fallback rungs.

The suspected failure where fallback settings or credentials were missing was disproved by executing both adapters’ run-path sandbox construction with a Codex subscription plus OpenAI and OpenRouter credentials. Both produced the expected ordered chain, wrote the OpenAI and OpenRouter entries to `settings.json`, and forwarded both API keys.

<h3>Confidence Score: 5/5</h3>

The PR is safe to merge.

No blocking failure remains. Both eval adapters were exercised through their sandbox command and environment construction and correctly persisted the fallback chain and its required credentials.

<sub>Reviews (2): Last reviewed commit: ["docs(evals): record why the fallback set..."](https://github.com/bastani-inc/atomic/commit/450441e9d674c748596a6a2a05a6f51a315ad865) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49766204)</sub>

<!-- /greptile_comment -->