### PR TITLE
docs(readme): restructure hero with production evidence and feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
-<h1 align="center">Atomic — The Verifiable Coding Agent Runtime</h1>
+<h1 align="center">Atomic</h1>
 
 <p align="center"><img width="800" height="450" alt="Atomic coding agent runtime" src="./assets/atomic-promo.gif" /></p>
 
 <p align="center">
-  <b>Run verifiable engineering loops with control, alignment, and confidence.</b>
+  <b>The verifiable coding agent runtime. Build your engineering process as explicit, checkable execution graphs.</b>
 </p>
 
 <p align="center">
-  Build agent work as explicit execution graphs with scoped context, specialized agents, structured handoffs, bounded stages, parallel branches, executable checks, evidence artifacts, review gates, and human approvals.<br>
-  Build the foundations of your own software factory without turning engineering into a black box.
+  <b>Run verifiable engineering loops with control, alignment, and confidence.</b>
 </p>
 
 <p align="center">
@@ -35,21 +34,34 @@
   If Atomic is useful to you, star the repository ⭐
 </p>
 
----
+**Users are reporting:**
 
-## Built for developers who want assurance
+- ⚡ A 1–1.5 hour reduction in manual verification per task compared to traditional coding agents, not including time saved from fewer follow-up fixes and reverts
+- 🔀 ~95% merge rate on Atomic-generated PRs, with reduced follow-ups and a 0% revert rate
+- 🛡️ Production incidents caught that CI did not cover
 
- Your engineering process should be yours, not tied to any single tool, agent, or model. A harness encodes that process: how work is scoped, divided, checked, verified, and approved.
+**Core capabilities:**
 
- Atomic is the first verifiable coding agent runtime for building your own harness. A set of composable, verifiable harnesses can form the foundation of your software factory.
- 
- Build your process as workflows with scoped context, model choice, tools, handoffs, artifacts, retries, executable checks, review gates, and human approvals. 
-  
- Atomic’s primitives are built for the software engineering lifecycle. Verification is built into the exeuction model. 
- 
- Atomic is open so you can inspect and adapt it. You own the workflow, the evidence, and the rules for completion.
+- **Workflows as versioned TypeScript** — stages, branches, parallelism, retries, and gates are code you review, not per-run model improvisation
+- **Verification built into the execution model** — stages declare outputs against schemas; the runtime validates them before the next stage starts
+- **Author/verifier separation** — fresh-context verifiers derive checks from requirements, not from the implementation's claims
+- **Evidence, not self-report** — builds, typechecks, tests, and browser checks run as tracked tool calls, checkpointed and auditable after the run
+- **Deterministic ship/repair decisions** — completion is decided by code from structured verifier output, with human approval gates where you put them
+- **Model-agnostic** — subscription login for Claude, Codex, Copilot, xAI, and more; swap providers without rewriting workflows
+- **Specialized subagents** — nine bundled agents with scoped context and tools; fan out research, keep implementation contexts small
+- **Agent Skills standard** — bring existing Claude Code or Codex skills without rewriting them
+- **MCP support** — connect Jira, GitHub, databases, and the rest of your stack as agent tools
+- **Durable, resumable runs** — attach to any running stage, watch, steer, pause, or resume; checkpoints survive interruption
+- **Author workflows in natural language** — Atomic knows its own runtime and writes the TypeScript definition; you refine it
+- **Open source (MIT)** — inspect, version, and own the workflow, the evidence, and the rules for completion
 
- Own your intelligence. Build in the open. Question the defaults. Keep control of the process. ☠︎
+Build your process as workflows with scoped context, model choice, tools, handoffs, artifacts, retries, executable checks, review gates, and human approvals.
+
+Atomic’s primitives are built for the software engineering lifecycle. Verification is built into the execution model.
+
+Atomic is open so you can inspect and adapt it. You own the workflow, the evidence, and the rules for completion.
+
+Own your intelligence. Build in the open. Question the defaults. Keep control of the process. ☠︎
 
 ---
 


### PR DESCRIPTION
## Summary

Restructure the README hero so engineers see production-use outcomes and Atomic's core capabilities before installation details.

## Changes

- Add three reported production outcomes covering manual verification time, PR merge and revert rates, and incidents missed by CI
- Add a plain, scannable list of core runtime capabilities
- Keep the product description and assurance principles near the top while removing repeated copy

## Notes

Documentation-only change; no code tests were needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788416298&installation_model_id=10562&pr_number=2182&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2182&signature=e9e3b989e8cafecabc78293e035f4e4f0bd69d2797dfd7237acdcd71f1dfe2e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The README hero now leads with Atomic’s verification-focused product positioning, reported user outcomes, and core capabilities before installation guidance. The updated README was checked against both the previous and current revisions: all four navigation anchors, 16 local documentation links, and the checked provider, Agent Skills, and bundled-subagent statements resolved successfully. No defects were reported or removed.

<h3>Confidence Score: 5/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The hero validation was run against the parent revision and the PR revision; both runs passed all four anchors, 16 local links, and the provider, skill, and subagent claims.
- The validation script source was uploaded to enable automated checks.
- The before and after validation logs were uploaded, showing baseline and PR results with four anchors, sixteen local links, and all claims passing.

<a href="https://app.greptile.com/trex/runs/17196149/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(readme): restructure hero with prod..."](https://github.com/bastani-inc/atomic/commit/f0a6d422a09673f6f8353e2b9f944f034741eab5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49956120)</sub>

<!-- /greptile_comment -->