### PR TITLE
docs(changelog): prepare 0.9.12 release notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+## [0.9.12] - 2026-08-04
+
+Cumulative release of the `0.9.12-alpha.1` prerelease. The summary below covers the user-visible outcome of that work; the per-change detail remains in the prerelease section below.
+
+### Added
+
+- Compaction honors `<keepContext>` / `</keepContext>` tags. Wrap any part of a prompt you never want compressed, and every line of the span — tag lines included — is protected verbatim regardless of the compression ratio. The guarantee is mechanical rather than advisory: deletion ranges are split around protected lines after the planner responds. Because the tag lines are protected too, a span is re-detected on each subsequent boundary and stays protected for the life of the session. Detection is bounded on three sides, because the transcript it scans is untrusted: a tag must be the whole line after any role header, a span is scoped to one message so an unclosed tag stops at the end of its own message rather than running to the end of the region, and tags inside tool results are inert — user and assistant messages may both protect, so prompts, steering, and an agent's own pinned information all work, but file, page, or command output an agent reads cannot mark itself unreclaimable or persist through compaction ahead of real content. Protected lines count against the keep target rather than raising it, so the compression ratio stays a real bound on output size and the unprotected remainder compresses harder. Results report force-preserved ranges as `keptRanges` ([#2172](https://github.com/bastani-inc/atomic/issues/2172)).
+
+### Fixed
+
+- The compaction relevance query is no longer truncated to 1,000 characters. Truncation made prompt section order the retention policy: for a long structured prompt only the leading section reached the planner, so a constraint stated later could not influence what was kept, while the objective it qualified survived and was acted on. Long queries are safe — an oversized planner request surfaces as an explicit provider-overflow failure rather than silent truncation ([#2172](https://github.com/bastani-inc/atomic/issues/2172)).
+- Cleared three advisories in the shipped dependency tree. `undici` moves 8.5.0 → 8.9.0, which covers five advisories against 8.0.0–8.8.0 — response desynchronization via the retry interceptor, two cross-user cache-directive disclosures, CRLF injection through a blob body `type`, and cookie-attribute injection — and it is the dispatcher behind `fetch_url` and every agent HTTP request. Transitively under `@modelcontextprotocol/sdk`, `ip-address` is pinned to 10.3.1 for three SSRF and trust-boundary bypasses (octal-decoded leading-zero octets, CIDR suffixes suppressing special-use classification, and misclassified IPv4-mapped/NAT64 addresses), and `hono` to 4.12.34 for a CORS-middleware ReDoS. `npm audit` is clean.
+- Fixed bundled builtin extensions failing to load on Windows when shared modules were evaluated twice, so bundled workflows and tools initialize correctly.
+
 ## [0.9.12-alpha.1] - 2026-08-04
 
 ### Added

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.12] - 2026-08-04
+
+### Fixed
+
+- Fixed bundled Intercom resources failing to load on Windows when shared modules used mixed `.ts` and `.js` import spellings.
+
 ## [0.9.12-alpha.1] - 2026-08-04
 
 ### Fixed

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.12] - 2026-08-04
+
+### Fixed
+
+- Fixed bundled MCP resources failing to load on Windows when shared modules used mixed `.ts` and `.js` import spellings.
+
 ## [0.9.12-alpha.1] - 2026-08-04
 
 ### Fixed

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.12] - 2026-08-04
+
+### Changed
+
+- Released with Atomic 0.9.12. No native transport changes were made after 0.9.11; the package is published in sync so `@bastani/atomic` resolves a matching `@bastani/atomic-natives` version.
+
 ## [0.9.11] - 2026-08-03
 
 ### Removed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.12] - 2026-08-04
+
+### Fixed
+
+- Fixed bundled subagent resources failing to load on Windows when shared modules used mixed `.ts` and `.js` import spellings.
+
 ## [0.9.12-alpha.1] - 2026-08-04
 
 ### Fixed

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.12] - 2026-08-04
+
+### Fixed
+
+- Fixed bundled web-access resources failing to load on Windows when shared modules used mixed `.ts` and `.js` import spellings.
+
 ## [0.9.12-alpha.1] - 2026-08-04
 
 ### Fixed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.12] - 2026-08-04
+
+Cumulative release of the `0.9.12-alpha.1` prerelease. The summary below covers the user-visible outcome of that work; the per-change detail remains in the prerelease section below.
+
+### Added
+
+- Added `keepContext` to the public authoring surface: `import { keepContext } from "@bastani/workflows"`. It wraps prompt text so compaction protects it verbatim regardless of the compression ratio, and is a pure, idempotent string helper rather than a `ctx.*` primitive — no graph node, no side effect, callable anywhere a prompt is assembled. `KEEP_CONTEXT_OPEN_TAG` and `KEEP_CONTEXT_CLOSE_TAG` are exported alongside it. Reserve it for text whose loss silently changes behavior — role constraints, acceptance criteria, explicit prohibitions, and identifiers a stage must not lose — and not for bulk context, since protected lines count against the keep target rather than raising it ([#2172](https://github.com/bastani-inc/atomic/issues/2172)).
+- `<keepContext>` tags also work in the run inputs and steering messages sent through the `workflow` tool, not only in authored stage prompts. Workflows inject inputs into their stage prompts, so a tagged clause in `prompt` or `acceptance_criteria` is inherited and protected by every stage that receives it, and a tagged `send` amendment survives until the stage acts on it instead of competing with the whole transcript for retention. Because `keepContext` is idempotent, an already-tagged input is not double-wrapped by a workflow that protects the same field. The workflow tool description and agent guidance now say so, so an agent can decide per launch or per steering message which clauses to protect ([#2172](https://github.com/bastani-inc/atomic/issues/2172)).
+
+### Fixed
+
+- Builtin workflows protect their own invariants with `keepContext`, so a long-running stage can no longer lose the rules that bound it: the steering propagation contract carried by every builtin stage prompt, the literal objective contract, scope discipline, worktree discipline, ralph's per-run acceptance criteria, ralph's research-only role constraint, and goal's reviewer "inspect and report; do not implement" constraint. Previously a research stage could be compacted past its own prohibition and start implementing, and a stage could lose the checkout it was bound to ([#2172](https://github.com/bastani-inc/atomic/issues/2172)).
+
 ## [0.9.12-alpha.1] - 2026-08-04
 
 ### Added


### PR DESCRIPTION
## Summary

Prepares the release notes for **0.9.12**. This is a changelog-only PR: it adds a cumulative `[0.9.12]` section to all seven package changelogs, summarizing the user-visible outcome of the `0.9.12-alpha.1` prerelease. Per-change detail stays in the prerelease sections below each new entry.

## Changes

- `packages/coding-agent` — `keepContext` compaction protection, the untruncated compaction relevance query, three cleared npm advisories (`undici` 8.5.0 → 8.9.0, `ip-address` 10.3.1, `hono` 4.12.34), and the Windows bundled-extension load fix.
- `packages/workflows` — the public `keepContext` authoring export, `<keepContext>` support in run inputs and steering messages, and builtin workflows protecting their own invariants.
- `packages/intercom`, `packages/mcp`, `packages/subagents`, `packages/web-access` — the Windows bundled-resource fix for mixed `.ts`/`.js` import spellings.
- `packages/natives` — released in sync so `@bastani/atomic` resolves a matching `@bastani/atomic-natives`.

## Notes

- **Changelog-only diff**: 57 insertions, 0 deletions, across the 7 `CHANGELOG.md` files only. No already-released version section was modified.
- **Versionless base preserved**: every package manifest, the `package-lock.json` workspace entries, and the Cargo/natives version files remain at the `0.0.0` placeholder. `scripts/cut-release.ts` stamps the real version on the detached `Release 0.9.12` commit after this merges; that tag push is what starts `publish.yml`.
- **Local validation**: `bun run check` (biome + `tsc --noEmit` + shrinkwrap), `test:unit` (5845 passed), `test:integration` (485 passed), and `test:ci-contracts` (39 passed) all green. Pre-commit and pre-push hooks ran unskipped and passed.

Assistant-model: Claude Opus 5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788423626&installation_model_id=10562&pr_number=2183&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2183&signature=24e0ca1ddff3a437fd84ed57558cebd7fa2835d5c82b75060c9e7698e444b38d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds 0.9.12 release notes across the coding-agent, workflows, intercom, mcp, natives, subagents, and web-access packages. The new release sections are correctly formatted and ordered beneath `Unreleased`, and appear before existing alpha release notes where applicable. Changelog, package metadata, and publish-workflow checks passed. No defects were found; this is safe to merge.

<h3>Confidence Score: 5/5</h3>

The release-note update is safe to merge.

No defects remain. The seven new 0.9.12 sections were verified for expected coverage, ordering, and parseability, and the repository's changelog, package metadata, and publish-workflow tests passed.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused changelog unit tests and the package-metadata plus publish-release-workflow tests; the changelog tests passed 11 of 11 and the package-metadata plus workflow tests passed 19 of 19.
- Compared the release-note state before PR 2183 and after PR HEAD; the before state contained no 0.9.12 sections while the after state contains exactly seven parseable 0.9.12 sections in the expected order.
- Reviewed the focused changelog release-contract validation script artifact to verify the validation workflow and cross-check the post-change state against the seven 0.9.12 sections.

<a href="https://app.greptile.com/trex/runs/17208199/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.12 release ..."](https://github.com/bastani-inc/atomic/commit/6fed365167aebfbf4a743a3b9ec2374fddf608e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49989623)</sub>

<!-- /greptile_comment -->