### PR TITLE
fix(workflows): mark runs awaiting human input with the awaiting-input indicator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -178,12 +178,13 @@ jobs:
             timeout_minutes: 5
           - os: blacksmith-4vcpu-windows-2025
             binary_platform: windows-x64
-            timeout_minutes: 6
+            timeout_minutes: 9
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    # Sampled at 74s Linux / 149s Windows and measured at 84s / 162s on the first
-    # split run, both including the native binding rebuild this job pays for
-    # itself (see the Rust toolchain note below).
+    # The warm sample measured 162s, but cold acquisition consumed 152s for
+    # rust-toolchain and 71s for checkout, on top of ~110s native build and
+    # ~40s archive smoke: an observed tail near 6m50s versus a healthy 4m04s.
+    # Keep 9m of headroom for that cold toolchain tail.
     timeout-minutes: ${{ matrix.timeout_minutes }}
     steps:
       - uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1.1

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -42,9 +42,15 @@ The test workflow runs on pushes to `main`, `release/**`, and `prerelease/**`, a
 | --- | --- | --- | ---: | ---: |
 | `suites` | both | build `@bastani/atomic` -> unit -> integration | 121 s | 195 s |
 | `agent-suite` | both | build native bindings -> coding-agent vitest (Node), then its Bun-hosted SQLite selector project | 126 s | 232 s |
-| `release-archive` | both | build package -> `scripts/build-binaries.sh` -> archive smoke | 74 s | 149 s |
+| `release-archive` | both | build package -> `scripts/build-binaries.sh` -> archive smoke | 74 s | 149 s warm / 4m04s healthy p100 |
 | `static-checks` | Linux only | typecheck, docs links, Mintlify, CI contracts | 30 s | – |
 | `test` | 2 gate legs | assert every work-job result is `success` | 15 s | – |
+
+The release-archive Windows samples above are warm-toolchain measurements. A cold
+run reached 6m12s and 6m13s before cancellation: `rust-toolchain` took 152s and
+140s (versus 12s and 36s warm), checkout took 71s and 64s, and the native build
+and archive smoke add roughly 110s and 40s. The 9-minute cap covers that observed
+near-6m50s tail rather than only the healthy 4m04s p100.
 
 Those are the per-step costs sampled from four sequential-job runs, which put the critical path on the Windows `agent-suite` chain at about 247 s against the 452 s (434–483 s, n=3 healthy) the single sequential job measured. Runner-seconds rise about 35 % (709 s to roughly 957 s); that is the price of the wall-clock cut.
 
@@ -53,11 +59,16 @@ Those are the per-step costs sampled from four sequential-job runs, which put th
 | Job | run 1 | run 2 |
 | --- | ---: | ---: |
 | `static-checks (linux-x64)` | 32 s | 50 s |
-| `release-archive` Linux / Windows | 84 s / 162 s | 83 s / 175 s |
+| `release-archive` Linux / Windows | 84 s / 162 s (warm) | 83 s / 175 s (warm) |
 | `suites` Linux / Windows | 230 s / 348 s | 147 s / 238 s |
 | `agent-suite` Linux / Windows | 138 s / **349 s** | 203 s / **380 s** |
 | `test` gate, both legs | 3 s / 4 s | 4 s / 5 s |
 | **whole run** | **433 s** | **440 s** |
+
+The older split-run release-archive values in this table are warm samples; later
+healthy Windows runs reached 4m04s, while two cold runs reached 6m12s and 6m13s
+and were cancelled by the former 6-minute cap. The Windows cap is therefore 9
+minutes to cover the cold toolchain and checkout tail.
 
 Read this carefully before planning further work, because it says two different things.
 
@@ -108,7 +119,7 @@ If maintainers later prefer real per-job required contexts, that is a separate d
 
 ### Per-job time limits
 
-The blanket 10/15-minute pair is gone. Each job declares its own cap as a hang detector at roughly 2x measured p100, with room for the one bounded flake retry it owns: `suites` 8/12, `agent-suite` 6/12, `release-archive` 5/6, `static-checks` 6, gate 5. The two Windows caps are 12 rather than the 8 and 9 that the sequential-job sampling implied, because the first split run measured 348 s and 349 s there; a cap that cancels a passing retried run is worse than a late hang detection. Every cap still sits under the 15-minute Windows blanket it replaced, and the contract test enforces that.
+The blanket 10/15-minute pair is gone. Each job declares its own cap as a hang detector at roughly 2x measured p100, with room for the one bounded flake retry it owns: `suites` 8/12, `agent-suite` 6/12, `release-archive` 5/9, `static-checks` 6, gate 5. The two Windows caps are 12 rather than the 8 and 9 that the sequential-job sampling implied, because the first split run measured 348 s and 349 s there; a cap that cancels a passing retried run is worse than a late hang detection. The release-archive Windows cap is 9 because cold setup observed a 152 s Rust toolchain acquisition and 71 s checkout before the roughly 110 s native build and 40 s archive smoke. Every cap still sits under the 15-minute Windows blanket it replaced, and the contract test enforces that.
 
 Every job that runs a suite through `scripts/run-flaky-test-suite.ts` uploads `.ci-diagnostics/` under a job-unique artifact name (`test-diagnostics-<job>-<binary_platform>`). `actions/upload-artifact@v4+` fails the entire run when two jobs upload the same name.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Workflow runs awaiting human input now use the blue `？` indicator in the BACKGROUND panel, `/workflow connect` picker, and `/workflow status` listing, including prompts raised by hidden nested workflow children; the indicator returns to the run's current state when the prompt resolves.
+
 ## [0.9.12] - 2026-08-04
 
 Cumulative release of the `0.9.12-alpha.1` prerelease. The summary below covers the user-visible outcome of that work; the per-change detail remains in the prerelease section below.

--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -117,7 +117,7 @@ Named workflow runs execute in the background. By default, after launch expect a
 
 For a request with several implementation items, do not turn list order into one serial workflow by default. Triage dependencies first, then launch independent items as a bounded wave of separate top-level runs; see [Task queues and software factories](#task-queues-and-software-factories).
 
-While a workflow is running, the visible below-editor `BACKGROUND` panel advances its elapsed label every second from the moment the run starts; it does not require opening or switching to the orchestrator. Updates repaint the existing mounted panel in place, paused timers stay frozen, the panel renders every qualifying top-level run, and terminal or quit cards retain their brief recent-run expiry. Quit cards remain resumable and discoverable with `/workflow status` after they leave the panel.
+While a workflow is running, the visible below-editor `BACKGROUND` panel advances its elapsed label every second from the moment the run starts; it does not require opening or switching to the orchestrator. Updates repaint the existing mounted panel in place, paused timers stay frozen, the panel renders every qualifying top-level run, and terminal or quit cards retain their brief recent-run expiry. Quit cards remain resumable and discoverable with `/workflow status` after they leave the panel. A run waiting for human input uses the blue `？` indicator in the BACKGROUND panel, the `/workflow connect` picker, and the `/workflow status` listing; answering or cancelling the prompt restores the run's current indicator.
 
 ### Workflow run identifiers and the BACKGROUND panel
 

--- a/packages/coding-agent/test/bash-session-metadata.test.ts
+++ b/packages/coding-agent/test/bash-session-metadata.test.ts
@@ -10,7 +10,7 @@ import { SettingsManager } from "../src/core/settings-manager.ts";
 import { type BashOperations, createBashTool } from "../src/core/tools/bash.ts";
 
 const roots: string[] = [];
-const ASYNC_JOB_WAIT_TIMEOUT_MS = 5_000,
+const ASYNC_JOB_WAIT_TIMEOUT_MS = 10_000,
 	ASYNC_JOB_POLL_INTERVAL_MS = 5;
 const model = getModel("anthropic", "claude-sonnet-4-5")!;
 const switchedModel = getModel("openai", "gpt-4o")!;

--- a/packages/coding-agent/test/bash-session-metadata.test.ts
+++ b/packages/coding-agent/test/bash-session-metadata.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getModel } from "@earendil-works/pi-ai/compat";
@@ -10,6 +10,8 @@ import { SettingsManager } from "../src/core/settings-manager.ts";
 import { type BashOperations, createBashTool } from "../src/core/tools/bash.ts";
 
 const roots: string[] = [];
+const ASYNC_JOB_WAIT_TIMEOUT_MS = 5_000,
+	ASYNC_JOB_POLL_INTERVAL_MS = 5;
 const model = getModel("anthropic", "claude-sonnet-4-5")!;
 const switchedModel = getModel("openai", "gpt-4o")!;
 
@@ -217,16 +219,54 @@ describe("session-aware bash environment", () => {
 	it("propagates the same snapshot into detached async jobs", async () => {
 		const { session, cwd } = await createSession({ persisted: false });
 		const bash = session.agent.state.tools.find((tool) => tool.name === "bash")!;
-		const outputPath = join(cwd, "async-session-env.txt");
-		await bash.execute("async-metadata", {
-			command: `printf '%s:%s' "$ATOMIC_SESSION_ID" "$PI_SESSION_ID" > '${outputPath}'`,
-			async: true,
-		});
-		for (let attempt = 0; attempt < 100 && !existsSync(outputPath); attempt += 1) {
-			await new Promise((resolve) => setTimeout(resolve, 5));
+		const outputName = "async-session-env.txt";
+		const outputPath = join(cwd, outputName);
+		const releaseName = ".async-session-env.release";
+		const releasePath = join(cwd, releaseName);
+		try {
+			const started = await bash.execute("async-metadata", {
+				command: `{ while [ ! -f '${releaseName}' ]; do sleep 0.01; done; printf '%s:%s' "$ATOMIC_SESSION_ID" "$PI_SESSION_ID"; } > '${outputName}'`,
+				async: true,
+			});
+			const jobId = started.details?.async?.jobId;
+			if (!jobId) throw new Error("Detached bash command did not return a job ID");
+			try {
+				const creationDeadline = Date.now() + ASYNC_JOB_WAIT_TIMEOUT_MS;
+				while (!existsSync(outputPath)) {
+					if (Date.now() >= creationDeadline) {
+						throw new Error(
+							`Timed out after ${ASYNC_JOB_WAIT_TIMEOUT_MS}ms waiting for async job ${jobId} to create ${outputPath}`,
+						);
+					}
+					await new Promise((resolve) => setTimeout(resolve, ASYNC_JOB_POLL_INTERVAL_MS));
+				}
+				expect(readFileSync(outputPath, "utf8")).toBe("");
+			} finally {
+				writeFileSync(releasePath, "");
+			}
+
+			const completionDeadline = Date.now() + ASYNC_JOB_WAIT_TIMEOUT_MS;
+			while (true) {
+				const polled = await bash.execute("async-metadata-poll", {
+					command: `__atomic_bash_job ${jobId}`,
+				});
+				const observedState = polled.details?.async?.state;
+				const observedOutput = text(polled);
+				if (observedState === "completed") break;
+				if (observedState === "failed") {
+					throw new Error(`Async bash job ${jobId} failed: ${observedOutput}`);
+				}
+				if (Date.now() >= completionDeadline) {
+					throw new Error(
+						`Timed out after ${ASYNC_JOB_WAIT_TIMEOUT_MS}ms waiting for async job ${jobId} to complete; observed state: ${String(observedState)}; observed output: ${JSON.stringify(observedOutput)}`,
+					);
+				}
+				await new Promise((resolve) => setTimeout(resolve, ASYNC_JOB_POLL_INTERVAL_MS));
+			}
+			expect(readFileSync(outputPath, "utf8")).toBe(`${session.sessionId}:${session.sessionId}`);
+		} finally {
+			session.dispose();
 		}
-		expect(readFileSync(outputPath, "utf8")).toBe(`${session.sessionId}:${session.sessionId}`);
-		session.dispose();
 	});
 
 	it("rejects retained tools after their session closes instead of using stale metadata", async () => {

--- a/packages/coding-agent/test/rpc-bash-session-replacement.test.ts
+++ b/packages/coding-agent/test/rpc-bash-session-replacement.test.ts
@@ -1,13 +1,40 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentSession } from "../src/core/agent-session.ts";
 import { AgentSessionRuntime } from "../src/core/agent-session-runtime.ts";
+import { SessionManager } from "../src/core/session-manager.ts";
 import { createRpcCommandHandler } from "../src/modes/rpc/rpc-command-handler.ts";
 import { RpcSessionBinding } from "../src/modes/rpc/rpc-session-binding.ts";
 import type { RpcCommand } from "../src/modes/rpc/rpc-types.ts";
 import { createHarness } from "./suite/harness.ts";
 
-async function waitFor(predicate: () => boolean): Promise<void> {
-	while (!predicate()) await new Promise((resolve) => setTimeout(resolve, 5));
+const RPC_OUTPUT_WAIT_TIMEOUT_MS = 5_000,
+	RPC_OUTPUT_POLL_INTERVAL_MS = 5;
+
+/**
+ * Holds a bash command in flight until the test releases it.
+ *
+ * These tests must issue the session replacement *while* the execution is still
+ * owned by the starting session. A fixed `sleep` cannot express that: the shell
+ * writes before and after it can be delivered in a single pipe read, so the
+ * observable output jumps straight to `beforeafter` and the intended in-flight
+ * window never exists. Blocking on a marker file makes the window explicit and
+ * independent of how the runtime chunks stdout.
+ *
+ * The marker lives in a freshly created temp directory that also serves as the
+ * session cwd, so the command can name it relatively (no Windows path quoting)
+ * and no leftover marker from an earlier run can release a later one early.
+ */
+function createBashGate(label: string) {
+	const cwd = mkdtempSync(join(tmpdir(), `atomic-rpc-bash-${label}-`));
+	return {
+		cwd,
+		command: (marker: string) => `printf before; while [ ! -f '${marker}' ]; do sleep 0.01; done; printf after`,
+		release: (marker: string) => writeFileSync(join(cwd, marker), ""),
+		cleanup: () => rmSync(cwd, { recursive: true, force: true }),
+	};
 }
 
 async function createRealReplacementContext() {
@@ -63,7 +90,28 @@ function updatesFor(output: object[], id: string): string {
 		.join("");
 }
 
+async function waitForOutput(output: object[], id: string, expectedPrefix: string): Promise<void> {
+	const deadline = Date.now() + RPC_OUTPUT_WAIT_TIMEOUT_MS;
+	while (true) {
+		const observed = updatesFor(output, id);
+		if (observed.startsWith(expectedPrefix)) return;
+		if (Date.now() >= deadline) {
+			throw new Error(
+				`Timed out after ${RPC_OUTPUT_WAIT_TIMEOUT_MS}ms waiting for RPC bash ${JSON.stringify(id)} output prefix ${JSON.stringify(expectedPrefix)}; observed accumulated output: ${JSON.stringify(observed)}`,
+			);
+		}
+		await new Promise((resolve) => setTimeout(resolve, RPC_OUTPUT_POLL_INTERVAL_MS));
+	}
+}
+
 describe("RPC bash ownership across session replacement", () => {
+	it("recognizes an expected prefix delivered in one coalesced RPC delta", async () => {
+		const output = [{ type: "bash_execution_update", id: "coalesced", channel: "stdout", delta: "beforeafter" }];
+
+		await waitForOutput(output, "coalesced", "before");
+		expect(updatesFor(output, "coalesced")).toBe("beforeafter");
+	});
+
 	it("keeps targeted cancellation reachable in the starting session after replacement", async () => {
 		const context = await createRealReplacementContext();
 		vi.spyOn(context.first.session, "isStreaming", "get").mockReturnValue(true);
@@ -72,7 +120,7 @@ describe("RPC bash ownership across session replacement", () => {
 			type: "bash",
 			command: "printf old-start; sleep 1; printf old-end",
 		});
-		await waitFor(() => updatesFor(context.output, "old-target") === "old-start");
+		await waitForOutput(context.output, "old-target", "old-start");
 		await context.handle({ id: "replace", type: "new_session" });
 		await expect(
 			context.handle({ id: "cancel-old", type: "abort_bash", requestId: "old-target" }),
@@ -109,14 +157,14 @@ describe("RPC bash ownership across session replacement", () => {
 			type: "bash",
 			command: "printf old-start; sleep 1; printf old-end",
 		});
-		await waitFor(() => updatesFor(context.output, "old-all") === "old-start");
+		await waitForOutput(context.output, "old-all", "old-start");
 		await context.handle({ id: "replace", type: "new_session" });
 		const newExecution = context.handle({
 			id: "new-all",
 			type: "bash",
 			command: "printf new-start; sleep 1; printf new-end",
 		});
-		await waitFor(() => updatesFor(context.output, "new-all") === "new-start");
+		await waitForOutput(context.output, "new-all", "new-start");
 		await context.handle({ id: "cancel-all", type: "abort_bash" });
 		const [oldResult, newResult] = await Promise.all([oldExecution, newExecution]);
 		expect(oldResult).toMatchObject({ success: true, data: { cancelled: true } });
@@ -127,7 +175,8 @@ describe("RPC bash ownership across session replacement", () => {
 	});
 
 	it("retains source ownership for every RPC replacement command and reload control", async () => {
-		const first = await createHarness();
+		const gate = createBashGate("replacement");
+		const first = await createHarness({ sessionManager: SessionManager.inMemory(gate.cwd) });
 		const second = await createHarness();
 		let current: AgentSession = first.session;
 		const replace = async () => {
@@ -173,10 +222,15 @@ describe("RPC bash ownership across session replacement", () => {
 		for (const transition of transitions) {
 			current = first.session;
 			const id = `bash-${transition.name}`;
-			const execution = handle({ id, type: "bash", command: "printf before; sleep 0.05; printf after" });
-			await waitFor(() => updatesFor(output, id) === "before");
-			await expect(handle(transition.command)).resolves.toMatchObject({ success: true });
-			expect(current === second.session).toBe(transition.replaces);
+			const marker = `${transition.name}.release`;
+			const execution = handle({ id, type: "bash", command: gate.command(marker) });
+			try {
+				await waitForOutput(output, id, "before");
+				await expect(handle(transition.command)).resolves.toMatchObject({ success: true });
+				expect(current === second.session).toBe(transition.replaces);
+			} finally {
+				gate.release(marker);
+			}
 			await expect(execution).resolves.toMatchObject({ success: true, data: { output: "beforeafter" } });
 			expect(updatesFor(output, id)).toBe("beforeafter");
 		}
@@ -186,10 +240,12 @@ describe("RPC bash ownership across session replacement", () => {
 		expect(second.session.messages.filter((message) => message.role === "bashExecution")).toHaveLength(0);
 		second.cleanup();
 		first.cleanup();
+		gate.cleanup();
 	});
 
 	it("leaves ownership unchanged when a replacement is cancelled", async () => {
-		const harness = await createHarness();
+		const gate = createBashGate("cancelled-swap");
+		const harness = await createHarness({ sessionManager: SessionManager.inMemory(gate.cwd) });
 		const output: object[] = [];
 		const runtimeHost = {
 			services: { agentDir: harness.tempDir },
@@ -203,19 +259,21 @@ describe("RPC bash ownership across session replacement", () => {
 			},
 			output: (event) => output.push(event),
 		});
-		const execution = handle({
-			id: "cancelled-swap-bash",
-			type: "bash",
-			command: "printf before; sleep 0.05; printf after",
-		});
-		await waitFor(() => updatesFor(output, "cancelled-swap-bash") === "before");
-		await expect(handle({ id: "cancelled-swap", type: "new_session" })).resolves.toMatchObject({
-			success: true,
-			data: { cancelled: true },
-		});
+		const marker = "cancelled-swap.release";
+		const execution = handle({ id: "cancelled-swap-bash", type: "bash", command: gate.command(marker) });
+		try {
+			await waitForOutput(output, "cancelled-swap-bash", "before");
+			await expect(handle({ id: "cancelled-swap", type: "new_session" })).resolves.toMatchObject({
+				success: true,
+				data: { cancelled: true },
+			});
+		} finally {
+			gate.release(marker);
+		}
 		await expect(execution).resolves.toMatchObject({ success: true, data: { output: "beforeafter" } });
 		expect(updatesFor(output, "cancelled-swap-bash")).toBe("beforeafter");
 		harness.cleanup();
+		gate.cleanup();
 	});
 
 	it("does not append a late result to the shared target manager after an actual unpersisted clone", async () => {
@@ -262,7 +320,7 @@ describe("RPC bash ownership across session replacement", () => {
 			type: "bash",
 			command: "printf source; sleep 0.2; printf result",
 		});
-		await waitFor(() => updatesFor(output, "shared-manager") === "source");
+		await waitForOutput(output, "shared-manager", "source");
 		await expect(handle({ id: "clone", type: "clone" })).resolves.toMatchObject({ success: true });
 		expect(source.sessionManager.getSessionId()).not.toBe(startingSessionId);
 
@@ -289,7 +347,7 @@ describe("RPC bash ownership across session replacement", () => {
 			output: (event) => output.push(event),
 		});
 		const execution = handle({ id: "shutdown-bash", type: "bash", command: "printf start; sleep 1; printf end" });
-		await waitFor(() => updatesFor(output, "shutdown-bash") === "start");
+		await waitForOutput(output, "shutdown-bash", "start");
 		await handle.disposeActiveBash();
 		await expect(execution).resolves.toMatchObject({ success: true, data: { cancelled: true } });
 		expect(updatesFor(output, "shutdown-bash")).toBe("start");

--- a/packages/coding-agent/test/rpc-bash-session-replacement.test.ts
+++ b/packages/coding-agent/test/rpc-bash-session-replacement.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -10,7 +10,7 @@ import { RpcSessionBinding } from "../src/modes/rpc/rpc-session-binding.ts";
 import type { RpcCommand } from "../src/modes/rpc/rpc-types.ts";
 import { createHarness } from "./suite/harness.ts";
 
-const RPC_OUTPUT_WAIT_TIMEOUT_MS = 5_000,
+const RPC_OUTPUT_WAIT_TIMEOUT_MS = 10_000,
 	RPC_OUTPUT_POLL_INTERVAL_MS = 5;
 
 /**
@@ -31,9 +31,17 @@ function createBashGate(label: string) {
 	const cwd = mkdtempSync(join(tmpdir(), `atomic-rpc-bash-${label}-`));
 	return {
 		cwd,
-		command: (marker: string) => `printf before; while [ ! -f '${marker}' ]; do sleep 0.01; done; printf after`,
+		command: (marker: string, before = "before", after = "after") =>
+			`: > '${marker}.waiting'; printf '${before}'; while [ ! -f '${marker}' ]; do sleep 0.01; done; printf '${after}'`,
+		isWaiting: (marker: string) => existsSync(join(cwd, `${marker}.waiting`)) && !existsSync(join(cwd, marker)),
 		release: (marker: string) => writeFileSync(join(cwd, marker), ""),
-		cleanup: () => rmSync(cwd, { recursive: true, force: true }),
+		cleanup: () => {
+			try {
+				rmSync(cwd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
+			} catch {
+				// Left for the OS to reclaim if a spawned shell still holds the cwd.
+			}
+		},
 	};
 }
 
@@ -176,165 +184,182 @@ describe("RPC bash ownership across session replacement", () => {
 
 	it("retains source ownership for every RPC replacement command and reload control", async () => {
 		const gate = createBashGate("replacement");
-		const first = await createHarness({ sessionManager: SessionManager.inMemory(gate.cwd) });
-		const second = await createHarness();
-		let current: AgentSession = first.session;
-		const replace = async () => {
-			current = second.session;
-			return { cancelled: false };
-		};
-		const runtimeHost = {
-			services: { agentDir: first.tempDir },
-			get session() {
-				return current;
-			},
-			newSession: replace,
-			switchSession: replace,
-			importFromJsonl: replace,
-			fork: async () => ({ ...(await replace()), selectedText: undefined }),
-		} as unknown as AgentSessionRuntime;
-		const output: object[] = [];
-		const handle = createRpcCommandHandler({
-			runtimeHost,
-			getSession: () => current,
-			rebindSession: async () => {},
-			output: (event) => output.push(event),
-		});
-		vi.spyOn(first.session.sessionManager, "getLeafId").mockReturnValue("leaf-for-clone");
-		vi.spyOn(first.session, "reload").mockResolvedValue();
-		const transitions: Array<{ name: string; command: RpcCommand; replaces: boolean }> = [
-			{ name: "new", command: { id: "swap-new", type: "new_session" }, replaces: true },
-			{
-				name: "switch",
-				command: { id: "swap-switch", type: "switch_session", sessionPath: "/tmp/target.jsonl" },
-				replaces: true,
-			},
-			{
-				name: "import",
-				command: { id: "swap-import", type: "import_session", inputPath: "/tmp/import.jsonl" },
-				replaces: true,
-			},
-			{ name: "fork", command: { id: "swap-fork", type: "fork", entryId: "entry" }, replaces: true },
-			{ name: "clone", command: { id: "swap-clone", type: "clone" }, replaces: true },
-			{ name: "reload", command: { id: "same-reload", type: "reload" }, replaces: false },
-		];
+		try {
+			const first = await createHarness({ sessionManager: SessionManager.inMemory(gate.cwd) });
+			const second = await createHarness();
+			let current: AgentSession = first.session;
+			const replace = async () => {
+				current = second.session;
+				return { cancelled: false };
+			};
+			const runtimeHost = {
+				services: { agentDir: first.tempDir },
+				get session() {
+					return current;
+				},
+				newSession: replace,
+				switchSession: replace,
+				importFromJsonl: replace,
+				fork: async () => ({ ...(await replace()), selectedText: undefined }),
+			} as unknown as AgentSessionRuntime;
+			const output: object[] = [];
+			const handle = createRpcCommandHandler({
+				runtimeHost,
+				getSession: () => current,
+				rebindSession: async () => {},
+				output: (event) => output.push(event),
+			});
+			vi.spyOn(first.session.sessionManager, "getLeafId").mockReturnValue("leaf-for-clone");
+			vi.spyOn(first.session, "reload").mockResolvedValue();
+			const transitions: Array<{ name: string; command: RpcCommand; replaces: boolean }> = [
+				{ name: "new", command: { id: "swap-new", type: "new_session" }, replaces: true },
+				{
+					name: "switch",
+					command: { id: "swap-switch", type: "switch_session", sessionPath: "/tmp/target.jsonl" },
+					replaces: true,
+				},
+				{
+					name: "import",
+					command: { id: "swap-import", type: "import_session", inputPath: "/tmp/import.jsonl" },
+					replaces: true,
+				},
+				{ name: "fork", command: { id: "swap-fork", type: "fork", entryId: "entry" }, replaces: true },
+				{ name: "clone", command: { id: "swap-clone", type: "clone" }, replaces: true },
+				{ name: "reload", command: { id: "same-reload", type: "reload" }, replaces: false },
+			];
 
-		for (const transition of transitions) {
-			current = first.session;
-			const id = `bash-${transition.name}`;
-			const marker = `${transition.name}.release`;
-			const execution = handle({ id, type: "bash", command: gate.command(marker) });
-			try {
-				await waitForOutput(output, id, "before");
-				await expect(handle(transition.command)).resolves.toMatchObject({ success: true });
-				expect(current === second.session).toBe(transition.replaces);
-			} finally {
-				gate.release(marker);
+			for (const transition of transitions) {
+				current = first.session;
+				const id = `bash-${transition.name}`;
+				const marker = `${transition.name}.release`;
+				const execution = handle({ id, type: "bash", command: gate.command(marker) });
+				try {
+					await waitForOutput(output, id, "before");
+					await expect(handle(transition.command)).resolves.toMatchObject({ success: true });
+					expect(current === second.session).toBe(transition.replaces);
+				} finally {
+					gate.release(marker);
+				}
+				await expect(execution).resolves.toMatchObject({ success: true, data: { output: "beforeafter" } });
+				expect(updatesFor(output, id)).toBe("beforeafter");
 			}
-			await expect(execution).resolves.toMatchObject({ success: true, data: { output: "beforeafter" } });
-			expect(updatesFor(output, id)).toBe("beforeafter");
+			expect(first.session.messages.filter((message) => message.role === "bashExecution")).toHaveLength(
+				transitions.length,
+			);
+			expect(second.session.messages.filter((message) => message.role === "bashExecution")).toHaveLength(0);
+			second.cleanup();
+			first.cleanup();
+		} finally {
+			gate.cleanup();
 		}
-		expect(first.session.messages.filter((message) => message.role === "bashExecution")).toHaveLength(
-			transitions.length,
-		);
-		expect(second.session.messages.filter((message) => message.role === "bashExecution")).toHaveLength(0);
-		second.cleanup();
-		first.cleanup();
-		gate.cleanup();
 	});
 
 	it("leaves ownership unchanged when a replacement is cancelled", async () => {
 		const gate = createBashGate("cancelled-swap");
-		const harness = await createHarness({ sessionManager: SessionManager.inMemory(gate.cwd) });
-		const output: object[] = [];
-		const runtimeHost = {
-			services: { agentDir: harness.tempDir },
-			newSession: async () => ({ cancelled: true }),
-		} as unknown as AgentSessionRuntime;
-		const handle = createRpcCommandHandler({
-			runtimeHost,
-			getSession: () => harness.session,
-			rebindSession: async () => {
-				throw new Error("must not rebind cancelled replacement");
-			},
-			output: (event) => output.push(event),
-		});
-		const marker = "cancelled-swap.release";
-		const execution = handle({ id: "cancelled-swap-bash", type: "bash", command: gate.command(marker) });
 		try {
-			await waitForOutput(output, "cancelled-swap-bash", "before");
-			await expect(handle({ id: "cancelled-swap", type: "new_session" })).resolves.toMatchObject({
-				success: true,
-				data: { cancelled: true },
+			const harness = await createHarness({ sessionManager: SessionManager.inMemory(gate.cwd) });
+			const output: object[] = [];
+			const runtimeHost = {
+				services: { agentDir: harness.tempDir },
+				newSession: async () => ({ cancelled: true }),
+			} as unknown as AgentSessionRuntime;
+			const handle = createRpcCommandHandler({
+				runtimeHost,
+				getSession: () => harness.session,
+				rebindSession: async () => {
+					throw new Error("must not rebind cancelled replacement");
+				},
+				output: (event) => output.push(event),
 			});
+			const marker = "cancelled-swap.release";
+			const execution = handle({ id: "cancelled-swap-bash", type: "bash", command: gate.command(marker) });
+			try {
+				await waitForOutput(output, "cancelled-swap-bash", "before");
+				await expect(handle({ id: "cancelled-swap", type: "new_session" })).resolves.toMatchObject({
+					success: true,
+					data: { cancelled: true },
+				});
+			} finally {
+				gate.release(marker);
+			}
+			await expect(execution).resolves.toMatchObject({ success: true, data: { output: "beforeafter" } });
+			expect(updatesFor(output, "cancelled-swap-bash")).toBe("beforeafter");
+			harness.cleanup();
 		} finally {
-			gate.release(marker);
+			gate.cleanup();
 		}
-		await expect(execution).resolves.toMatchObject({ success: true, data: { output: "beforeafter" } });
-		expect(updatesFor(output, "cancelled-swap-bash")).toBe("beforeafter");
-		harness.cleanup();
-		gate.cleanup();
 	});
 
 	it("does not append a late result to the shared target manager after an actual unpersisted clone", async () => {
-		const source = await createHarness();
-		source.session.recordBashResult("seed", {
-			output: "seed",
-			exitCode: 0,
-			cancelled: false,
-			truncated: false,
-		});
-		const startingSessionId = source.sessionManager.getSessionId();
-		let target: Awaited<ReturnType<typeof createHarness>> | undefined;
-		const runtime = new AgentSessionRuntime(
-			source.session,
-			{ cwd: source.tempDir, agentDir: source.tempDir } as never,
-			(async (options: { sessionManager: typeof source.sessionManager }) => {
-				target = await createHarness({ sessionManager: options.sessionManager });
-				target.session.agent.state.messages = options.sessionManager.buildSessionContext().messages;
-				return {
-					session: target.session,
-					services: {
-						cwd: target.tempDir,
-						agentDir: target.tempDir,
-						settingsManager: target.settingsManager,
-						modelRegistry: target.session.modelRegistry,
-						resourceLoader: target.session.resourceLoader,
-					},
-					diagnostics: [],
-				};
-			}) as never,
-		);
-		let current = source.session;
-		const output: object[] = [];
-		const handle = createRpcCommandHandler({
-			runtimeHost: runtime,
-			getSession: () => current,
-			rebindSession: async () => {
-				current = runtime.session;
-			},
-			output: (event) => output.push(event),
-		});
-		const execution = handle({
-			id: "shared-manager",
-			type: "bash",
-			command: "printf source; sleep 0.2; printf result",
-		});
-		await waitForOutput(output, "shared-manager", "source");
-		await expect(handle({ id: "clone", type: "clone" })).resolves.toMatchObject({ success: true });
-		expect(source.sessionManager.getSessionId()).not.toBe(startingSessionId);
+		const gate = createBashGate("shared-manager");
+		try {
+			const source = await createHarness({ sessionManager: SessionManager.inMemory(gate.cwd) });
+			source.session.recordBashResult("seed", {
+				output: "seed",
+				exitCode: 0,
+				cancelled: false,
+				truncated: false,
+			});
+			const startingSessionId = source.sessionManager.getSessionId();
+			let target: Awaited<ReturnType<typeof createHarness>> | undefined;
+			const runtime = new AgentSessionRuntime(
+				source.session,
+				{ cwd: source.tempDir, agentDir: source.tempDir } as never,
+				(async (options: { sessionManager: typeof source.sessionManager }) => {
+					target = await createHarness({ sessionManager: options.sessionManager });
+					target.session.agent.state.messages = options.sessionManager.buildSessionContext().messages;
+					return {
+						session: target.session,
+						services: {
+							cwd: target.tempDir,
+							agentDir: target.tempDir,
+							settingsManager: target.settingsManager,
+							modelRegistry: target.session.modelRegistry,
+							resourceLoader: target.session.resourceLoader,
+						},
+						diagnostics: [],
+					};
+				}) as never,
+			);
+			let current = source.session;
+			const output: object[] = [];
+			const handle = createRpcCommandHandler({
+				runtimeHost: runtime,
+				getSession: () => current,
+				rebindSession: async () => {
+					current = runtime.session;
+				},
+				output: (event) => output.push(event),
+			});
+			const marker = "shared-manager.release";
+			const execution = handle({
+				id: "shared-manager",
+				type: "bash",
+				command: gate.command(marker, "source", "result"),
+			});
+			try {
+				await waitForOutput(output, "shared-manager", "source");
+				expect(gate.isWaiting(marker)).toBe(true);
+				await expect(handle({ id: "clone", type: "clone" })).resolves.toMatchObject({ success: true });
+				expect(source.sessionManager.getSessionId()).not.toBe(startingSessionId);
+			} finally {
+				gate.release(marker);
+			}
 
-		await expect(execution).resolves.toMatchObject({ success: true, data: { output: "sourceresult" } });
-		expect(source.session.messages.filter((message) => message.role === "bashExecution")).toHaveLength(2);
-		expect(target?.session.messages.filter((message) => message.role === "bashExecution")).toHaveLength(1);
-		expect(
-			source.sessionManager
-				.getEntries()
-				.filter((entry) => entry.type === "message" && entry.message.role === "bashExecution"),
-		).toHaveLength(1);
+			await expect(execution).resolves.toMatchObject({ success: true, data: { output: "sourceresult" } });
+			expect(source.session.messages.filter((message) => message.role === "bashExecution")).toHaveLength(2);
+			expect(target?.session.messages.filter((message) => message.role === "bashExecution")).toHaveLength(1);
+			expect(
+				source.sessionManager
+					.getEntries()
+					.filter((entry) => entry.type === "message" && entry.message.role === "bashExecution"),
+			).toHaveLength(1);
 
-		target?.cleanup();
-		source.cleanup();
+			target?.cleanup();
+			source.cleanup();
+		} finally {
+			gate.cleanup();
+		}
 	});
 
 	it("cancels and drains active owners during RPC shutdown", async () => {

--- a/packages/workflows/src/extension/render-result.ts
+++ b/packages/workflows/src/extension/render-result.ts
@@ -32,6 +32,7 @@ import { truncateToWidth } from "../tui/text-helpers.js";
 import { renderWorkflowList } from "../tui/workflow-list.js";
 import type { WorkflowReloadReport } from "./workflow-reload-report.js";
 import type { WorkflowRunStatusFilter, WorkflowRunStatusSummary } from "./workflow-status-summary.js";
+import { getWorkflowStatusRenderRuns } from "./workflow-status-summary.js";
 
 // ---------------------------------------------------------------------------
 // Result variants
@@ -240,6 +241,8 @@ export interface RenderResultOpts {
 	 * not implement synchronized output (e.g. mosh).
 	 */
 	now?: number;
+	/** Point-in-time full run collection used only to resolve hidden nested indicators. */
+	allRuns?: readonly RunSnapshot[];
 }
 
 /**
@@ -335,6 +338,7 @@ export function renderResult(result: WorkflowToolResult, opts?: RenderResultOpts
 				theme: themed ? deriveGraphTheme({}) : undefined,
 				width: opts?.width,
 				now: opts?.now,
+				allRuns: opts?.allRuns ?? getWorkflowStatusRenderRuns(r) ?? r.snapshots,
 			});
 		}
 

--- a/packages/workflows/src/extension/workflow-command-registration.ts
+++ b/packages/workflows/src/extension/workflow-command-registration.ts
@@ -3,7 +3,7 @@ import { renderInputsSchema } from "../shared/render-inputs-schema.js";
 import { schemaIsRequired } from "../shared/schema-introspection.js";
 import { store } from "../shared/store.js";
 import type { WorkflowExecutionPolicy } from "../shared/types.js";
-import { emitChatSurface } from "../tui/chat-surface-message.js";
+import { emitChatSurface, setStatusPayloadRenderRuns } from "../tui/chat-surface-message.js";
 import { deriveGraphTheme } from "../tui/graph-theme.js";
 import { openHostInputsForm } from "../tui/host-input-form.js";
 import { openInlineInputsForm } from "../tui/inline-form-overlay.js";
@@ -158,8 +158,11 @@ async function workflowSlashHandler(
 			emitChatSurface(pi, { kind: "detail", detail: inspected.detail });
 			return;
 		}
-		const rows = selectRunsForPicker(store.runs(), "", true, Date.now());
-		emitChatSurface(pi, { kind: "status", runs: rows.map((r) => r.run) });
+		const capturedRuns = store.graphSnapshot().runs;
+		const rows = selectRunsForPicker(capturedRuns, "", true, Date.now());
+		const payload = { kind: "status" as const, runs: rows.map((r) => r.run) };
+		setStatusPayloadRenderRuns(payload, capturedRuns);
+		emitChatSurface(pi, payload);
 		return;
 	}
 	if (subcommand === "reload") {

--- a/packages/workflows/src/extension/workflow-command-registration.ts
+++ b/packages/workflows/src/extension/workflow-command-registration.ts
@@ -1,9 +1,10 @@
 import { inspectRun } from "../runs/background/status.js";
 import { renderInputsSchema } from "../shared/render-inputs-schema.js";
+import { resolveRunIndicatorStatuses } from "../shared/run-indicator-status.js";
 import { schemaIsRequired } from "../shared/schema-introspection.js";
 import { store } from "../shared/store.js";
 import type { WorkflowExecutionPolicy } from "../shared/types.js";
-import { emitChatSurface, setStatusPayloadRenderRuns } from "../tui/chat-surface-message.js";
+import { emitChatSurface } from "../tui/chat-surface-message.js";
 import { deriveGraphTheme } from "../tui/graph-theme.js";
 import { openHostInputsForm } from "../tui/host-input-form.js";
 import { openInlineInputsForm } from "../tui/inline-form-overlay.js";
@@ -160,9 +161,12 @@ async function workflowSlashHandler(
 		}
 		const capturedRuns = store.graphSnapshot().runs;
 		const rows = selectRunsForPicker(capturedRuns, "", true, Date.now());
-		const payload = { kind: "status" as const, runs: rows.map((r) => r.run) };
-		setStatusPayloadRenderRuns(payload, capturedRuns);
-		emitChatSurface(pi, payload);
+		const visibleRuns = rows.map((r) => r.run);
+		emitChatSurface(pi, {
+			kind: "status",
+			runs: visibleRuns,
+			indicatorStatuses: resolveRunIndicatorStatuses(visibleRuns, capturedRuns),
+		});
 		return;
 	}
 	if (subcommand === "reload") {

--- a/packages/workflows/src/extension/workflow-status-summary.ts
+++ b/packages/workflows/src/extension/workflow-status-summary.ts
@@ -102,6 +102,17 @@ export interface WorkflowStatusListing {
 	readonly snapshots: RunSnapshot[];
 }
 
+const workflowStatusRenderRuns = new WeakMap<object, readonly RunSnapshot[]>();
+
+/** Keep the full point-in-time run collection out of agent-facing result JSON. */
+export function setWorkflowStatusRenderRuns(result: object, runs: readonly RunSnapshot[]): void {
+	workflowStatusRenderRuns.set(result, runs);
+}
+
+export function getWorkflowStatusRenderRuns(result: object): readonly RunSnapshot[] | undefined {
+	return workflowStatusRenderRuns.get(result);
+}
+
 function stageIsActive(stage: StageSnapshot): boolean {
 	return stage.status === "running" || stage.status === "awaiting_input";
 }

--- a/packages/workflows/src/extension/workflow-tool-content.ts
+++ b/packages/workflows/src/extension/workflow-tool-content.ts
@@ -1,10 +1,13 @@
+import { runIndicatorStatus } from "../shared/run-indicator-status.js";
 import { deriveInputFields } from "../shared/schema-introspection.js";
+import type { RunSnapshot } from "../shared/store-types.js";
 import type { WorkflowSerializableValue } from "../shared/types.js";
-import { fmtDuration } from "../tui/status-helpers.js";
+import { fmtDuration, statusIcon } from "../tui/status-helpers.js";
 import type { WorkflowToolArgs } from "./public-types.js";
 import type { WorkflowToolResult } from "./render-result.js";
 import type { ExtensionRuntime } from "./runtime.js";
 import type { WorkflowRunStatusSummary, WorkflowStatusAwaitingInput } from "./workflow-status-summary.js";
+import { getWorkflowStatusRenderRuns } from "./workflow-status-summary.js";
 
 function stringifyWorkflowToolResult(result: WorkflowToolResult): string {
 	return JSON.stringify(result, null, 2);
@@ -69,7 +72,20 @@ function statusAwaitingInputLine(entry: WorkflowStatusAwaitingInput): string {
 	return `    awaiting input: ${target}${prompt}${message}`;
 }
 
+function statusRunIcon(
+	run: WorkflowRunStatusSummary,
+	snapshot: RunSnapshot | undefined,
+	allRuns: readonly RunSnapshot[],
+): string {
+	if (snapshot === undefined) return statusIcon(run.status);
+	const indicatorStatus = runIndicatorStatus(snapshot, allRuns);
+	if (snapshot.endedAt === undefined && snapshot.status === "paused" && snapshot.exitReason === "quit") {
+		return statusIcon("pending");
+	}
+	return statusIcon(indicatorStatus);
+}
 function renderStatusToolContent(result: Extract<WorkflowToolResult, { action: "status" }>): string {
+	const allRuns = getWorkflowStatusRenderRuns(result) ?? result.snapshots;
 	const lines = ["action: status", `filter: ${result.filter}`];
 	if (result.runs.length === 0) {
 		lines.push(result.filter === "all" ? "runs: none" : `runs: none (statusFilter: ${result.filter})`);
@@ -81,6 +97,7 @@ function renderStatusToolContent(result: Extract<WorkflowToolResult, { action: "
 		const hint = statusRunHint(run);
 		const summaryLine = [
 			`[${index + 1}]`,
+			statusRunIcon(run, result.snapshots[index], allRuns),
 			run.runId,
 			run.name,
 			run.status,

--- a/packages/workflows/src/extension/workflow-tool.ts
+++ b/packages/workflows/src/extension/workflow-tool.ts
@@ -1,5 +1,6 @@
 import { getSupportedThinkingLevels } from "@earendil-works/pi-ai/compat";
 import { inspectRun } from "../runs/background/status.js";
+import { store } from "../shared/store.js";
 import type { WorkflowExecutionPolicy } from "../shared/types.js";
 import type { PiExecuteContext, WorkflowToolArgs } from "./public-types.js";
 import type { WorkflowToolResult } from "./render-result.js";
@@ -7,7 +8,7 @@ import type { ExtensionRuntime } from "./runtime.js";
 import { formatWorkflowResourceLoadWarning } from "./workflow-command-surfaces.js";
 import { workflowPolicyFromContext } from "./workflow-policy.js";
 import type { WorkflowReloadReport } from "./workflow-reload-report.js";
-import { buildWorkflowStatusListing } from "./workflow-status-summary.js";
+import { buildWorkflowStatusListing, setWorkflowStatusRenderRuns } from "./workflow-status-summary.js";
 import { isWorkflowStageToolContext, resolveRunId, topLevelExpandedSnapshots } from "./workflow-targets.js";
 import { workflowGetResult } from "./workflow-tool-content.js";
 import {
@@ -94,12 +95,14 @@ export function makeExecuteWorkflowTool(
 						: { action: "statusDetail", runId: target, error: `run not found: ${target}` };
 				}
 				const listing = buildWorkflowStatusListing(topLevelExpandedSnapshots(), args.statusFilter ?? "all");
-				return {
-					action: "status",
+				const result = {
+					action: "status" as const,
 					filter: listing.filter,
 					runs: listing.runs,
 					snapshots: listing.snapshots,
 				};
+				setWorkflowStatusRenderRuns(result, store.graphSnapshot().runs);
+				return result;
 			}
 			case "stages":
 				return workflowStagesResult(args);

--- a/packages/workflows/src/shared/run-indicator-status.ts
+++ b/packages/workflows/src/shared/run-indicator-status.ts
@@ -29,6 +29,22 @@ export function runIndicatorStatus(run: RunSnapshot, allRuns: readonly RunSnapsh
 	return status;
 }
 
+/**
+ * Precompute the indicator status of each listed run against the complete
+ * run collection. The result is plain serializable data, so a surface whose
+ * payload is persisted and re-rendered after a session restore (e.g. the
+ * `/workflow status` chat entry) keeps hidden-descendant prompt attribution
+ * without serializing the hidden run snapshots themselves.
+ */
+export function resolveRunIndicatorStatuses(
+	runs: readonly RunSnapshot[],
+	allRuns: readonly RunSnapshot[],
+): Readonly<Record<string, RunIndicatorStatus>> {
+	const statuses: Record<string, RunIndicatorStatus> = {};
+	for (const run of runs) statuses[run.id] = runIndicatorStatus(run, allRuns);
+	return statuses;
+}
+
 function runHasPendingInput(run: RunSnapshot): boolean {
 	if (run.pendingPrompt !== undefined) return true;
 	return run.stages.some(

--- a/packages/workflows/src/shared/run-indicator-status.ts
+++ b/packages/workflows/src/shared/run-indicator-status.ts
@@ -1,0 +1,59 @@
+import { effectiveRunStatus } from "./returned-run-status.js";
+import type { RunSnapshot, RunStatus } from "./store-types.js";
+
+/** The status represented by a run's primary indicator. */
+export type RunIndicatorStatus = RunStatus | "awaiting_input";
+
+const TERMINAL_OR_BLOCKED = new Set<RunStatus>(["completed", "failed", "killed", "cancelled", "skipped", "blocked"]);
+
+/**
+ * Resolve the status represented by a run's primary indicator.
+ *
+ * A live run with a pending run/stage prompt is awaiting input. When the
+ * caller supplies the complete run collection, pending prompts in hidden
+ * nested descendants are attributed to the visible ancestor by following
+ * `rootRunId` and `parentRunId`. Effective terminal and blocked statuses are
+ * authoritative, even when a stale prompt marker remains in a snapshot.
+ */
+export function runIndicatorStatus(run: RunSnapshot, allRuns: readonly RunSnapshot[] = [run]): RunIndicatorStatus {
+	const status = effectiveRunStatus(run);
+	if (TERMINAL_OR_BLOCKED.has(status)) return status;
+	if (runHasPendingInput(run)) return "awaiting_input";
+
+	const runsById = new Map(allRuns.map((candidate) => [candidate.id, candidate]));
+	for (const candidate of allRuns) {
+		if (candidate.id === run.id || !runBelongsTo(candidate, run, runsById)) continue;
+		const candidateStatus = effectiveRunStatus(candidate);
+		if (!TERMINAL_OR_BLOCKED.has(candidateStatus) && runHasPendingInput(candidate)) return "awaiting_input";
+	}
+	return status;
+}
+
+function runHasPendingInput(run: RunSnapshot): boolean {
+	if (run.pendingPrompt !== undefined) return true;
+	return run.stages.some(
+		(stage) =>
+			stage.status === "awaiting_input" ||
+			stage.awaitingInputSince !== undefined ||
+			stage.pendingPrompt !== undefined ||
+			stage.inputRequest !== undefined,
+	);
+}
+
+function runBelongsTo(
+	candidate: RunSnapshot,
+	ancestor: RunSnapshot,
+	runsById: ReadonlyMap<string, RunSnapshot>,
+): boolean {
+	if (candidate.rootRunId === ancestor.id) return true;
+
+	const visited = new Set<string>();
+	let current: RunSnapshot | undefined = candidate;
+	while (current !== undefined && current.parentRunId !== undefined) {
+		if (current.parentRunId === ancestor.id) return true;
+		if (visited.has(current.id)) return false;
+		visited.add(current.id);
+		current = runsById.get(current.parentRunId);
+	}
+	return false;
+}

--- a/packages/workflows/src/tui/chat-surface-message.ts
+++ b/packages/workflows/src/tui/chat-surface-message.ts
@@ -27,6 +27,7 @@
 
 import type { ExtensionAPI } from "../extension/index.js";
 import type { RunDetail } from "../runs/background/status.js";
+import type { RunIndicatorStatus } from "../shared/run-indicator-status.js";
 import type { RunSnapshot } from "../shared/store-types.js";
 import type { WorkflowInputValues } from "../shared/types.js";
 import { renderDispatchConfirm } from "./dispatch-confirm.js";
@@ -67,17 +68,15 @@ export interface DispatchPayload {
 export interface StatusPayload {
 	kind: "status";
 	runs: readonly RunSnapshot[];
-}
-
-const statusPayloadRenderRuns = new WeakMap<StatusPayload, readonly RunSnapshot[]>();
-
-/** Attach a point-in-time full run collection without exposing it in message details. */
-export function setStatusPayloadRenderRuns(payload: StatusPayload, runs: readonly RunSnapshot[]): void {
-	statusPayloadRenderRuns.set(payload, runs);
-}
-
-function statusRunsForRender(payload: StatusPayload): readonly RunSnapshot[] {
-	return statusPayloadRenderRuns.get(payload) ?? payload.runs;
+	/**
+	 * Emit-time indicator status per visible run id, resolved against the
+	 * complete point-in-time run collection (including hidden nested
+	 * descendants). Persisted with the payload because chat entries are
+	 * re-rendered from `details` after a session restore, where the full
+	 * collection is gone; storing only the derived statuses keeps hidden
+	 * run snapshots out of the serialized message.
+	 */
+	indicatorStatuses?: Readonly<Record<string, RunIndicatorStatus>>;
 }
 
 /** Workflow catalogue after `/workflow list`. */
@@ -179,7 +178,7 @@ export function renderChatSurfacePlainText(
 				width,
 				now,
 				...themed,
-				allRuns: statusRunsForRender(payload),
+				indicatorStatuses: payload.indicatorStatuses,
 			});
 			if (payload.runs.length === 0) return rendered;
 			return [
@@ -308,7 +307,7 @@ function renderPayload(payload: ChatSurfacePayload, theme: GraphTheme, width: nu
 				theme,
 				width,
 				now,
-				allRuns: statusRunsForRender(payload),
+				indicatorStatuses: payload.indicatorStatuses,
 			});
 		case "list":
 			return renderWorkflowList(payload.entries, { theme, width });

--- a/packages/workflows/src/tui/chat-surface-message.ts
+++ b/packages/workflows/src/tui/chat-surface-message.ts
@@ -69,6 +69,17 @@ export interface StatusPayload {
 	runs: readonly RunSnapshot[];
 }
 
+const statusPayloadRenderRuns = new WeakMap<StatusPayload, readonly RunSnapshot[]>();
+
+/** Attach a point-in-time full run collection without exposing it in message details. */
+export function setStatusPayloadRenderRuns(payload: StatusPayload, runs: readonly RunSnapshot[]): void {
+	statusPayloadRenderRuns.set(payload, runs);
+}
+
+function statusRunsForRender(payload: StatusPayload): readonly RunSnapshot[] {
+	return statusPayloadRenderRuns.get(payload) ?? payload.runs;
+}
+
 /** Workflow catalogue after `/workflow list`. */
 export interface ListPayload {
 	kind: "list";
@@ -164,7 +175,12 @@ export function renderChatSurfacePlainText(
 			return [rendered, `run id: ${payload.runId}`, `inputs: ${formatPlainRecord(payload.inputs)}`].join("\n");
 		}
 		case "status": {
-			const rendered = renderStatusList(payload.runs, { width, now, ...themed });
+			const rendered = renderStatusList(payload.runs, {
+				width,
+				now,
+				...themed,
+				allRuns: statusRunsForRender(payload),
+			});
 			if (payload.runs.length === 0) return rendered;
 			return [
 				rendered,
@@ -288,7 +304,12 @@ function renderPayload(payload: ChatSurfacePayload, theme: GraphTheme, width: nu
 				width,
 			});
 		case "status":
-			return renderStatusList(payload.runs, { theme, width, now });
+			return renderStatusList(payload.runs, {
+				theme,
+				width,
+				now,
+				allRuns: statusRunsForRender(payload),
+			});
 		case "list":
 			return renderWorkflowList(payload.entries, { theme, width });
 		case "detail":

--- a/packages/workflows/src/tui/session-list.ts
+++ b/packages/workflows/src/tui/session-list.ts
@@ -34,5 +34,5 @@ export function renderSessionList(runs: readonly RunSnapshot[], opts: SessionLis
 			toolNodes: graph.tools.map((tool) => structuredClone(tool)),
 		};
 	});
-	return renderStatusList(filtered, { theme: opts.theme, now });
+	return renderStatusList(filtered, { theme: opts.theme, now, allRuns: runs });
 }

--- a/packages/workflows/src/tui/session-overlays.ts
+++ b/packages/workflows/src/tui/session-overlays.ts
@@ -25,7 +25,7 @@
 
 import type { PiCustomComponent, PiCustomOverlayFactoryTui, PiCustomOverlayFunction } from "../extension/wiring.js";
 import type { Store } from "../shared/store.js";
-import { readGraphStoreSnapshot, subscribeStoreInvalidation } from "../shared/store-observation.js";
+import { subscribeStoreInvalidation } from "../shared/store-observation.js";
 import type { GraphTheme } from "./graph-theme.js";
 import {
 	createSessionPickerResumeCandidateCache,
@@ -81,6 +81,7 @@ export function openSessionPicker(
 		const state = createSessionPickerState();
 		let settled = false;
 		let unsubscribe: (() => void) | null = null;
+		let pickerRevision = 0;
 
 		const resumeCandidateCache = createSessionPickerResumeCandidateCache();
 
@@ -100,16 +101,16 @@ export function openSessionPicker(
 			};
 			// Re-render on store changes so newly-started runs appear and
 			// status icons refresh without the user having to press a key.
-			// Read one memoized payload-free projection per render rather than
-			// caching a snapshot from the subscription callback: the
-			// invalidation channel carries no snapshot, so a cached one would
-			// go stale and newly-started runs would never appear.
+			// The picker only needs live run references for rendering; a small local
+			// revision keeps resume-probe caching coherent without cloning the store.
 			const selectRows = (): ReturnType<typeof selectRunsForPicker> => {
-				const snapshot = readGraphStoreSnapshot(store);
+				const liveRuns = store.runs();
 				const resumeCandidateLookup =
-					intent === "resume" ? resumeCandidateCache({ ...snapshot, runs: store.runs() }) : undefined;
+					intent === "resume"
+						? resumeCandidateCache({ runs: liveRuns, notices: store.notices(), version: pickerRevision })
+						: undefined;
 				return selectRunsForPicker(
-					snapshot.runs,
+					liveRuns,
 					state.query,
 					state.includeAll,
 					Date.now(),
@@ -117,11 +118,14 @@ export function openSessionPicker(
 					resumeCandidateLookup,
 				);
 			};
-			unsubscribe = subscribeStoreInvalidation(store, () => tui.requestRender?.());
+			unsubscribe = subscribeStoreInvalidation(store, () => {
+				pickerRevision++;
+				tui.requestRender?.();
+			});
 			return {
 				render: (width: number) => {
 					const rows = selectRows();
-					return renderSessionPicker({ width, theme, rows, state });
+					return renderSessionPicker({ width, theme, rows, state, allRuns: store.runs() });
 				},
 				handleInput: (data: string) => {
 					const rows = selectRows();

--- a/packages/workflows/src/tui/session-picker.ts
+++ b/packages/workflows/src/tui/session-picker.ts
@@ -20,6 +20,7 @@
 
 import { keyText } from "@bastani/atomic";
 import { isWorkflowRunResumable, type WorkflowRunResumeCandidate } from "../durable/resume-eligibility.js";
+import { runIndicatorStatus } from "../shared/run-indicator-status.js";
 import { isTopLevelWorkflowRun } from "../shared/run-visibility.js";
 import type { RunSnapshot, StoreSnapshot } from "../shared/store-types.js";
 import { elapsedRunMs } from "../shared/timing.js";
@@ -31,6 +32,10 @@ import { fmtDuration, statusColor, statusIcon } from "./status-helpers.js";
 import { Key, matchesKey, truncateToWidth, visibleWidth } from "./text-helpers.js";
 
 const ESCAPE_CODE = 0x1b;
+
+function isQuitRun(run: RunSnapshot): boolean {
+	return run.endedAt === undefined && run.status === "paused" && run.exitReason === "quit";
+}
 const DOUBLE_ESCAPE_SEQUENCE = String.fromCharCode(ESCAPE_CODE, ESCAPE_CODE);
 
 // ---------------------------------------------------------------------------
@@ -146,6 +151,8 @@ export interface SessionPickerRenderOpts {
 	state: SessionPickerState;
 	/** Optional: now override for deterministic tests. */
 	now?: number;
+	/** Point-in-time/live run collection used to attribute hidden child prompts. */
+	allRuns?: readonly RunSnapshot[];
 }
 
 /** Pad a visible string (any embedded ANSI is OK; we measure visibly). */
@@ -257,12 +264,20 @@ function stageProgress(run: RunSnapshot): string {
 	return `${done}/${total} stages`;
 }
 
-function renderRunRow(row: PickerRow, isSelected: boolean, inner: number, theme: GraphTheme, now: number): string[] {
+function renderRunRow(
+	row: PickerRow,
+	isSelected: boolean,
+	inner: number,
+	theme: GraphTheme,
+	now: number,
+	allRuns: readonly RunSnapshot[],
+): string[] {
 	const border = hexToAnsi(theme.border);
 	const panelBg = hexBg(theme.bg);
 	const run = row.run;
-	const icon = statusIcon(run.status);
-	const iconColor = hexToAnsi(statusColor(run.status, theme));
+	const indicatorStatus = isQuitRun(run) ? run.status : runIndicatorStatus(run, allRuns);
+	const icon = statusIcon(indicatorStatus);
+	const iconColor = hexToAnsi(statusColor(indicatorStatus, theme));
 	const dim = hexToAnsi(theme.dim);
 	const text = hexToAnsi(theme.text);
 	const muted = hexToAnsi(theme.textMuted);
@@ -349,6 +364,7 @@ export function renderSessionPicker(opts: SessionPickerRenderOpts): string[] {
 	const visible = rows.slice(Math.max(0, start), Math.max(0, start) + VIEWPORT);
 
 	let prevBucket: PickerRow["bucket"] | null = null;
+	const allRuns = opts.allRuns ?? rows.map(({ run }) => run);
 	for (let i = 0; i < visible.length; i++) {
 		const row = visible[i]!;
 		if (row.bucket !== prevBucket) {
@@ -356,7 +372,7 @@ export function renderSessionPicker(opts: SessionPickerRenderOpts): string[] {
 			prevBucket = row.bucket;
 		}
 		const absIndex = Math.max(0, start) + i;
-		lines.push(...renderRunRow(row, absIndex === sel, inner, theme, now));
+		lines.push(...renderRunRow(row, absIndex === sel, inner, theme, now, allRuns));
 	}
 	lines.push(renderBlankRow(inner, theme));
 	lines.push(renderBottomBorder(width, theme));

--- a/packages/workflows/src/tui/status-list.ts
+++ b/packages/workflows/src/tui/status-list.ts
@@ -22,6 +22,7 @@
  */
 
 import { effectiveRunStatus } from "../shared/returned-run-status.js";
+import type { RunIndicatorStatus } from "../shared/run-indicator-status.js";
 import { runIndicatorStatus } from "../shared/run-indicator-status.js";
 import type { RunSnapshot, StageSnapshot, StageStatus } from "../shared/store-types.js";
 import { elapsedRunMs, elapsedStageMs } from "../shared/timing.js";
@@ -46,6 +47,13 @@ export interface RenderStatusListOpts {
 	width?: number;
 	/** Point-in-time run collection used to attribute hidden child prompts. */
 	allRuns?: readonly RunSnapshot[];
+	/**
+	 * Emit-time indicator status per run id, taking precedence over deriving
+	 * from `allRuns`. Lets persisted payloads (e.g. the `/workflow status`
+	 * chat entry) keep hidden-descendant prompt attribution after a session
+	 * restore, when the full run collection is no longer available.
+	 */
+	indicatorStatuses?: Readonly<Record<string, RunIndicatorStatus>>;
 }
 
 function isQuitRun(run: RunSnapshot): boolean {
@@ -77,7 +85,9 @@ export function renderStatusList(runs: readonly RunSnapshot[], opts: RenderStatu
 	} else {
 		for (let i = 0; i < sorted.length; i++) {
 			if (i > 0) body.push("");
-			body.push(...renderRunEntry(sorted[i]!, now, cardWidth, opts.theme, opts.allRuns ?? runs));
+			body.push(
+				...renderRunEntry(sorted[i]!, now, cardWidth, opts.theme, opts.allRuns ?? runs, opts.indicatorStatuses),
+			);
 		}
 	}
 	if (opts.showDetailHint !== false && sorted.length > 0) {
@@ -103,11 +113,13 @@ function renderRunEntry(
 	width: number,
 	theme: GraphTheme | undefined,
 	allRuns: readonly RunSnapshot[],
+	indicatorStatuses?: Readonly<Record<string, RunIndicatorStatus>>,
 ): string[] {
 	const bodyWidth = effectiveWidth(width);
 	const interior = Math.max(8, bodyWidth - 4);
-	const glyph = statusIconForRun(run, allRuns);
-	const glyphFg = theme ? hexToAnsi(runAccent(run, theme, allRuns)) : "";
+	const indicatorStatus = indicatorStatuses?.[run.id] ?? runIndicatorStatus(run, allRuns);
+	const glyph = statusIconForRun(run, indicatorStatus);
+	const glyphFg = theme ? hexToAnsi(runAccent(run, theme, indicatorStatus)) : "";
 	const accent = theme ? hexToAnsi(theme.accent) : "";
 	const text = theme ? hexToAnsi(theme.text) : "";
 	const muted = theme ? hexToAnsi(theme.textMuted) : "";
@@ -150,10 +162,10 @@ function renderRunEntry(
 	return [...identityRows, identity, metaLine];
 }
 
-function runAccent(run: RunSnapshot, theme?: GraphTheme, allRuns: readonly RunSnapshot[] = [run]): string {
+function runAccent(run: RunSnapshot, theme: GraphTheme | undefined, indicatorStatus: RunIndicatorStatus): string {
 	if (!theme) return "#000000";
 	if (isQuitRun(run)) return theme.warning;
-	return statusColor(runIndicatorStatus(run, allRuns), theme);
+	return statusColor(indicatorStatus, theme);
 }
 
 function runTrailing(run: RunSnapshot, theme?: GraphTheme): { text: string; fg?: string } | undefined {
@@ -426,9 +438,9 @@ function emptyStateLine(theme?: GraphTheme): string {
 	return `  ${hexToAnsi(theme.dim)}no workflow runs in current session${RESET}`;
 }
 
-function statusIconForRun(run: RunSnapshot, allRuns: readonly RunSnapshot[] = [run]): string {
+function statusIconForRun(run: RunSnapshot, indicatorStatus: RunIndicatorStatus): string {
 	if (isQuitRun(run)) return statusIcon("pending");
-	return statusIcon(runIndicatorStatus(run, allRuns));
+	return statusIcon(indicatorStatus);
 }
 
 // Re-export for callers that need to inspect width budgeting.

--- a/packages/workflows/src/tui/status-list.ts
+++ b/packages/workflows/src/tui/status-list.ts
@@ -22,6 +22,7 @@
  */
 
 import { effectiveRunStatus } from "../shared/returned-run-status.js";
+import { runIndicatorStatus } from "../shared/run-indicator-status.js";
 import type { RunSnapshot, StageSnapshot, StageStatus } from "../shared/store-types.js";
 import { elapsedRunMs, elapsedStageMs } from "../shared/timing.js";
 import type { FlatBandBadge } from "./chat-surface.js";
@@ -29,7 +30,7 @@ import { chatWidth, ELLIPSIS, progressStrip, renderRoundedBox } from "./chat-sur
 import { BOLD, hexToAnsi, RESET } from "./color-utils.js";
 import type { GraphTheme } from "./graph-theme.js";
 import { wrapIdentifierLines } from "./run-identity-rows.js";
-import { fmtDuration } from "./status-helpers.js";
+import { fmtDuration, statusColor, statusIcon } from "./status-helpers.js";
 import { truncateToWidth, visibleWidth } from "./text-helpers.js";
 
 const STAGE_LABEL_BUDGET = 24;
@@ -43,6 +44,8 @@ export interface RenderStatusListOpts {
 	showDetailHint?: boolean;
 	/** Render width (cells). Defaults to `process.stdout.columns`. */
 	width?: number;
+	/** Point-in-time run collection used to attribute hidden child prompts. */
+	allRuns?: readonly RunSnapshot[];
 }
 
 function isQuitRun(run: RunSnapshot): boolean {
@@ -74,7 +77,7 @@ export function renderStatusList(runs: readonly RunSnapshot[], opts: RenderStatu
 	} else {
 		for (let i = 0; i < sorted.length; i++) {
 			if (i > 0) body.push("");
-			body.push(...renderRunEntry(sorted[i]!, now, cardWidth, opts.theme));
+			body.push(...renderRunEntry(sorted[i]!, now, cardWidth, opts.theme, opts.allRuns ?? runs));
 		}
 	}
 	if (opts.showDetailHint !== false && sorted.length > 0) {
@@ -94,11 +97,17 @@ export function renderStatusList(runs: readonly RunSnapshot[], opts: RenderStatu
 // Run card
 // ---------------------------------------------------------------------------
 
-function renderRunEntry(run: RunSnapshot, now: number, width: number, theme?: GraphTheme): string[] {
+function renderRunEntry(
+	run: RunSnapshot,
+	now: number,
+	width: number,
+	theme: GraphTheme | undefined,
+	allRuns: readonly RunSnapshot[],
+): string[] {
 	const bodyWidth = effectiveWidth(width);
 	const interior = Math.max(8, bodyWidth - 4);
-	const glyph = statusIconForRun(run);
-	const glyphFg = theme ? hexToAnsi(runAccent(run, theme)) : "";
+	const glyph = statusIconForRun(run, allRuns);
+	const glyphFg = theme ? hexToAnsi(runAccent(run, theme, allRuns)) : "";
 	const accent = theme ? hexToAnsi(theme.accent) : "";
 	const text = theme ? hexToAnsi(theme.text) : "";
 	const muted = theme ? hexToAnsi(theme.textMuted) : "";
@@ -141,29 +150,10 @@ function renderRunEntry(run: RunSnapshot, now: number, width: number, theme?: Gr
 	return [...identityRows, identity, metaLine];
 }
 
-function runAccent(run: RunSnapshot, theme?: GraphTheme): string {
+function runAccent(run: RunSnapshot, theme?: GraphTheme, allRuns: readonly RunSnapshot[] = [run]): string {
 	if (!theme) return "#000000";
 	if (isQuitRun(run)) return theme.warning;
-	switch (effectiveRunStatus(run)) {
-		case "completed":
-			return theme.success;
-		case "running":
-			return theme.warning;
-		case "paused":
-			return theme.warning;
-		case "skipped":
-			return theme.dim;
-		case "cancelled":
-			return theme.dim;
-		case "blocked":
-			return theme.dim;
-		case "failed":
-			return theme.error;
-		case "killed":
-			return theme.error;
-		default:
-			return theme.dim;
-	}
+	return statusColor(runIndicatorStatus(run, allRuns), theme);
 }
 
 function runTrailing(run: RunSnapshot, theme?: GraphTheme): { text: string; fg?: string } | undefined {
@@ -436,27 +426,9 @@ function emptyStateLine(theme?: GraphTheme): string {
 	return `  ${hexToAnsi(theme.dim)}no workflow runs in current session${RESET}`;
 }
 
-function statusIconForRun(run: RunSnapshot): string {
-	if (isQuitRun(run)) return "○";
-	switch (effectiveRunStatus(run)) {
-		case "completed":
-			return "✓";
-		case "skipped":
-		case "cancelled":
-			return "⊘";
-		case "blocked":
-			return "↑";
-		case "running":
-			return "●";
-		case "paused":
-			return "❚❚";
-		case "failed":
-			return "✗";
-		case "killed":
-			return "⊘";
-		default:
-			return "○";
-	}
+function statusIconForRun(run: RunSnapshot, allRuns: readonly RunSnapshot[] = [run]): string {
+	if (isQuitRun(run)) return statusIcon("pending");
+	return statusIcon(runIndicatorStatus(run, allRuns));
 }
 
 // Re-export for callers that need to inspect width budgeting.

--- a/packages/workflows/src/tui/store-widget-installer.ts
+++ b/packages/workflows/src/tui/store-widget-installer.ts
@@ -86,6 +86,14 @@ function isStale(err: unknown): boolean {
 	return err instanceof Error && err.message.includes(STALE_CONTEXT);
 }
 
+function liveWidgetSnapshot(storeInstance: Store): StoreSnapshot {
+	return {
+		runs: storeInstance.runs(),
+		notices: storeInstance.notices(),
+		version: 0,
+	};
+}
+
 export function decideWidgetAction(prev: WidgetRenderState, nextLines: readonly string[]): WidgetAction {
 	return decideReactiveWidgetAction(prev, nextLines);
 }
@@ -107,7 +115,7 @@ export function installStoreWidget(
 		key: WIDGET_KEY,
 		placement: "belowEditor",
 		timers,
-		getSnapshot: () => readGraphStoreSnapshot(storeInstance),
+		getSnapshot: () => liveWidgetSnapshot(storeInstance),
 		subscribe: (listener) => subscribeStoreInvalidation(storeInstance, listener),
 		getPreviewLines: (snap, now) => buildThemedWidgetLines(snap, undefined, 120, now),
 		render: (snap, { theme, width, now }) => buildThemedWidgetLines(snap, theme as PiTheme | undefined, width, now),

--- a/packages/workflows/src/tui/widget.ts
+++ b/packages/workflows/src/tui/widget.ts
@@ -22,6 +22,7 @@
  */
 
 import { effectiveRunStatus } from "../shared/returned-run-status.js";
+import { runIndicatorStatus } from "../shared/run-indicator-status.js";
 import { topLevelWorkflowRuns } from "../shared/run-visibility.js";
 import type { RunSnapshot, StoreSnapshot } from "../shared/store-types.js";
 import { elapsedRunMs } from "../shared/timing.js";
@@ -31,7 +32,7 @@ import { hexToAnsi, RESET } from "./color-utils.js";
 import type { GraphTheme } from "./graph-theme.js";
 import { deriveGraphTheme } from "./graph-theme.js";
 import { renderRunIdentityRows } from "./run-identity-rows.js";
-import { statusIcon } from "./status-helpers.js";
+import { statusColor, statusIcon } from "./status-helpers.js";
 import type { PiTheme } from "./store-widget-installer.js";
 
 // ---------------------------------------------------------------------------
@@ -96,23 +97,8 @@ interface RunCounts {
 	awaiting: number;
 }
 
-function runAwaitsInput(run: RunSnapshot): boolean {
-	return (
-		run.endedAt === undefined &&
-		(run.pendingPrompt !== undefined || run.stages.some((s) => s.status === "awaiting_input"))
-	);
-}
-
-/**
- * A top-level run "needs attention" when it OR any of its nested
- * `ctx.workflow()` descendants is awaiting human input. Nested child runs are
- * hidden from the widget, but each carries `rootRunId` pointing at the ultimate
- * top-level run, so a hidden child's awaiting (HiL) state surfaces on the
- * visible ancestor instead of vanishing with it.
- */
 function subtreeAwaitsInput(root: RunSnapshot, allRuns: readonly RunSnapshot[]): boolean {
-	if (runAwaitsInput(root)) return true;
-	return allRuns.some((run) => run.rootRunId === root.id && runAwaitsInput(run));
+	return runIndicatorStatus(root, allRuns) === "awaiting_input";
 }
 
 function countRuns(runs: readonly RunSnapshot[], allRuns: readonly RunSnapshot[] = runs): RunCounts {
@@ -125,7 +111,7 @@ function countRuns(runs: readonly RunSnapshot[], allRuns: readonly RunSnapshot[]
 		else if (r.endedAt === undefined) counts.active++;
 		else if (status === "completed" || status === "skipped" || status === "cancelled") counts.done++;
 		else if (status === "failed" || status === "killed") counts.failed++;
-		if (r.endedAt === undefined && subtreeAwaitsInput(r, allRuns)) counts.awaiting++;
+		if (r.endedAt === undefined && !isQuitRun(r) && subtreeAwaitsInput(r, allRuns)) counts.awaiting++;
 	}
 	return counts;
 }
@@ -175,31 +161,15 @@ function selectDisplayRuns(snap: StoreSnapshot, now: number): RunSnapshot[] {
 // Per-run derived strings
 // ---------------------------------------------------------------------------
 
-function statusGlyph(run: RunSnapshot): string {
-	if (isQuitRun(run)) return "○";
-	switch (effectiveRunStatus(run)) {
-		case "running":
-			return "●";
-		case "paused":
-			return "❚❚";
-		case "completed":
-			return "✓";
-		case "skipped":
-		case "cancelled":
-			return "⊘";
-		case "blocked":
-			return "↑";
-		case "failed":
-			return "✗";
-		case "killed":
-			return "⊘";
-		default:
-			return "○";
-	}
+function statusGlyph(run: RunSnapshot, allRuns: readonly RunSnapshot[]): string {
+	if (isQuitRun(run)) return statusIcon("pending");
+	return statusIcon(runIndicatorStatus(run, allRuns));
 }
 
-function statusFg(run: RunSnapshot, theme: GraphTheme): string {
+function statusFg(run: RunSnapshot, theme: GraphTheme, allRuns: readonly RunSnapshot[]): string {
 	if (isQuitRun(run)) return theme.warning;
+	const indicatorStatus = runIndicatorStatus(run, allRuns);
+	if (indicatorStatus === "awaiting_input") return statusColor(indicatorStatus, theme);
 	switch (effectiveRunStatus(run)) {
 		case "running":
 		case "paused":
@@ -307,7 +277,7 @@ function formatTitleBadges(badges: readonly FlatBandBadge[], theme: GraphTheme, 
 // Themed rendering (ANSI + Catppuccin)
 // ---------------------------------------------------------------------------
 
-function themedRunLines(run: RunSnapshot, now: number, theme: GraphTheme): string[] {
+function themedRunLines(run: RunSnapshot, now: number, theme: GraphTheme, allRuns: readonly RunSnapshot[]): string[] {
 	const meta = metaLine(run, now);
 	// Render the meta line in muted while running so the elapsed-time
 	// gradient stays readable; dim it once the run has terminated.
@@ -316,19 +286,19 @@ function themedRunLines(run: RunSnapshot, now: number, theme: GraphTheme): strin
 		runId: run.id,
 		name: run.name,
 		meta,
-		glyph: statusGlyph(run),
-		glyphColor: statusFg(run, theme),
+		glyph: statusGlyph(run, allRuns),
+		glyphColor: statusFg(run, theme, allRuns),
 		metaColor,
 		theme,
 	});
 }
 
-function plainRunLines(run: RunSnapshot, now: number): string[] {
+function plainRunLines(run: RunSnapshot, now: number, allRuns: readonly RunSnapshot[]): string[] {
 	return renderRunIdentityRows({
 		runId: run.id,
 		name: run.name,
 		meta: metaLine(run, now),
-		glyph: statusGlyph(run),
+		glyph: statusGlyph(run, allRuns),
 	});
 }
 
@@ -415,7 +385,7 @@ export function buildThemedWidgetLines(
 
 	for (let i = 0; i < display.length; i++) {
 		const run = display[i]!;
-		const runLines = themed ? themedRunLines(run, now, graphTheme) : plainRunLines(run, now);
+		const runLines = themed ? themedRunLines(run, now, graphTheme, snap.runs) : plainRunLines(run, now, snap.runs);
 		body.push(...runLines);
 		if (i < display.length - 1) body.push("");
 	}

--- a/test/ci/test-workflow-topology.test.ts
+++ b/test/ci/test-workflow-topology.test.ts
@@ -64,7 +64,10 @@ test("every work job the gate names exists and is otherwise independent", async 
  * Per-job wall-clock caps replace the blanket 10/15 minute pair. A cap is a hang
  * detector at roughly 2x measured p100 and must leave room for the one bounded
  * flake retry the job owns: the first split run fired that retry on both
- * platforms and took 230 s / 348 s in `suites` alone.
+ * platforms and took 230 s / 348 s in `suites` alone. The Windows
+ * `release-archive` cap is 9 minutes because cold setup observed 152 s for
+ * `rust-toolchain` and 71 s for checkout, followed by roughly 110 s native
+ * build and 40 s archive smoke (near 6m50s versus a healthy 4m04s p100).
  */
 test("each split job declares its own measured timeout", async () => {
 	const workflow = await readText(testPath);
@@ -72,7 +75,7 @@ test("each split job declares its own measured timeout", async () => {
 	const caps: Record<string, [number, number]> = {
 		suites: [8, 12],
 		"agent-suite": [6, 12],
-		"release-archive": [5, 6],
+		"release-archive": [5, 9],
 	};
 	for (const [job, [linux, windows]] of Object.entries(caps)) {
 		const block = blocks.get(job) as string;

--- a/test/unit/chat-surface.test.ts
+++ b/test/unit/chat-surface.test.ts
@@ -8,6 +8,7 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import type { RunDetail } from "../../packages/workflows/src/runs/background/status.js";
+import { resolveRunIndicatorStatuses } from "../../packages/workflows/src/shared/run-indicator-status.js";
 import type { RunSnapshot } from "../../packages/workflows/src/shared/store-types.js";
 import {
 	chatWidth,
@@ -25,6 +26,7 @@ import {
 	renderChatSurfacePlainText,
 } from "../../packages/workflows/src/tui/chat-surface-message.js";
 import { deriveGraphTheme } from "../../packages/workflows/src/tui/graph-theme.js";
+import { statusIcon } from "../../packages/workflows/src/tui/status-helpers.js";
 
 const ANSI_RE = /\x1b\[[0-9;]*m/g;
 const stripAnsi = (s: string) => s.replace(ANSI_RE, "");
@@ -411,6 +413,57 @@ describe("registerChatSurfaceRenderer", () => {
 				Date.now = originalNow;
 			}
 		}
+	});
+	test("restored status payloads keep hidden-descendant awaiting attribution without object-identity state", () => {
+		// Regression: the complete run collection used to live in a WeakMap
+		// keyed by the in-memory StatusPayload. A payload deserialized from a
+		// persisted session is a different object, so the WeakMap missed and a
+		// visible running ancestor with a hidden nested child awaiting input
+		// re-rendered with the ordinary running indicator. The emit-time
+		// `indicatorStatuses` record must survive a JSON round-trip instead.
+		class ClassBackedPi {
+			readonly renderers = new Map<string, (payload: unknown) => unknown>();
+			registerMessageRenderer(event: string, renderer: (payload: unknown) => unknown): void {
+				this.renderers.set(event, renderer);
+			}
+		}
+		const pi = new ClassBackedPi();
+		registerChatSurfaceRenderer(pi as never, deriveGraphTheme({}));
+		const renderer = pi.renderers.get(CHAT_SURFACE_CUSTOM_TYPE);
+		assert.notEqual(renderer, undefined);
+		const root: RunSnapshot = {
+			id: "root-run-1234567890",
+			name: "visible-root",
+			inputs: {},
+			status: "running",
+			stages: [{ id: "s1", name: "plan", status: "running", parentIds: [], toolEvents: [] }],
+			startedAt: 1_000,
+		};
+		const hiddenChild: RunSnapshot = {
+			id: "child-run-1234567890",
+			name: "hidden-child",
+			inputs: {},
+			status: "running",
+			stages: [{ id: "ask", name: "ask", status: "awaiting_input", parentIds: [], toolEvents: [] }],
+			startedAt: 1_100,
+			parentRunId: "root-run-1234567890",
+		};
+		const payload: ChatSurfacePayload = {
+			kind: "status",
+			runs: [root],
+			indicatorStatuses: resolveRunIndicatorStatuses([root], [root, hiddenChild]),
+		};
+		// Simulate the session-restore path: the renderer receives a payload
+		// rebuilt from persisted JSON, never the emit-time object.
+		const restored = JSON.parse(JSON.stringify(payload)) as ChatSurfacePayload;
+		const component = renderer!({ details: restored }) as { render(width: number): string[] };
+		const plain = stripAnsi(component.render(100).join("\n"));
+		const idLine = plain.split("\n").find((line) => line.includes(root.id));
+		assert.ok(idLine !== undefined, "status card must render the visible root's identifier row");
+		assert.ok(
+			idLine.includes(statusIcon("awaiting_input")),
+			`restored ancestor row must carry the awaiting-input indicator, got: ${idLine}`,
+		);
 	});
 });
 describe("chatWidth", () => {

--- a/test/unit/run-indicator-status.test.ts
+++ b/test/unit/run-indicator-status.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { runIndicatorStatus } from "../../packages/workflows/src/shared/run-indicator-status.js";
+import type { RunSnapshot, StageSnapshot } from "../../packages/workflows/src/shared/store-types.js";
+
+function makeRun(id: string, status: RunSnapshot["status"], stages: StageSnapshot[] = []): RunSnapshot {
+	return {
+		id,
+		name: id,
+		inputs: {},
+		status,
+		stages,
+		startedAt: 1,
+	};
+}
+
+function awaitingStage(id = "ask"): StageSnapshot {
+	return {
+		id,
+		name: id,
+		status: "awaiting_input",
+		parentIds: [],
+		toolEvents: [],
+		pendingPrompt: {
+			id: `${id}-prompt`,
+			kind: "confirm",
+			message: "Continue?",
+			createdAt: 1,
+		},
+	};
+}
+
+describe("runIndicatorStatus", () => {
+	test("returns awaiting_input for a live run-level or stage prompt", () => {
+		const runPrompt = makeRun("run-prompt", "running");
+		runPrompt.pendingPrompt = { id: "run-prompt-id", kind: "confirm", message: "Continue?", createdAt: 1 };
+		assert.equal(runIndicatorStatus(runPrompt), "awaiting_input");
+		assert.equal(runIndicatorStatus(makeRun("stage-prompt", "running", [awaitingStage()])), "awaiting_input");
+	});
+
+	test("walks parentRunId ancestry and attributes a hidden descendant to its visible ancestor", () => {
+		const root = makeRun("root", "running");
+		const parent = { ...makeRun("parent", "running"), parentRunId: root.id };
+		const child = { ...makeRun("child", "running", [awaitingStage()]), parentRunId: parent.id };
+		const unrelated = makeRun("unrelated", "running");
+		const allRuns = [root, parent, child, unrelated];
+
+		assert.equal(runIndicatorStatus(root, allRuns), "awaiting_input");
+		assert.equal(runIndicatorStatus(parent, allRuns), "awaiting_input");
+		assert.equal(runIndicatorStatus(unrelated, allRuns), "running");
+		assert.equal(runIndicatorStatus(makeRun("clean", "running"), allRuns), "running");
+	});
+
+	test("accepts an explicit rootRunId and does not infer unrelated runs", () => {
+		const root = makeRun("root", "running");
+		const child = { ...makeRun("child", "running", [awaitingStage()]), rootRunId: root.id, parentRunId: "missing" };
+		const unrelated = makeRun("unrelated", "running");
+		assert.equal(runIndicatorStatus(root, [root, child, unrelated]), "awaiting_input");
+		assert.equal(runIndicatorStatus(unrelated, [root, child, unrelated]), "running");
+	});
+
+	test("reverts immediately when a prompt is answered or cancelled", () => {
+		const answered = makeRun("answered", "running", [awaitingStage()]);
+		assert.equal(runIndicatorStatus(answered), "awaiting_input");
+		answered.stages[0]!.status = "running";
+		answered.stages[0]!.pendingPrompt = undefined;
+		assert.equal(runIndicatorStatus(answered), "running");
+
+		const cancelled = makeRun("cancelled", "running");
+		cancelled.pendingPrompt = { id: "cancel-prompt", kind: "input", message: "Continue?", createdAt: 1 };
+		assert.equal(runIndicatorStatus(cancelled), "awaiting_input");
+		cancelled.pendingPrompt = undefined;
+		assert.equal(runIndicatorStatus(cancelled), "running");
+	});
+
+	test("terminal and blocked statuses beat stale pending prompts", () => {
+		for (const status of ["completed", "failed", "killed", "cancelled", "skipped", "blocked"] as const) {
+			const run = makeRun(status, status, [awaitingStage()]);
+			run.pendingPrompt = { id: `${status}-prompt`, kind: "confirm", message: "Continue?", createdAt: 1 };
+			assert.equal(runIndicatorStatus(run), status);
+		}
+	});
+});

--- a/test/unit/run-indicator-status.test.ts
+++ b/test/unit/run-indicator-status.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { runIndicatorStatus } from "../../packages/workflows/src/shared/run-indicator-status.js";
+import {
+	resolveRunIndicatorStatuses,
+	runIndicatorStatus,
+} from "../../packages/workflows/src/shared/run-indicator-status.js";
 import type { RunSnapshot, StageSnapshot } from "../../packages/workflows/src/shared/store-types.js";
 
 function makeRun(id: string, status: RunSnapshot["status"], stages: StageSnapshot[] = []): RunSnapshot {
@@ -79,5 +82,25 @@ describe("runIndicatorStatus", () => {
 			run.pendingPrompt = { id: `${status}-prompt`, kind: "confirm", message: "Continue?", createdAt: 1 };
 			assert.equal(runIndicatorStatus(run), status);
 		}
+	});
+});
+
+describe("resolveRunIndicatorStatuses", () => {
+	test("resolves each listed run against the complete collection into serializable data", () => {
+		const root = makeRun("root", "running");
+		const child = { ...makeRun("child", "running", [awaitingStage()]), parentRunId: root.id };
+		const unrelated = makeRun("unrelated", "running");
+		const statuses = resolveRunIndicatorStatuses([root, unrelated], [root, child, unrelated]);
+		assert.deepEqual(statuses, { root: "awaiting_input", unrelated: "running" });
+		// The record must survive a JSON round-trip: it is persisted with the
+		// /workflow status chat payload and consumed after a session restore.
+		assert.deepEqual(JSON.parse(JSON.stringify(statuses)), statuses);
+	});
+
+	test("keeps terminal precedence and covers only the listed runs", () => {
+		const done = makeRun("done", "completed", [awaitingStage()]);
+		const hidden = makeRun("hidden", "running", [awaitingStage()]);
+		const statuses = resolveRunIndicatorStatuses([done], [done, hidden]);
+		assert.deepEqual(statuses, { done: "completed" });
 	});
 });

--- a/test/unit/session-picker.test.ts
+++ b/test/unit/session-picker.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../../packages/workflows/src/durable/resume-eligibility.ts";
 import type { RunSnapshot, StoreSnapshot } from "../../packages/workflows/src/shared/store-types.ts";
 import { ENV_WORKFLOW_ARTIFACT_DIR } from "../../packages/workflows/src/shared/workflow-artifacts.ts";
+import { hexToAnsi } from "../../packages/workflows/src/tui/color-utils.js";
 import { deriveGraphTheme } from "../../packages/workflows/src/tui/graph-theme.ts";
 import {
 	createSessionPickerResumeCandidateCache,
@@ -22,6 +23,7 @@ import {
 	renderSessionPicker,
 	selectRunsForPicker,
 } from "../../packages/workflows/src/tui/session-picker.ts";
+import { statusColor, statusIcon } from "../../packages/workflows/src/tui/status-helpers.js";
 import { visibleWidth } from "../../packages/workflows/src/tui/text-helpers.ts";
 
 function makeRun(over: Partial<RunSnapshot>): RunSnapshot {
@@ -313,6 +315,68 @@ test("renderSessionPicker emits header, sections, and footer hints", () => {
 	assert.match(joined, /Navigate/);
 	assert.match(joined, /Connect/);
 	assert.doesNotMatch(joined, /Kill/);
+});
+
+test("renderSessionPicker uses the awaiting-input glyph and info colour for a prompted run", () => {
+	const theme = deriveGraphTheme({});
+	const awaiting = makeRun({
+		id: "awaiting111-0000-0000-0000-000000000000",
+		name: "awaiting-workflow",
+		stages: [
+			{
+				id: "ask",
+				name: "ask",
+				status: "awaiting_input",
+				parentIds: [],
+				toolEvents: [],
+			},
+		],
+	});
+	const rows = [
+		{ run: makeRun({ id: "other111-0000-0000-0000-000000000000" }), bucket: "active" as const },
+		{ run: awaiting, bucket: "active" as const },
+	];
+	const state = createSessionPickerState();
+	const joined = renderSessionPicker({ width: 100, theme, rows, state, allRuns: [rows[0]!.run, awaiting] })
+		.join("\n")
+		.replace(/\x1b\[[0-9;]*m/g, "");
+	assert.match(joined, new RegExp(`${statusIcon("awaiting_input")} awaiting111`));
+	assert.ok(
+		renderSessionPicker({ width: 100, theme, rows, state, allRuns: [rows[0]!.run, awaiting] })
+			.join("\n")
+			.includes(hexToAnsi(statusColor("awaiting_input", theme))),
+	);
+});
+
+test("renderSessionPicker keeps paused quit treatment when the run carries a pending prompt", () => {
+	const theme = deriveGraphTheme({});
+	const quit: RunSnapshot = {
+		...makeRun({
+			id: "quit-picker-prompt",
+			name: "resume-me",
+			status: "paused",
+			exitReason: "quit",
+			resumable: true,
+		}),
+		pendingPrompt: {
+			id: "quit-picker-prompt-id",
+			kind: "confirm",
+			message: "Continue?",
+			createdAt: 900,
+		},
+	};
+	const other = makeRun({ id: "other-picker-run", name: "other-workflow" });
+	const rows = [
+		{ run: other, bucket: "active" as const },
+		{ run: quit, bucket: "active" as const },
+	];
+	const state = createSessionPickerState();
+	const rendered = renderSessionPicker({ width: 100, theme, rows, state, allRuns: [other, quit] }).join("\n");
+	const plain = rendered.replace(/\x1b\[[0-9;]*m/g, "");
+	assert.match(plain, new RegExp(`${statusIcon(quit.status)}\\s+${quit.id}`));
+	assert.ok(rendered.includes(hexToAnsi(statusColor(quit.status, theme))));
+	assert.doesNotMatch(plain, new RegExp(statusIcon("awaiting_input")));
+	assert.equal(rendered.includes(hexToAnsi(statusColor("awaiting_input", theme))), false);
 });
 
 test("renderSessionPicker shows empty state when no rows", () => {

--- a/test/unit/status-list-render.test.ts
+++ b/test/unit/status-list-render.test.ts
@@ -188,6 +188,21 @@ describe("renderStatusList — populated", () => {
 		assert.match(plain, /single\s+\[●\]/);
 	});
 
+	test("precomputed indicatorStatuses drive the indicator without the full run collection (restored payloads)", () => {
+		const theme = deriveGraphTheme({});
+		const root = makeRun({ id: "root-restored", name: "root-restored", status: "running" });
+		const out = renderStatusList([root], {
+			theme,
+			width: 100,
+			indicatorStatuses: { [root.id]: "awaiting_input" },
+			showDetailHint: false,
+		});
+		const plain = stripAnsi(out);
+		const idLine = plain.split("\n").find((line) => line.includes(root.id));
+		assert.ok(idLine?.includes(statusIcon("awaiting_input")));
+		assert.ok(out.includes(hexToAnsi(statusColor("awaiting_input", theme))));
+	});
+
 	test("legacy completed snapshots with incomplete returned status render blocked", () => {
 		const now = 1_000_000;
 		const out = renderStatusList(

--- a/test/unit/status-list-render.test.ts
+++ b/test/unit/status-list-render.test.ts
@@ -19,7 +19,7 @@ import type { RunSnapshot, StageSnapshot } from "../../packages/workflows/src/sh
 import { chatWidth } from "../../packages/workflows/src/tui/chat-surface.js";
 import { hexToAnsi, RESET } from "../../packages/workflows/src/tui/color-utils.js";
 import { deriveGraphTheme } from "../../packages/workflows/src/tui/graph-theme.js";
-import { statusIcon } from "../../packages/workflows/src/tui/status-helpers.js";
+import { statusColor, statusIcon } from "../../packages/workflows/src/tui/status-helpers.js";
 import { renderStatusList } from "../../packages/workflows/src/tui/status-list.js";
 import { visibleWidth } from "../../packages/workflows/src/tui/text-helpers.js";
 
@@ -169,6 +169,25 @@ describe("renderStatusList — populated", () => {
 		assert.doesNotMatch(out, /✓ completed/);
 	});
 
+	test("awaiting input changes only the run indicator glyph/colour and attributes nested prompts to the root", () => {
+		const theme = deriveGraphTheme({});
+		const root = makeRun({ id: "root-awaiting", name: "root-awaiting", status: "running" });
+		const child = makeRun({
+			id: "child-awaiting",
+			name: "hidden-child",
+			status: "running",
+			stages: [makeStage("ask", "ask", "awaiting_input")],
+		});
+		child.parentRunId = root.id;
+		const out = renderStatusList([root], { theme, width: 100, allRuns: [root, child], showDetailHint: false });
+		const plain = stripAnsi(out);
+		const idLine = plain.split("\n").find((line) => line.includes(root.id));
+		assert.ok(idLine?.includes(statusIcon("awaiting_input")));
+		assert.ok(out.includes(hexToAnsi(statusColor("awaiting_input", theme))));
+		assert.ok(plain.includes("root-awaiting"));
+		assert.match(plain, /single\s+\[●\]/);
+	});
+
 	test("legacy completed snapshots with incomplete returned status render blocked", () => {
 		const now = 1_000_000;
 		const out = renderStatusList(
@@ -283,6 +302,35 @@ describe("renderStatusList — populated", () => {
 		assert.match(plain, /resume-me/);
 		assert.match(plain, /resumable via \/workflow resume/);
 		assert.doesNotMatch(plain, /failed/);
+	});
+	test("quit run with a pending prompt keeps the prompt-free resumable card byte-identical", () => {
+		const now = 10_000;
+		const theme = deriveGraphTheme({});
+		const promptFree: RunSnapshot = makeRun({
+			id: "quit-prompt-list",
+			name: "resume-me",
+			status: "paused",
+			startedAt: now - 1_000,
+			exitReason: "quit",
+			resumable: true,
+		});
+		const prompted: RunSnapshot = {
+			...promptFree,
+			pendingPrompt: {
+				id: "quit-prompt",
+				kind: "confirm",
+				message: "Continue?",
+				createdAt: now - 100,
+			},
+		};
+		const opts = { theme, now, width: 120 };
+		const promptFreeOutput = renderStatusList([promptFree], opts);
+		const promptedOutput = renderStatusList([prompted], opts);
+		assert.equal(promptedOutput, promptFreeOutput);
+		const plain = stripAnsi(promptedOutput);
+		assert.match(plain, new RegExp(`${statusIcon("pending")}\\s+quit-prompt-list`));
+		assert.match(plain, new RegExp(`resume-me.*${statusIcon("pending")}\\s+quit`));
+		assert.match(plain, /resumable via \/workflow resume/);
 	});
 
 	test("mixed running and paused snapshot keeps paused runs out of running counts and labels their rows", () => {

--- a/test/unit/widget-rendering.test.ts
+++ b/test/unit/widget-rendering.test.ts
@@ -142,6 +142,30 @@ describe("renderWidgetLines — standard form", () => {
 		assert.ok(lines[0]!.includes("BACKGROUND  1 run  1 quit"));
 		assert.ok(joined.includes("quit · resumable via /workflow resume"));
 	});
+	test("quit run with a pending prompt keeps quit treatment and is excluded from needs-attention count", () => {
+		const now = 10_000;
+		const theme = deriveGraphTheme({});
+		const quit: RunSnapshot = {
+			...makeRun("quit-with-prompt", "resume-me", "paused", [], now - 1_000),
+			exitReason: "quit",
+			resumable: true,
+			pendingPrompt: {
+				id: "quit-prompt",
+				kind: "confirm",
+				message: "Continue?",
+				createdAt: now - 100,
+			},
+		};
+		const lines = buildThemedWidgetLines(makeSnap([quit]), NULL_PI_THEME, 120, now);
+		const joined = lines.join("\n");
+		assert.ok(joined.includes(statusIcon("pending")), "quit card keeps the pending glyph");
+		assert.ok(
+			joined.includes(hexToAnsi(statusColor(quit.status, theme))),
+			"quit card keeps the paused warning colour",
+		);
+		assert.doesNotMatch(stripAnsi(lines[0]!), /needs attention/);
+		assert.ok(stripAnsi(lines[0]!).includes("1 quit"), "quit count remains visible");
+	});
 	test("quit card expires from the widget after the recent window while status stays resumable", () => {
 		const originalNow = Date.now;
 		let now = 1_000_000;
@@ -553,9 +577,7 @@ describe("run identity rows", () => {
 
 		const cases = [
 			{ id: ids.running, name: "stage-output-transcript", glyph: statusIcon("running") },
-			// Provisional pin: today's card keeps the running glyph; the objective example shows `？`,
-			// but changing awaiting-input attribution belongs to PR #2135.
-			{ id: ids.awaiting, name: "build-check", glyph: statusIcon("running") },
+			{ id: ids.awaiting, name: "build-check", glyph: statusIcon("awaiting_input") },
 			{ id: ids.quit, name: "release-docs", glyph: statusIcon("pending") },
 			{ id: ids.completed, name: "publish-release", glyph: statusIcon("completed") },
 			{ id: ids.failed, name: "verify-release", glyph: statusIcon("failed") },
@@ -581,6 +603,9 @@ describe("run identity rows", () => {
 		const themed = buildThemedWidgetLines(makeSnap([running]), NULL_PI_THEME, 120);
 		assert.ok(themed[1]?.includes(hexToAnsi(statusColor("running", theme))));
 		assert.ok(themed[1]?.includes(statusIcon("running")));
+		const themedAwaiting = buildThemedWidgetLines(makeSnap([awaiting]), NULL_PI_THEME, 120);
+		assert.ok(themedAwaiting[1]?.includes(hexToAnsi(statusColor("awaiting_input", theme))));
+		assert.ok(themedAwaiting[1]?.includes(statusIcon("awaiting_input")));
 	});
 
 	test("keeps every widget border line at the collapsed breakpoint", () => {

--- a/test/unit/workflow-status-listing.test.ts
+++ b/test/unit/workflow-status-listing.test.ts
@@ -8,6 +8,7 @@
 import { beforeEach, describe, test } from "vitest";
 import type { WorkflowRunStatusSummary } from "../../packages/workflows/src/extension/workflow-status-summary.js";
 import { renderWorkflowToolContent } from "../../packages/workflows/src/extension/workflow-tool-content.js";
+import { statusIcon } from "../../packages/workflows/src/tui/status-helpers.js";
 import {
 	assert,
 	createExtensionRuntime,
@@ -164,6 +165,31 @@ describe("workflow tool status run listing", () => {
 		assert.equal(result.runs[0]!.awaitingInputCount, 1);
 	});
 
+	test.sequential("status rendering attributes a run-level prompt in a hidden child without exposing it in JSON", async () => {
+		const rootId = `status-nested-root-${Date.now()}`;
+		const childId = `status-nested-child-${Date.now()}`;
+		store.recordRunStart(makeInflightRun(rootId));
+		store.recordRunStart({
+			...makeInflightRun(childId),
+			parentRunId: rootId,
+			rootRunId: rootId,
+			pendingPrompt: {
+				id: "nested-prompt",
+				kind: "confirm",
+				message: "Continue nested workflow?",
+				createdAt: Date.now(),
+			},
+		});
+		const result = await makeToolHandler()({ action: "status" }, {} as never);
+		const text = renderWorkflowToolContent(result, { action: "status" });
+		const summaryLine = text.split("\n").find((line) => line.startsWith("[1]"));
+		assert.notEqual(summaryLine, undefined);
+		assert.match(summaryLine!, new RegExp(`${statusIcon("awaiting_input")}.*${rootId}`));
+
+		const json = renderWorkflowToolContent(result, { action: "status", format: "json" });
+		assert.doesNotMatch(json, new RegExp(childId));
+	});
+
 	test.sequential("status text output is a concise per-run listing; json format returns structured data", async () => {
 		const activeId = `status-content-active-${Date.now()}`;
 		recordRunningRunWithStages(activeId);
@@ -181,6 +207,14 @@ describe("workflow tool status run listing", () => {
 		assert.match(summaryLine!, /release-docs/);
 		assert.match(summaryLine!, /running/);
 		assert.match(summaryLine!, /awaiting input \(1\): approve/);
+		assert.match(summaryLine!, new RegExp(statusIcon("awaiting_input")));
+
+		// The rendered result keeps the point-in-time snapshot even when the live store resolves the prompt later.
+		const liveStage = store.runs().find((run) => run.id === activeId)?.stages[1];
+		assert.notEqual(liveStage, undefined);
+		liveStage!.status = "running";
+		liveStage!.pendingPrompt = undefined;
+		assert.equal(renderWorkflowToolContent(result, { action: "status" }), text);
 		// Full identifiers for pause/resume/interrupt/quit/send follow-ups.
 		assert.match(text, new RegExp(`runId: ${activeId}`));
 		assert.match(text, new RegExp(`${activeId}-stage-approve`));


### PR DESCRIPTION
Closes #2185

## Summary

Runs paused on a human-input prompt now show a distinct awaiting-input indicator instead of the generic running spinner.

- **Shared predicate**: new `packages/workflows/src/shared/run-indicator-status.ts` exports `runIndicatorStatus(run, allRuns)`, the single source of truth for a run's primary indicator status.
- **Three surfaces**: the BACKGROUND widget, the `/workflow connect` picker, and the `/workflow status` listing all resolve their indicator through the shared predicate.
- **Nested-ancestor marking**: a pending prompt in a hidden nested descendant is attributed to the visible top-level ancestor by following `rootRunId`/`parentRunId` (with cycle protection), so the surface the user can see is the one that lights up.
- **Revert**: once the prompt is answered the indicator returns to the plain running status; quit runs stay resumable.
- **Precedence**: effective terminal and blocked statuses (`completed`, `failed`, `killed`, `cancelled`, `skipped`, `blocked`) win over a stale pending-prompt marker left in a snapshot.
- **No copy changes**: the BACKGROUND widget header badge, meta lines, and progress text stay byte-identical. PR #2135's prompt-attribution header (`AWAITING INPUT · <run id> <name>`) is deliberately not relanded — it is out of scope.

## Relationship to closed PR #2135

This is a fresh implementation from clean `main`. Nothing was checked out, cherry-picked, merged, or copied from `fix/hil-run-attribution-indicator`; PR #2135's description was consulted only as a spec reference.

## Verification (local)

- `npm run check` — biome, `tsc --noEmit`, and shrinkwrap check all pass.
- Targeted vitest run of the touched suites (`run-indicator-status`, `session-picker`, `status-list-render`, `widget-rendering`, `workflow-status-listing`): 5 files, 86 tests, all pass.
- `npm run test:unit` — 630 files, 5890 passed, 1 skipped.
- Pre-push hooks (biome, `npm run check`, `test:unit`, `test:integration`, `test:ci-contracts`) all passed on the pushed commit. One earlier hook run saw two unrelated interactive-engine tests fail under parallel-suite load; both pass standalone and on the accepted run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788457242&installation_model_id=10562&pr_number=2192&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2192&signature=276bad60eac37487d3de9eb5dbe96ff3ba75d01a9604e7b265906e9c458780ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds a shared workflow indicator for runs awaiting human input, including attribution from hidden nested runs, and carries that indicator into status cards, widgets, pickers, and restored chat entries.

A reproduced behavior gap remains: an unfiltered status listing correctly marks a visible parent workflow as awaiting input when its hidden nested child has a prompt, but `/workflow status` filtered to awaiting-input returns no matching workflow. Users and agents can therefore miss an actionable workflow when relying on that filter.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until the awaiting-input filter includes visible workflows whose nested descendants require input.

The status display and filtered status results disagree for the same active workflow. This makes an actionable human-input request undiscoverable through the filter intended to surface it.

**Files Needing Attention:** packages/workflows/src/extension/workflow-status-summary.ts, packages/workflows/src/extension/workflow-tool.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a finding-comment-proof for a posted P1 finding and attached four artifacts showing the workflow status with and without a hidden child prompt, plus the nested-prompt reproduction harness and a focused test run.
- T-Rex issued a second finding-comment-proof for another P1 finding.
- T-Rex validated the contract behavior by inspecting the unfiltered and statusFilter results, confirming the nested prompt status behavior using the accompanying logs.
- T-Rex attached the harness source for the nested prompt status and ran a focused regression, with the focused run log captured for review.

<a href="https://app.greptile.com/trex/runs/17342049/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/workflows/src/extension/workflow-status-summary.ts`, line 206 ([link](https://github.com/bastani-inc/atomic/blob/f8680c0426d38fb458a87e4e3e400ea04d9a1619/packages/workflows/src/extension/workflow-status-summary.ts#L206)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Awaiting-input filter ignores nested workflow prompts**

   `statusFilter: "awaiting_input"` only checks `summary.awaitingInputCount`, which is derived from the visible run's own snapshot. A top-level run with a hidden nested descendant awaiting a prompt is therefore omitted from the filtered `/workflow status` result, even though the unfiltered status renderer correctly marks that same top-level run with the awaiting-input indicator. This prevents users and agents from discovering the actionable visible workflow through the awaiting-input filter. Resolve descendant-aware indicator status against the complete run collection before filtering, and treat a resolved `awaiting_input` status as a match.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Unfiltered workflow status with a hidden child prompt](https://app.greptile.com/trex/artifacts/e735d7c3-854f-483e-8288-df551fc877d2)**

   - Executed the narrow harness without a filter; the visible root is listed and rendered with the awaiting-input glyph even though its own summary reports zero prompts, demonstrating rendering-side descendant attribution. Takeaway: unfiltered text recognizes the hidden child prompt.

   **[Filtered workflow status with a hidden child prompt](https://app.greptile.com/trex/artifacts/eb039480-49bb-4d6f-b7f5-6ca10324d603)**

   - Executed the same seeded workflow through \`statusFilter: awaiting\_input\`; the exact status path returns an empty listing. Takeaway: the filter drops the visible root that needs attention.

   **[Nested prompt status reproduction harness source](https://app.greptile.com/trex/artifacts/ec121e24-71d1-4c2b-864a-e09f6612f8c2)**

   - Authored narrow Vitest harness that seeds the top-level and hidden child runs, invokes \`makeExecuteWorkflowTool\`, and records both comparison modes. Takeaway: the reproduction is executable and directly exercises the reported path.

   **[Focused workflow status and indicator test run](https://app.greptile.com/trex/artifacts/b213b72f-8b9e-4f41-912e-9befebdf32d6)**

   - Ran the reproduction alongside existing workflow status-listing and indicator tests; all 14 focused tests passed while the harness recorded the unfiltered indicator behavior. Takeaway: the defect is isolated to filtered listing semantics rather than a failed runtime setup.

   <a href="https://app.greptile.com/trex/runs/17342049/artifacts?artifact=e735d7c3-854f-483e-8288-df551fc877d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/workflows/src/extension/workflow-status-summary.ts
   Line: 206

   Comment:
   **Awaiting-input filter ignores nested workflow prompts**

   `statusFilter: "awaiting_input"` only checks `summary.awaitingInputCount`, which is derived from the visible run's own snapshot. A top-level run with a hidden nested descendant awaiting a prompt is therefore omitted from the filtered `/workflow status` result, even though the unfiltered status renderer correctly marks that same top-level run with the awaiting-input indicator. This prevents users and agents from discovering the actionable visible workflow through the awaiting-input filter. Resolve descendant-aware indicator status against the complete run collection before filtering, and treat a resolved `awaiting_input` status as a match.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **awaiting_input status filter omits visible roots whose hidden descendants need input**

   - **Bug**
     - The user-facing root is shown as needing attention by unfiltered status text, but is absent from the filtered status result. This prevents an agent/user using `/workflow status` with `statusFilter: "awaiting_input"` from discovering the actionable visible workflow whenever the pending prompt belongs to a nested hidden run.
   - **Cause**
     - `makeExecuteWorkflowTool` invokes `buildWorkflowStatusListing(topLevelExpandedSnapshots(), args.statusFilter ?? "all")` at `packages/workflows/src/extension/workflow-tool.ts:97`. `buildWorkflowStatusListing` summarizes only each visible snapshot and filters it at `packages/workflows/src/extension/workflow-status-summary.ts:219-221`; the `awaiting_input` predicate at `:204-207` only checks that summary's own `awaitingInputCount`. By contrast, unfiltered rendering calls `runIndicatorStatus(snapshot, allRuns)` at `packages/workflows/src/extension/workflow-tool-content.ts:75-85`, and the resolver attributes descendant prompts through `rootRunId`/`parentRunId` at `packages/workflows/src/shared/run-indicator-status.ts:18-28,64-74`.
   - **Fix**
     - Resolve each visible run's descendant-aware indicator status against the complete store snapshot before filtering, and treat resolved `awaiting_input` as matching the filter. Ensure the summary/detail representation also exposes enough descendant prompt attribution to make the returned root actionable.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/workflows/src/extension/workflow-status-summary.ts:206
**Awaiting-input filter ignores nested workflow prompts**

`statusFilter: "awaiting_input"` only checks `summary.awaitingInputCount`, which is derived from the visible run's own snapshot. A top-level run with a hidden nested descendant awaiting a prompt is therefore omitted from the filtered `/workflow status` result, even though the unfiltered status renderer correctly marks that same top-level run with the awaiting-input indicator. This prevents users and agents from discovering the actionable visible workflow through the awaiting-input filter. Resolve descendant-aware indicator status against the complete run collection before filtering, and treat a resolved `awaiting_input` status as a match.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(test): harden gated bash synchroniza..."](https://github.com/bastani-inc/atomic/commit/f8680c0426d38fb458a87e4e3e400ea04d9a1619) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50144595)</sub>

<!-- /greptile_comment -->