### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,13 @@ Atomic does not require package install scripts. Add `--ignore-scripts` to the i
 
 ### Authenticate and run
 
-Atomic supports subscription login for Codex, Claude, GitHub Copilot, xAI, and Radius, as well as API-key providers such as OpenRouter:
-
+Start Atomic:
 ```bash
 atomic
+```
+Login. Atomic supports subscription login for Codex, Claude, GitHub Copilot, xAI, as well as API-key providers such as OpenRouter:
+
+```bash
 /login   # then select your provider
 ```
 


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788497179&installation_model_id=10562&pr_number=2202&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2202&signature=6d6a9014caf68131f1350b9faed23db20a6871395bc69cfda4d1266eef6a595c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The README now separates starting Atomic from signing in. However, the authentication overview no longer names Radius even though `/login` still offers Radius as a subscription provider. Restore Radius in the provider list so users receive complete setup guidance.

<h3>Confidence Score: 4/5</h3>





<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P2 finding and attached three artifacts documenting the focused Radius README and login-provider runtime check around the PR.
- T-Rex produced proof for another posted P2 finding (proofIndex 1) with no artifacts attached.
- T-Rex completed a general-contract-validation-proof showing the Radius entry was present before the change and omitted after, while the executed runtime list still included Radius and both runs exited 0.

<a href="https://app.greptile.com/trex/runs/17379693/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **README omits the still-supported Radius subscription login**

   - **Bug**
     - `README.md:104` lists Codex, Claude, GitHub Copilot, and xAI as subscription-login providers but omits Radius. The `/login` runtime source obtains subscription choices from `ModelRuntime.getOAuthProviderMetadata()`, and the executed runtime metadata includes Radius.
   - **Cause**
     - Commit `67eb8f2f` rewrote the authentication instructions and deleted `and Radius` from the provider sentence without changing the registered login providers.
   - **Fix**
     - Add `and Radius` back to the subscription-login provider list in `README.md:104`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:104
**Radius omitted from provider list**

The subscription-login overview omits Radius even though `/login` still presents Radius as a supported subscription provider. This makes the README incorrectly imply that Radius authentication is unavailable. Add Radius back to the list of subscription providers.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Update README.md"](https://github.com/bastani-inc/atomic/commit/67eb8f2f3d8095a500fbe5d537e283618b4762e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50324056)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->