### PR TITLE
docs(changelog): prepare 0.9.13-alpha.1 release notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.13-alpha.1] - 2026-08-05
+
 ### Added
 
 - `CreateAgentSessionOptions` and `ExtensionContext` now carry an immutable typed subagent child capability policy for in-process tool registration ([#2188](https://github.com/bastani-inc/atomic/issues/2188)).

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.13-alpha.1] - 2026-08-05
+
 ### Changed
 
 - In-process child identities and supervisor capabilities now arrive through typed admission policy and are captured on each `IntercomClient` at connect time instead of being read from environment for every message. Descendants cannot inherit a parent's supervisor grant through process environment; legacy Atomic/Pi bridge metadata remains available for older hosts ([#2188](https://github.com/bastani-inc/atomic/issues/2188)).

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.13-alpha.1] - 2026-08-05
+
 ### Changed
 
 - In-process subagents now receive MCP direct-tool selection through typed admission policy. Omitted selection preserves MCP configuration defaults, a list selects exact server/tool entries, and an empty list disables direct tools; the process-era environment bridge has been removed ([#2188](https://github.com/bastani-inc/atomic/issues/2188)).

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,14 +2,16 @@
 
 ## [Unreleased]
 
+## [0.9.13-alpha.1] - 2026-08-05
+
 ### Added
 
-- Added the Rust `SubagentControl` N-API surface with canonical child identities, RAII spawn reservations, turn-scoped execution guards, LRU residency, status watches, and explicit 100 ms interruption grace for in-process subagents (#2188).
+- Added the Rust `SubagentControl` N-API surface with canonical child identities, RAII spawn reservations, turn-scoped execution guards, LRU residency, status watches, and explicit 100 ms interruption grace for in-process subagents ([#2188](https://github.com/bastani-inc/atomic/issues/2188)).
 
 ### Changed
 
 - Generated N-API string-enum declarations as literal TypeScript unions so strict isolated-module consumers can use subagent statuses and causes without ambient const-enum errors ([#2188](https://github.com/bastani-inc/atomic/issues/2188)).
-- Made child termination awaitable across the N-API boundary so the literal 100 ms cooperative grace does not block the JavaScript thread, and exposed termination causes on child identities and status-watch updates (#2188).
+- Made child termination awaitable across the N-API boundary so the literal 100 ms cooperative grace does not block the JavaScript thread, and exposed termination causes on child identities and status-watch updates ([#2188](https://github.com/bastani-inc/atomic/issues/2188)).
 
 ## [0.9.12] - 2026-08-04
 

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.13-alpha.1] - 2026-08-05
+
 ### Breaking Changes
 
 - `async: true` no longer survives parent exit. Async subagents now run as in-process children of the parent session on the same foreground executor, so quitting Atomic ends any in-flight async run. The child's canonical identity and its session file persist on disk and can be reloaded on a later start, but the running work does not continue in the background across a restart. The detached runner process that previously provided parent-exit survival has been deleted ([#2188](https://github.com/bastani-inc/atomic/issues/2188)).
@@ -24,14 +26,11 @@
 ### Fixed
 
 - Fixed in-process parallel siblings colliding on the same canonical identity and terminal artifact path, and fixed async completions omitting their persisted result envelope from the parent notification ([#2188](https://github.com/bastani-inc/atomic/issues/2188)).
+- Fixed model-failure classification sharing so subagent fallback decisions stay aligned with main chat and workflow candidates for auth, unavailable-model, request-incompatible, quota, and transport failures ([#2170](https://github.com/bastani-inc/atomic/issues/2170)).
 
 ### Removed
 
 - Removed every remaining OS child-process code path from subagent execution, satisfying the spec's zero-process goal: the detached jiti async runner and its twelve `subagent-runner*` modules, the `async-execution-*` spawn layer, the async event journal, the idle/wall attempt watchdog, the stdout drain grace, the CLI spawn resolver, the environment-bridge builder, and the post-exit stdio guard ([#2188](https://github.com/bastani-inc/atomic/issues/2188)).
-
-### Fixed
-
-- Fixed model-failure classification sharing so subagent fallback decisions stay aligned with main chat and workflow candidates for auth, unavailable-model, request-incompatible, quota, and transport failures ([#2170](https://github.com/bastani-inc/atomic/issues/2170)).
 
 ## [0.9.12] - 2026-08-04
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.13-alpha.1] - 2026-08-05
+
 ### Added
 
 - Added four user-initiated workflow lifecycle notices — `started`, `paused`, `quit`, and `resumed` — so the main chat learns when a top-level background run begins, stops, or picks back up. Each travels the same steer delivery, capped-backoff retry, and notice-card path the failure notice already uses, so an agent waiting on a background run no longer mistakes a deliberate stop for work still in progress. `WORKFLOW STARTED` (`▶`), `WORKFLOW PAUSED` (`⏸`, warning tone), `WORKFLOW QUIT` (`⏹`, warning tone, also reporting whether the run stayed resumable), and `WORKFLOW RESUMED` (`▶`) render as cards; the paused and quit text states that the stop was deliberate and user-requested and tells the model not to resume the run or take over the work unless asked, hinting `/workflow resume <run-id>`, while the resumed text does not, because the run is progressing again ([#2177](https://github.com/bastani-inc/atomic/issues/2177)).


### PR DESCRIPTION
## Summary

Prepares release notes for prerelease **0.9.13-alpha.1**. Changelog-only.

Promotes each package's accumulated `[Unreleased]` entries into a `## [0.9.13-alpha.1] - 2026-08-05` section:

- `packages/coding-agent/CHANGELOG.md`
- `packages/intercom/CHANGELOG.md`
- `packages/mcp/CHANGELOG.md`
- `packages/natives/CHANGELOG.md`
- `packages/subagents/CHANGELOG.md`
- `packages/workflows/CHANGELOG.md`

Two incidental cleanups within the promoted content:

- `packages/natives`: two bare `(#2188)` references normalized to full issue links, matching every other entry.
- `packages/subagents`: the duplicate trailing `### Fixed` heading folded into the existing one, so section order stays Breaking Changes / Added / Changed / Fixed / Removed.

No already-released section is touched; `0.9.12` and earlier are unchanged.

## Versionless base is preserved

The diff is changelog-only. No package manifest, lockfile, Cargo manifest, or generated version file is modified — every package remains at the `0.0.0` placeholder. `scripts/cut-release.ts` stamps the real version on the detached `Release 0.9.13-alpha.1` commit after this merges; pushing that tag is what starts `publish.yml`.

## Validation

Run locally before commit and push:

- `npm run check` (biome + `tsc --noEmit` + shrinkwrap check) — passed
- `npm run test:unit`, `npm run test:integration`, `npm run test:ci-contracts` — passed
- Targeted: `test/unit/changelog.test.ts`, `test/unit/package-metadata.test.ts`, `test/ci/release-publisher-contracts.test.ts` — passed

Biome reports no files processed for `.md` paths; it does not lint markdown in this repo.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788556273&installation_model_id=10562&pr_number=2207&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2207&signature=a8294032af5aaf20091a386807e11bc941c61795a72b238f2038ed8925636dc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prepares the `0.9.13-alpha.1` release notes across six package changelogs, including normalized natives issue links and consolidated subagents fix notes. The exercised release-contract failure paths were disproved: all new sections have valid placement and formatting, referenced issue links resolve, the focused changelog suite passed all 11 tests, and a release simulation produced matching tag, package version, and release commit metadata.

<h3>Confidence Score: 5/5</h3>

Safe to merge; no blocking failure remains.

The release-note formatting, issue links, package-version stamping, release tag, and publication metadata contract were exercised successfully.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before stamping the release, the checked-out changelog commit showed version 0.0.0, a non-release subject, and no release tag, establishing the expected release-base state.
- The focused changelog Vitest suite was run and all 11 tests passed, with the referenced GitHub issues returning HTTP 200.
- A release-contract assertion script was executed and a clean-clone tag-and-stamp simulation completed; six changelog sections passed placement and formatting checks, and the simulated tag, stamped package version, and release subject matched 0.9.13-alpha.1.
- No findings were reported in the validation; all asserted failure paths were disproven at the tested scope.

<a href="https://app.greptile.com/trex/runs/17544044/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(changelog): prepare 0.9.13-alpha.1 ..."](https://github.com/bastani-inc/atomic/commit/6ee28288d96242258a69bb90f9c14d0d7a387f17) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50601230)</sub>

<!-- /greptile_comment -->