### PR TITLE
ci: stop double-running one SHA and re-derive the drifted suites caps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,23 @@ env:
 permissions:
   contents: read
 
+# Only `main` runs on push. A release/** or prerelease/** branch always reaches
+# CI through its pull request (AGENTS.md, "Agent publishing requests"), so
+# listing those globs here made one SHA run the entire workflow twice: two sets
+# of runners competing for the same 4vCPU pool, and two competing check runs per
+# required context. GitHub keeps the latest result per context name, so one
+# spurious failure in the push run blocked the pull request permanently even
+# though the pull_request run for that exact SHA was fully green -- runs
+# 31047506585 (push, Linux `suites` cancelled on its cap) and 31047542976
+# (pull_request, every job green) on sha 772a373.
+#
+# There is deliberately no `concurrency:` block. A group that cancels a run
+# already in flight can kill a run that has published `test (...)`, leaving a
+# cancelled required context on a SHA with no superseding successful run, which
+# is the failure being fixed here rather than a fix for it.
 on:
   push:
-    branches: [main, "release/**", "prerelease/**"]
+    branches: [main]
   pull_request:
 
 # The work runs as four concurrent jobs instead of one sequential per-platform
@@ -31,17 +45,25 @@ jobs:
         include:
           - os: blacksmith-4vcpu-ubuntu-2404
             binary_platform: linux-x64
-            timeout_minutes: 8
+            timeout_minutes: 13
           - os: blacksmith-4vcpu-windows-2025
             binary_platform: windows-x64
-            timeout_minutes: 12
+            timeout_minutes: 14
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    # Sequential-job sampling put this at 121s Linux / 195s Windows, but the
-    # first split run measured 230s / 348s with the unit step's one bounded flake
-    # retry firing on both platforms. The cap is a hang detector at roughly 2x
-    # measured p100, not a performance budget, and a cap that cancels a passing
-    # retried run is worse than a late hang detection.
+    # Measured p100 on the last fully green run of this workflow, run
+    # 31047542976 (pull_request, sha 772a373): 400s Linux (unit 291s, native
+    # bindings 45s, integration 29s) and 595s Windows (unit 401s). The previous
+    # 8/12 caps were sized against older 230s/348s measurements and had decayed
+    # to 1.2x, so the Linux leg was cancelled at 497s on run 31047506585 while
+    # the same SHA passed on the pull_request event.
+    #
+    # The cap is a hang detector, not a performance budget. Linux is 13 min
+    # (780s, 1.95x of 400s). Windows would need 20 min for that same ratio, and
+    # every cap here stays strictly under 15 min, so Windows takes the
+    # ceiling-bounded 14 min (840s, 1.41x of 595s). That covers the measured
+    # p100 plus a slow runner but not a full replay of the 401s Windows unit
+    # step; shortening that step is what would restore a true 2x detector.
     timeout-minutes: ${{ matrix.timeout_minutes }}
     steps:
       # Sticky disks are Blacksmith-Linux-only; Windows takes a standard clone.
@@ -122,15 +144,20 @@ jobs:
         include:
           - os: blacksmith-4vcpu-ubuntu-2404
             binary_platform: linux-x64
-            timeout_minutes: 6
+            timeout_minutes: 8
           - os: blacksmith-4vcpu-windows-2025
             binary_platform: windows-x64
             timeout_minutes: 12
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    # Sampled at 126s Linux / 232s Windows; the first split run measured 138s /
-    # 349s. This is the critical path of the whole workflow, so it is the chain
-    # to shard first if a further cut is wanted.
+    # Measured on sha 772a373: 154s / 250s in the green run 31047542976, and a
+    # worst observation of 221s Linux / 270s Windows across both events on that
+    # SHA; the first split run measured 138s / 349s. Linux moves 6 -> 8 min
+    # (480s, 2.17x of the 221s worst observation) because 6 min had decayed to
+    # 1.6x, the same drift that cancelled `suites`. Windows stays at 12 min
+    # (720s), still 2.06x the 349s worst case this job has ever produced. This
+    # is the critical path of the whole workflow, so it is the chain to shard
+    # first if a further cut is wanted.
     timeout-minutes: ${{ matrix.timeout_minutes }}
     steps:
       - uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1.1

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -36,7 +36,22 @@ This release graph follows pi's draft-first publication shape. Public GitHub Rel
 
 ## Tests (`test.yml`)
 
-The test workflow runs on pushes to `main`, `release/**`, and `prerelease/**`, and on every pull request. Its work runs as four independent jobs so the wall clock is one job's longest dependent chain rather than the sum of every step in file order.
+The test workflow runs on pushes to `main` and on every pull request. Release
+branches carry no push trigger: `release/**` and `prerelease/**` always reach CI
+through their pull request, so listing those globs made one SHA run the whole
+workflow twice — two sets of runners competing for the same pool, and two
+competing check runs per required context. GitHub keeps the latest result per
+context name, so a spurious failure in either copy blocked the pull request even
+when the other copy was fully green. Runs `31047506585` (push, Linux `suites`
+cancelled on its cap) and `31047542976` (pull_request, every job green) on the
+same sha `772a373` are the worked example.
+
+There is deliberately no `concurrency:` block. A group that cancels an
+in-flight run can kill a run that has already published `test (...)`, leaving a
+cancelled required context on a SHA with no superseding successful run — the
+failure above, not a fix for it.
+
+Its work runs as four independent jobs so the wall clock is one job's longest dependent chain rather than the sum of every step in file order.
 
 | Job | Platforms | Chain | Linux | Windows |
 | --- | --- | --- | ---: | ---: |
@@ -119,7 +134,28 @@ If maintainers later prefer real per-job required contexts, that is a separate d
 
 ### Per-job time limits
 
-The blanket 10/15-minute pair is gone. Each job declares its own cap as a hang detector at roughly 2x measured p100, with room for the one bounded flake retry it owns: `suites` 8/12, `agent-suite` 6/12, `release-archive` 5/9, `static-checks` 6, gate 5. The two Windows caps are 12 rather than the 8 and 9 that the sequential-job sampling implied, because the first split run measured 348 s and 349 s there; a cap that cancels a passing retried run is worse than a late hang detection. The release-archive Windows cap is 9 because cold setup observed a 152 s Rust toolchain acquisition and 71 s checkout before the roughly 110 s native build and 40 s archive smoke. Every cap still sits under the 15-minute Windows blanket it replaced, and the contract test enforces that.
+The blanket 10/15-minute pair is gone. Each job declares its own cap as a hang
+detector with room for the one bounded flake retry it owns: `suites` 13/14,
+`agent-suite` 8/12, `release-archive` 5/9, `static-checks` 6, gate 5. Every cap
+sits under the 15-minute Windows blanket it replaced, and the contract test
+enforces that.
+
+The target is roughly 2x measured p100, and **Windows `suites` does not meet
+it**. Run `31047542976` measured 400 s Linux and 595 s Windows for that job, so
+Linux at 13 min is 1.95x but 2x of the Windows leg is 19.8 min, which the
+under-15 rule forbids. Windows takes the ceiling-bounded 14 min (1.41x): enough
+for the measured p100 plus a slow runner, not enough for a full replay of the
+401 s Windows unit step. Shortening that step is what would restore a true 2x
+detector there; until then this leg can still be cancelled while healthy.
+
+The earlier 8/12 `suites` pair was sized against 230 s/348 s samples and had
+decayed to about 1.2x, which is what cancelled the Linux leg at 497 s on run
+`31047506585` while the same commit passed on the pull_request event. The
+`agent-suite` Windows cap stays 12 because the first split run measured 349 s
+there; its Linux cap moved 6 → 8 for the same drift. The release-archive Windows
+cap is 9 because cold setup observed a 152 s Rust toolchain acquisition and 71 s
+checkout before the roughly 110 s native build and 40 s archive smoke. A cap that
+cancels a passing retried run is worse than a late hang detection.
 
 Every job that runs a suite through `scripts/run-flaky-test-suite.ts` uploads `.ci-diagnostics/` under a job-unique artifact name (`test-diagnostics-<job>-<binary_platform>`). `actions/upload-artifact@v4+` fails the entire run when two jobs upload the same name.
 
@@ -366,7 +402,7 @@ Repository-wide workflow permissions are read-only. Only draft staging, undrafti
 
 | File | Trigger | Purpose |
 | --- | --- | --- |
-| `.github/workflows/test.yml` | selected pushes and every pull request | workspace tests and cross-platform release smoke |
+| `.github/workflows/test.yml` | pushes to `main`; every pull request | workspace tests and cross-platform release smoke |
 | `.github/workflows/publish.yml` | release tag push; manual recovery dispatch | verify, build, stage draft, publish npm, undraft, clean failed drafts |
 | `.github/workflows/warm-toolchain-cache.yml` | manual dispatch (see gate above) | write the Zig and MSVC CRT cache keys into the default-branch scope |
 

--- a/test/ci/test-workflow-topology.test.ts
+++ b/test/ci/test-workflow-topology.test.ts
@@ -51,6 +51,46 @@ test("the test job is a fail-closed result gate carrying both required contexts"
 	assert.match(gate, /^[ \t]+runs-on: blacksmith-4vcpu-ubuntu-2404$/mu);
 });
 
+/**
+ * `push: branches: [main, "release/**", "prerelease/**"]` sitting next to an
+ * unfiltered `pull_request:` made every release and prerelease pull request run
+ * this workflow twice for one SHA. Both runs publish the same two required
+ * context names, GitHub keeps the latest result per name, and the duplicate load
+ * doubles contention on the shared runner pool. On sha 772a373 the push run
+ * 31047506585 lost its Linux `suites` leg to its own cap and published FAILURE
+ * for both contexts, while the pull_request run 31047542976 for the identical
+ * SHA was green throughout: the pull request stayed blocked with nothing wrong
+ * in it.
+ *
+ * A `concurrency` group is not the remedy. Cancelling an in-flight run that has
+ * already published `test (...)` strands a cancelled required context on a SHA
+ * with no superseding successful run, which is the exact state being fixed.
+ */
+test("one SHA runs this workflow once, and no group can cancel a run mid-flight", async () => {
+	const workflow = await readText(testPath);
+	const onIndex = workflow.indexOf("\non:\n");
+	const jobsIndex = workflow.indexOf("\njobs:\n");
+	assert.ok(onIndex >= 0 && jobsIndex > onIndex, "test.yml must declare `on:` above `jobs:`");
+	const triggers = workflow.slice(onIndex + 1, jobsIndex + 1);
+
+	const branches = /^ {4}branches: \[([^\]]*)\]$/mu.exec(triggers);
+	assert.ok(branches, "the push trigger must carry an explicit branch filter");
+	assert.deepEqual(
+		(branches[1] as string).split(",").map((branch) => branch.trim().replace(/^"|"$/gu, "")),
+		["main"],
+		"only main runs on push; every other branch reaches CI through its pull request",
+	);
+
+	const pullRequestIndex = triggers.indexOf("  pull_request:");
+	assert.ok(pullRequestIndex >= 0, "pull requests must keep producing the two required contexts");
+	const pullRequest = triggers.slice(pullRequestIndex);
+	assert.match(pullRequest, /^ {2}pull_request:[ \t]*$/mu);
+	assert.doesNotMatch(pullRequest, /^ {4}\S/mu, "the pull_request trigger stays unfiltered");
+
+	assert.doesNotMatch(workflow, /^[ \t]*concurrency:/mu, "a cancelled run can strand a failing required context");
+	assert.doesNotMatch(workflow, /cancel-in-progress/u);
+});
+
 test("every work job the gate names exists and is otherwise independent", async () => {
 	const blocks = await jobs();
 	assert.deepEqual([...blocks.keys()], [...WORK_JOBS, "test"]);
@@ -62,19 +102,28 @@ test("every work job the gate names exists and is otherwise independent", async 
 
 /**
  * Per-job wall-clock caps replace the blanket 10/15 minute pair. A cap is a hang
- * detector at roughly 2x measured p100 and must leave room for the one bounded
- * flake retry the job owns: the first split run fired that retry on both
- * platforms and took 230 s / 348 s in `suites` alone. The Windows
- * `release-archive` cap is 9 minutes because cold setup observed 152 s for
- * `rust-toolchain` and 71 s for checkout, followed by roughly 110 s native
- * build and 40 s archive smoke (near 6m50s versus a healthy 4m04s p100).
+ * detector at roughly 2x measured p100, and it decays into a false-failure
+ * generator as the suites grow: the 8-minute `suites` Linux cap was sized
+ * against a 230 s measurement, the job now measures 400 s, and it cancelled a
+ * healthy run at 497 s on 31047506585 while the same SHA passed on the
+ * pull_request event. The current numbers come from run 31047542976 on sha
+ * 772a373 -- `suites` 400 s / 595 s, `agent-suite` 154 s / 250 s (221 s / 270 s
+ * worst observation across both events on that SHA), `release-archive` 102 s /
+ * 192 s.
+ *
+ * Every cap stays strictly under the 15-minute Windows blanket it replaced, so
+ * Windows `suites` takes 14 minutes (1.41x) rather than the 20 that 2x of 595 s
+ * would ask for. The Windows `release-archive` cap is 9 minutes because cold
+ * setup observed 152 s for `rust-toolchain` and 71 s for checkout, followed by
+ * roughly 110 s native build and 40 s archive smoke (near 6m50s versus a
+ * healthy 4m04s p100).
  */
 test("each split job declares its own measured timeout", async () => {
 	const workflow = await readText(testPath);
 	const blocks = await jobs();
 	const caps: Record<string, [number, number]> = {
-		suites: [8, 12],
-		"agent-suite": [6, 12],
+		suites: [13, 14],
+		"agent-suite": [8, 12],
 		"release-archive": [5, 9],
 	};
 	for (const [job, [linux, windows]] of Object.entries(caps)) {

--- a/test/ci/test-workflow-topology.test.ts
+++ b/test/ci/test-workflow-topology.test.ts
@@ -73,7 +73,19 @@ test("one SHA runs this workflow once, and no group can cancel a run mid-flight"
 	assert.ok(onIndex >= 0 && jobsIndex > onIndex, "test.yml must declare `on:` above `jobs:`");
 	const triggers = workflow.slice(onIndex + 1, jobsIndex + 1);
 
-	const branches = /^ {4}branches: \[([^\]]*)\]$/mu.exec(triggers);
+	// Scoped to the `push` mapping rather than the whole trigger block. A bare
+	// four-space `branches:` search can be satisfied by a filter belonging to some
+	// other trigger, which would leave "only main runs on push" asserted by
+	// nothing at all -- including in the case this test exists to catch, where
+	// `push:` is dropped or re-widened while another trigger carries `[main]`.
+	const pushIndex = triggers.indexOf("  push:");
+	assert.ok(pushIndex >= 0, "the workflow must still run on pushes to main");
+	const afterPush = triggers.slice(pushIndex);
+	const pushBodyStart = afterPush.indexOf("\n") + 1;
+	const pushBodyEnd = afterPush.slice(pushBodyStart).search(/^ {0,2}\S/mu);
+	const push = pushBodyEnd >= 0 ? afterPush.slice(0, pushBodyStart + pushBodyEnd) : afterPush;
+
+	const branches = /^ {4}branches: \[([^\]]*)\]$/mu.exec(push);
 	assert.ok(branches, "the push trigger must carry an explicit branch filter");
 	assert.deepEqual(
 		(branches[1] as string).split(",").map((branch) => branch.trim().replace(/^"|"$/gu, "")),


### PR DESCRIPTION
## Summary

The two required check contexts, `test (blacksmith-4vcpu-ubuntu-2404, linux-x64)` and `test (blacksmith-4vcpu-windows-2025, windows-x64)`, could be poisoned by a job cancellation that had nothing wrong with the code. On sha `772a373`, push run [31047506585](https://github.com/bastani-inc/atomic/actions/runs/31047506585) lost its Linux `suites` leg to its own `timeout-minutes` cap at 497s, which failed the aggregate `test` gate and published FAILURE for both contexts. The `pull_request` run [31047542976](https://github.com/bastani-inc/atomic/actions/runs/31047542976) for the *identical* SHA was green in every job. GitHub keeps the latest result per context name, so the pull request stayed blocked with nothing wrong in it.

Two independent defects produced that state, and this PR fixes both.

## Defect 1 — the `suites` caps had decayed into false-failure generators

A `timeout-minutes` value here is a hang detector sized at roughly 2x measured p100, not a performance budget. The existing caps were sized against 230s/348s measurements from the first split run. The job now measures, on green run 31047542976:

| leg | measured p100 | old cap | ratio | new cap | ratio |
|---|---|---|---|---|---|
| `suites` linux | **400s** (unit 291s, native bindings 45s, integration 29s) | 8 min | 1.20x | **13 min** (780s) | 1.95x |
| `suites` windows | **595s** (unit 401s) | 12 min | 1.21x | **14 min** (840s) | 1.41x |
| `agent-suite` linux | **221s** worst observation across both events on that SHA | 6 min | 1.63x | **8 min** (480s) | 2.17x |
| `agent-suite` windows | 349s worst case ever produced | 12 min | 2.06x | 12 min — unchanged | 2.06x |
| `release-archive` | 102s / 192s | 5 / 9 min | 2.83x / 2.76x | unchanged | — |

At 1.2x, a single bounded flake retry exceeds the cap, which is exactly what cancelled the Linux leg. Every in-file comment now states the real measurements and run IDs it was sized against, instead of the superseded numbers.

**Disclosed tradeoff.** Windows `suites` does not reach 2x. Two clauses of the task are jointly unsatisfiable there: ~2x of 595s is 19.8 minutes, while every cap must stay strictly below 15 and never be exactly 10 or 15. The hard constraint wins, so Windows takes the ceiling-bounded 14 minutes. The workflow comment says so plainly and names the 401s Windows unit step as what must shrink to restore a true 2x detector. A Windows unit-step flake replay (595 + 401 = 996s) will still be cancelled at 840s; making that step faster is out of scope here.

## Defect 2 — one SHA ran the whole workflow twice

`push: branches: [main, "release/**", "prerelease/**"]` sat next to an unfiltered `pull_request:`. Every release and prerelease pull request therefore ran the entire suite twice for the same SHA: two sets of runners competing for the same 4vCPU pool (making the timeouts likelier), and two competing check runs per required context (so a single spurious failure blocked the PR permanently).

`push.branches` is now `[main]`. Every other branch reaches CI through its pull request, which is already how the release pipeline watches required checks — `.atomic/workflows/publish-release.ts:213-221` runs `gh pr checks/view` against the PR head, never a push run.

**There is deliberately no `concurrency:` block.** A group that cancels an in-flight run can kill a run that has already published `test (...)`, stranding a cancelled required context on a SHA with no superseding successful run. That is the failure being fixed, not a fix for it. A new contract test asserts the absence of both `concurrency:` and `cancel-in-progress`.

## Safety invariants preserved

The `test` job is unchanged and remains a fail-closed result gate: `if: always()`, `needs: [suites, agent-suite, release-archive, static-checks]`, and one step that fails on any `failure|cancelled|skipped` work job. A skipped required check counts as PASSED on GitHub, so nothing here may let the gate skip. Its matrix still reproduces the two required context strings character-for-character, and pull requests still produce them.

## Tests

`test/ci/test-workflow-topology.test.ts` gains a trigger/concurrency contract test and has its caps map updated in lockstep with the workflow file (`suites: [13, 14]`, `agent-suite: [8, 12]`). The cap docblock is rewritten around the current measurements.

Red-before-green was confirmed by stashing only the workflow change and running the new assertions against the original file:

- `one SHA runs this workflow once…` → `AssertionError`, expected `["main"]`, received `["main","release/**","prerelease/**"]`
- `each split job declares its own measured timeout` → `AssertionError: suites`

The produced config was also verified by parsing the YAML and evaluating real GitHub branch-glob matching rather than trusting regexes: `release/0.9.13` and `prerelease/0.9.13-alpha.1` go from 2 runs per SHA to 1, PR runs still fire for every branch, no top-level `concurrency`, and all caps enumerate strictly under 15 with none at 10 or 15.

| command | result |
|---|---|
| `npm run test:ci-contracts` | 41 passed / 6 files (topology file 8 → 9 tests) |
| `npm run test:unit` | 617 files, 5824 passed, 2 skipped |
| `npm run check` | biome, `tsc --noEmit`, shrinkwrap all clean |

## Scope

The diff touches only `.github/workflows/test.yml` and `test/ci/test-workflow-topology.test.ts`. No CHANGELOG entry: AGENTS.md excludes CI configuration and release-pipeline changes from package changelogs unless shipped behavior changes. No `package.json` version, and no `--parallel`/`--shard`/`--concurrent`/`--max-concurrency`, vitest `pool`/`maxWorkers`/`poolOptions`/`fileParallelism`, `TEST_TIMEOUT_MS`, or `WARN_RATIO` changes.

## Not verified here, and follow-up

- **The fix's behavior on GitHub itself** is unverified; confirming it needs a workflow run, and the task forbade rerunning any workflow or interacting with PR #2207. The YAML parses and its semantics are asserted structurally. `actionlint` is not installed locally.
- **`docs/ci.md:39` is now stale** — it still says the workflow runs on pushes to `main`, `release/**`, and `prerelease/**`, and the duration table below it still carries the superseded 121s/195s samples. The scope constraint kept it out of this diff; it wants a one-line follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788566000&installation_model_id=10562&pr_number=2209&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2209&signature=39f888ad92bd21f333e25841af50ad5df1d9de7a7a41dcb411b225575045e1ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change prevents duplicate test workflow runs for release and prerelease pull requests by restricting push-triggered runs to `main` while retaining unfiltered pull-request coverage. It also raises the affected suite timeout caps and updates the CI documentation.

The CI topology test passed all 9 checks. Workflow parsing confirmed a valid main-only push filter, unfiltered pull requests, `suites` timeouts of 13/14 minutes, and `agent-suite` timeouts of 8/12 minutes. A focused mutation that widened only the push filter with `release/**` failed as expected, while the current workflow passed.

<h3>Confidence Score: 5/5</h3>

The PR is safe to merge; no blocking failure remains.

The changed workflow structure, timeout matrices, and push-filter regression guard were exercised successfully. The release-branch duplicate-run path is prevented while pull-request coverage remains intact.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the narrow CI topology tests and confirmed that all 9 tests passed.
- Parsed the live workflow YAML and confirmed a \[main\] push filter, unfiltered pull\_request, and timeout matrices for suites and agent-suites.
- Executed the mutation harness to mutate the push mapping; the attempt to add release/\*\* to push was rejected, confirming the guard is scoped to the push mapping.
- Verified the unmodified workflow mapping is accepted by the guard, with the current-workflow invocation exiting successfully.

<a href="https://app.greptile.com/trex/runs/17542638/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["test: scope the push-branches contract t..."](https://github.com/bastani-inc/atomic/commit/a467801382fbd89eca58d81473aa3f963aaa86ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50647909)</sub>

<!-- /greptile_comment -->