### PR TITLE
fix(coding-agent): paste clipboard images on macOS Cmd+V

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -147,7 +147,7 @@
 - Fixed a context overflow that compaction cannot resolve to advance the configured `fallbackModels` chain instead of ending the turn, so a larger-context candidate can answer. Compaction still runs first, and a compactable overflow spends no fallback candidate ([#2170](https://github.com/bastani-inc/atomic/issues/2170)).
 - Fixed a reasoning-level change during a model fallback stranding the session on the fallback model. Changing reasoning effort is not a model choice, so it no longer cancels the pending restore; the next turn returns to the user-selected primary and keeps the reasoning level that was chosen. Only an explicit `/model` selection or model cycle cancels the restore ([#2170](https://github.com/bastani-inc/atomic/issues/2170)).
 - Fixed gRPC `ResourceExhausted` provider errors, seen from providers such as NVIDIA NIM, bypassing the same-model auto-retry budget. They are now retried like other transient provider failures, matching upstream pi-ai, and still advance a configured fallback chain when the retries are exhausted ([#2170](https://github.com/bastani-inc/atomic/issues/2170)).
-- Fixed native macOS `Cmd+V` so clipboard images paste into the editor ([#2186](https://github.com/bastani-inc/atomic/issues/2186)).
+- Fixed native macOS `Cmd+V` so clipboard images paste into the editor without duplicate image inserts from terminal key repeats ([#2186](https://github.com/bastani-inc/atomic/issues/2186)).
 
 ## [0.9.12] - 2026-08-04
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -120,6 +120,7 @@
 - Fixed linked project session directories being omitted from the session picker ([#7552](https://github.com/earendil-works/pi/issues/7552)).
 - Fixed standalone x64 binaries failing to start on pre-Haswell CPUs that lack AVX2/BMI2 by using Bun's baseline target, including musl archives ([#7390](https://github.com/earendil-works/pi/issues/7390)).
 - Fixed credential-resolved model endpoints — including GitHub Copilot Business and Enterprise hosts — falling back to the catalog endpoint for Verbatim Compaction, branch summaries, MCP sampling, and direct web summaries. Atomic now retains the resolved `baseUrl` alongside request auth, so request-header `null` suppression markers still pass through unchanged ([#6768](https://github.com/earendil-works/pi/issues/6768), [#7579](https://github.com/earendil-works/pi/issues/7579)).
+- Fixed native macOS `Cmd+V` so clipboard images paste into the editor without duplicate image inserts from terminal key repeats ([#2186](https://github.com/bastani-inc/atomic/issues/2186)).
 
 ### Removed
 
@@ -147,7 +148,6 @@
 - Fixed a context overflow that compaction cannot resolve to advance the configured `fallbackModels` chain instead of ending the turn, so a larger-context candidate can answer. Compaction still runs first, and a compactable overflow spends no fallback candidate ([#2170](https://github.com/bastani-inc/atomic/issues/2170)).
 - Fixed a reasoning-level change during a model fallback stranding the session on the fallback model. Changing reasoning effort is not a model choice, so it no longer cancels the pending restore; the next turn returns to the user-selected primary and keeps the reasoning level that was chosen. Only an explicit `/model` selection or model cycle cancels the restore ([#2170](https://github.com/bastani-inc/atomic/issues/2170)).
 - Fixed gRPC `ResourceExhausted` provider errors, seen from providers such as NVIDIA NIM, bypassing the same-model auto-retry budget. They are now retried like other transient provider failures, matching upstream pi-ai, and still advance a configured fallback chain when the retries are exhausted ([#2170](https://github.com/bastani-inc/atomic/issues/2170)).
-- Fixed native macOS `Cmd+V` so clipboard images paste into the editor without duplicate image inserts from terminal key repeats ([#2186](https://github.com/bastani-inc/atomic/issues/2186)).
 
 ## [0.9.12] - 2026-08-04
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -147,6 +147,7 @@
 - Fixed a context overflow that compaction cannot resolve to advance the configured `fallbackModels` chain instead of ending the turn, so a larger-context candidate can answer. Compaction still runs first, and a compactable overflow spends no fallback candidate ([#2170](https://github.com/bastani-inc/atomic/issues/2170)).
 - Fixed a reasoning-level change during a model fallback stranding the session on the fallback model. Changing reasoning effort is not a model choice, so it no longer cancels the pending restore; the next turn returns to the user-selected primary and keeps the reasoning level that was chosen. Only an explicit `/model` selection or model cycle cancels the restore ([#2170](https://github.com/bastani-inc/atomic/issues/2170)).
 - Fixed gRPC `ResourceExhausted` provider errors, seen from providers such as NVIDIA NIM, bypassing the same-model auto-retry budget. They are now retried like other transient provider failures, matching upstream pi-ai, and still advance a configured fallback chain when the retries are exhausted ([#2170](https://github.com/bastani-inc/atomic/issues/2170)).
+- Fixed native macOS `Cmd+V` so clipboard images paste into the editor ([#2186](https://github.com/bastani-inc/atomic/issues/2186)).
 
 ## [0.9.12] - 2026-08-04
 

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -129,7 +129,7 @@ In fullscreen mode, a successful `app.message.copy` shortcut shows a short `Copi
 
 When `app.clipboard.pasteImage` finds text rather than an image, Atomic inserts that clipboard text into the editor instead of reporting an image-paste failure.
 
-On macOS, native `Cmd+V` also pastes a clipboard image when the copy was image-only. Terminals may deliver that as an empty bracketed-paste event or (with Kitty keyboard protocol, e.g. Ghostty) as `super+v`. Text under `Cmd+V` still goes through normal terminal paste. `Cmd+V` is not a configurable Atomic keybinding. When the clipboard has both text and an image, `Cmd+V` may paste the text while `Ctrl+V` prefers the image. Apple Terminal may send nothing for image-only paste; use Ghostty/iTerm/Kitty or `Ctrl+V` in that case.
+On macOS, native `Cmd+V` also pastes a clipboard image when the copy was image-only. Terminals may deliver that as an empty bracketed-paste event or (with Kitty keyboard protocol, e.g. Ghostty) as `super+v`. Text under `Cmd+V` still goes through normal terminal paste when the terminal sends a paste event. `Cmd+V` is not a configurable Atomic keybinding. When the clipboard has both text and an image, behavior depends on the terminal: empty-paste terminals may insert the text on `Cmd+V`, while Kitty-protocol terminals that deliver `super+v` go through the image path (same preference as `Ctrl+V`). `Ctrl+V` always prefers the image. Apple Terminal may send nothing for image-only paste; use Ghostty/iTerm/Kitty or `Ctrl+V` in that case.
 
 A held paused queue by itself is idle for Ctrl+C handling. After an interruption settles, the next Ctrl+C clears the editor without releasing or dequeuing the hold, and a second quick idle press exits normally.
 

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -129,7 +129,11 @@ In fullscreen mode, a successful `app.message.copy` shortcut shows a short `Copi
 
 When `app.clipboard.pasteImage` finds text rather than an image, Atomic inserts that clipboard text into the editor instead of reporting an image-paste failure.
 
-On macOS, native `Cmd+V` also pastes a clipboard image when the copy was image-only. Terminals may deliver that as an empty bracketed-paste event or (with Kitty keyboard protocol, e.g. Ghostty) as `super+v`. Text under `Cmd+V` still goes through normal terminal paste when the terminal sends a paste event. `Cmd+V` is not a configurable Atomic keybinding. When the clipboard has both text and an image, behavior depends on the terminal: empty-paste terminals may insert the text on `Cmd+V`, while Kitty-protocol terminals that deliver `super+v` go through the image path (same preference as `Ctrl+V`). `Ctrl+V` always prefers the image. Apple Terminal may send nothing for image-only paste; use Ghostty/iTerm/Kitty or `Ctrl+V` in that case.
+On macOS, native `Cmd+V` also pastes a clipboard image when the copy was image-only. Terminals may deliver that as an empty bracketed-paste event or (with Kitty keyboard protocol, e.g. Ghostty) as `super+v`. Text under `Cmd+V` still goes through normal terminal paste when the terminal sends a paste event. `Cmd+V` is not a configurable Atomic keybinding.
+
+Inside tmux on macOS, `Ctrl+V` is the reliable image-paste shortcut; native `Cmd+V` depends on terminal forwarding. VS Code's terminal may forward the empty bracketed-paste route through tmux, while Ghostty may not forward its Kitty `super+v` route through tmux. This is terminal forwarding behavior, not an Atomic defect.
+
+When the clipboard has both text and an image, behavior depends on the terminal: empty-paste terminals may insert the text on `Cmd+V`, while Kitty-protocol terminals that deliver `super+v` go through the image path (same preference as `Ctrl+V`). `Ctrl+V` always prefers the image. Apple Terminal may send nothing for image-only paste; use Ghostty/iTerm/Kitty or `Ctrl+V` in that case.
 
 A held paused queue by itself is idle for Ctrl+C handling. After an interruption settles, the next Ctrl+C clears the editor without releasing or dequeuing the hold, and a second quick idle press exits normally.
 

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -129,6 +129,8 @@ In fullscreen mode, a successful `app.message.copy` shortcut shows a short `Copi
 
 When `app.clipboard.pasteImage` finds text rather than an image, Atomic inserts that clipboard text into the editor instead of reporting an image-paste failure.
 
+On macOS, native `Cmd+V` also pastes a clipboard image when the copy was image-only. Terminals may deliver that as an empty bracketed-paste event or (with Kitty keyboard protocol, e.g. Ghostty) as `super+v`. Text under `Cmd+V` still goes through normal terminal paste. `Cmd+V` is not a configurable Atomic keybinding. When the clipboard has both text and an image, `Cmd+V` may paste the text while `Ctrl+V` prefers the image. Apple Terminal may send nothing for image-only paste; use Ghostty/iTerm/Kitty or `Ctrl+V` in that case.
+
 A held paused queue by itself is idle for Ctrl+C handling. After an interruption settles, the next Ctrl+C clears the editor without releasing or dequeuing the hold, and a second quick idle press exits normally.
 
 In interactive sessions the agent runs in a supervised engine child (see [Extensions](/extensions#interactive-callback-isolation)). Escape there requests the engine's cooperative cancellation and waits for it with no deadline; it never terminates or replaces the engine.

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -243,7 +243,7 @@ atomic @README.md "Summarize this"
 atomic @src/app.ts @src/app.test.ts "Review these together"
 ```
 
-Images can be pasted with CTRL+V (ALT+V on Windows) or dragged into supported terminals.
+Images can be pasted with native macOS Cmd+V, Ctrl+V (Alt+V on Windows), or dragged into supported terminals. When the clipboard has both text and an image, Cmd+V may paste the text while Ctrl+V prefers the image.
 
 ### Run shell commands
 

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -74,7 +74,7 @@ Then select a provider. Built-in subscription logins include Claude Pro/Max, Cha
 Set an API key before launching Atomic:
 
 ```bash
-export ANTHROPIC_API_KEY=[REDACTED:API key param]
+export ANTHROPIC_API_KEY=sk-ant-...
 atomic
 ```
 
@@ -243,7 +243,7 @@ atomic @README.md "Summarize this"
 atomic @src/app.ts @src/app.test.ts "Review these together"
 ```
 
-Images can be pasted with native macOS Cmd+V, Ctrl+V (Alt+V on Windows), or dragged into supported terminals. When the clipboard has both text and an image, Ctrl+V prefers the image; Cmd+V may paste text or the image depending on how the terminal delivers the gesture.
+Images can be pasted with native macOS Cmd+V, Ctrl+V (Alt+V on Windows), or dragged into supported terminals. Inside tmux on macOS, use `Ctrl+V` for reliable image paste; native `Cmd+V` depends on terminal forwarding. VS Code's terminal may forward the empty bracketed-paste route through tmux, while Ghostty may not forward its Kitty `super+v` route through tmux. When the clipboard has both text and an image, Ctrl+V prefers the image; Cmd+V may paste text or the image depending on how the terminal delivers the gesture.
 
 ### Run shell commands
 

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -74,7 +74,7 @@ Then select a provider. Built-in subscription logins include Claude Pro/Max, Cha
 Set an API key before launching Atomic:
 
 ```bash
-export ANTHROPIC_API_KEY=sk-ant-...
+export ANTHROPIC_API_KEY=[REDACTED:API key param]
 atomic
 ```
 
@@ -243,7 +243,7 @@ atomic @README.md "Summarize this"
 atomic @src/app.ts @src/app.test.ts "Review these together"
 ```
 
-Images can be pasted with native macOS Cmd+V, Ctrl+V (Alt+V on Windows), or dragged into supported terminals. When the clipboard has both text and an image, Cmd+V may paste the text while Ctrl+V prefers the image.
+Images can be pasted with native macOS Cmd+V, Ctrl+V (Alt+V on Windows), or dragged into supported terminals. When the clipboard has both text and an image, Ctrl+V prefers the image; Cmd+V may paste text or the image depending on how the terminal delivers the gesture.
 
 ### Run shell commands
 

--- a/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
@@ -3,6 +3,7 @@ import {
 	Editor,
 	type EditorOptions,
 	type EditorTheme,
+	isKeyRepeat,
 	matchesKey,
 	type TUI,
 	truncateToWidth,
@@ -157,8 +158,12 @@ export class CustomEditor extends Editor {
 
 		// Explicit Image Paste keybinding, or macOS Native Paste (image-only Cmd+V
 		// as empty bracketed paste or Kitty-protocol super+v).
-		if (this.keybindings.matches(data, "app.clipboard.pasteImage") || isMacosNativeImagePasteSignal(data)) {
-			this.onPasteImage?.();
+		const isPasteImageSignal =
+			this.keybindings.matches(data, "app.clipboard.pasteImage") || isMacosNativeImagePasteSignal(data);
+		if (isPasteImageSignal) {
+			if (!isKeyRepeat(data)) {
+				this.onPasteImage?.();
+			}
 			return true;
 		}
 

--- a/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
@@ -3,6 +3,7 @@ import {
 	Editor,
 	type EditorOptions,
 	type EditorTheme,
+	matchesKey,
 	type TUI,
 	truncateToWidth,
 	visibleWidth,
@@ -18,6 +19,17 @@ export interface CustomEditorOptions extends EditorOptions {
 
 const ANSI_ESCAPE_PATTERN = /\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07]*(?:\x07|\x1b\\)|\x1b[PX_][\s\S]*?\x1b\\/g;
 const BORDER_LINE_PATTERN = /^[─ ↑↓0-9more]+$/;
+/** Exact Empty Bracketed Paste sequence from the terminal (image-only macOS Cmd+V). */
+const EMPTY_BRACKETED_PASTE = "\x1b[200~\x1b[201~";
+
+function isMacosNativeImagePasteSignal(data: string): boolean {
+	if (process.platform !== "darwin") {
+		return false;
+	}
+	// Image-only Cmd+V: some terminals emit Empty Bracketed Paste; Kitty-protocol
+	// terminals (e.g. Ghostty) emit super+v as a CSI-u key event instead.
+	return data === EMPTY_BRACKETED_PASTE || matchesKey(data, "super+v");
+}
 
 /**
  * Custom editor that handles app-level keybindings for coding-agent.
@@ -143,8 +155,9 @@ export class CustomEditor extends Editor {
 			return true;
 		}
 
-		// Check for paste image keybinding
-		if (this.keybindings.matches(data, "app.clipboard.pasteImage")) {
+		// Explicit Image Paste keybinding, or macOS Native Paste (image-only Cmd+V
+		// as empty bracketed paste or Kitty-protocol super+v).
+		if (this.keybindings.matches(data, "app.clipboard.pasteImage") || isMacosNativeImagePasteSignal(data)) {
 			this.onPasteImage?.();
 			return true;
 		}

--- a/packages/coding-agent/test/custom-editor-macos-paste.test.ts
+++ b/packages/coding-agent/test/custom-editor-macos-paste.test.ts
@@ -1,4 +1,4 @@
-import { type Terminal, TUI } from "@earendil-works/pi-tui";
+import { type Terminal, TuiMainScreen } from "@earendil-works/pi-tui";
 import { beforeAll, describe, expect, it } from "vitest";
 import { KeybindingsManager } from "../src/core/keybindings.ts";
 import { CustomEditor } from "../src/modes/interactive/components/custom-editor.ts";
@@ -45,7 +45,11 @@ function withPlatform(platform: NodeJS.Platform, run: () => void): void {
 }
 
 function createEditor(userBindings: ConstructorParameters<typeof KeybindingsManager>[0] = {}): CustomEditor {
-	return new CustomEditor(new TUI(new FakeTerminal()), getEditorTheme(), new KeybindingsManager(userBindings));
+	return new CustomEditor(
+		new TuiMainScreen(new FakeTerminal()),
+		getEditorTheme(),
+		new KeybindingsManager(userBindings),
+	);
 }
 
 describe("CustomEditor macOS empty paste routing", () => {

--- a/packages/coding-agent/test/custom-editor-macos-paste.test.ts
+++ b/packages/coding-agent/test/custom-editor-macos-paste.test.ts
@@ -7,6 +7,8 @@ import { getEditorTheme, initTheme } from "../src/modes/interactive/theme/theme.
 const EMPTY_BRACKETED_PASTE = "\x1b[200~\x1b[201~";
 const F9_SEQUENCE = "\x1b[20~";
 const KITTY_SUPER_V = "\x1b[118;9u";
+const KITTY_SUPER_V_REPEAT = "\x1b[118;9:2u";
+const KITTY_CTRL_V_REPEAT = "\x1b[118;5:2u";
 
 class FakeTerminal implements Terminal {
 	columns = 80;
@@ -167,7 +169,6 @@ describe("CustomEditor macOS empty paste routing", () => {
 		});
 	});
 
-
 	it("routes Kitty-protocol super+v on darwin to onPasteImage once without changing the draft", () => {
 		withPlatform("darwin", () => {
 			const editor = createEditor();
@@ -185,6 +186,22 @@ describe("CustomEditor macOS empty paste routing", () => {
 		});
 	});
 
+	it("does not repeat image paste for Kitty-protocol super+v repeat events on darwin", () => {
+		withPlatform("darwin", () => {
+			const editor = createEditor();
+			let pasteImageCalls = 0;
+			editor.onPasteImage = () => {
+				pasteImageCalls += 1;
+			};
+			editor.setText("seed");
+
+			editor.handleInput(KITTY_SUPER_V_REPEAT);
+
+			expect(pasteImageCalls).toBe(0);
+			expect(editor.getText()).toBe("seed");
+		});
+	});
+
 	it("does not call onPasteImage for Kitty-protocol super+v on linux", () => {
 		withPlatform("linux", () => {
 			const editor = createEditor();
@@ -195,6 +212,22 @@ describe("CustomEditor macOS empty paste routing", () => {
 			editor.setText("seed");
 
 			editor.handleInput(KITTY_SUPER_V);
+
+			expect(pasteImageCalls).toBe(0);
+			expect(editor.getText()).toBe("seed");
+		});
+	});
+
+	it("does not repeat the explicit pasteImage keybinding for Kitty repeat events", () => {
+		withPlatform("linux", () => {
+			const editor = createEditor({ "app.clipboard.pasteImage": "ctrl+v" });
+			let pasteImageCalls = 0;
+			editor.onPasteImage = () => {
+				pasteImageCalls += 1;
+			};
+			editor.setText("seed");
+
+			editor.handleInput(KITTY_CTRL_V_REPEAT);
 
 			expect(pasteImageCalls).toBe(0);
 			expect(editor.getText()).toBe("seed");

--- a/packages/coding-agent/test/custom-editor-macos-paste.test.ts
+++ b/packages/coding-agent/test/custom-editor-macos-paste.test.ts
@@ -1,0 +1,213 @@
+import { type Terminal, TUI } from "@earendil-works/pi-tui";
+import { beforeAll, describe, expect, it } from "vitest";
+import { KeybindingsManager } from "../src/core/keybindings.ts";
+import { CustomEditor } from "../src/modes/interactive/components/custom-editor.ts";
+import { getEditorTheme, initTheme } from "../src/modes/interactive/theme/theme.ts";
+
+const EMPTY_BRACKETED_PASTE = "\x1b[200~\x1b[201~";
+const F9_SEQUENCE = "\x1b[20~";
+const KITTY_SUPER_V = "\x1b[118;9u";
+
+class FakeTerminal implements Terminal {
+	columns = 80;
+	rows = 24;
+	kittyProtocolActive = true;
+
+	start(): void {}
+	stop(): void {}
+	async drainInput(): Promise<void> {}
+	write(_data: string): void {}
+	moveBy(_lines: number): void {}
+	hideCursor(): void {}
+	showCursor(): void {}
+	clearLine(): void {}
+	clearFromCursor(): void {}
+	clearScreen(): void {}
+	setTitle(_title: string): void {}
+	setProgress(_active: boolean): void {}
+}
+
+function withPlatform(platform: NodeJS.Platform, run: () => void): void {
+	const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+	Object.defineProperty(process, "platform", {
+		configurable: true,
+		value: platform,
+	});
+	try {
+		run();
+	} finally {
+		if (platformDescriptor) {
+			Object.defineProperty(process, "platform", platformDescriptor);
+		}
+	}
+}
+
+function createEditor(userBindings: ConstructorParameters<typeof KeybindingsManager>[0] = {}): CustomEditor {
+	return new CustomEditor(new TUI(new FakeTerminal()), getEditorTheme(), new KeybindingsManager(userBindings));
+}
+
+describe("CustomEditor macOS empty paste routing", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	it("inserts non-empty macOS bracketed paste text without calling onPasteImage", () => {
+		withPlatform("darwin", () => {
+			const editor = createEditor();
+			let pasteImageCalls = 0;
+			editor.onPasteImage = () => {
+				pasteImageCalls += 1;
+			};
+			editor.setText("draft");
+
+			editor.handleInput("\x1b[200~hello\x1b[201~");
+
+			expect(pasteImageCalls).toBe(0);
+			expect(editor.getText()).toBe("drafthello");
+		});
+	});
+
+	it("does not call onPasteImage for empty bracketed paste on linux", () => {
+		withPlatform("linux", () => {
+			const editor = createEditor();
+			let pasteImageCalls = 0;
+			editor.onPasteImage = () => {
+				pasteImageCalls += 1;
+			};
+			editor.setText("seed");
+
+			editor.handleInput(EMPTY_BRACKETED_PASTE);
+
+			expect(pasteImageCalls).toBe(0);
+			expect(editor.getText()).toBe("seed");
+		});
+	});
+
+	it("does not call onPasteImage for empty bracketed paste on win32", () => {
+		withPlatform("win32", () => {
+			const editor = createEditor();
+			let pasteImageCalls = 0;
+			editor.onPasteImage = () => {
+				pasteImageCalls += 1;
+			};
+			editor.setText("seed");
+
+			editor.handleInput(EMPTY_BRACKETED_PASTE);
+
+			expect(pasteImageCalls).toBe(0);
+			expect(editor.getText()).toBe("seed");
+		});
+	});
+
+	it("routes the explicit pasteImage keybinding through onPasteImage once", () => {
+		withPlatform("linux", () => {
+			const editor = createEditor({ "app.clipboard.pasteImage": "f9" });
+			let pasteImageCalls = 0;
+			editor.onPasteImage = () => {
+				pasteImageCalls += 1;
+			};
+			editor.setText("seed");
+
+			editor.handleInput(F9_SEQUENCE);
+
+			expect(pasteImageCalls).toBe(1);
+			expect(editor.getText()).toBe("seed");
+		});
+	});
+
+	it("consumes the explicit pasteImage keybinding safely when onPasteImage is missing", () => {
+		withPlatform("linux", () => {
+			const editor = createEditor({ "app.clipboard.pasteImage": "f9" });
+			editor.setText("seed");
+
+			expect(() => editor.handleInput(F9_SEQUENCE)).not.toThrow();
+			expect(editor.getText()).toBe("seed");
+		});
+	});
+
+	it("does not treat partial or embedded empty-paste sequences as image paste", () => {
+		withPlatform("darwin", () => {
+			const sequences = [
+				"\x1b[200~",
+				"\x1b[201~",
+				`prefix${EMPTY_BRACKETED_PASTE}`,
+				`${EMPTY_BRACKETED_PASTE}suffix`,
+				`\x1b[200~ \x1b[201~`,
+			];
+
+			for (const sequence of sequences) {
+				const editor = createEditor();
+				let pasteImageCalls = 0;
+				editor.onPasteImage = () => {
+					pasteImageCalls += 1;
+				};
+				editor.setText("seed");
+
+				editor.handleInput(sequence);
+
+				expect(pasteImageCalls, JSON.stringify(sequence)).toBe(0);
+			}
+		});
+	});
+
+	it("routes exact empty bracketed paste on darwin to onPasteImage once without changing the draft", () => {
+		withPlatform("darwin", () => {
+			const editor = createEditor();
+			let pasteImageCalls = 0;
+			editor.onPasteImage = () => {
+				pasteImageCalls += 1;
+			};
+			const seeded = "keep-me-byte-for-byte";
+			editor.setText(seeded);
+
+			editor.handleInput(EMPTY_BRACKETED_PASTE);
+
+			expect(pasteImageCalls).toBe(1);
+			expect(editor.getText()).toBe(seeded);
+		});
+	});
+
+
+	it("routes Kitty-protocol super+v on darwin to onPasteImage once without changing the draft", () => {
+		withPlatform("darwin", () => {
+			const editor = createEditor();
+			let pasteImageCalls = 0;
+			editor.onPasteImage = () => {
+				pasteImageCalls += 1;
+			};
+			const seeded = "keep-me-byte-for-byte";
+			editor.setText(seeded);
+
+			editor.handleInput(KITTY_SUPER_V);
+
+			expect(pasteImageCalls).toBe(1);
+			expect(editor.getText()).toBe(seeded);
+		});
+	});
+
+	it("does not call onPasteImage for Kitty-protocol super+v on linux", () => {
+		withPlatform("linux", () => {
+			const editor = createEditor();
+			let pasteImageCalls = 0;
+			editor.onPasteImage = () => {
+				pasteImageCalls += 1;
+			};
+			editor.setText("seed");
+
+			editor.handleInput(KITTY_SUPER_V);
+
+			expect(pasteImageCalls).toBe(0);
+			expect(editor.getText()).toBe("seed");
+		});
+	});
+
+	it("consumes macOS empty paste safely when onPasteImage is missing", () => {
+		withPlatform("darwin", () => {
+			const editor = createEditor();
+			editor.setText("seed");
+
+			expect(() => editor.handleInput(EMPTY_BRACKETED_PASTE)).not.toThrow();
+			expect(editor.getText()).toBe("seed");
+		});
+	});
+});

--- a/packages/coding-agent/test/custom-editor-macos-paste.test.ts
+++ b/packages/coding-agent/test/custom-editor-macos-paste.test.ts
@@ -169,6 +169,54 @@ describe("CustomEditor macOS empty paste routing", () => {
 		});
 	});
 
+	it("prefers an extension shortcut over exact empty bracketed paste on darwin", () => {
+		withPlatform("darwin", () => {
+			const editor = createEditor();
+			let extensionCalls = 0;
+			let pasteImageCalls = 0;
+			editor.onExtensionShortcut = (data) => {
+				if (data !== EMPTY_BRACKETED_PASTE) return false;
+				extensionCalls += 1;
+				return true;
+			};
+			editor.onPasteImage = () => {
+				pasteImageCalls += 1;
+			};
+			const seeded = "keep-me-byte-for-byte";
+			editor.setText(seeded);
+
+			editor.handleInput(EMPTY_BRACKETED_PASTE);
+
+			expect(extensionCalls).toBe(1);
+			expect(pasteImageCalls).toBe(0);
+			expect(editor.getText()).toBe(seeded);
+		});
+	});
+
+	it("prefers an extension shortcut over Kitty-protocol super+v on darwin", () => {
+		withPlatform("darwin", () => {
+			const editor = createEditor();
+			let extensionCalls = 0;
+			let pasteImageCalls = 0;
+			editor.onExtensionShortcut = (data) => {
+				if (data !== KITTY_SUPER_V) return false;
+				extensionCalls += 1;
+				return true;
+			};
+			editor.onPasteImage = () => {
+				pasteImageCalls += 1;
+			};
+			const seeded = "keep-me-byte-for-byte";
+			editor.setText(seeded);
+
+			editor.handleInput(KITTY_SUPER_V);
+
+			expect(extensionCalls).toBe(1);
+			expect(pasteImageCalls).toBe(0);
+			expect(editor.getText()).toBe(seeded);
+		});
+	});
+
 	it("routes Kitty-protocol super+v on darwin to onPasteImage once without changing the draft", () => {
 		withPlatform("darwin", () => {
 			const editor = createEditor();


### PR DESCRIPTION
## Summary

On macOS, `Ctrl+V` could paste a screenshot into Atomic, but native `Cmd+V` often did nothing. That is the shortcut Mac users actually hit, so it felt broken even though the explicit image-paste binding worked fine.

[#2186](https://github.com/bastani-inc/atomic/issues/2186) has the full story. Short version: the terminal owns `Cmd+V`. For an image-only clipboard it usually does not send ordinary text paste. Some terminals send an empty bracketed-paste sequence (`ESC[200~` right next to `ESC[201~`). Kitty-protocol terminals like Ghostty send a `super+v` key event instead. pi-tui's base editor ignores empty paste, and Atomic never treated either signal as image paste, so `onPasteImage` never ran.

This PR does not touch the clipboard reader or the `app.clipboard.pasteImage` binding. It only teaches chat `CustomEditor` to recognize those two macOS deliveries and call the same `onPasteImage` path `Ctrl+V` already uses. Fixes #2186.

## Scope vs #2186

The issue asked for a small macOS `CustomEditor.handleInput()` guard for empty bracketed paste, plus tests and docs. No new clipboard reader, no native module.

That covers terminals that still send Atomic *something* for image-only `Cmd+V` (empty paste or Kitty `super+v`). It does not cover Apple Terminal.app when image-only `Cmd+V` produces no PTY event at all. Fixing that would need an OS-level key intercept or a non-PTY input path, which is outside #2186.

The acceptance text says "on macOS, `Cmd+V`…" without naming a terminal. I read that as: wherever the host forwards the gesture, Atomic should paste the image. Terminal.app's silent drop is a host limit; we document it instead of pretending this PR fixes it.

## What changed

In `packages/coding-agent/src/modes/interactive/components/custom-editor.ts`, `handleInput` still checks extension shortcuts first. After that, a paste-image signal is either:

- the configured `app.clipboard.pasteImage` keybinding (`Ctrl+V` on macOS/Linux, `Alt+V` on Windows), or
- on darwin only, an exact empty bracketed-paste event, or Kitty-protocol `super+v` via `matchesKey`

Both call `onPasteImage?.()` and return without handing the bytes to the base editor, so empty paste does not leak control sequences into the draft.

Exact equality with `\x1b[200~\x1b[201~` is intentional. Partial or embedded sequences stay ordinary input. A looser matcher would risk swallowing adjacent text.

Ghostty can emit Kitty repeat events while the key is held. Without a guard, one held `Cmd+V` stacked duplicate images. The paste-image branch now skips `isKeyRepeat(data)` for every paste-image signal (including held `Ctrl+V`), then still consumes the event so repeats do not fall through as editor input.

Docs and changelog:

- `docs/keybindings.md` and `docs/quickstart.md` cover native macOS `Cmd+V` for images, that it is not a bindable Atomic shortcut, the Apple Terminal caveat, and that mixed text+image clipboards can disagree depending on how the terminal delivered the gesture
- `[Unreleased]` Fixed notes the user-facing fix without bracketed-paste implementation detail

## Before / after

Before:

- Image-only `Cmd+V` in VS Code's terminal: empty paste, draft unchanged, no attachment
- Image-only `Cmd+V` in Ghostty: `super+v` ignored for image paste
- Held paste key could insert the same image repeatedly
- Docs only mentioned `Ctrl+V` / `Alt+V`

After:

- macOS empty bracketed paste calls `onPasteImage` once and leaves a seeded draft unchanged
- macOS Kitty `super+v` takes the same path
- Linux/Windows empty paste and Linux `super+v` still do not call the image handler
- Repeat events are consumed without a second paste
- Extension shortcuts still win when they claim the same input
- Terminal.app image-only `Cmd+V` still does nothing when the host sends no event; `Ctrl+V` remains the workaround there

## Apple Terminal.app

Manual check: image-only `Cmd+V` in Terminal.app often never reaches Atomic. No empty paste, no `super+v`, no key event on the PTY. This PR cannot route what it never receives.

Workaround there: `Ctrl+V` (explicit `app.clipboard.pasteImage`), or use Ghostty / iTerm / Kitty / VS Code's terminal, where the host does forward a signal.

Making Terminal.app `Cmd+V` work for images would be a separate follow-up (native event tap or non-PTY UI), not an extension of this `CustomEditor` guard.

## Tests

`packages/coding-agent/test/custom-editor-macos-paste.test.ts` drives a real `CustomEditor` with a platform stub and a call counter (no OS clipboard). It covers:

- non-empty macOS bracketed paste inserts text and does not call `onPasteImage`
- empty bracketed paste on linux / win32 does not call `onPasteImage`
- explicit `pasteImage` keybinding still routes once, including when the handler is missing
- partial / embedded empty-paste sequences are not treated as image paste
- exact empty paste on darwin calls the handler once without changing the draft
- extension shortcuts beat empty paste and `super+v` on darwin
- Kitty `super+v` on darwin routes once; repeat events do not
- Kitty `super+v` on linux does not call the handler
- Kitty repeat on the explicit `ctrl+v` binding does not re-fire paste

## Verification

| Command | Outcome |
| --- | --- |
| `npm run test --workspace=@bastani/atomic -- test/custom-editor-macos-paste.test.ts` | pass |
| Manual: Ghostty image-only `Cmd+V` | one image via Kitty `super+v` |
| Manual: VS Code integrated terminal image-only `Cmd+V` | one image via empty bracketed paste |
| Manual: `Ctrl+V` image paste | unchanged |
| Manual: Apple Terminal.app image-only `Cmd+V` | no PTY event (out of scope); `Ctrl+V` still works |

## Notes

- Scope is chat `CustomEditor` only. No new clipboard reader, native module, or pi-tui `onEmptyPaste` hook.
- A user-facing `cmd+v` / `super+v` keybinding would not fix the common case: the terminal often never delivers a normal keybinding event for native paste.
- Mixed clipboard: empty-paste terminals may still insert text on `Cmd+V` while `Ctrl+V` prefers the image. Ghostty-style `super+v` goes through the image path, so it can prefer the image the same way `Ctrl+V` does. Docs mention that instead of promising one universal split.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update adds macOS image-paste routing for empty bracketed-paste and Kitty `super+v` input, prevents repeated terminal key events from invoking image paste again, and documents terminal-specific Cmd+V behavior. The focused editor suite passes all 14 routing, shortcut-precedence, and repeat-event checks with the runtime `TuiMainScreen` fixture.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The focused macOS paste suite passed all 14 checks, including native signal routing, extension shortcut precedence, repeat-event suppression, and fixture construction with the installed terminal UI runtime.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex completed the requested verification but did not upload local artifact references.
- T-Rex ran the focused fixture against the installed runtime, which produced 14 failures due to TUI not being a constructor, and then ran the updated focused suite with TuiMainScreen, which passed all 14 tests.
- T-Rex again ran the requested verification but did not upload local artifact references.
- T-Rex executed two exact Vitest commands for the macOS paste tests: the paste-before tests failed with 14 failures caused by TypeError: TUI is not a constructor, and the custom-editor tests passed with 14 tests across 1 file; no new executable validation source was authored.

<a href="https://app.greptile.com/trex/runs/18437883/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (7): Last reviewed commit: ["fix(coding-agent): finish macOS image pa..."](https://github.com/bastani-inc/atomic/commit/376246edc2019146666c45c19704ed3e607982e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50714409)</sub>

<!-- /greptile_comment -->