### PR TITLE
fix(workflows): keep multi-line inputs from breaking the DISPATCHED box

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `DISPATCHED` confirmation panel being torn apart by any workflow input containing a newline. Input values were truncated by visible width, which a control character does not have, so an embedded newline survived truncation and emitted extra physical lines that no border ever wrapped — the box was destroyed from that row down. Multi-line inputs are ordinary, so this fired for most real launches: a `prompt` or an `acceptance_criteria` block reliably reproduced it. String values and the object/array JSON projection now collapse control characters, `U+2028`, and `U+2029` to single spaces before truncation, so a run card stays one row per value. `U+2028`/`U+2029` are included because `JSON.stringify` does not escape them and some terminals still break lines on them. As a side effect, escape sequences in an input value can no longer inject ANSI styling into the chat surface.
+
 ## [0.9.13-alpha.1] - 2026-08-05
 
 ### Added

--- a/packages/workflows/src/tui/dispatch-confirm.ts
+++ b/packages/workflows/src/tui/dispatch-confirm.ts
@@ -273,11 +273,34 @@ function renderInputsSegment(
 	};
 }
 
+/**
+ * Anything that would break a value out of its single card row.
+ *
+ * Card rows are spliced into a bordered box by `renderRoundedBox`, which pads
+ * each row to the interior width. A value carrying a literal newline emits a
+ * second physical line that no border ever wraps, destroying the box from that
+ * row down. `truncateToWidth` cannot save us: it measures *visible width*, and
+ * a control character has none, so a `\n` survives truncation intact.
+ *
+ * This is reachable from ordinary use — any multi-line workflow input (a
+ * `prompt`, an `acceptance_criteria` block) contains newlines by nature.
+ *
+ * U+2028/U+2029 are included deliberately: `JSON.stringify` does *not* escape
+ * them, so they survive the object/array projection below, and some terminals
+ * treat them as line breaks.
+ */
+const ROW_BREAKING_RE = /[\p{Cc}\p{Cf}\u2028\u2029]+/gu;
+
+/** Collapse row-breaking characters and whitespace runs into single spaces. */
+function toSingleLine(value: string): string {
+	return value.replace(ROW_BREAKING_RE, " ").replace(/ {2,}/g, " ").trim();
+}
+
 function renderInputValue(value: unknown, budget: number): string {
 	if (typeof value === "string") {
 		// Reserve 2 cells for the surrounding quotes; truncate the interior.
 		const interior = Math.max(0, budget - 2);
-		const trimmed = truncateToWidth(value, interior, ELLIPSIS);
+		const trimmed = truncateToWidth(toSingleLine(value), interior, ELLIPSIS);
 		return `"${trimmed}"`;
 	}
 	if (typeof value === "number" || typeof value === "boolean") {
@@ -285,8 +308,9 @@ function renderInputValue(value: unknown, budget: number): string {
 	}
 	if (value === null) return "null";
 	// Objects / arrays — show a compact JSON projection within budget.
+	// JSON.stringify escapes \n as literal backslash-n, but not U+2028/U+2029.
 	const json = JSON.stringify(value);
-	return truncateToWidth(json ?? "", budget, ELLIPSIS);
+	return truncateToWidth(toSingleLine(json ?? ""), budget, ELLIPSIS);
 }
 
 /**

--- a/packages/workflows/src/tui/dispatch-confirm.ts
+++ b/packages/workflows/src/tui/dispatch-confirm.ts
@@ -285,15 +285,26 @@ function renderInputsSegment(
  * This is reachable from ordinary use — any multi-line workflow input (a
  * `prompt`, an `acceptance_criteria` block) contains newlines by nature.
  *
- * U+2028/U+2029 are included deliberately: `JSON.stringify` does *not* escape
- * them, so they survive the object/array projection below, and some terminals
- * treat them as line breaks.
+ * Scoped to `\p{Cc}` (C0/C1 controls, so `\n`, `\r`, `\t`, and a stray ESC that
+ * would otherwise inject styling) plus the two separators `JSON.stringify` does
+ * *not* escape, which some terminals still break lines on. It deliberately does
+ * NOT cover all of `\p{Cf}`: that class includes U+200D ZERO WIDTH JOINER, and
+ * stripping it splits emoji sequences such as a family glyph into their
+ * components. A format character that occupies no cell cannot break a row, so
+ * removing it only corrupts the value the user asked to see.
  */
-const ROW_BREAKING_RE = /[\p{Cc}\p{Cf}\u2028\u2029]+/gu;
+const ROW_BREAKING_RE = /[\p{Cc}\u2028\u2029]+/gu;
 
-/** Collapse row-breaking characters and whitespace runs into single spaces. */
+/**
+ * Replace runs of row-breaking characters with a single space.
+ *
+ * Only the replaced runs collapse. Pre-existing spacing is left alone and the
+ * result is not trimmed, because a value's own leading, trailing, or repeated
+ * spaces are content: the card renders inside quotes, so `"  alpha   beta  "`
+ * should still read as what was passed rather than as `"alpha beta"`.
+ */
 function toSingleLine(value: string): string {
-	return value.replace(ROW_BREAKING_RE, " ").replace(/ {2,}/g, " ").trim();
+	return value.replace(ROW_BREAKING_RE, " ");
 }
 
 function renderInputValue(value: unknown, budget: number): string {

--- a/test/unit/dispatch-confirm-render.test.ts
+++ b/test/unit/dispatch-confirm-render.test.ts
@@ -234,3 +234,112 @@ describe("renderDispatchConfirm — plain", () => {
 		assert.match(out, /▸ \/workflow connect 5b91ee54-aaaa-bbbb-cccc-dddddddddddd/);
 	});
 });
+
+describe("renderDispatchConfirm — multi-line input values", () => {
+	const WIDTH = 120;
+
+	/**
+	 * Every rendered row must be exactly the render width. A value carrying a
+	 * literal newline used to emit extra physical lines that no border wrapped,
+	 * so the box was destroyed from that row down. Multi-line inputs are
+	 * ordinary: any `prompt` or `acceptance_criteria` block contains newlines.
+	 */
+	const assertAllRowsExactWidth = (out: string, width: number) => {
+		const offenders = out
+			.split("\n")
+			.map((line, index) => ({ index, width: visibleWidth(line), line }))
+			.filter((row) => row.width !== width);
+		assert.deepEqual(
+			offenders.map((row) => ({ index: row.index, width: row.width })),
+			[],
+			`every row must be ${width} cells; got ${JSON.stringify(offenders, null, 2)}`,
+		);
+	};
+
+	const multiLineInputs = {
+		prompt: "<keepContext>\nImplement the thing.\n</keepContext>",
+		acceptance_criteria: "<keepContext>\nAll criteria must hold.\n</keepContext>",
+		git_worktree_dir: "/Users/example/projects/checkout",
+		base_branch: "main",
+		create_pr: false,
+	};
+
+	test("newline-bearing values never break the box (themed)", () => {
+		const out = renderDispatchConfirm({
+			workflowName: "ralph",
+			runId: "12ffba70-4883-408e-9101-8dc400a1d999",
+			inputs: multiLineInputs,
+			theme: deriveGraphTheme({}),
+			width: WIDTH,
+		});
+		assertAllRowsExactWidth(out, WIDTH);
+		assert.doesNotMatch(stripAnsi(out).split("\n").slice(1, -1).join("\n"), /^[^│]/m);
+	});
+
+	test("newline-bearing values never break the box (plain)", () => {
+		const out = renderDispatchConfirm({
+			workflowName: "ralph",
+			runId: "12ffba70-4883-408e-9101-8dc400a1d999",
+			inputs: multiLineInputs,
+			width: WIDTH,
+		});
+		assertAllRowsExactWidth(out, WIDTH);
+	});
+
+	test("CR, CRLF, and tab are collapsed rather than emitted", () => {
+		const out = renderDispatchConfirm({
+			workflowName: "primer",
+			runId: "7c02aa31-aaaa-bbbb-cccc-dddddddddddd",
+			inputs: { note: "alpha\r\nbeta\rgamma\tdelta" },
+			width: WIDTH,
+		});
+		assertAllRowsExactWidth(out, WIDTH);
+		const plain = stripAnsi(out);
+		assert.doesNotMatch(plain, /\r/);
+		assert.doesNotMatch(plain, /\t/);
+		// The surviving text stays readable on one row.
+		assert.match(plain, /alpha beta gamma delta/);
+	});
+
+	test("U+2028/U+2029 survive JSON.stringify and must still be collapsed", () => {
+		// JSON.stringify does NOT escape these, so the object projection would
+		// otherwise carry a terminal-visible line break into a card row.
+		const out = renderDispatchConfirm({
+			workflowName: "primer",
+			runId: "9a41bb02-aaaa-bbbb-cccc-dddddddddddd",
+			inputs: { cfg: { label: "one\u2028two\u2029three" } },
+			width: WIDTH,
+		});
+		assertAllRowsExactWidth(out, WIDTH);
+		assert.doesNotMatch(out, /[\u2028\u2029]/);
+	});
+
+	test("escape sequences in an input value cannot inject ANSI into the card", () => {
+		const out = renderDispatchConfirm({
+			workflowName: "primer",
+			runId: "3f7c1d90-aaaa-bbbb-cccc-dddddddddddd",
+			inputs: { note: "safe\u001b[31mINJECTED\u001b[0m" },
+			width: WIDTH,
+		});
+		assertAllRowsExactWidth(out, WIDTH);
+		assert.match(stripAnsi(out), /safe\[31mINJECTED\[0m|safe/);
+		assert.doesNotMatch(out, /\u001b\[31m/);
+	});
+
+	test("single-line inputs are unchanged by the sanitizer", () => {
+		// 140 cells, not WIDTH: at 120 the per-pair value budget truncates
+		// "map the codebase" on its own. That is pre-existing truncation
+		// policy, and asserting against it here would test the wrong thing —
+		// this case exists to prove the sanitizer leaves clean values alone.
+		const wideEnough = 140;
+		const out = renderDispatchConfirm({
+			workflowName: "primer",
+			runId: "1d5e7a44-aaaa-bbbb-cccc-dddddddddddd",
+			inputs: { prompt: "map the codebase", max_branches: 4 },
+			width: wideEnough,
+		});
+		assertAllRowsExactWidth(out, wideEnough);
+		assert.match(stripAnsi(out), /prompt="map the codebase"/);
+		assert.match(stripAnsi(out), /max_branches=4/);
+	});
+});

--- a/test/unit/dispatch-confirm-render.test.ts
+++ b/test/unit/dispatch-confirm-render.test.ts
@@ -286,7 +286,7 @@ describe("renderDispatchConfirm — multi-line input values", () => {
 		assertAllRowsExactWidth(out, WIDTH);
 	});
 
-	test("CR, CRLF, and tab are collapsed rather than emitted", () => {
+	test("CR, CRLF, and tab become spaces without touching the rest", () => {
 		const out = renderDispatchConfirm({
 			workflowName: "primer",
 			runId: "7c02aa31-aaaa-bbbb-cccc-dddddddddddd",
@@ -295,10 +295,40 @@ describe("renderDispatchConfirm — multi-line input values", () => {
 		});
 		assertAllRowsExactWidth(out, WIDTH);
 		const plain = stripAnsi(out);
-		assert.doesNotMatch(plain, /\r/);
-		assert.doesNotMatch(plain, /\t/);
-		// The surviving text stays readable on one row.
-		assert.match(plain, /alpha beta gamma delta/);
+		assert.doesNotMatch(plain, /[\r\t]/u);
+		// `\r\n` is one run and collapses to one space, so the exact surviving
+		// text is pinned rather than merely "contains the words".
+		assert.match(plain, /note="alpha beta gamma delta"/u);
+	});
+
+	test("spacing inside a value is content and survives untouched", () => {
+		// An earlier revision collapsed runs of spaces and trimmed the result, so
+		// a value rendered as something the caller never passed. Only the
+		// row-breaking characters may be rewritten.
+		const out = renderDispatchConfirm({
+			workflowName: "primer",
+			runId: "5c19ba77-aaaa-bbbb-cccc-dddddddddddd",
+			inputs: { note: "  alpha   beta  " },
+			width: WIDTH,
+		});
+		assertAllRowsExactWidth(out, WIDTH);
+		// Exact substring rather than a regex: the whole point is the precise run
+		// lengths, which are unreadable as a pattern and which biome rightly flags.
+		assert.ok(stripAnsi(out).includes('note="  alpha   beta  "'), stripAnsi(out));
+	});
+
+	test("a zero-width joiner is preserved so emoji sequences survive", () => {
+		// U+200D is \p{Cf}, but it occupies no cell and so cannot break a row.
+		// Stripping the whole format class split this family glyph into four.
+		const family = "\u{1F468}\u200D\u{1F469}\u200D\u{1F467}";
+		const out = renderDispatchConfirm({
+			workflowName: "primer",
+			runId: "6e2ad418-aaaa-bbbb-cccc-dddddddddddd",
+			inputs: { note: family },
+			width: WIDTH,
+		});
+		assertAllRowsExactWidth(out, WIDTH);
+		assert.ok(stripAnsi(out).includes(family), "the joined emoji sequence must survive intact");
 	});
 
 	test("U+2028/U+2029 survive JSON.stringify and must still be collapsed", () => {
@@ -311,7 +341,7 @@ describe("renderDispatchConfirm — multi-line input values", () => {
 			width: WIDTH,
 		});
 		assertAllRowsExactWidth(out, WIDTH);
-		assert.doesNotMatch(out, /[\u2028\u2029]/);
+		assert.doesNotMatch(out, /[\u2028\u2029]/u);
 	});
 
 	test("escape sequences in an input value cannot inject ANSI into the card", () => {
@@ -322,8 +352,12 @@ describe("renderDispatchConfirm — multi-line input values", () => {
 			width: WIDTH,
 		});
 		assertAllRowsExactWidth(out, WIDTH);
-		assert.match(stripAnsi(out), /safe\[31mINJECTED\[0m|safe/);
-		assert.doesNotMatch(out, /\u001b\[31m/);
+		// Pinned exactly. An earlier revision allowed `|safe`, which would also
+		// have passed had the sanitizer dropped everything after the escape --
+		// the assertion could not fail for the reason it existed to catch.
+		// ESC is removed; its payload stays as ordinary text.
+		assert.match(stripAnsi(out), /note="safe \[31mINJECTED \[0m"/u);
+		assert.doesNotMatch(out, /\u001b\[31m/u);
 	});
 
 	test("single-line inputs are unchanged by the sanitizer", () => {


### PR DESCRIPTION
## Problem

Any workflow input containing a newline tore apart the `DISPATCHED` confirmation panel:

```
│   prompt="<keepContext>
…"  ·  acceptance_criteria="<keepContext>
…"  ·  git_worktree_dir="/Users/tonyst…"  ·  +3 more                    │
```

Multi-line inputs are ordinary rather than exotic — any `prompt` or `acceptance_criteria` block reproduces it — so this fired on most real launches.

## Cause

`renderInputValue` truncated values by **visible width**. A control character has no visible width, so an embedded newline survived `truncateToWidth` intact and emitted a physical line break inside a bordered row, destroying the box from that row down.

Reproduced at width 120: the inputs row split into three physical lines of 25/41/54 cells against a 120-cell box, identically in themed and plain mode.

## Fix

String values and the object/array JSON projection now collapse control characters, `U+2028`, and `U+2029` to single spaces before truncation.

`U+2028`/`U+2029` are included deliberately — `JSON.stringify` does **not** escape them, so they survive the object projection, and some terminals still break lines on them.

Side effect: escape sequences in an input value can no longer inject ANSI styling into the chat surface.

## Tests

Six regression tests assert every rendered row is exactly the render width. Verified discriminating by reverting the two sanitizer call sites: **5 fail without the fix**; the 6th is the control case proving clean single-line values are left untouched.

## Verification

- `npm run check` — exit 0
- `npm run test:unit` — exit 0, 617 files, 5830 passed, 2 skipped

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788597040&installation_model_id=10562&pr_number=2216&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2216&signature=65422bf0100e91e91dc124f14b4494ce0733c4186ec6c79ed8a9cfdc2272ea07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The dispatch confirmation renderer now preserves user-provided spacing and joined emoji while safely replacing characters that could split the bordered terminal card.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The focused renderer checks exercise spacing preservation, joined emoji rendering, control-character replacement, ANSI handling, and bordered-row width behavior without identifying an accepted blocking failure.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the unit tests against the parent revision and observed two failures out of 17, caused by spacing being collapsed and U+200D being removed from joined emoji.
- Re-ran the same tests against the current revision and confirmed all 17 cases passed, including spacing preservation, emoji handling, control-character replacement, ANSI handling, and bordered-row width checks.
- Executed the pre-change test run in the before-change environment and observed an exit code of 1 with 2 failed and 15 passed; the rendered value was note=\\"alpha beta\\" and the joined emoji assertion failed.
- Executed the post-change test run in the post-change environment and observed an exit code of 0 with 17 passed.
- Uploaded evidence artifacts were captured to support verification; no repository source was modified.

<a href="https://app.greptile.com/trex/runs/17691287/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(workflows): narrow the row sanitizer..."](https://github.com/bastani-inc/atomic/commit/52ea1fa0315b0e22d3cbcb27c75eae3611f72e41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50749624)</sub>

<!-- /greptile_comment -->