### PR TITLE
test: build the native binding when it is missing, warn when it is stale

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -28,12 +28,35 @@ npm run build --workspace=@bastani/atomic-natives
 The natives build is a required one-time step (and again after pulling changes to
 `crates/` or `packages/natives/`). `npm ci --ignore-scripts` deliberately skips
 lifecycle scripts, and the workspace natives package has no install hook anyway —
-only published releases ship prebuilt binaries. Without the compiled
-`packages/natives/native/*.node`, the CLI still runs but silently degrades:
-`pty:true` bash falls back to pipes, native grep/find/tree-sitter block
-resolution fall back to slower JS paths, and several `packages/coding-agent`
-tests fail (`bash-pty-native`, `search-tool-*`, `hashline-tools`). CI builds the
+only published releases ship prebuilt binaries.
+
+**`vitest` now builds it for you when it is missing.** The `globalSetup` in
+`test/global-setup-natives.ts` checks for `packages/natives/native/*.node`
+before collecting any file: present and current, it returns after one stat and
+costs nothing; missing, it prints what it is doing and runs the build; older
+than the Rust sources, it warns and runs anyway, because `git checkout` rewrites
+mtimes and blocking a suite on that evidence is worse than one build too few.
+You still need a Rust toolchain — without cargo it fails with that prerequisite
+rather than a compile error.
+
+Running the CLI is not covered by that, so build it yourself before using the
+agent from a fresh checkout. Without the compiled binding, `pty:true` bash falls
+back to pipes and native grep/find/tree-sitter block resolution fall back to
+slower JS paths.
+
+What is **not** a graceful degradation is the test suites. Since the in-process
+subagent runner landed, `packages/subagents` reaches the Rust control plane
+through a *static* import, so a missing binding throws while the module graph is
+still loading and takes roughly twenty root unit and integration files with it —
+not just `bash-pty-native`, `search-tool-*`, and `hashline-tools`. The errors
+name whatever imported the extension, such as `workflow-stage-bundled-resources`,
+so the failure reads like a regression in an unrelated subsystem. CI builds the
 module explicitly for the same reason (see `.github/workflows/test.yml`).
+
+Note that the generated napi-rs loader's own miss message suggests removing
+`package-lock.json` and `node_modules` and re-running `npm i`. That advice does
+not apply here: with `--ignore-scripts`, reinstalling never produces the
+binding. `npm run build --workspace=@bastani/atomic-natives` is the fix.
 
 The committed `.npmrc` applies a three-day minimum release age to anything you add with
 `npm install`, and pins exact versions. `package-lock.json` is the only lockfile.

--- a/test/global-setup-natives.ts
+++ b/test/global-setup-natives.ts
@@ -1,51 +1,43 @@
-import { spawnSync } from "node:child_process";
 import { existsSync, readdirSync, statSync } from "node:fs";
+import { createRequire } from "node:module";
 import { join } from "node:path";
+import { spawnSyncCollect } from "./helpers/runtime.js";
 
 /**
- * Make `@bastani/atomic-natives` present before the suites run, and say so out
+ * Make `@bastani/atomic-natives` loadable before the suites run, and say so out
  * loud when it is not.
  *
  * `npm ci --ignore-scripts` is the mandated install (AGENTS.md) and the natives
  * workspace has no install hook, so a fresh checkout or a new git worktree has
- * no `.node` at all. Since the in-process subagent runner landed,
+ * no compiled binding. Since the in-process subagent runner landed,
  * `packages/subagents` reaches the Rust control plane through a *static*
- * import, so a missing binding is not a graceful degradation: the bundled
- * extension throws while the module graph is still loading and takes roughly
- * twenty root unit and integration files down with it.
+ * import, so that is not a graceful degradation: the bundled extension throws
+ * while the module graph is still loading and takes roughly twenty root unit
+ * and integration files down with it.
  *
  * The errors name whatever imported the extension — `workflow-stage-bundled-
  * resources`, the in-process runner suites — rather than the missing binding,
  * so the failure reads like a regression in an unrelated subsystem.
  *
- * The generated napi-rs loader makes that worse. Its own miss message is:
- *
- *   Cannot find native binding. npm has a bug related to optional dependencies
- *   ... Please try `npm i` again after removing both package-lock.json and
- *   node_modules directory.
- *
- * That advice is wrong here. Reinstalling under `--ignore-scripts` never
- * produces the binding, so a developer who follows it loops. `native/index.js`
- * is generated (`@ts-nocheck`) and would lose any hand edit at the next
- * `napi artifacts`, so the correct instruction has to live here.
+ * The generated napi-rs loader makes that worse. Its own miss message says to
+ * remove `package-lock.json` and `node_modules` and re-run `npm i`. That advice
+ * is wrong here: under `--ignore-scripts`, reinstalling never produces the
+ * binding, so a developer who follows it loops. `native/index.js` is generated
+ * (`@ts-nocheck`) and would lose a hand edit at the next `napi artifacts`, so
+ * the correct instruction has to live here.
  *
  * Shape borrowed from `can1357/oh-my-pi`'s `packages/natives/native/
- * loader-state.js`, which solves the same problem for its runtime loader:
- * report every candidate that was tried, give the exact command for the context
- * you are actually in, and let a dev tree keep running on a stale binding
- * rather than hard-failing while a rebuild is pending. Two deliberate
- * differences: this runs at test setup rather than load time, so it can repair
- * the missing case instead of only describing it; and staleness here is a
- * timestamp comparison rather than their embedded version sentinel, because our
- * `.node` carries no sentinel to compare against.
- *
- * Cost model: one `existsSync` plus a 27-file stat walk (~4 ms) on the happy
- * path. CI builds the binding in an explicit step before invoking vitest, and a
- * warm worktree already has it, so neither pays for the build.
+ * loader-state.js`: report what was tried, give the exact command for the
+ * context you are in, and let a dev tree keep running on a stale binding rather
+ * than hard-failing while a rebuild is pending. Two deliberate differences —
+ * this runs at test setup rather than load time, so it can repair the missing
+ * case instead of only describing it, and staleness is a timestamp comparison
+ * because our `.node` carries no embedded version sentinel.
  */
 
 const REPO_ROOT = join(import.meta.dirname, "..");
 const NATIVE_DIR = join(REPO_ROOT, "packages", "natives", "native");
+const NATIVE_ENTRY = join(NATIVE_DIR, "index.js");
 const BUILD_COMMAND = "npm run build --workspace=@bastani/atomic-natives";
 /** Sources whose edit invalidates a compiled binding. */
 const SOURCE_ROOTS = [join(REPO_ROOT, "crates"), join(REPO_ROOT, "packages", "natives", "src")];
@@ -54,15 +46,24 @@ function note(lines: readonly string[]): void {
 	process.stderr.write(`\n${lines.join("\n")}\n\n`);
 }
 
-/** Every compiled binding present, newest first. */
-function compiledBindings(): string[] {
-	if (!existsSync(NATIVE_DIR)) return [];
+/**
+ * Whether a binding usable *by this host* is present.
+ *
+ * Deliberately a load attempt rather than a filename scan. napi-rs resolves a
+ * platform-arch-libc triple through roughly seven hundred lines that also cover
+ * musl detection, Android, and WASI; a scan that accepted any `.node` would skip
+ * the build when the directory holds only a binding for another platform — a
+ * real state after copying a native directory between checkouts or unpacking
+ * release artifacts. Requiring the generated entrypoint asks the exact question
+ * the suites will ask, so it cannot drift from the loader.
+ */
+function bindingLoads(): boolean {
+	if (!existsSync(NATIVE_ENTRY)) return false;
 	try {
-		return readdirSync(NATIVE_DIR)
-			.filter((entry) => entry.endsWith(".node"))
-			.map((entry) => join(NATIVE_DIR, entry));
+		createRequire(import.meta.url)(NATIVE_ENTRY);
+		return true;
 	} catch {
-		return [];
+		return false;
 	}
 }
 
@@ -95,27 +96,25 @@ function newestSourceMtime(): number {
 	return newest;
 }
 
-function buildNatives(): { ok: true } | { ok: false; reason: string } {
-	const result = spawnSync("npm", ["run", "build", "--workspace=@bastani/atomic-natives"], {
-		cwd: REPO_ROOT,
-		stdio: "inherit",
-		shell: process.platform === "win32",
-	});
-	if (result.error !== undefined) return { ok: false, reason: result.error.message };
-	if (result.status !== 0) return { ok: false, reason: `the build exited with status ${result.status}` };
-	return { ok: true };
+/** Compiled bindings on disk, for staleness reporting only. */
+function bindingFiles(): string[] {
+	try {
+		return readdirSync(NATIVE_DIR)
+			.filter((entry) => entry.endsWith(".node"))
+			.map((entry) => join(NATIVE_DIR, entry));
+	} catch {
+		return [];
+	}
 }
 
 export default function setup(): void {
-	const existing = compiledBindings();
-
-	if (existing.length > 0) {
+	if (bindingLoads()) {
 		// Stale is a warning, never a rebuild and never a failure. A timestamp is
 		// weaker evidence than a version sentinel -- `git checkout` rewrites
 		// mtimes, so this can cry wolf after a branch switch -- and blocking a
 		// suite on weak evidence is worse than running one build too few.
 		const newestSource = newestSourceMtime();
-		const stale = existing.filter((binding) => {
+		const stale = bindingFiles().filter((binding) => {
 			try {
 				return statSync(binding).mtimeMs < newestSource;
 			} catch {
@@ -135,9 +134,13 @@ export default function setup(): void {
 		return;
 	}
 
+	const present = bindingFiles();
 	note([
-		"@bastani/atomic-natives has no compiled binding, so it is being built now.",
+		"@bastani/atomic-natives has no binding this host can load, so it is being built now.",
 		`  looked in: ${NATIVE_DIR}`,
+		...(present.length > 0
+			? ["  present but not loadable here:", ...present.map((binding) => `    ${binding}`)]
+			: ["  no .node files found"]),
 		"",
 		"Without it packages/subagents fails at import and takes roughly twenty",
 		"unrelated unit and integration files down with it, naming the importer",
@@ -147,13 +150,17 @@ export default function setup(): void {
 		`  ${BUILD_COMMAND}`,
 	]);
 
-	const built = buildNatives();
-	if (!built.ok) {
+	const result = spawnSyncCollect(["npm", "run", "build", "--workspace=@bastani/atomic-natives"], { cwd: REPO_ROOT });
+
+	if (!result.success) {
 		throw new Error(
 			[
-				`Could not build @bastani/atomic-natives: ${built.reason}.`,
+				`Could not build @bastani/atomic-natives (exit ${result.exitCode}).`,
 				"",
-				`Looked for a compiled binding in: ${NATIVE_DIR}`,
+				`Looked for a loadable binding in: ${NATIVE_DIR}`,
+				...(present.length > 0 ? ["Present but not loadable on this host:", ...present.map((b) => `  ${b}`)] : []),
+				"",
+				result.stderr.toString().trim().split("\n").slice(-12).join("\n"),
 				"",
 				"The suites cannot run without it: packages/subagents imports the Rust",
 				"control plane statically, so the bundled extension fails at import.",
@@ -168,9 +175,9 @@ export default function setup(): void {
 		);
 	}
 
-	if (compiledBindings().length === 0) {
+	if (!bindingLoads()) {
 		throw new Error(
-			`${BUILD_COMMAND} reported success but left no .node file in ${NATIVE_DIR}. Run it directly to see why.`,
+			`${BUILD_COMMAND} reported success but produced no binding this host can load in ${NATIVE_DIR}. Run it directly to see why.`,
 		);
 	}
 }

--- a/test/global-setup-natives.ts
+++ b/test/global-setup-natives.ts
@@ -1,0 +1,176 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Make `@bastani/atomic-natives` present before the suites run, and say so out
+ * loud when it is not.
+ *
+ * `npm ci --ignore-scripts` is the mandated install (AGENTS.md) and the natives
+ * workspace has no install hook, so a fresh checkout or a new git worktree has
+ * no `.node` at all. Since the in-process subagent runner landed,
+ * `packages/subagents` reaches the Rust control plane through a *static*
+ * import, so a missing binding is not a graceful degradation: the bundled
+ * extension throws while the module graph is still loading and takes roughly
+ * twenty root unit and integration files down with it.
+ *
+ * The errors name whatever imported the extension — `workflow-stage-bundled-
+ * resources`, the in-process runner suites — rather than the missing binding,
+ * so the failure reads like a regression in an unrelated subsystem.
+ *
+ * The generated napi-rs loader makes that worse. Its own miss message is:
+ *
+ *   Cannot find native binding. npm has a bug related to optional dependencies
+ *   ... Please try `npm i` again after removing both package-lock.json and
+ *   node_modules directory.
+ *
+ * That advice is wrong here. Reinstalling under `--ignore-scripts` never
+ * produces the binding, so a developer who follows it loops. `native/index.js`
+ * is generated (`@ts-nocheck`) and would lose any hand edit at the next
+ * `napi artifacts`, so the correct instruction has to live here.
+ *
+ * Shape borrowed from `can1357/oh-my-pi`'s `packages/natives/native/
+ * loader-state.js`, which solves the same problem for its runtime loader:
+ * report every candidate that was tried, give the exact command for the context
+ * you are actually in, and let a dev tree keep running on a stale binding
+ * rather than hard-failing while a rebuild is pending. Two deliberate
+ * differences: this runs at test setup rather than load time, so it can repair
+ * the missing case instead of only describing it; and staleness here is a
+ * timestamp comparison rather than their embedded version sentinel, because our
+ * `.node` carries no sentinel to compare against.
+ *
+ * Cost model: one `existsSync` plus a 27-file stat walk (~4 ms) on the happy
+ * path. CI builds the binding in an explicit step before invoking vitest, and a
+ * warm worktree already has it, so neither pays for the build.
+ */
+
+const REPO_ROOT = join(import.meta.dirname, "..");
+const NATIVE_DIR = join(REPO_ROOT, "packages", "natives", "native");
+const BUILD_COMMAND = "npm run build --workspace=@bastani/atomic-natives";
+/** Sources whose edit invalidates a compiled binding. */
+const SOURCE_ROOTS = [join(REPO_ROOT, "crates"), join(REPO_ROOT, "packages", "natives", "src")];
+
+function note(lines: readonly string[]): void {
+	process.stderr.write(`\n${lines.join("\n")}\n\n`);
+}
+
+/** Every compiled binding present, newest first. */
+function compiledBindings(): string[] {
+	if (!existsSync(NATIVE_DIR)) return [];
+	try {
+		return readdirSync(NATIVE_DIR)
+			.filter((entry) => entry.endsWith(".node"))
+			.map((entry) => join(NATIVE_DIR, entry));
+	} catch {
+		return [];
+	}
+}
+
+/** Newest mtime across Rust sources, or 0 when none can be read. */
+function newestSourceMtime(): number {
+	let newest = 0;
+	const visit = (directory: string): void => {
+		let entries: string[];
+		try {
+			entries = readdirSync(directory);
+		} catch {
+			return;
+		}
+		for (const entry of entries) {
+			const path = join(directory, entry);
+			let stats: ReturnType<typeof statSync>;
+			try {
+				stats = statSync(path);
+			} catch {
+				continue;
+			}
+			if (stats.isDirectory()) {
+				if (entry !== "target" && entry !== "node_modules") visit(path);
+				continue;
+			}
+			if (entry.endsWith(".rs") || entry === "Cargo.toml") newest = Math.max(newest, stats.mtimeMs);
+		}
+	};
+	for (const root of SOURCE_ROOTS) visit(root);
+	return newest;
+}
+
+function buildNatives(): { ok: true } | { ok: false; reason: string } {
+	const result = spawnSync("npm", ["run", "build", "--workspace=@bastani/atomic-natives"], {
+		cwd: REPO_ROOT,
+		stdio: "inherit",
+		shell: process.platform === "win32",
+	});
+	if (result.error !== undefined) return { ok: false, reason: result.error.message };
+	if (result.status !== 0) return { ok: false, reason: `the build exited with status ${result.status}` };
+	return { ok: true };
+}
+
+export default function setup(): void {
+	const existing = compiledBindings();
+
+	if (existing.length > 0) {
+		// Stale is a warning, never a rebuild and never a failure. A timestamp is
+		// weaker evidence than a version sentinel -- `git checkout` rewrites
+		// mtimes, so this can cry wolf after a branch switch -- and blocking a
+		// suite on weak evidence is worse than running one build too few.
+		const newestSource = newestSourceMtime();
+		const stale = existing.filter((binding) => {
+			try {
+				return statSync(binding).mtimeMs < newestSource;
+			} catch {
+				return false;
+			}
+		});
+		if (stale.length > 0) {
+			note([
+				"WARNING: the compiled native binding is older than the Rust sources.",
+				...stale.map((binding) => `  stale: ${binding}`),
+				"",
+				"Tests will run against the binding already on disk. If results look",
+				"impossible, rebuild first:",
+				`  ${BUILD_COMMAND}`,
+			]);
+		}
+		return;
+	}
+
+	note([
+		"@bastani/atomic-natives has no compiled binding, so it is being built now.",
+		`  looked in: ${NATIVE_DIR}`,
+		"",
+		"Without it packages/subagents fails at import and takes roughly twenty",
+		"unrelated unit and integration files down with it, naming the importer",
+		"rather than the binding.",
+		"",
+		"This happens once per checkout or git worktree, and takes about 35 seconds.",
+		`  ${BUILD_COMMAND}`,
+	]);
+
+	const built = buildNatives();
+	if (!built.ok) {
+		throw new Error(
+			[
+				`Could not build @bastani/atomic-natives: ${built.reason}.`,
+				"",
+				`Looked for a compiled binding in: ${NATIVE_DIR}`,
+				"",
+				"The suites cannot run without it: packages/subagents imports the Rust",
+				"control plane statically, so the bundled extension fails at import.",
+				"",
+				"This build needs a stable Rust toolchain with cargo (https://rustup.rs).",
+				"The generated napi-rs loader will instead suggest reinstalling with npm;",
+				"that cannot work here, because the mandated `npm ci --ignore-scripts`",
+				"never runs the build.",
+				"",
+				`Once cargo is available, run: ${BUILD_COMMAND}`,
+			].join("\n"),
+		);
+	}
+
+	if (compiledBindings().length === 0) {
+		throw new Error(
+			`${BUILD_COMMAND} reported success but left no .node file in ${NATIVE_DIR}. Run it directly to see why.`,
+		);
+	}
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,19 @@ export { TEST_TIMEOUT_MS };
  */
 const setupFiles = ["./test/setup-workflow-durability.ts"];
 
+/**
+ * Runs once per project, before any file is collected. It builds
+ * `@bastani/atomic-natives` only when no compiled binding exists, because a
+ * missing binding no longer degrades gracefully: `packages/subagents` imports
+ * the Rust control plane statically, so the bundled extension throws during
+ * module loading and takes roughly twenty unrelated files down with it under
+ * errors that name the importer rather than the binding.
+ *
+ * On the happy path this is a single `existsSync`, so CI — which builds the
+ * binding in an explicit step first — and any warm worktree pay nothing.
+ */
+const globalSetup = ["./test/global-setup-natives.ts"];
+
 const project = (name: string, directory: string) => ({
 	resolve: { alias: sharedAliases },
 	test: {
@@ -21,6 +34,7 @@ const project = (name: string, directory: string) => ({
 		include: [`${directory}/**/*.test.ts`],
 		exclude: ["**/node_modules/**"],
 		setupFiles,
+		globalSetup,
 		testTimeout: TEST_TIMEOUT_MS,
 		hookTimeout: TEST_TIMEOUT_MS,
 	},


### PR DESCRIPTION
A fresh checkout or a new git worktree has no compiled native binding, and the resulting failure names the wrong subsystem. It was convincing enough that I twice diagnosed it as a broken `main` while working in this repo.

## The trap

`npm ci --ignore-scripts` is the mandated install (AGENTS.md) and the natives workspace has no install hook, so nothing builds `packages/natives/native/*.node`.

Since the in-process subagent runner landed, `packages/subagents` reaches the Rust control plane through a **static** import. A missing binding therefore throws while the module graph is still loading and takes roughly **twenty** root unit and integration files with it. `.github/workflows/test.yml` already says so:

> the bundled subagent extension **fails to load at import** without a binding. That takes the **root unit and integration suites** down with it, not just the in-process runner tests.

The errors name whatever imported the extension — `workflow-stage-bundled-resources`, the in-process runner suites — not the missing `.node`. So it reads like a regression somewhere else entirely.

The generated napi-rs loader makes it worse:

> Cannot find native binding. npm has a bug related to optional dependencies … Please try `npm i` again after removing both package-lock.json and node_modules directory.

That advice **cannot work here**. With `--ignore-scripts`, reinstalling never produces the binding, so following it loops. `native/index.js` is generated (`@ts-nocheck`) and would lose a hand edit at the next `napi artifacts`, so the correct instruction has to live at test setup.

## What this adds

A vitest `globalSetup` that runs before any file is collected:

| State | Behaviour |
| --- | --- |
| present and current | returns after one stat — CI (which builds in an explicit step first) and warm worktrees pay nothing |
| **missing** | prints what it is doing and builds (~35 s, once per worktree) |
| **older than `crates/`** | **warns** and runs anyway |
| build failed | fails with the Rust prerequisite, the paths searched, and the command that actually works |

Staleness only warns. `git checkout` rewrites mtimes, so a timestamp is weaker evidence than a version sentinel, and blocking a suite on weak evidence is worse than running one build too few.

## Prior art

Shape borrowed from [`can1357/oh-my-pi`](https://github.com/can1357/oh-my-pi)'s `packages/natives/native/loader-state.js`, which solves the same problem for its runtime loader: report every candidate that was tried, give the exact command for the context you are actually in, and let a dev tree keep running on a stale binding rather than hard-failing while a rebuild is pending (`isWorkspaceLoad`).

Two deliberate differences:

- **This runs at test setup, not load time**, so it can repair the missing case instead of only describing it.
- **Staleness is a timestamp comparison**, because our `.node` carries no embedded version sentinel. oh-my-pi embeds `__piNativesV<version>` and uses it to distinguish *disk stale* ("reinstall") from *process stale* ("restart — reinstalling changes nothing"). Adding an equivalent sentinel to `crates/atomic-natives` would be a strictly better signal than mtimes and is worth doing separately.

## Verification

All four paths exercised directly:

```
present + fresh     1.98s, silent
stale               WARNING printed, 23 tests still pass
missing             builds, then 7 tests pass in the file that used to die at import
missing, no cargo   fails naming rustup.rs and the build command
```

- `npm run check` — exit 0
- `npm run test:unit` — 617 files, 5824 passed, 2 skipped
- `npm run test:ci-contracts` — 6 files, 41 tests, exit 0

## Also

`DEV_SETUP.md` claimed a missing binding "silently degrades" and failed "several `packages/coding-agent` tests (`bash-pty-native`, `search-tool-*`, `hashline-tools`)". That predates the static import and is corrected here — the CLI does still degrade gracefully, but the suites do not.

No package changelog entry: per `AGENTS.md`, repository tooling is infrastructure-level and does not change shipped package behaviour.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788635173&installation_model_id=10562&pr_number=2224&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2224&signature=45ed465780b2df8f5b762d5af67800bfd1b6a8c675b1a7f8501830fb8797893b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The native test setup now checks whether the generated loader can load a binding for the current host and rebuilds the binding when it cannot. An isolated test with an unusable native artifact confirmed that setup rebuilds the host binding before the CI test project runs successfully.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The host-binding recovery path was exercised with an invalid native artifact and the configured CI test project completed after rebuilding a usable binding.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated that the retained generated loader previously failed on an invalid artifact with file too short, and that after the changes the Vitest global setup prints a message indicating it is building now, with the CI project passing.
- Concluded that no additional work is required and recommended preserving the current load-attempt behavior rather than reverting to a filename-only .node scan.
- Verified that runtime.ts exports fileExists but not existsSync, readdirSync, or statSync, and that the tests pass with Vitest 4.1.10 on Node 24.19.0.
- Observed that no primary workspace files were changed; only artifact-contained validation files were created.

<a href="https://app.greptile.com/trex/runs/17689927/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(natives): detect a binding by loadi..."](https://github.com/bastani-inc/atomic/commit/046e7258825d66417afc8824ea7278cf2382f8f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50914069)</sub>

<!-- /greptile_comment -->