### PR TITLE
ci: size the suites caps for the retries that job actually owns

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,25 +45,40 @@ jobs:
         include:
           - os: blacksmith-4vcpu-ubuntu-2404
             binary_platform: linux-x64
-            timeout_minutes: 13
+            timeout_minutes: 20
           - os: blacksmith-4vcpu-windows-2025
             binary_platform: windows-x64
-            timeout_minutes: 14
+            timeout_minutes: 20
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    # Measured p100 on the last fully green run of this workflow, run
-    # 31047542976 (pull_request, sha 772a373): 400s Linux (unit 291s, native
-    # bindings 45s, integration 29s) and 595s Windows (unit 401s). The previous
-    # 8/12 caps were sized against older 230s/348s measurements and had decayed
-    # to 1.2x, so the Linux leg was cancelled at 497s on run 31047506585 while
-    # the same SHA passed on the pull_request event.
+    # This job owns TWO retryable steps -- unit and integration each run behind
+    # the bounded flake-retry wrapper -- so its cap must cover a replay of both,
+    # not just one pass. The retry replays only those steps, so the budget is
+    # `setup + 2 x (unit + integration)` rather than 2x the whole job.
     #
-    # The cap is a hang detector, not a performance budget. Linux is 13 min
-    # (780s, 1.95x of 400s). Windows would need 20 min for that same ratio, and
-    # every cap here stays strictly under 15 min, so Windows takes the
-    # ceiling-bounded 14 min (840s, 1.41x of 595s). That covers the measured
-    # p100 plus a slow runner but not a full replay of the 401s Windows unit
-    # step; shortening that step is what would restore a true 2x detector.
+    # Worst observed per step, runs 31085190975 and 31088323060:
+    #   Linux   setup 86s,  unit 355s, integration 31s -> 86 + 2*386 =  858s (14.3 min)
+    #   Windows setup 232s, unit 324s, integration 44s -> 232 + 2*368 = 968s (16.1 min)
+    # The Windows setup figure is a cold runner (122s "Set up job" alone), which
+    # is the right pessimistic input for a cap.
+    #
+    # Both legs take 20 min: 1.40x Linux, 1.24x Windows. A single number is
+    # deliberate. The previous 13/14 pair encoded a per-platform precision the
+    # measurements do not support -- these are 4-vCPU shared runners whose setup
+    # alone varied 73s to 232s across two samples of the same job -- and a split
+    # cap invites re-tuning each leg as suites grow, which is how 8/12 decayed
+    # into cancelling healthy runs. One cap tracks one question: has this job
+    # hung, given it may legitimately run its suites twice.
+    #
+    # The previous 13/14 pair sat BELOW both retry-inclusive figures, so any
+    # genuine failure that triggered the retry was cancelled at the cap rather
+    # than reporting a failure -- and `gh run view --log` refuses to serve logs
+    # until the whole run completes, so those cancellations arrived with no test
+    # names at all. That is how three PRs reported `cancelled` at 14m08s while
+    # the underlying defect was two ordinary Windows test bugs.
+    #
+    # This stays a hang detector, not a performance budget. Shortening the
+    # ~5.5 min unit step is still what would buy the headroom back.
     timeout-minutes: ${{ matrix.timeout_minutes }}
     steps:
       # Sticky disks are Blacksmith-Linux-only; Windows takes a standard clone.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -135,27 +135,50 @@ If maintainers later prefer real per-job required contexts, that is a separate d
 ### Per-job time limits
 
 The blanket 10/15-minute pair is gone. Each job declares its own cap as a hang
-detector with room for the one bounded flake retry it owns: `suites` 13/14,
-`agent-suite` 8/12, `release-archive` 5/9, `static-checks` 6, gate 5. Every cap
-sits under the 15-minute Windows blanket it replaced, and the contract test
-enforces that.
+detector with room for the bounded flake retries it owns: `suites` 20/20,
+`agent-suite` 8/12, `release-archive` 5/9, `static-checks` 6, gate 5. The
+contract test in `test/ci/test-workflow-topology.test.ts` pins every value.
 
-The target is roughly 2x measured p100, and **Windows `suites` does not meet
-it**. Run `31047542976` measured 400 s Linux and 595 s Windows for that job, so
-Linux at 13 min is 1.95x but 2x of the Windows leg is 19.8 min, which the
-under-15 rule forbids. Windows takes the ceiling-bounded 14 min (1.41x): enough
-for the measured p100 plus a slow runner, not enough for a full replay of the
-401 s Windows unit step. Shortening that step is what would restore a true 2x
-detector there; until then this leg can still be cancelled while healthy.
+A cap has to cover the retries its job owns. `scripts/run-flaky-test-suite.ts`
+replays only the step it wraps, so the budget is `setup + 2 × (retryable steps)`
+rather than 2× the whole job — and `suites` wraps **two** steps, unit and
+integration, so a legitimate retried run is close to double its test time.
 
-The earlier 8/12 `suites` pair was sized against 230 s/348 s samples and had
-decayed to about 1.2x, which is what cancelled the Linux leg at 497 s on run
-`31047506585` while the same commit passed on the pull_request event. The
-`agent-suite` Windows cap stays 12 because the first split run measured 349 s
-there; its Linux cap moved 6 → 8 for the same drift. The release-archive Windows
-cap is 9 because cold setup observed a 152 s Rust toolchain acquisition and 71 s
-checkout before the roughly 110 s native build and 40 s archive smoke. A cap that
-cancels a passing retried run is worse than a late hang detection.
+Worst observed per step, runs `31085190975` and `31088323060`:
+
+| Job | Platform | Setup | Retryable steps | Worst with retry | Cap | Ratio |
+| --- | --- | --- | --- | --- | --- | --- |
+| `suites` | Linux | 86 s | unit 355 s + integration 31 s | 858 s (14.3 min) | 20 | 1.40× |
+| `suites` | Windows | 232 s | unit 324 s + integration 44 s | 968 s (16.1 min) | 20 | 1.24× |
+| `agent-suite` | Linux | 72 s | suite 105 s | 282 s (4.7 min) | 8 | 1.70× |
+| `agent-suite` | Windows | 125 s | suite 208 s | 541 s (9.0 min) | 12 | 1.33× |
+
+The previous `suites` pair was 13/14, **below both retry-inclusive figures**. A
+genuine failure that triggered the retry was therefore cancelled at the cap
+instead of reporting a failure, and GitHub withholds job logs until the whole
+run completes, so the cancellation arrived with no test names. Three PRs
+reported `cancelled` at 14m08s while the underlying defect was two ordinary
+Windows test bugs; each cost a full diagnostic cycle to recover.
+
+Both `suites` legs now share one 20-minute cap. The per-platform split encoded a
+precision these shared 4-vCPU runners do not support — setup alone varied 73 s to
+232 s across two samples of the same job — and it invited re-tuning each leg as
+the suites grew, which is how the earlier 8/12 pair decayed to about 1.2× and
+cancelled the Linux leg at 497 s on run `31047506585` while the same commit
+passed on the pull_request event. One cap tracks one question: has this job hung,
+given it may legitimately run its suites twice.
+
+`agent-suite` keeps its 8/12 pair because it already clears its retry-inclusive
+worst case, and `release-archive` keeps 5/9 because it runs no retryable step at
+all; its Windows cap is 9 because cold setup observed a 152 s Rust toolchain
+acquisition and 71 s checkout before the roughly 110 s native build and 40 s
+archive smoke. A cap that cancels a passing retried run is worse than a late hang
+detection.
+
+These caps are wall-clock ceilings, not performance budgets. Shortening the
+~5.5 min unit step is what buys headroom back; raising a cap again should come
+with fresh measurements, and the contract test bounds every cap at 20 minutes so
+that stays a deliberate decision.
 
 Every job that runs a suite through `scripts/run-flaky-test-suite.ts` uploads `.ci-diagnostics/` under a job-unique artifact name (`test-diagnostics-<job>-<binary_platform>`). `actions/upload-artifact@v4+` fails the entire run when two jobs upload the same name.
 

--- a/test/ci/test-workflow-topology.test.ts
+++ b/test/ci/test-workflow-topology.test.ts
@@ -114,27 +114,41 @@ test("every work job the gate names exists and is otherwise independent", async 
 
 /**
  * Per-job wall-clock caps replace the blanket 10/15 minute pair. A cap is a hang
- * detector at roughly 2x measured p100, and it decays into a false-failure
- * generator as the suites grow: the 8-minute `suites` Linux cap was sized
- * against a 230 s measurement, the job now measures 400 s, and it cancelled a
- * healthy run at 497 s on 31047506585 while the same SHA passed on the
- * pull_request event. The current numbers come from run 31047542976 on sha
- * 772a373 -- `suites` 400 s / 595 s, `agent-suite` 154 s / 250 s (221 s / 270 s
- * worst observation across both events on that SHA), `release-archive` 102 s /
- * 192 s.
+ * detector, and it decays into a false-failure generator as the suites grow: the
+ * 8-minute `suites` Linux cap was sized against a 230 s measurement, the job now
+ * measures 400 s, and it cancelled a healthy run at 497 s on 31047506585 while
+ * the same SHA passed on the pull_request event.
  *
- * Every cap stays strictly under the 15-minute Windows blanket it replaced, so
- * Windows `suites` takes 14 minutes (1.41x) rather than the 20 that 2x of 595 s
- * would ask for. The Windows `release-archive` cap is 9 minutes because cold
- * setup observed 152 s for `rust-toolchain` and 71 s for checkout, followed by
- * roughly 110 s native build and 40 s archive smoke (near 6m50s versus a
- * healthy 4m04s p100).
+ * A cap must cover the retries its job owns, because a retry replays only the
+ * retryable steps: the budget is `setup + 2 x (retryable steps)`, not 2x the
+ * whole job. `suites` owns TWO retryable steps (unit and integration), so its
+ * worst legitimate run is roughly double its test time.
+ *
+ * Worst observed per step across runs 31085190975 and 31088323060:
+ *   suites  Linux   setup  86 s, unit 355 s, integration 31 s ->  858 s (14.3 min)
+ *   suites  Windows setup 232 s, unit 324 s, integration 44 s ->  968 s (16.1 min)
+ *   agent-suite Linux   setup  72 s, suite 105 s             ->  282 s ( 4.7 min)
+ *   agent-suite Windows setup 125 s, suite 208 s             ->  541 s ( 9.0 min)
+ *
+ * The former `suites` 13/14 pair sat BELOW both retry-inclusive figures, so a
+ * genuine failure that triggered the retry was cancelled at the cap instead of
+ * reporting a failure -- and GitHub withholds job logs until the whole run
+ * completes, so the cancellation carried no test names. Both `suites` legs now
+ * take a single 20-minute cap (1.40x Linux, 1.24x Windows): the per-platform
+ * split encoded precision these shared 4-vCPU runners do not support, given
+ * setup alone varied 73 s to 232 s across two samples of the same job.
+ *
+ * `agent-suite` and `release-archive` keep their pairs: agent-suite already
+ * clears its retry-inclusive worst case at 1.70x/1.33x, and release-archive
+ * runs no retryable step at all. The Windows `release-archive` cap is 9 minutes
+ * because cold setup observed 152 s for `rust-toolchain` and 71 s for checkout,
+ * followed by roughly 110 s native build and 40 s archive smoke.
  */
 test("each split job declares its own measured timeout", async () => {
 	const workflow = await readText(testPath);
 	const blocks = await jobs();
 	const caps: Record<string, [number, number]> = {
-		suites: [13, 14],
+		suites: [20, 20],
 		"agent-suite": [8, 12],
 		"release-archive": [5, 9],
 	};
@@ -158,12 +172,14 @@ test("each split job declares its own measured timeout", async () => {
 	}
 	assert.match(blocks.get("static-checks") as string, /^[ \t]+timeout-minutes: 6$/mu);
 	assert.match(blocks.get("test") as string, /^[ \t]+timeout-minutes: 5$/mu);
-	// The blanket per-platform pair covered fourteen sequential steps and detected
-	// nothing about the step that actually hung. Every cap must also stay under
-	// the 15-minute Windows blanket it replaced.
-	assert.doesNotMatch(workflow, /timeout_minutes: (10|15)\b/u);
+	// A cap is still a hang detector: it must bound a stuck job to minutes rather
+	// than GitHub's six-hour default. The former assertion was `< 15`, inherited
+	// from the blanket pair these caps replaced rather than from any measurement,
+	// and it is what forced Windows `suites` to 14 minutes -- below the 16.1 min
+	// a legitimate retried run needs. The bound is now the largest cap the
+	// measurements justify, so raising one further has to come with new numbers.
 	for (const [, value] of workflow.matchAll(/^\s+timeout_minutes: (\d+)$/gmu)) {
-		assert.ok(Number(value) < 15, `cap ${value} is no tighter than the blanket it replaced`);
+		assert.ok(Number(value) <= 20, `cap ${value} is too loose to detect a hang`);
 	}
 });
 


### PR DESCRIPTION
The `suites` timeout caps could not fit the flake retry that job is built around, so a genuine test failure was reported as an opaque cancellation with no test names.

## The arithmetic

`suites` wraps **two** retryable steps — unit and integration. The wrapper replays only the step it wraps, so the budget is `setup + 2 × (retryable steps)`, not 2× the whole job.

Worst observed per step across runs `31085190975` and `31088323060`:

| Job | Platform | Setup | Retryable steps | Worst with retry | Old cap | New cap |
| --- | --- | --- | --- | --- | --- | --- |
| `suites` | Linux | 86 s | unit 355 s + integration 31 s | **858 s (14.3 min)** | 13 | 20 (1.40×) |
| `suites` | Windows | 232 s | unit 324 s + integration 44 s | **968 s (16.1 min)** | 14 | 20 (1.24×) |
| `agent-suite` | Linux | 72 s | suite 105 s | 282 s (4.7 min) | 8 | 8 (1.70×) |
| `agent-suite` | Windows | 125 s | suite 208 s | 541 s (9.0 min) | 12 | 12 (1.33×) |

Both `suites` caps sat **below** their retry-inclusive worst case. Any failure that triggered the retry hit the cap first.

## Why that hurt more than a slow build

GitHub withholds job logs until the whole run completes, so a cap-cancelled job yields no test names at all — `gh run view --log` answers `run … is still in progress`. Three PRs reported `cancelled` at 14m08s while the underlying defect was two ordinary Windows test bugs. Each cost a full diagnostic cycle: re-run, wait for a `failure` instead of a `cancelled`, then read the log.

The aggregate gate then reports:

```
A required work job did not succeed: cancelled,success,success,success
```

which reads like infrastructure noise even when a test is genuinely broken.

## One cap, not two

Both legs now take 20 minutes. The per-platform split encoded a precision these shared 4-vCPU runners do not support — setup alone varied 73 s to 232 s across two samples of the same job — and it invited re-tuning each leg as the suites grew, which is how the earlier 8/12 pair decayed to ~1.2× and cancelled the Linux leg at 497 s on run `31047506585` while the same commit passed on the `pull_request` event.

One cap tracks one question: has this job hung, given it may legitimately run its suites twice.

`agent-suite` and `release-archive` are untouched — the former already clears its retry-inclusive worst case, the latter runs no retryable step.

## The contract test

`test/ci/test-workflow-topology.test.ts` asserted every cap was `< 15`. That bound was inherited from the blanket 10/15-minute pair these caps replaced, not from any measurement, and it is exactly what pinned Windows `suites` to 14 minutes. The workflow comment said so outright:

> Windows would need 20 min for that same ratio, and every cap here stays strictly under 15 min, so Windows takes the ceiling-bounded 14 min (1.41x) … not enough for a full replay of the 401 s Windows unit step

and `docs/ci.md` conceded the consequence:

> **Windows `suites` does not meet it** … until then this leg can still be cancelled while healthy.

The bound becomes `<= 20` — still a hang detector rather than GitHub's six-hour default — with the full derivation recorded in the test, the workflow, and the docs so raising it again has to come with fresh measurements.

## Verification

- `npm run test:ci-contracts` — 6 files, 41 tests, exit 0
- `npm run check` — exit 0
- Workflow YAML re-parsed: `suites linux-x64=20 windows-x64=20`, `agent-suite 8/12`, `release-archive 5/9` unchanged

## Note

No package changelog entry: per `AGENTS.md`, CI configuration is infrastructure-level and does not change shipped package behaviour.

These caps are ceilings, not budgets. Shortening the ~5.5 min unit step is what buys real headroom back; this PR stops a correctly-sized retry from being killed while that work happens.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788639261&installation_model_id=10562&pr_number=2225&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2225&signature=f4ac5eb80ed3d09b2366fdfedf66845a26c76c32b03904bf970d3ba51f4d05ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

## Summary
This change gives both Linux and Windows `suites` jobs a 20-minute time limit, updates the retry-duration documentation, and adjusts the workflow contract test to match.

The CI contract suite passed with all 41 tests successful. It confirmed that the Linux and Windows `suites` entries remain present, both use the intended time limit, and all configured matrix time limits remain within the documented bound.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the changed workflow configuration and its contract are consistent and the focused CI contract suite passed.

No defects were found. The executed contract test covered the changed `suites` matrix values, preserved job topology, and the configured time-limit bound.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the CI contract tests with a 180-second timeout from the repository root and verified that the workflow topology was preserved and all matrix time limits remain at or below 20 minutes.
- Re-ran the exact command with the same environment and confirmed the same success: 6 files passed, 41 tests passed, exit code 0; the baseline comparison shows the HEAD^ run was blocked by an unrelated missing napi executable, not by the timeout or topology constraints.

<a href="https://app.greptile.com/trex/runs/17686680/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: size the suites caps for the retries..."](https://github.com/bastani-inc/atomic/commit/b090fbb07f07445e01123edf6bd430264b802a00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50942907)</sub>

<!-- /greptile_comment -->