### PR TITLE
feat(workflows): add heartbeat config contract

### DIFF
--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -934,6 +934,7 @@ Authoring basics:
 - Workflow names normalize for lookup: trim, lowercase, convert whitespace/underscore to hyphen, remove other punctuation, and collapse hyphens.
 - `description` sets the listing text.
 - `autoAttach: true` opens the graph overlay when an interactive top-level named launch through `/workflow <name>` or the registered `workflow` tool is accepted. Only exact `true` is retained on the compiled definition; omission and `false` do not opt a definition into auto-attachment. Existing input-form launch behavior is unchanged.
+- `heartbeatIntervalMinutes` declares the workflow's heartbeat cadence in minutes. Omission uses the `15`-minute default; `0` disables heartbeats for the workflow. Negative and non-finite values are rejected when the definition is authored. The authoring contract lands first; scheduling and parent delivery follow in a separate change.
 - `inputs` declares typed user inputs.
 - `worktreeFromInputs` optionally maps input names to workflow-wide reusable Git worktree defaults.
 - `outputs` declares typed outputs that parent workflows receive from `ctx.workflow(childWorkflow, ...)`.
@@ -1900,6 +1901,26 @@ readonly autoAttach?: boolean;
 
 Exact `true` opts interactive top-level named launches through `/workflow <name>` and the registered `workflow` tool into opening the graph overlay immediately. Omission and `false` do not opt in. This option does not affect headless launches, nested `ctx.workflow(...)` calls, or the existing input-form launch path. Compiled definitions retain this field only as literal `true`.
 
+### `heartbeatIntervalMinutes`
+
+```typescript
+readonly heartbeatIntervalMinutes?: number;
+```
+
+The heartbeat cadence for the workflow, in minutes, measured from the run's persisted start time. Omission resolves to the `15`-minute default and `0` explicitly disables heartbeats; negative and non-finite values are rejected with a `TypeError` when the definition is authored. Every compiled definition carries the resolved value, so consumers read a number rather than re-deriving the default.
+
+```ts
+export default workflow({
+  name: "audit-auth",
+  description: "Audit the authentication module.",
+  heartbeatIntervalMinutes: 30,
+  outputs: {},
+  run: async (ctx) => ({}),
+});
+```
+
+This is the authoring contract only. Scheduling the cadence and delivering heartbeats to the parent chat land in a separate change, so a positive interval does not yet produce heartbeat messages.
+
 ### `inputs`
 
 ```typescript
@@ -1976,6 +1997,7 @@ interface WorkflowDefinition<
   readonly normalizedName: string;
   readonly description: string;
   readonly autoAttach?: true;
+  readonly heartbeatIntervalMinutes: number;
   readonly inputs: WorkflowInputSchemaMap;
   readonly outputs?: WorkflowOutputSchemaMap;
   readonly inputBindings?: { readonly worktree?: WorkflowWorktreeInputBinding };

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added `heartbeatIntervalMinutes` to the workflow authoring surface: an optional cadence in minutes that resolves to the `15`-minute default when omitted, treats `0` as an explicit disable, and rejects negative and non-finite values with a `TypeError` while the definition is authored, so a bad cadence fails at authoring rather than at schedule time. Every compiled definition carries the resolved value, and a distinct `workflows:workflow-heartbeat` event contract is declared alongside it — run id, workflow name, start time, scheduled time, and interval, with heartbeat identity keyed by run id plus scheduled time. The default interval constant, heartbeat custom type, and heartbeat event types are exported from the `@bastani/workflows` package root. Scheduling and parent delivery are not part of this change, so a positive interval does not yet emit heartbeats ([#1975](https://github.com/bastani-inc/atomic/issues/1975)).
+
 ## [0.9.13] - 2026-08-13
 
 Cumulative release of the `0.9.13-alpha.1` – `0.9.13-alpha.4` prereleases. The summary below covers the user-visible outcome of that work; the per-change detail remains in the prerelease sections below.

--- a/packages/workflows/README.md
+++ b/packages/workflows/README.md
@@ -702,6 +702,8 @@ Because human input is runtime-only and workflows no longer carry a declaration-
 
 For library or package authoring, define reusable workflows with `workflow({...})` and export the returned definition. Hand-written objects with `__piWorkflow: true` are rejected by discovery and composition; `workflow({...})` is the public authoring surface. Standalone TypeScript workflow packages import `workflow` from `@bastani/workflows` and `Type` from `typebox` directly with no local `.d.ts` file or `declare module` shim. Migration from the removed builder API is mechanical: move `.description(...)` to `description`, `.input(key, schema)` calls into `inputs`, `.output(key, schema)` calls into `outputs`, `.worktreeFromInputs(...)` to `worktreeFromInputs`, and the `.run(fn)` callback to `run: fn`; delete `.compile()`. The former imperative `runWorkflow` object-form API is removed; use workflow definitions with the exported `run()` / registry helpers for programmatic execution.
 
+Set `heartbeatIntervalMinutes` to declare the workflow's heartbeat cadence in minutes. Omitting it uses the `15`-minute default; `0` explicitly disables heartbeats. Negative and non-finite values are rejected when the workflow definition is authored. The definition stores this validated setting for the scheduler/delivery layer.
+
 ```ts
 import { workflow } from "@bastani/workflows";
 import { Type } from "typebox";
@@ -709,6 +711,7 @@ import { Type } from "typebox";
 export default workflow({
   name: "audit-auth",
   description: "Audit the authentication module.",
+  heartbeatIntervalMinutes: 30,
   inputs: {
     prompt: Type.String({ default: "Investigate the auth module" }),
   },

--- a/packages/workflows/src/authoring.ts
+++ b/packages/workflows/src/authoring.ts
@@ -126,6 +126,11 @@ export type {
 	WorkflowOutputsFromSchemas,
 	WorkflowProvidedInputsFromSchemas,
 } from "./shared/workflow-authoring-types.js";
+export type {
+	WorkflowHeartbeatEvent,
+	WorkflowHeartbeatEventDetails,
+	WorkflowHeartbeatIdentity,
+} from "./shared/workflow-heartbeat-contract.js";
 
 import type {
 	GitWorktreeSetupOptions,
@@ -250,6 +255,8 @@ export declare function workflow<
 export declare function keepContext(text: string): string;
 export declare const KEEP_CONTEXT_OPEN_TAG: string;
 export declare const KEEP_CONTEXT_CLOSE_TAG: string;
+export declare const DEFAULT_WORKFLOW_HEARTBEAT_INTERVAL_MINUTES: 15;
+export declare const WORKFLOW_HEARTBEAT_CUSTOM_TYPE: "workflows:workflow-heartbeat";
 export declare function createRegistry<
 	TDefinitions extends readonly AnyWorkflowDefinition[] = readonly AnyWorkflowDefinition[],
 >(initial?: TDefinitions): WorkflowRegistry;

--- a/packages/workflows/src/authoring/workflow.ts
+++ b/packages/workflows/src/authoring/workflow.ts
@@ -26,6 +26,7 @@ export type {
 } from "../shared/workflow-authoring-types.js";
 
 const BRANDED_WORKFLOW_DEFINITIONS = new WeakSet<object>();
+export const DEFAULT_WORKFLOW_HEARTBEAT_INTERVAL_MINUTES = 15;
 
 export type AuthoredWorkflowSpec<
 	TInputs extends WorkflowInputSchemaMap = Record<never, never>,
@@ -158,6 +159,13 @@ export function workflow<
 	) {
 		throw new TypeError("workflow: inputs must be a schema map");
 	}
+	const heartbeatIntervalMinutes =
+		spec.heartbeatIntervalMinutes === undefined
+			? DEFAULT_WORKFLOW_HEARTBEAT_INTERVAL_MINUTES
+			: spec.heartbeatIntervalMinutes;
+	if (!Number.isFinite(heartbeatIntervalMinutes) || heartbeatIntervalMinutes < 0) {
+		throw new TypeError("workflow: heartbeatIntervalMinutes must be a non-negative finite number");
+	}
 
 	const name = resolveWorkflowName(spec.name);
 	const normalizedName = normalizeWorkflowName(name);
@@ -174,6 +182,7 @@ export function workflow<
 		normalizedName,
 		description: spec.description,
 		...(spec.autoAttach === true ? { autoAttach: true } : {}),
+		heartbeatIntervalMinutes,
 		inputs: frozenInputs,
 		outputs: frozenOutputs,
 		...(inputBindings !== undefined ? { inputBindings } : {}),

--- a/packages/workflows/src/authoring/workflow.ts
+++ b/packages/workflows/src/authoring/workflow.ts
@@ -17,6 +17,7 @@ import type {
 	WorkflowOutputsFromSchemas,
 	WorkflowProvidedInputsFromSchemas,
 } from "../shared/workflow-authoring-types.js";
+import { DEFAULT_WORKFLOW_HEARTBEAT_INTERVAL_MINUTES } from "../shared/workflow-heartbeat-contract.js";
 import { normalizeWorkflowName } from "../workflows/identity.js";
 
 export type {
@@ -26,7 +27,6 @@ export type {
 } from "../shared/workflow-authoring-types.js";
 
 const BRANDED_WORKFLOW_DEFINITIONS = new WeakSet<object>();
-export const DEFAULT_WORKFLOW_HEARTBEAT_INTERVAL_MINUTES = 15;
 
 export type AuthoredWorkflowSpec<
 	TInputs extends WorkflowInputSchemaMap = Record<never, never>,

--- a/packages/workflows/src/extension/lifecycle-notifications.ts
+++ b/packages/workflows/src/extension/lifecycle-notifications.ts
@@ -25,13 +25,6 @@ import { renderWorkflowNoticeCard, type WorkflowNoticeTone } from "../tui/workfl
 import type { ExtensionAPI, PiMessageRenderComponent, PiMessageRenderer } from "./index.js";
 import { createLifecycleNoticeDelivery } from "./lifecycle-notification-delivery.js";
 
-export {
-	WORKFLOW_HEARTBEAT_CUSTOM_TYPE,
-	type WorkflowHeartbeatEvent,
-	type WorkflowHeartbeatEventDetails,
-	type WorkflowHeartbeatIdentity,
-} from "../shared/workflow-heartbeat-contract.js";
-
 export const LIFECYCLE_NOTICE_CUSTOM_TYPE = "workflows:lifecycle-notice";
 export const LIFECYCLE_NOTICE_SNIPPET_LIMIT = 240;
 

--- a/packages/workflows/src/extension/lifecycle-notifications.ts
+++ b/packages/workflows/src/extension/lifecycle-notifications.ts
@@ -27,6 +27,28 @@ import { createLifecycleNoticeDelivery } from "./lifecycle-notification-delivery
 
 export const LIFECYCLE_NOTICE_CUSTOM_TYPE = "workflows:lifecycle-notice";
 export const LIFECYCLE_NOTICE_SNIPPET_LIMIT = 240;
+export const WORKFLOW_HEARTBEAT_CUSTOM_TYPE = "workflows:workflow-heartbeat";
+
+/** Stable identity for one scheduled boundary of a workflow run. */
+export interface WorkflowHeartbeatIdentity {
+	readonly runId: string;
+	/** Unix timestamp in milliseconds for the cadence boundary. */
+	readonly scheduledAt: number;
+}
+
+/** Deterministic context carried by a workflow heartbeat event. */
+export interface WorkflowHeartbeatEventDetails extends WorkflowHeartbeatIdentity {
+	readonly workflowName: string;
+	/** Persisted workflow start timestamp in Unix milliseconds. */
+	readonly startedAt: number;
+	readonly intervalMinutes: number;
+}
+
+/** Slice-1 event envelope; scheduling and delivery are wired separately. */
+export interface WorkflowHeartbeatEvent {
+	readonly customType: typeof WORKFLOW_HEARTBEAT_CUSTOM_TYPE;
+	readonly details: WorkflowHeartbeatEventDetails;
+}
 
 export type WorkflowLifecycleNoticeKind =
 	| "started"

--- a/packages/workflows/src/extension/lifecycle-notifications.ts
+++ b/packages/workflows/src/extension/lifecycle-notifications.ts
@@ -25,30 +25,15 @@ import { renderWorkflowNoticeCard, type WorkflowNoticeTone } from "../tui/workfl
 import type { ExtensionAPI, PiMessageRenderComponent, PiMessageRenderer } from "./index.js";
 import { createLifecycleNoticeDelivery } from "./lifecycle-notification-delivery.js";
 
+export {
+	WORKFLOW_HEARTBEAT_CUSTOM_TYPE,
+	type WorkflowHeartbeatEvent,
+	type WorkflowHeartbeatEventDetails,
+	type WorkflowHeartbeatIdentity,
+} from "../shared/workflow-heartbeat-contract.js";
+
 export const LIFECYCLE_NOTICE_CUSTOM_TYPE = "workflows:lifecycle-notice";
 export const LIFECYCLE_NOTICE_SNIPPET_LIMIT = 240;
-export const WORKFLOW_HEARTBEAT_CUSTOM_TYPE = "workflows:workflow-heartbeat";
-
-/** Stable identity for one scheduled boundary of a workflow run. */
-export interface WorkflowHeartbeatIdentity {
-	readonly runId: string;
-	/** Unix timestamp in milliseconds for the cadence boundary. */
-	readonly scheduledAt: number;
-}
-
-/** Deterministic context carried by a workflow heartbeat event. */
-export interface WorkflowHeartbeatEventDetails extends WorkflowHeartbeatIdentity {
-	readonly workflowName: string;
-	/** Persisted workflow start timestamp in Unix milliseconds. */
-	readonly startedAt: number;
-	readonly intervalMinutes: number;
-}
-
-/** Slice-1 event envelope; scheduling and delivery are wired separately. */
-export interface WorkflowHeartbeatEvent {
-	readonly customType: typeof WORKFLOW_HEARTBEAT_CUSTOM_TYPE;
-	readonly details: WorkflowHeartbeatEventDetails;
-}
 
 export type WorkflowLifecycleNoticeKind =
 	| "started"

--- a/packages/workflows/src/sdk-surface.ts
+++ b/packages/workflows/src/sdk-surface.ts
@@ -7,13 +7,16 @@
 
 export type { Static, TSchema } from "typebox";
 export { KEEP_CONTEXT_CLOSE_TAG, KEEP_CONTEXT_OPEN_TAG, keepContext } from "./authoring/keep-context.js";
-export { DEFAULT_WORKFLOW_HEARTBEAT_INTERVAL_MINUTES, workflow } from "./authoring/workflow.js";
+export { workflow } from "./authoring/workflow.js";
 export type {
 	WorkflowHeartbeatEvent,
 	WorkflowHeartbeatEventDetails,
 	WorkflowHeartbeatIdentity,
 } from "./shared/workflow-heartbeat-contract.js";
-export { WORKFLOW_HEARTBEAT_CUSTOM_TYPE } from "./shared/workflow-heartbeat-contract.js";
+export {
+	DEFAULT_WORKFLOW_HEARTBEAT_INTERVAL_MINUTES,
+	WORKFLOW_HEARTBEAT_CUSTOM_TYPE,
+} from "./shared/workflow-heartbeat-contract.js";
 
 const REMOVED_RUN_WORKFLOW_MESSAGE =
 	"@bastani/workflows no longer exports runWorkflow; author workflows with workflow({...})";

--- a/packages/workflows/src/sdk-surface.ts
+++ b/packages/workflows/src/sdk-surface.ts
@@ -7,7 +7,13 @@
 
 export type { Static, TSchema } from "typebox";
 export { KEEP_CONTEXT_CLOSE_TAG, KEEP_CONTEXT_OPEN_TAG, keepContext } from "./authoring/keep-context.js";
-export { workflow } from "./authoring/workflow.js";
+export { DEFAULT_WORKFLOW_HEARTBEAT_INTERVAL_MINUTES, workflow } from "./authoring/workflow.js";
+export type {
+	WorkflowHeartbeatEvent,
+	WorkflowHeartbeatEventDetails,
+	WorkflowHeartbeatIdentity,
+} from "./shared/workflow-heartbeat-contract.js";
+export { WORKFLOW_HEARTBEAT_CUSTOM_TYPE } from "./shared/workflow-heartbeat-contract.js";
 
 const REMOVED_RUN_WORKFLOW_MESSAGE =
 	"@bastani/workflows no longer exports runWorkflow; author workflows with workflow({...})";

--- a/packages/workflows/src/shared/authoring-contract-ui.ts
+++ b/packages/workflows/src/shared/authoring-contract-ui.ts
@@ -235,6 +235,7 @@ export interface WorkflowDefinition<
 	readonly normalizedName: string;
 	readonly description: string;
 	readonly autoAttach?: true;
+	readonly heartbeatIntervalMinutes: number;
 	readonly inputs: WorkflowInputSchemaMap;
 	readonly outputs?: WorkflowOutputSchemaMap;
 	readonly inputBindings?: WorkflowInputBindings;

--- a/packages/workflows/src/shared/workflow-authoring-types.ts
+++ b/packages/workflows/src/shared/workflow-authoring-types.ts
@@ -97,6 +97,7 @@ export interface AuthoredWorkflowSpec<
 > {
 	readonly name?: string;
 	readonly autoAttach?: boolean;
+	readonly heartbeatIntervalMinutes?: number;
 	readonly description: string;
 	readonly inputs?: TInputs;
 	readonly outputs: TOutputs;

--- a/packages/workflows/src/shared/workflow-heartbeat-contract.ts
+++ b/packages/workflows/src/shared/workflow-heartbeat-contract.ts
@@ -1,3 +1,6 @@
+/** Cadence used when a workflow definition omits `heartbeatIntervalMinutes`. */
+export const DEFAULT_WORKFLOW_HEARTBEAT_INTERVAL_MINUTES = 15;
+
 export const WORKFLOW_HEARTBEAT_CUSTOM_TYPE = "workflows:workflow-heartbeat";
 
 /** Stable identity for one scheduled boundary of a workflow run. */

--- a/packages/workflows/src/shared/workflow-heartbeat-contract.ts
+++ b/packages/workflows/src/shared/workflow-heartbeat-contract.ts
@@ -1,0 +1,22 @@
+export const WORKFLOW_HEARTBEAT_CUSTOM_TYPE = "workflows:workflow-heartbeat";
+
+/** Stable identity for one scheduled boundary of a workflow run. */
+export interface WorkflowHeartbeatIdentity {
+	readonly runId: string;
+	/** Unix timestamp in milliseconds for the cadence boundary. */
+	readonly scheduledAt: number;
+}
+
+/** Deterministic context carried by a workflow heartbeat event. */
+export interface WorkflowHeartbeatEventDetails extends WorkflowHeartbeatIdentity {
+	readonly workflowName: string;
+	/** Persisted workflow start timestamp in Unix milliseconds. */
+	readonly startedAt: number;
+	readonly intervalMinutes: number;
+}
+
+/** Slice-1 event envelope; scheduling and delivery are wired separately. */
+export interface WorkflowHeartbeatEvent {
+	readonly customType: typeof WORKFLOW_HEARTBEAT_CUSTOM_TYPE;
+	readonly details: WorkflowHeartbeatEventDetails;
+}

--- a/specs/2026-08-06-workflow-heartbeats.md
+++ b/specs/2026-08-06-workflow-heartbeats.md
@@ -1,0 +1,292 @@
+# Workflow Heartbeats — Technical Design Document / RFC
+
+| Document Metadata | Details |
+| --- | --- |
+| Author(s) | morgan-coded |
+| Status | In Review (RFC) — design questions resolved; slice 1 is the current PR scope |
+| Team / Owner | `packages/workflows` |
+| Created / Last Updated | 2026-08-06 |
+| Design authority | [Issue #1975](https://github.com/bastani-inc/atomic/issues/1975), [three-slice contract and answers](https://github.com/bastani-inc/atomic/issues/1975#issuecomment-5182034997), [payload amendment](https://github.com/bastani-inc/atomic/issues/1975#issuecomment-5201461460), [green light](https://github.com/bastani-inc/atomic/issues/1975#issuecomment-5201465620) |
+| Compatibility posture | Backwards compatible: existing definitions omit the option and receive the documented default. See §10. |
+
+---
+
+## 1. Executive Summary
+
+Long-running workflows currently report lifecycle transitions but have no periodic way to return control to their parent chat for an alignment check. This RFC adds an opt-out workflow heartbeat, configured in minutes and anchored to the persisted workflow start time. The public `workflow({...})` authoring door validates and freezes the interval. Later slices add one scheduler door that raises deterministic events and one cleanup door that removes or invalidates heartbeat work when a run becomes terminal.
+
+The work lands as three separately reviewed slices. Slice 1 defines only configuration, event payload, stable identity, documentation, and tests. Slice 2 owns scheduling and queued delivery. Slice 3 owns terminal cleanup and recovery. Heartbeats never become user, stage, or follow-up messages, never interrupt an active parent response, and never add behavior outside workflow execution.
+
+## 2. Context and Motivation
+
+### 2.1 Current State
+
+- `workflow({...})` is the public authoring boundary. It validates authored fields and returns a frozen, branded definition ([`workflow-authoring-types.ts`](../packages/workflows/src/shared/workflow-authoring-types.ts), [`workflow.ts`](../packages/workflows/src/authoring/workflow.ts)).
+- A `RunSnapshot` already persists the run id, workflow name, inputs, and start timestamp; `workflow.run.start` session entries persist the same run identity and timestamp ([`store-types.ts`](../packages/workflows/src/shared/store-types.ts), [`run.ts`](../packages/workflows/src/engine/run.ts), [`persistence-session-entries.ts`](../packages/workflows/src/shared/persistence-session-entries.ts)).
+- Workflow lifecycle notices already use a typed details object and the parent message path with `triggerTurn: true`, `deliverAs: "steer"`, and `persistWhenStreaming: true` ([`lifecycle-notifications.ts`](../packages/workflows/src/extension/lifecycle-notifications.ts)).
+- There is no workflow heartbeat configuration, schedule, event, or cleanup path.
+
+### 2.2 The Problem
+
+A workflow may run long enough to drift while its parent chat is busy or waiting. The issue requires a deterministic, configurable signal that returns oversight to the parent without interrupting the active turn. The scheduler must remain cheap, durable, restart-safe, pause-aware, and deduplicated; the parent agent, not the scheduler, decides what response is appropriate.
+
+### 2.3 Contract Amendment
+
+The maintainer removed `originalGoal` from this iteration's payload in [comment 5201461460](https://github.com/bastani-inc/atomic/issues/1975#issuecomment-5201461460). That amendment supersedes the issue body's recovery acceptance criterion and its corresponding “How?” payload paragraph. The payload for this design therefore carries only run identity, workflow name, start time, scheduled time, and interval; no substitute is derived from workflow inputs.
+
+## 3. Goals and Non-Goals
+
+### 3.1 Functional Goals
+
+- [ ] Workflow definitions accept `heartbeatIntervalMinutes`.
+- [ ] Omission resolves to `15`; `0` disables; every positive finite number is accepted.
+- [ ] Negative, `NaN`, and positive or negative infinity values fail at the authoring door with a clear validation error.
+- [ ] The compiled workflow definition always carries the resolved interval so later slices do not repeat defaulting.
+- [ ] A distinct `workflows:workflow-heartbeat` event contract carries `runId`, `workflowName`, `startedAt`, `scheduledAt`, and `intervalMinutes`.
+- [ ] A heartbeat identity is defined by `runId` plus `scheduledAt`; retries reuse it.
+- [ ] Positive intervals are scheduled from `startedAt + n × interval` with at most one pending heartbeat per run.
+- [ ] Paused runs emit nothing and receive no backfill; active recovered runs resume at the next future boundary.
+- [ ] Due heartbeats enter the parent queue in scheduled-time order, with run id as the stable tie-break.
+- [ ] Terminal cleanup is idempotent for completed, failed, blocked, skipped, cancelled, and killed runs.
+- [ ] User-facing workflow documentation states the parameter, minute units, default, disable behavior, and an example.
+
+The first six items define slice 1. Scheduling and delivery are slice 2. Cleanup and recovery are slice 3. The schedule, pause, delivery, overhead, and cleanup requirements trace to [comment 5182034997](https://github.com/bastani-inc/atomic/issues/1975#issuecomment-5182034997); the split and permission trace to that comment and [comment 5201465620](https://github.com/bastani-inc/atomic/issues/1975#issuecomment-5201465620).
+
+### 3.2 Non-Goals
+
+- [ ] Slice 1 will not create a timer, durable schedule, queued message, or renderer.
+- [ ] Slice 1 will not emit, deliver, steer, deduplicate, pause, resume, recover, or clean up heartbeats.
+- [ ] Heartbeats will not target the main chat independently of a workflow parent.
+- [ ] Heartbeats will not be user messages, stage messages, or follow-up messages.
+- [ ] Scheduling will not poll status, run one recurring process timer per workflow, or make model calls.
+- [ ] No input field or other existing value will stand in for the removed payload field.
+- [ ] The work will not redesign DBOS or modify unrelated workflow lifecycle notices.
+
+## 4. Proposed Solution
+
+### 4.1 System Architecture Diagram
+
+```mermaid
+flowchart TD
+    Author["Workflow author"] --> Door["workflow({...})\nvalidation airlock"]
+    Door --> Definition["Frozen WorkflowDefinition\nresolved interval"]
+    Definition -. "Slice 2" .-> Scheduler["scheduleWorkflowHeartbeats\none next-due wake-up"]
+    Snapshot["RunSnapshot\nid · name · startedAt · status"] -. "Slice 2" .-> Scheduler
+    Scheduler -. "due and active" .-> Event["workflows:workflow-heartbeat\nstable payload + identity"]
+    Event -. "queued steer" .-> Parent["Parent chat decides\ncontinue · steer · stop/replace · ask user"]
+    Snapshot -. "Slice 3 terminal transition" .-> Cleanup["clearWorkflowHeartbeats\nidempotent invalidation"]
+    Cleanup -.-> Scheduler
+```
+
+Solid edges are slice 1. Dotted edges specify the separately reviewed follow-up slices.
+
+### 4.2 Architectural Pattern
+
+Use a persisted cadence with a single next-due scheduler wake-up. The cadence is calculated from the immutable run start timestamp rather than from the previous delivery time, so retries and restarts cannot shift it. The custom event follows the existing lifecycle-notice queued-steer path, but keeps a distinct custom type and payload.
+
+### 4.3 Slice Boundaries
+
+| Slice | Owns | Explicitly excludes |
+| --- | --- | --- |
+| 1 — config/contract | authoring option, validation/defaulting, resolved definition field, event/payload/identity types, docs, spec, contract tests | timers, schedules, persistence records, delivery, cleanup |
+| 2 — scheduler/delivery | cadence calculation, one next-due wake-up, durable schedule, dedupe, pause/restart rules, queued-steer delivery | terminal cleanup implementation beyond pre-enqueue/pre-process guards |
+| 3 — terminal cleanup/recovery | idempotent schedule/timer cleanup, queued-event invalidation, all terminal paths, restart/race recovery | new payload fields or delivery modes |
+
+### 4.4 Door Set at a Glance
+
+`workflow` · `scheduleWorkflowHeartbeats` · `enqueueWorkflowHeartbeat` · `clearWorkflowHeartbeats`
+
+No door in this design performs an externally irreversible effect. Queued parent turns and durable schedule writes are controlled internal effects and remain concentrated in the scheduler/delivery and cleanup doors.
+
+## 5. Detailed Design
+
+### 5.1 The Doors
+
+#### `workflow`
+
+```ts
+workflow(spec: AuthoredWorkflowSpec & {
+  heartbeatIntervalMinutes?: number;
+}): AuthoredWorkflowDefinition & {
+  readonly heartbeatIntervalMinutes: number;
+}
+```
+
+Guarantee: returns a frozen workflow definition with one valid resolved heartbeat interval.
+
+Failure: `TypeError("workflow: heartbeatIntervalMinutes must be a non-negative finite number")`.
+
+Refusals:
+
+- Omitted input becomes `15` at the boundary.
+- `0` remains `0`; it is not removed or replaced by the default.
+- Negative and non-finite values are rejected before branding or freezing.
+- The resolved field is a required `number` on `WorkflowDefinition`, so downstream code cannot observe an unresolved optional value.
+
+Rubric result: this is the existing domain authoring joint; validation is at the boundary; every accepted exit carries the invariant; no alternate authoring path can mint a branded definition.
+
+#### `scheduleWorkflowHeartbeats` (slice 2)
+
+```ts
+scheduleWorkflowHeartbeats(
+  run: Pick<RunSnapshot, "id" | "name" | "startedAt" | "status">,
+  intervalMinutes: number,
+): Disabled | Scheduled
+```
+
+Guarantee: maintains at most one next-due heartbeat schedule for an enabled active workflow.
+
+Refusals: `0` creates no timer or durable schedule; paused and terminal runs create no due event; recovery skips missed boundaries and selects the next future boundary.
+
+Rubric result: one internal door owns schedule creation, cadence anchoring, and the single-wake-up invariant. Slice 2 must reuse the repository's durable scheduling and store-status authorities rather than create parallel truth.
+
+#### `enqueueWorkflowHeartbeat` (slice 2)
+
+```ts
+enqueueWorkflowHeartbeat(payload: WorkflowHeartbeatEventDetails): Enqueued | Suppressed
+```
+
+Guarantee: queues one due heartbeat for the parent chat without interrupting its active response.
+
+Refusals: terminal runs are suppressed; an already pending identity is not duplicated; the event is never converted to a user, stage, or follow-up message.
+
+Rubric result: this is the sole heartbeat delivery chokepoint. It must use the existing parent-message call shape: trigger a turn, deliver as steer, and persist while streaming. Processing order is `scheduledAt`, then `runId`.
+
+#### `clearWorkflowHeartbeats` (slice 3)
+
+```ts
+clearWorkflowHeartbeats(runId: string): Cleared | AlreadyClear
+```
+
+Guarantee: leaves no deliverable heartbeat schedule or queued heartbeat for a terminal workflow.
+
+Refusals: repeat cleanup cannot create state or re-enable a schedule. Both enqueue and processing recheck terminal state so cleanup races converge on suppression.
+
+Rubric result: one door owns timer, durable-record, and queued-event invalidation for all terminal statuses recognized by `isTerminalRunStatus`.
+
+### 5.2 Slice-1 Contract Types
+
+```ts
+const DEFAULT_WORKFLOW_HEARTBEAT_INTERVAL_MINUTES = 15;
+const WORKFLOW_HEARTBEAT_CUSTOM_TYPE = "workflows:workflow-heartbeat";
+
+interface WorkflowHeartbeatIdentity {
+  readonly runId: string;
+  readonly scheduledAt: number;
+}
+
+interface WorkflowHeartbeatEventDetails extends WorkflowHeartbeatIdentity {
+  readonly workflowName: string;
+  readonly startedAt: number;
+  readonly intervalMinutes: number;
+}
+```
+
+`runId + scheduledAt` is the identity boundary. `intervalMinutes` remains in the payload so a parent can interpret the cadence without reading mutable workflow source. Slice 1 declares no event constructor or sender.
+
+### 5.3 Cadence and State Rules (Slices 2–3)
+
+For interval `I > 0`, boundaries are `startedAt + n × I` for positive integer `n`.
+
+- Normal running: schedule only the next boundary.
+- Retry: reuse the same `runId + scheduledAt` identity.
+- Busy parent: retain one pending event and process it through queued steer when available.
+- Pause: emit nothing and do not backfill elapsed boundaries.
+- Resume/restart: select the first future boundary on the original cadence.
+- Terminal transition: clear schedule ownership and invalidate any queued identity.
+- Race: check terminal state immediately before enqueue and again immediately before processing.
+- Multiple due workflows: order by `scheduledAt`, then `runId`.
+
+These rules are the maintainer's answers 1–5 in [comment 5182034997](https://github.com/bastani-inc/atomic/issues/1975#issuecomment-5182034997).
+
+### 5.4 Parent Delivery (Slice 2)
+
+The event uses the same delivery options as lifecycle notices:
+
+```ts
+{ triggerTurn: true, deliverAs: "steer", persistWhenStreaming: true }
+```
+
+The scheduler raises the event; it does not decide whether the run is aligned and it makes no model call. The parent agent inspects conversation context and workflow status, then decides whether to continue, steer, stop and replace, or delegate the decision to the user when the appropriate question tool is available. The exact model-facing instruction belongs only to slice 2.
+
+### 5.5 Persistence
+
+Slice 1 adds no persisted run field or schedule record. It relies on the existing `RunSnapshot` identity fields and carries the resolved authoring value on `WorkflowDefinition`. Slice 2 must define the durable schedule record and preserve these invariants:
+
+- no record when the resolved interval is `0`;
+- no more than one record and one pending event per enabled active run;
+- stable identity across retries;
+- recovery chooses a future boundary rather than replaying missed boundaries.
+
+Slice 3 owns deletion/invalidation across all terminal paths.
+
+## 6. Alternatives Considered
+
+| Option | Pros | Cons | Decision |
+| --- | --- | --- | --- |
+| Default disabled | No new background work | Contradicts issue acceptance criteria | Rejected; default is `15` |
+| Per-run recurring process timer | Simple local implementation | Violates restart durability and overhead answer | Rejected |
+| Deliver as user/stage/follow-up message | Reuses visible message shapes | Contradicts the maintainer's explicit parent-queue contract | Rejected |
+| Interrupt the parent | Immediate | Violates busy-parent behavior | Rejected |
+| Use workflow inputs as extra context | Already persisted | Invents semantics and contradicts the payload amendment | Rejected |
+| Central next-due wake-up plus distinct queued event | Deterministic, bounded, compatible with lifecycle delivery | Requires separate scheduler and cleanup slices | Selected |
+
+## 7. Cross-Cutting Concerns
+
+### 7.1 Performance and Resource Use
+
+- `0` means zero timer and zero durable schedule.
+- Scheduling performs no status polling and no model calls.
+- At most one durable record and one pending event exist per enabled active workflow.
+- Prefer one wake-up for the globally next-due heartbeat rather than one recurring process timer per run.
+
+### 7.2 Reliability
+
+- Cadence derives from persisted `startedAt`, never prior delivery completion.
+- Identity survives retries and prevents duplicate pending events.
+- Pause/restart recovery never bursts missed heartbeats.
+- Terminal checks at enqueue and processing close completion races.
+- Cleanup is idempotent.
+
+### 7.3 Security and Privacy
+
+The heartbeat payload contains identifiers and timestamps already present in workflow runtime state. It adds no secret-bearing or free-form user content. The parent consumes it through the existing internal custom-message path.
+
+## 8. Test Plan
+
+### 8.1 Slice 1
+
+- Authoring default: omitted option resolves to `15`.
+- Disable boundary: explicit `0` survives on the frozen definition.
+- Positive finite values: representative fractional, small, and large finite values survive unchanged.
+- Invalid lower boundary: negative values throw the named validation error.
+- Invalid numeric values: `NaN`, positive infinity, and negative infinity throw the same error.
+- Immutability: the resolved interval cannot be mutated after authoring.
+- Event contract: custom type is stable and the payload exposes exactly five keys.
+- Identity contract: identity exposes exactly `runId` and `scheduledAt`.
+
+### 8.2 Slice 2
+
+Use a deterministic clock to prove cadence anchoring, recurring delivery, one-pending dedupe, retry identity reuse, busy-parent queuing, scheduled-time ordering, pause suppression, resume without backfill, restart without catch-up bursts, and zero-value absence of timer/schedule work.
+
+### 8.3 Slice 3
+
+Use deterministic race tests for completed, failed, blocked, skipped, cancelled, and killed transitions; repeat cleanup; terminal-before-enqueue; terminal-after-enqueue/before-processing; and recovery with stale durable or queued records.
+
+### 8.4 Interactive Verification
+
+Each PR includes tmux screenshot evidence on its thread, as requested in [comment 5182034997](https://github.com/bastani-inc/atomic/issues/1975#issuecomment-5182034997). Slice 1 evidence shows definition authoring for omitted, disabled, positive, negative, and non-finite values. Later slices show real queued delivery and terminal/restart behavior.
+
+## 9. Open Questions / Unresolved Issues
+
+None. The maintainer resolved cadence/dedupe, pause/restart/busy behavior, delivery, cleanup ownership, overhead, evidence, and the payload amendment in the three design-authority comments linked above.
+
+## 10. Backwards Compatibility
+
+This design preserves existing workflow source compatibility. `heartbeatIntervalMinutes` is optional for authors, so existing `workflow({...})` calls continue to typecheck and resolve to the documented `15` default. The resulting `WorkflowDefinition` field is required only after the authoring boundary, making downstream behavior explicit without requiring source migrations. The event type is additive and distinct from lifecycle notices. No persisted run schema changes in slice 1.
+
+## 11. Implementation Sequence and Acceptance
+
+1. Slice 1 lands the spec, authoring config/default/validation, definition plumbing, event and identity contracts, documentation, and tests.
+2. Slice 2 begins only after slice 1 review and lands scheduling plus queued delivery.
+3. Slice 3 begins only after slice 2 review and lands terminal cleanup plus recovery.

--- a/test/unit/workflow-heartbeat-contract.test.ts
+++ b/test/unit/workflow-heartbeat-contract.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { workflow } from "../../packages/workflows/src/authoring/workflow.js";
+import {
+	WORKFLOW_HEARTBEAT_CUSTOM_TYPE,
+	type WorkflowHeartbeatEvent,
+	type WorkflowHeartbeatEventDetails,
+	type WorkflowHeartbeatIdentity,
+} from "../../packages/workflows/src/extension/lifecycle-notifications.js";
+
+function minimalWorkflow(heartbeatIntervalMinutes?: number) {
+	return workflow({
+		name: "heartbeat-contract",
+		description: "heartbeat contract test",
+		outputs: {},
+		run: () => ({}),
+		...(heartbeatIntervalMinutes !== undefined ? { heartbeatIntervalMinutes } : {}),
+	});
+}
+
+describe("workflow heartbeat authoring contract", () => {
+	test("defaults the interval to 15 minutes", () => {
+		const definition = minimalWorkflow();
+
+		assert.equal(definition.heartbeatIntervalMinutes, 15);
+	});
+
+	test("preserves 0 as the disabled interval", () => {
+		const definition = minimalWorkflow(0);
+
+		assert.equal(definition.heartbeatIntervalMinutes, 0);
+	});
+
+	test("freezes the resolved interval with the definition", () => {
+		const definition = minimalWorkflow(30);
+
+		assert.throws(() => Object.defineProperty(definition, "heartbeatIntervalMinutes", { value: 5 }), TypeError);
+		assert.equal(definition.heartbeatIntervalMinutes, 30);
+	});
+
+	test("preserves positive finite interval bounds", () => {
+		for (const heartbeatIntervalMinutes of [Number.MIN_VALUE, 0.5, Number.MAX_VALUE]) {
+			const definition = minimalWorkflow(heartbeatIntervalMinutes);
+
+			assert.equal(definition.heartbeatIntervalMinutes, heartbeatIntervalMinutes);
+		}
+	});
+
+	test("rejects negative intervals", () => {
+		for (const heartbeatIntervalMinutes of [-Number.MIN_VALUE, -1]) {
+			assert.throws(() => minimalWorkflow(heartbeatIntervalMinutes), {
+				name: "TypeError",
+				message: "workflow: heartbeatIntervalMinutes must be a non-negative finite number",
+			});
+		}
+	});
+
+	test("rejects non-finite intervals", () => {
+		for (const heartbeatIntervalMinutes of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+			assert.throws(() => minimalWorkflow(heartbeatIntervalMinutes), {
+				name: "TypeError",
+				message: "workflow: heartbeatIntervalMinutes must be a non-negative finite number",
+			});
+		}
+	});
+});
+
+describe("workflow heartbeat event contract", () => {
+	test("declares a distinct custom event with the complete payload", () => {
+		const details = {
+			runId: "run-17",
+			workflowName: "release-check",
+			startedAt: 1_000,
+			scheduledAt: 901_000,
+			intervalMinutes: 15,
+		} satisfies WorkflowHeartbeatEventDetails;
+		const event = {
+			customType: WORKFLOW_HEARTBEAT_CUSTOM_TYPE,
+			details,
+		} satisfies WorkflowHeartbeatEvent;
+
+		assert.equal(event.customType, "workflows:workflow-heartbeat");
+		assert.deepEqual(Object.keys(event.details).sort(), [
+			"intervalMinutes",
+			"runId",
+			"scheduledAt",
+			"startedAt",
+			"workflowName",
+		]);
+	});
+
+	test("anchors identity to the run and scheduled boundary", () => {
+		const identity = {
+			runId: "run-17",
+			scheduledAt: 901_000,
+		} satisfies WorkflowHeartbeatIdentity;
+
+		assert.deepEqual(Object.keys(identity).sort(), ["runId", "scheduledAt"]);
+	});
+});

--- a/test/unit/workflow-heartbeat-contract.test.ts
+++ b/test/unit/workflow-heartbeat-contract.test.ts
@@ -2,11 +2,12 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { workflow } from "../../packages/workflows/src/authoring/workflow.js";
 import {
+	DEFAULT_WORKFLOW_HEARTBEAT_INTERVAL_MINUTES,
 	WORKFLOW_HEARTBEAT_CUSTOM_TYPE,
 	type WorkflowHeartbeatEvent,
 	type WorkflowHeartbeatEventDetails,
 	type WorkflowHeartbeatIdentity,
-} from "../../packages/workflows/src/extension/lifecycle-notifications.js";
+} from "../../packages/workflows/src/shared/workflow-heartbeat-contract.js";
 
 function minimalWorkflow(heartbeatIntervalMinutes?: number) {
 	return workflow({
@@ -23,6 +24,7 @@ describe("workflow heartbeat authoring contract", () => {
 		const definition = minimalWorkflow();
 
 		assert.equal(definition.heartbeatIntervalMinutes, 15);
+		assert.equal(DEFAULT_WORKFLOW_HEARTBEAT_INTERVAL_MINUTES, 15);
 	});
 
 	test("preserves 0 as the disabled interval", () => {

--- a/test/unit/workflow-heartbeat-package-root.test.ts
+++ b/test/unit/workflow-heartbeat-package-root.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import {
+	DEFAULT_WORKFLOW_HEARTBEAT_INTERVAL_MINUTES,
+	WORKFLOW_HEARTBEAT_CUSTOM_TYPE,
+	type WorkflowHeartbeatEvent,
+	type WorkflowHeartbeatEventDetails,
+	type WorkflowHeartbeatIdentity,
+} from "@bastani/workflows";
+import { test } from "vitest";
+
+test("exports the workflow heartbeat contract from the package root", () => {
+	const identity = {
+		runId: "run-17",
+		scheduledAt: 901_000,
+	} satisfies WorkflowHeartbeatIdentity;
+	const details = {
+		...identity,
+		workflowName: "release-check",
+		startedAt: 1_000,
+		intervalMinutes: DEFAULT_WORKFLOW_HEARTBEAT_INTERVAL_MINUTES,
+	} satisfies WorkflowHeartbeatEventDetails;
+	const event = {
+		customType: WORKFLOW_HEARTBEAT_CUSTOM_TYPE,
+		details,
+	} satisfies WorkflowHeartbeatEvent;
+
+	assert.equal(DEFAULT_WORKFLOW_HEARTBEAT_INTERVAL_MINUTES, 15);
+	assert.equal(event.customType, "workflows:workflow-heartbeat");
+	assert.deepEqual(event.details, {
+		runId: "run-17",
+		scheduledAt: 901_000,
+		workflowName: "release-check",
+		startedAt: 1_000,
+		intervalMinutes: 15,
+	});
+});


### PR DESCRIPTION
### Stack for #1975

Merge bottom to top; each PR is based on the one below it.

| | PR | Slice |
|---|---|---|
| top | #2383 | builtin heartbeat cadences |
| | #2379 | terminal cleanup and restart recovery |
| | #2377 | scheduling and queued parent delivery |
| bottom | #2229 ← **you are here** | authoring contract and event payload |

Base of the stack is `main`. #2377, #2379 and #2383 are linked as GitHub stack #2380. #2229 cannot join it because its head branch lives on a fork, so this table carries the full chain.

---

Workflows have no authored heartbeat cadence or typed event contract for periodic parent alignment checks. This first slice adds `heartbeatIntervalMinutes` with a 15-minute default, explicit `0` disable behavior, finite non-negative validation, and a five-field event payload with identity keyed by `runId` plus `scheduledAt` — no goal field, per your amendment. Scheduling/delivery and terminal cleanup/recovery stay out of this slice and will follow separately; the three-slice design is recorded in `specs/2026-08-06-workflow-heartbeats.md`. `docs/workflows.md` and the workflows README carry the parameter, minute units, default, `0` semantics, and an example, each stating that a positive interval does not deliver heartbeats until the scheduler slice lands — say the word if you would rather hold the user-facing docs until then. Terminal evidence follows in a comment below. Part of #1975

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788654181&installation_model_id=10562&pr_number=2229&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2229&signature=7332aae632bb3174497a2bba43d061c44332ccce2fb8aacafccf0e0d1ae71b58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds workflow heartbeat authoring configuration, a public heartbeat event contract, and documentation for the resolved default and disable behavior. Public-package verification confirmed that omitted intervals resolve to 15 minutes, explicit zero is retained, invalid numeric values are rejected, and the required package-root exports are available.

<h3>Confidence Score: 5/5</h3>

Safe to merge; no blocking failure remains.

No accepted blocking findings remain. The public workflow package contract was exercised successfully for defaulting, explicit disable behavior, invalid-value rejection, and package-root exports.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the heartbeat authoring E2E script against the public package interface and ran the heartbeat contract tests; both passed with exit code 0.
- After the package-root export, the authored script passed all required authoring-contract tests with exit code 0.
- The public package heartbeat interface provides the heartbeat default and authoring behavior documented for workflow authors.

<a href="https://app.greptile.com/trex/runs/18922396/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (6): Last reviewed commit: ["refactor(workflows): colocate heartbeat ..."](https://github.com/bastani-inc/atomic/commit/9097e1863dd92c7103d5f066465e7546ca722b95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51013830)</sub>

<!-- /greptile_comment -->