### PR TITLE
chore(deps): bump js-yaml to 4.3.1 (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6384,9 +6384,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Closes Dependabot alert [#33](https://github.com/bastani-inc/atomic/security/dependabot/33).

## What

Lockfile-only bump of `js-yaml` `4.3.0` → `4.3.1`.

## Why

[GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) — high (CVSS 7.5, CWE-407). `resolveYamlOmap()` enforced key uniqueness with a linear `objectKeys.indexOf(...)` scan inside the per-element loop, making `!!omap` resolution O(n²). `!!omap` is in the default schema, so a plain `yaml.load(untrusted)` is affected, and the loop is synchronous — one small document stalls the whole event loop. This is the same weakness as CVE-2026-59870, fixed in 5.x but never backported until 4.3.1.

## Scope

Dev-scope **transitive** dependency, pulled in by `@napi-rs/cli` (`js-yaml: ^4.2.0`). 4.3.1 is inside that range, so this is `npm update js-yaml --package-lock-only` and nothing else — no manifest edits, one lockfile entry, three lines.

Nothing in this repo parses untrusted YAML with it; exposure is build-tooling only. Bumping anyway because the fix is free and in-range.

## Verification

- `npm ci --ignore-scripts` resolves cleanly and installs 4.3.1; `npm ci --dry-run` confirms lockfile/manifest agreement.
- `npm run check:shrinkwrap` — up to date. The published `@bastani/atomic` shrinkwrap excludes dev dependencies, so it contains no `js-yaml` entry and is untouched.
- `npm run check` and `npm run test:unit` pass (pre-commit hooks, not skipped).
- Advisory proof of concept run against the installed 4.3.1:

  | entries | 4.3.0 (advisory) | 4.3.1 (measured) |
  | --- | --- | --- |
  | 10,000 | 54 ms | 27 ms |
  | 20,000 | 169 ms | 28 ms |
  | 40,000 | 646 ms | 48 ms |
  | 80,000 | 2607 ms | 90 ms |

  4.3.0 quadrupled per doubling; 4.3.1 roughly doubles. The fix replaces the linear scan with an O(1) own-property lookup and keeps duplicate-key rejection semantics identical.

## Changelog

None. Per `AGENTS.md`, `packages/*/CHANGELOG.md` covers shipped package behavior; a dev-only transitive lockfile bump changes nothing users consume.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788662002&installation_model_id=10562&pr_number=2230&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2230&signature=37a53facf2ae4da9de568414bbdab0e39cbacb854cf3f72f91ca54afe8b4e8fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->