### PR TITLE
fix(test): probe the native binding out of process

### DIFF
--- a/test/global-setup-natives.ts
+++ b/test/global-setup-natives.ts
@@ -1,5 +1,4 @@
 import { existsSync, readdirSync, statSync } from "node:fs";
-import { createRequire } from "node:module";
 import { join } from "node:path";
 import { spawnSyncCollect } from "./helpers/runtime.js";
 
@@ -56,15 +55,26 @@ function note(lines: readonly string[]): void {
  * real state after copying a native directory between checkouts or unpacking
  * release artifacts. Requiring the generated entrypoint asks the exact question
  * the suites will ask, so it cannot drift from the loader.
+ *
+ * The load happens in a CHILD process, and that is the whole point.
+ *
+ * `globalSetup` runs in vitest's orchestrator, the process that owns the worker
+ * pool. Requiring the addon there dlopens it into the orchestrator, which
+ * nothing else does: workers load it on demand, in their own processes. On
+ * glibc Linux the addon's destructors then run at exit alongside the pool
+ * teardown and the process dies with SIGSEGV — every test passing first, then
+ * `exit code 139`. It reproduced on every Linux `suites` run and on no macOS or
+ * Windows one, which is why local runs never showed it.
+ *
+ * A child pays one short spawn on a path that already spawns a Rust build when
+ * the binding is missing, and the orchestrator never touches the addon.
  */
 function bindingLoads(): boolean {
 	if (!existsSync(NATIVE_ENTRY)) return false;
-	try {
-		createRequire(import.meta.url)(NATIVE_ENTRY);
-		return true;
-	} catch {
-		return false;
-	}
+	const probe = spawnSyncCollect([process.execPath, "-e", `require(${JSON.stringify(NATIVE_ENTRY)})`], {
+		cwd: REPO_ROOT,
+	});
+	return probe.success;
 }
 
 /** Newest mtime across Rust sources, or 0 when none can be read. */


### PR DESCRIPTION
The natives `globalSetup` I added in #2224 turned every Linux `suites` run red — **including on `main`**, and therefore on every PR branched from it.

Each run passes all ~5960 tests on **both** retry attempts and then dies with `exit code 139` (SIGSEGV) during exit.

## Attribution

| `main` run | sha | `suites` (linux-x64) |
| --- | --- | --- |
| 08-06T00:33 | `ad2155163` | **success** |
| 08-06T21:21 | `65469006c` | **failure** |
| 08-07T02:33 | `70d862d24` | failure |

`ad2155163..65469006c` contains exactly two commits, both mine:

- `e43c64932` #2225 — timeout numbers, a contract test, docs. Cannot segfault.
- `65469006c` #2224 — adds `test/global-setup-natives.ts`, the only new executable code in the range.

## Cause

```ts
function bindingLoads(): boolean {
	if (!existsSync(NATIVE_ENTRY)) return false;
	try {
		createRequire(import.meta.url)(NATIVE_ENTRY);   // ← in the orchestrator
		return true;
	} catch { return false; }
}
```

`globalSetup` runs in vitest's **orchestrator** — the process that owns the worker pool. That `require` dlopens the NAPI addon into a process which otherwise never touches it; workers load it on demand, in their own processes.

The addon carries #2205's Rust control plane and its Tokio runtime. On glibc Linux its destructors run at exit alongside pool teardown, and the process dies *after* the suite has already succeeded. Consistent with every observation: exit 139 after `5968 passed`, on both attempts, Linux only.

## Fix

Probe in a child process. Exit 0 means loadable; the orchestrator never loads the addon.

```ts
const probe = spawnSyncCollect([process.execPath, "-e", `require(${JSON.stringify(NATIVE_ENTRY)})`], {
	cwd: REPO_ROOT,
});
return probe.success;
```

This keeps every property the load-check was chosen for in review:

- **A real load attempt, not a filename scan** — greptile rejected the scan on #2224 because a directory holding only a foreign-platform `.node` would skip the build. Still true here.
- **No reimplementation of napi-rs's ~700 lines** of platform/arch/libc resolution, so it cannot drift from the loader.

Cost is one short spawn, on a path that already spawns a Rust build when the binding is missing.

## Verification

Three paths, locally:

```
warm (binding present)        2.9s, silent
foreign binding only          "present but not loadable here" → rebuilds
full unit suite               625 files / 5957 tests, exit 0
```

`npm run check` clean.

## What I got wrong

I ran that suite locally many times while writing #2224 — always on macOS, which does not reproduce this. I chose the `require()` probe *because* the filename scan was correctly rejected in review, and never asked which process would be doing the loading.

I have not reproduced the segfault locally. The attribution rests on the exact commit boundary, the inert alternative, and a mechanism consistent with the platform split. **The proof is this PR's own Linux `suites` job.**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788667628&installation_model_id=10562&pr_number=2232&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2232&signature=dbb1db03d1c648f5e57ef06b1365b50391ba9abd4aa60663e7ac3e1f937896de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change moves the native addon load check out of Vitest’s orchestrator and into a short-lived Node process, avoiding direct native-module loading in the process that manages test workers. Runtime checks confirmed that the real binding loads successfully, Vitest completes with the updated setup, and an intentionally non-loadable binding enters the rebuild-and-fail path rather than being accepted.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the focused native-binding and Vitest setup checks.

The exercised success path completed normally with the real native binding, and the exercised failure path correctly rejected a non-loadable binding and invoked the rebuild behavior.

**Files Needing Attention:** No files need additional attention; the reviewed change is limited to test/global-setup-natives.ts.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the review-authored native-load isolation validation script and exercised the prior in-process and updated child-process Vitest flows with a real worker test.
- The available-binding Vitest runs completed successfully and the direct child probe exited cleanly, while the isolated non-loadable fixture invoked a mocked rebuild and then failed with the rebuild exit code, proving that the updated probe accepts only a loadable binding.
- I reviewed the executable validation script trex-artifacts/native-load-isolation-validation.mjs which runs the before/after Vitest flows and the isolated non-loadable fixture without modifying repository source.
- I inspected the captured outputs in native-load-isolation-02-after.log and the before.log, which show the pass of both Vitest runs, the direct child probe loading, and the rebuild path for the non-loadable fixture.

<a href="https://app.greptile.com/trex/runs/17745730/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(test): probe the native binding out ..."](https://github.com/bastani-inc/atomic/commit/85fbbf6faf0881d01c05e9d6ba90bd3bc7836392) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51057216)</sub>

<!-- /greptile_comment -->