### PR TITLE
ci: convert CodeQL to advanced setup so stacked PRs are analyzed

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,82 @@
+name: CodeQL
+
+# This replaces GitHub's *default setup* for code scanning, which was migrated
+# to this advanced setup for one reason: default setup analyzes only pushes to
+# the default branch and pull requests **targeting** it, and that trigger set is
+# not configurable. Repository ruleset 9310196 carries a `code_scanning` rule
+# requiring CodeQL results, so a stacked pull request -- one whose base is
+# another feature branch rather than `main` -- arrived with no results and sat
+# at mergeStateStatus BLOCKED with every other check green. Retargeting it to
+# `main` did not help, because the head SHA had already been seen without an
+# analysis; only a fresh push produced one. PR #2235 hit exactly that.
+#
+# `pull_request:` below therefore carries no branch filter, matching test.yml:
+# every pull request is analyzed regardless of base, so a stacked PR satisfies
+# the rule on its first push.
+#
+# Default setup must be disabled for this workflow to upload results. The two
+# cannot coexist -- an advanced-setup run rejects its SARIF while default setup
+# owns the configuration -- so that switch is flipped as this lands rather than
+# as a follow-up.
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  # Default setup ran on a weekly schedule. Keeping it means a newly published
+  # CodeQL query still reaches code that is not being actively changed.
+  schedule:
+    - cron: "31 4 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze
+    # Blacksmith, not ubuntu-latest: `ci-workflow-contracts.test.ts` enumerates
+    # every workflow in this directory and allows exactly two GitHub-hosted jobs
+    # (macos-26-intel for the darwin-x64 native binding, ubuntu-latest for npm
+    # trusted publishing). Default setup escaped that check only because it was
+    # not a file here; an advanced setup is subject to it.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
+    permissions:
+      # Uploading the SARIF results is the whole point of the job.
+      security-events: write
+      # Lets the action read workflow run metadata when analyzing `actions`.
+      actions: read
+      contents: read
+    strategy:
+      # One language must not cancel the others: a partial upload still leaves
+      # the ruleset unsatisfied, and the failure is easier to read per language.
+      fail-fast: false
+      matrix:
+        # Mirrors the languages default setup had configured. `javascript` and
+        # `typescript` are aliases that CodeQL resolves to `javascript-typescript`,
+        # so listing that one covers both without analyzing the tree twice.
+        language: [actions, javascript-typescript, rust]
+    steps:
+      # Sticky disks are Blacksmith-Linux-only, and this job is Linux-only.
+      - uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1.1
+        with:
+          # No `lfs: true` and no `fetch-depth: 0`: CodeQL analyzes the working
+          # tree at one commit, so LFS fixtures and full history are cost with
+          # no analytical benefit.
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@18420e3271f74589575af831a523c833acda327f # codeql-bundle-v2.26.2
+        with:
+          languages: ${{ matrix.language }}
+          # `none` means CodeQL extracts without invoking a build. Every language
+          # here supports it, which keeps the job off the Rust toolchain and off
+          # `npm ci` entirely.
+          build-mode: none
+          # Default setup used the `default` query suite rather than
+          # `security-extended`; the ruleset thresholds were tuned against it.
+          queries: ""
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@18420e3271f74589575af831a523c833acda327f # codeql-bundle-v2.26.2
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

CodeQL was on GitHub's **default setup**, which analyzes only pushes to the default branch and pull requests *targeting* it. That trigger set is not configurable. Ruleset `9310196` carries a `code_scanning` rule requiring CodeQL results, so a **stacked PR** — one based on another feature branch — arrives with no results and sits at `BLOCKED` with every other check green.

[#2235](https://github.com/bastani-inc/atomic/pull/2235) hit exactly this. Retargeting it to `main` did not clear it, because the head SHA had already been seen without an analysis. Only a fresh push produced one, so it needed a rebase to merge.

## Changes

- Added `.github/workflows/codeql.yml`. The `pull_request:` trigger carries **no branch filter** — matching `test.yml` — so every PR is analyzed regardless of base and a stacked PR satisfies the rule on its first push.
- Disabled default setup. The two cannot coexist: an advanced run rejects its SARIF while default setup owns the configuration, so the switch is flipped as this lands rather than as a follow-up.

## Notes

**Why Blacksmith and not `ubuntu-latest`.** `test/ci/ci-workflow-contracts.test.ts:543` enumerates every workflow in `.github/workflows` and allows exactly two GitHub-hosted jobs — `macos-26-intel` for the darwin-x64 native binding, and `ubuntu-latest` because npm trusted publishing rejects self-hosted runners. Default setup escaped that check only by not being a file in that directory; an advanced setup is subject to it. The job runs on `blacksmith-4vcpu-ubuntu-2404`, and `npm run test:ci-contracts` passes 41/41 with it.

**Configuration parity with what default setup had:**

| Setting | Default setup | This workflow |
|---|---|---|
| Languages | `actions`, `javascript`, `javascript-typescript`, `rust`, `typescript` | `actions`, `javascript-typescript`, `rust` |
| Query suite | `default` | `default` |
| Schedule | weekly | weekly (`31 4 * * 1`) |

`javascript` and `typescript` are aliases CodeQL resolves to `javascript-typescript`, so one matrix entry covers both without analyzing the tree twice. `build-mode: none` keeps the job off the Rust toolchain and off `npm ci` entirely.

**Out of scope.** The separate *Code Quality* run (`Analyze (python)`, and a second `Analyze (javascript-typescript)`) is a distinct GitHub-managed feature, not code scanning, and is untouched by this change.

**Rollback.** Re-enabling default setup is one API call; the prior configuration is recorded in the commit message and the table above.

## Testing

- `npm run test:ci-contracts` — 41/41 pass, including the runner enumeration that gates this file
- `npm run check` — pass
- The `Analyze (...)` checks on this PR are produced by the new workflow itself, so a green run here is the migration verifying itself.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788718219&installation_model_id=10562&pr_number=2236&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2236&signature=3f6405ab93be5e10707d89072230e237c37b5b654801d55fbe8fc9c96ac55906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change replaces default CodeQL setup with an advanced workflow that analyzes pushes to `main`, all pull requests including stacked pull requests, and weekly scheduled scans. It runs separate Actions, JavaScript/TypeScript, and Rust analyses with scoped permissions.

One P2 maintainability issue remains: the action-pinning contract checks a fixed list of existing workflow files and does not include the new CodeQL workflow. A later change could replace one of these SHA-pinned actions with a floating tag without the contract suite detecting it.

## T-Rex validation blocked
The completed validation did not provide the required uploaded artifact references for the action-pinning coverage result. The missing item is the Greptile artifact-upload reference, so no execution proof is emitted.

<h3>Confidence Score: 4/5</h3>

Merge is safe with respect to the workflow’s current action references, but the repository contract should be extended before relying on it to protect this new workflow.

There is one independent P2, non-security finding. Under the scoring table, a nonempty set containing only P2 findings receives a score of 4.

**Files Needing Attention:** test/ci/ci-workflow-contracts.test.ts needs to enumerate the CodeQL workflow in its third-party action pinning assertion, or derive that assertion from the workflow directory.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the general-contract-validation-proof and confirmed that the action-pinning coverage validation completed but could not publish a verification record due to the missing artifact-upload reference.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/codeql.yml:58-68
**CodeQL pins lack contract coverage**

The new workflow's action references are excluded from the repository's fixed-list action-pinning contract test, so a future floating-tag update here would pass the CI contract suite and weaken supply-chain protection.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: convert CodeQL to advanced setup so ..."](https://github.com/bastani-inc/atomic/commit/4dace3becc12bdafb6fbb3a0a2268323dc459de7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51258456)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->