### PR TITLE
perf(test): stop transforming the workflows graph in every test file

### DIFF
--- a/packages/workflows/src/shared/workflow-artifact-env.ts
+++ b/packages/workflows/src/shared/workflow-artifact-env.ts
@@ -1,0 +1,21 @@
+/**
+ * Leaf module: durable workflow-artifact constants with no imports.
+ *
+ * These values are plain data, but their previous home — `workflow-artifacts.ts`
+ * — sits atop roughly fifty modules including `@bastani/atomic` itself. Any
+ * consumer that wanted only a constant paid to transform that whole graph.
+ *
+ * `test/setup-workflow-durability.ts` is such a consumer, and vitest runs it
+ * once per test file, so every unit file transformed ten thousand lines to read
+ * one string. Keeping these constants importable without dependencies is what
+ * lets that setup stay cheap; `workflow-artifacts.ts` re-exports them, so this
+ * split is invisible to every existing caller.
+ *
+ * Keep this module dependency-free.
+ */
+
+/** Maximum age of durable workflow run artifacts before the next workflow write prunes them. */
+export const WORKFLOW_ARTIFACT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Overrides the durable workflow-artifact root, mirroring the agent-directory override convention. */
+export const ENV_WORKFLOW_ARTIFACT_DIR = "ATOMIC_WORKFLOW_ARTIFACT_DIR";

--- a/packages/workflows/src/shared/workflow-artifacts.ts
+++ b/packages/workflows/src/shared/workflow-artifacts.ts
@@ -6,14 +6,11 @@ import { getAgentDir, getEnvValue } from "@bastani/atomic";
 import type { DurableWorkflowBackend } from "../durable/backend.js";
 import { getDurableBackend } from "../durable/factory.js";
 import { type WorkflowRunResumeCandidate, workflowRunHasPausedState } from "../durable/resume-eligibility.js";
+import { ENV_WORKFLOW_ARTIFACT_DIR, WORKFLOW_ARTIFACT_RETENTION_MS } from "./workflow-artifact-env.js";
 import { store } from "./store.js";
 import type { RunSnapshot } from "./store-types.js";
 
-/** Maximum age of durable workflow run artifacts before the next workflow write prunes them. */
-export const WORKFLOW_ARTIFACT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
-
-/** Overrides the durable workflow-artifact root, mirroring the agent-directory override convention. */
-export const ENV_WORKFLOW_ARTIFACT_DIR = "ATOMIC_WORKFLOW_ARTIFACT_DIR";
+export { ENV_WORKFLOW_ARTIFACT_DIR, WORKFLOW_ARTIFACT_RETENTION_MS };
 
 export type WorkflowArtifactRunState = "protected" | "terminal" | "orphan";
 export type WorkflowArtifactRunStateResolver = (runId: string) => WorkflowArtifactRunState | undefined;

--- a/packages/workflows/src/shared/workflow-artifacts.ts
+++ b/packages/workflows/src/shared/workflow-artifacts.ts
@@ -6,9 +6,9 @@ import { getAgentDir, getEnvValue } from "@bastani/atomic";
 import type { DurableWorkflowBackend } from "../durable/backend.js";
 import { getDurableBackend } from "../durable/factory.js";
 import { type WorkflowRunResumeCandidate, workflowRunHasPausedState } from "../durable/resume-eligibility.js";
-import { ENV_WORKFLOW_ARTIFACT_DIR, WORKFLOW_ARTIFACT_RETENTION_MS } from "./workflow-artifact-env.js";
 import { store } from "./store.js";
 import type { RunSnapshot } from "./store-types.js";
+import { ENV_WORKFLOW_ARTIFACT_DIR, WORKFLOW_ARTIFACT_RETENTION_MS } from "./workflow-artifact-env.js";
 
 export { ENV_WORKFLOW_ARTIFACT_DIR, WORKFLOW_ARTIFACT_RETENTION_MS };
 

--- a/test/setup-workflow-durability.ts
+++ b/test/setup-workflow-durability.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeEach } from "vitest";
 import { createInMemoryTestBackend, setDurableBackend } from "../packages/workflows/src/durable/factory.js";
-import { ENV_WORKFLOW_ARTIFACT_DIR } from "../packages/workflows/src/shared/workflow-artifacts.js";
+import { ENV_WORKFLOW_ARTIFACT_DIR } from "../packages/workflows/src/shared/workflow-artifact-env.js";
 
 /**
  * Durable workflow artifacts (stage transcripts, ledgers, run notes) default to

--- a/test/unit/test-setup-import-graph.test.ts
+++ b/test/unit/test-setup-import-graph.test.ts
@@ -1,0 +1,99 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, normalize } from "node:path";
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { repositoryRoot } from "../../vitest.base.js";
+
+/**
+ * vitest runs `setupFiles` once per test file, each with a fresh module
+ * registry. Every relative import reachable from the setup file is therefore
+ * transformed and instantiated ~600 times per unit run, whether or not the test
+ * under it touches workflows.
+ *
+ * This guard exists because that cost is invisible at the call site: adding one
+ * `import { SOME_CONSTANT } from "…/workflow-artifacts.js"` to the setup file
+ * looks free and silently drags fifty modules — including `@bastani/atomic`
+ * itself — into every test process. Measured before that import was removed:
+ * a single trivial test file cost 28.37s, of which 27.79s was setup.
+ *
+ * The bound is deliberately close to the current graph rather than generous. It
+ * is a ratchet: if a change legitimately needs a larger graph, re-measure the
+ * per-file cost first and move the number with the evidence in the commit
+ * message. Do not raise it to make a red test green.
+ */
+const SETUP_FILE = "test/setup-workflow-durability.ts";
+
+/**
+ * Current reachable count is 39, dominated by `durable/factory.ts` pulling the
+ * DBOS backend. 45 leaves headroom for incidental churn inside that existing
+ * subsystem while still failing loudly if another hub module is imported.
+ */
+const MAX_REACHABLE_MODULES = 45;
+
+/** Relative specifiers in a TypeScript source, as written (`.js` per ESM convention). */
+function relativeImports(source: string): string[] {
+	return [...source.matchAll(/from\s+"(\.[^"]+)"/g)].map((match) => match[1] as string);
+}
+
+/** Every repository module transitively reachable from `entry` through relative imports. */
+function reachableModules(entry: string): Set<string> {
+	const seen = new Set<string>();
+	const pending = [entry];
+
+	while (pending.length > 0) {
+		const current = pending.pop();
+		if (current === undefined || seen.has(current)) continue;
+
+		const absolute = join(repositoryRoot, current);
+		if (!existsSync(absolute)) continue;
+
+		seen.add(current);
+		for (const specifier of relativeImports(readFileSync(absolute, "utf8"))) {
+			const resolved = normalize(join(dirname(current), specifier.replace(/\.js$/, ".ts")));
+			pending.push(resolved);
+		}
+	}
+
+	return seen;
+}
+
+test("the vitest setup file's import graph stays small", () => {
+	const reachable = reachableModules(SETUP_FILE);
+
+	assert.ok(
+		reachable.size <= MAX_REACHABLE_MODULES,
+		`${SETUP_FILE} reaches ${reachable.size} modules, above the ${MAX_REACHABLE_MODULES} ceiling. ` +
+			"Every one is transformed once per test file. Import a dependency-free leaf instead of a hub " +
+			`module, or re-measure and move the ceiling deliberately. Reachable:\n${[...reachable].sort().join("\n")}`,
+	);
+});
+
+test("the setup file does not import the workflow-artifacts hub", () => {
+	const source = readFileSync(join(repositoryRoot, SETUP_FILE), "utf8");
+
+	assert.ok(
+		!source.includes("shared/workflow-artifacts.js"),
+		`${SETUP_FILE} imports shared/workflow-artifacts.js, which reaches ~50 modules including ` +
+			"@bastani/atomic, to read a string constant. Import shared/workflow-artifact-env.js instead.",
+	);
+});
+
+test("the workflow-artifact-env leaf has no relative imports", () => {
+	const leaf = "packages/workflows/src/shared/workflow-artifact-env.ts";
+	const imports = relativeImports(readFileSync(join(repositoryRoot, leaf), "utf8"));
+
+	assert.deepEqual(
+		imports,
+		[],
+		`${leaf} must stay dependency-free: it exists so the vitest setup file can read constants ` +
+			`without transforming a module graph. Found: ${imports.join(", ")}`,
+	);
+});
+
+test("the leaf and the hub agree on the constants", async () => {
+	const leaf = await import("../../packages/workflows/src/shared/workflow-artifact-env.js");
+	const hub = await import("../../packages/workflows/src/shared/workflow-artifacts.js");
+
+	assert.equal(hub.ENV_WORKFLOW_ARTIFACT_DIR, leaf.ENV_WORKFLOW_ARTIFACT_DIR);
+	assert.equal(hub.WORKFLOW_ARTIFACT_RETENTION_MS, leaf.WORKFLOW_ARTIFACT_RETENTION_MS);
+});

--- a/test/unit/test-setup-import-graph.test.ts
+++ b/test/unit/test-setup-import-graph.test.ts
@@ -30,9 +30,31 @@ const SETUP_FILE = "test/setup-workflow-durability.ts";
  */
 const MAX_REACHABLE_MODULES = 45;
 
+/**
+ * Every static and dynamic import form that can pull a module into the graph.
+ *
+ * A guard that only recognizes `from "…"` can be walked straight past: a
+ * side-effect import or a dynamic `import()` is a real edge that costs the same
+ * transform, and matching one narrow source form would let an expensive module
+ * in without tripping the ceiling. Biome enforces double quotes repo-wide, but
+ * single quotes are matched too so the guard does not depend on lint ordering.
+ */
+const RELATIVE_SPECIFIER_PATTERNS: readonly RegExp[] = [
+	/\bfrom\s*["'](\.[^"']+)["']/g, // import … from "x" / export … from "x"
+	/^\s*import\s+["'](\.[^"']+)["']/gm, // side effect: import "x"
+	/\bimport\s*\(\s*["'](\.[^"']+)["']/g, // dynamic: import("x")
+];
+
 /** Relative specifiers in a TypeScript source, as written (`.js` per ESM convention). */
 function relativeImports(source: string): string[] {
-	return [...source.matchAll(/from\s+"(\.[^"]+)"/g)].map((match) => match[1] as string);
+	const found = new Set<string>();
+	for (const pattern of RELATIVE_SPECIFIER_PATTERNS) {
+		for (const match of source.matchAll(pattern)) {
+			const specifier = match[1];
+			if (specifier !== undefined) found.add(specifier);
+		}
+	}
+	return [...found];
 }
 
 /** Every repository module transitively reachable from `entry` through relative imports. */

--- a/test/unit/test-setup-import-graph.test.ts
+++ b/test/unit/test-setup-import-graph.test.ts
@@ -1,6 +1,6 @@
+import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, normalize } from "node:path";
-import assert from "node:assert/strict";
 import { test } from "vitest";
 import { repositoryRoot } from "../../vitest.base.js";
 


### PR DESCRIPTION
## Problem

`test/setup-workflow-durability.ts` imported `ENV_WORKFLOW_ARTIFACT_DIR` from `shared/workflow-artifacts.ts`. That constant is a string, but its module sits atop ~50 modules and 10,408 lines — including `@bastani/atomic` itself.

vitest runs `setupFiles` **once per test file** with a fresh module registry, so all 622 unit files transformed that graph to read one string. 333 of them (54%) genuinely import workflows; the other 289 paid for nothing.

## Change

Move the two plain constants into a dependency-free leaf, `shared/workflow-artifact-env.ts`, and re-export them from `workflow-artifacts.ts` so every existing caller is unaffected.

## Measurements

Targeted single-file run — the loop an agent or developer actually iterates on:

| | Duration | setup | transform |
| --- | --- | --- | --- |
| before | **28.37s** | 27.79s | 24.42s |
| after | **2.88s** | 1.86s | 1.96s |

Full unit suite:

| | Duration | setup | import |
| --- | --- | --- | --- |
| before | 507.23s | 4239.62s | 325.70s |
| after | 406.25s | 238.80s | 2988.20s |

**Caveat on the full-suite numbers:** both were taken while a second heavy workflow ran concurrently, so absolute values are inflated and the `tests` phase moved 803s → 999s, which this change cannot affect. Treat the 20% wall-clock delta as indicative, not precise. The targeted-run 10x was measured twice on a quiet machine and is the solid number.

Note the cost **relocates rather than disappears**: aggregate setup drops 94%, but `import` rises by 2662s, paid only by the files that genuinely pull in workflows. That is the intended shape.

## Guard

Four assertions in `test/unit/test-setup-import-graph.test.ts`:

- the reachable graph stays at or below 45 modules (currently 39, dominated by `durable/factory.ts` pulling the DBOS backend)
- the setup file does not import the artifacts hub
- the leaf stays dependency-free
- leaf and hub agree on both constants, so the re-export cannot drift

Verified the guard fails when the regression is reintroduced: `reaches 52 modules, above the 45 ceiling`, plus the specific remedy. A ceiling that cannot fail is not a ceiling.

The bound is a ratchet, not a budget — raising it requires re-measuring the per-file cost and saying so in the commit message.

## Verification

`npm run check`, `test:unit` (623 files, 5950 passed), `test:integration`, `test:ci-contracts`, `test:scripts` all green. Behaviour-neutral: identical pass/skip counts before and after.

## Changelog

No entry: per `AGENTS.md`, test-infrastructure changes are infrastructure-level and do not change shipped package behaviour.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788758674&installation_model_id=10562&pr_number=2244&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2244&signature=3e5543eb7ac34ca4e961cd444529741a3c2542b18cbcaaad4d4a6d6849b04cf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Workflow durability setup now reads artifact environment constants from a dependency-free module, avoiding unnecessary workflow dependencies during unit-test initialization. The focused import-graph tests passed, confirming the setup graph limit, direct leaf import, dependency-free leaf, and matching hub exports.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

No accepted blocking findings remain after exercising the focused setup import graph and export behavior.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Focused Vitest run disproved a repository-wide prohibition on direct node:fs imports, showing 208 tests that use node:fs and completing without failures, with the import at test/unit/test-setup-import-graph.test.ts:2 used to inspect repository files synchronously.
- The parser edge rules were expanded to recognize seven import forms (static double, static single, re-export single, side-effect double and single, and dynamic double and single), and the focused test passed all four assertions.
- PR behavior was validated by confirming that ENV\_WORKFLOW\_ARTIFACT\_DIR is imported from the new leaf, that the constants are defined and re-exported as expected, and that the related focused test suite covering graph-size, hub-prohibition, leaf-isolation, and leaf/hub-value-equivalence passed.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(perf): recognize every import form ..."](https://github.com/bastani-inc/atomic/commit/a387da69a6c3b247323b332d5f650a46a1724190) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51397570)</sub>

<!-- /greptile_comment -->