### PR TITLE
fix/2791 theme watcher flake

### DIFF
--- a/packages/coding-agent/test/suite/regressions/2791-fswatch-error-crash.test.ts
+++ b/packages/coding-agent/test/suite/regressions/2791-fswatch-error-crash.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { bunExecutable } from "../../../../../test/helpers/runtime.ts";
 
 /**
  * Regression test for https://github.com/earendil-works/pi-mono/issues/2791
@@ -102,7 +103,7 @@ process.exit(0);
 		let exitCode: number;
 		let signal: NodeJS.Signals | null = null;
 		try {
-			_stdout = execFileSync("bun", ["-e", script], {
+			_stdout = execFileSync(bunExecutable(), ["-e", script], {
 				timeout: WATCHER_CHILD_TIMEOUT_MS,
 				encoding: "utf-8",
 				env: { ...process.env, ATOMIC_CODING_AGENT_DIR: agentDir },
@@ -110,7 +111,21 @@ process.exit(0);
 			});
 			exitCode = 0;
 		} catch (err: unknown) {
-			const e = err as { status: number | null; stdout?: string; stderr?: string; signal?: NodeJS.Signals | null };
+			// `code` distinguishes a starved child from a crashed one. Without it a
+			// timeout surfaces as `status: null` -> exit 1 -> "Child crashed", which
+			// is the exact failure this test exists to detect, so a loaded machine
+			// reads as the #2791 regression returning.
+			const e = err as {
+				status: number | null;
+				code?: string;
+				stdout?: string;
+				stderr?: string;
+				signal?: NodeJS.Signals | null;
+			};
+			expect(
+				e.code,
+				`Theme watcher child timed out after ${WATCHER_CHILD_TIMEOUT_MS} ms; it never reached the watcher assertion. This is starvation, not the #2791 crash.`,
+			).not.toBe("ETIMEDOUT");
 			_stdout = e.stdout ?? "";
 			stderr = e.stderr ?? "";
 			signal = e.signal ?? null;


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788823867&installation_model_id=10562&pr_number=2253&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2253&signature=ee2b34ae7a169a6383cc2383801fafd56a3ad97b09d8e41fc1f48b5d31b56453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change improves the filesystem-watcher regression test by resolving the configured Bun executable and making timeout failures easier to distinguish from the behavior under test.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

No accepted P0 or P1 findings remain.

<sub>Reviews (2): Last reviewed commit: ["test(regressions): distinguish a starved..."](https://github.com/bastani-inc/atomic/commit/6192b3aec2486e8260f16953258f2ca6ccd15a8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52094785)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->