### PR TITLE
feat(coding-agent): port pi 0.84 tool and credential contracts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,11 @@
 - Added `atomic auth check` to verify a provider or model's effective authentication before a session starts. It reports `ready`, `not_ready`, or `invalid`, supports JSON output and a no-refresh read-only mode, and does not emit credential material unless `--credentials` explicitly requests it.
 
 - Added the explicit `--credentials` opt-in to `atomic auth check` for scripts that need the resolved credential. Checks remain status-only unless that flag is present.
+- Added immutable system-prompt contribution constants for Atomic's builtin coding tools, with alignment coverage that keeps each factory's prompt metadata in sync without duplicating prompt assembly.
+
+- Added `CredentialSynchronizationError` for credential mutations that commit successfully but fail to update local model state. Credential-save failures remain distinct from post-commit synchronization failures, and interactive auth surfaces report the distinction.
+
+- Added `terminate` to blocked extension `tool_call` results. A terminating blocked call suppresses the follow-up model request only when every finalized call in its batch also terminates.
 
 - Added the configurable and package-exported `createCodingAgentHarness()` factory, with Atomic's hashline coding tools, live prompt metadata, Atomic and `PI_*` bash session variables, injectable pi-agent-core execution environments for read (including directory trees), bash, edit, write, and find, and runtime rejection of environments that omit `renameFile()`. URL reads now use the session id for cache scope, avoid unsupported session-manager access, and do not persist host-local artifacts in factory contexts. The default `search` tool remains local until its filesystem and matching pipeline gains a complete remote operations seam; read and edit retain local path-variant probes and notebook projection, read also retains local archive, SQLite, and internal-resource selectors, write retains local generated-file, shebang, conflict, and resource helpers, and bash validates its cwd locally and uses Atomic's local temp storage for overflow output.
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -810,7 +810,8 @@ Behavior guarantees:
 - Mutations to `event.input` affect the actual tool execution
 - Later `tool_call` handlers see mutations made by earlier handlers
 - No re-validation is performed after your mutation
-- Return values from `tool_call` only control blocking via `{ block: true, reason?: string }`
+- Return values from `tool_call` control blocking via `{ block: true, reason?: string, terminate?: boolean }`
+- `terminate` only applies to a blocked call; the agent stops early only when every finalized result in the batch is terminating
 
 ```typescript
 import { isToolCallEventType } from "@bastani/atomic";
@@ -826,7 +827,7 @@ pi.on("tool_call", async (event, ctx) => {
     event.input.command = `source ~/.profile\n${event.input.command}`;
 
     if (event.input.command.includes("rm -rf")) {
-      return { block: true, reason: "Dangerous command" };
+      return { block: true, reason: "Dangerous command", terminate: true };
     }
   }
 

--- a/packages/coding-agent/src/core/agent-session-runtime-auth.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime-auth.ts
@@ -1,5 +1,6 @@
 import { ModelsError } from "@earendil-works/pi-ai";
 import type { AgentSession } from "./agent-session.ts";
+import { CredentialSynchronizationError } from "./model-runtime.ts";
 import {
 	type AtomicOAuthLoginCallbacks,
 	createAuthInteraction,
@@ -19,6 +20,7 @@ export async function loginRuntimeOAuthProvider(
 	try {
 		await runtime.login(provider, "oauth", createAuthInteraction(callbacks));
 	} catch (error) {
+		if (error instanceof CredentialSynchronizationError) throw error;
 		if (
 			error instanceof ModelsError &&
 			error.code === "auth" &&

--- a/packages/coding-agent/src/core/agent-session-tool-hooks.ts
+++ b/packages/coding-agent/src/core/agent-session-tool-hooks.ts
@@ -14,12 +14,18 @@ export function _installAgentToolHooks(this: AgentSession): void {
 		await this._agentEventQueue;
 
 		try {
-			return await runner.emitToolCall({
+			const result = await runner.emitToolCall({
 				type: "tool_call",
 				toolName: toolCall.name,
 				toolCallId: toolCall.id,
 				input: args as Record<string, unknown>,
 			});
+			if (result?.block && result.terminate === true) {
+				this._terminatingToolCallIds.add(toolCall.id);
+			} else {
+				this._terminatingToolCallIds.delete(toolCall.id);
+			}
+			return result;
 		} catch (err) {
 			if (err instanceof Error) {
 				throw err;

--- a/packages/coding-agent/src/core/extensions/event-results.ts
+++ b/packages/coding-agent/src/core/extensions/event-results.ts
@@ -14,6 +14,11 @@ export interface ToolCallEventResult {
 	/** Block tool execution. To modify arguments, mutate `event.input` in place instead. */
 	block?: boolean;
 	reason?: string;
+	/**
+	 * Hint that the agent should stop after the current tool batch when this call is blocked.
+	 * Early termination only happens when every finalized tool result in the batch sets this to true.
+	 */
+	terminate?: boolean;
 }
 
 /** Result from user_bash event handler */

--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -88,8 +88,18 @@ export class CredentialSynchronizationError extends Error {
 		this.name = "CredentialSynchronizationError";
 		this.providerId = providerId;
 		this.operation = operation;
-		this.credential = credential;
-		Object.defineProperty(this, "credential", { enumerable: false });
+		// One call rather than assign-then-redefine: the two-step form is
+		// equivalent (defineProperty with only `enumerable` preserves the existing
+		// value) but reads as a redundant write and trips static analysis. The
+		// non-enumerable descriptor is the load-bearing part — it keeps the
+		// credential out of JSON.stringify, console.log, and structured error
+		// reporting.
+		Object.defineProperty(this, "credential", {
+			value: credential,
+			enumerable: false,
+			writable: true,
+			configurable: true,
+		});
 	}
 }
 

--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -65,8 +65,46 @@ import { canRestoreUnknownModel as canRestoreUnknownModelProvider } from "./mode
 import { ModelRuntimeStreaming } from "./model-runtime-streaming.ts";
 import type { CreateModelRuntimeOptions, ModelRuntimeAuthOverrides } from "./model-runtime-types.ts";
 
+export type CredentialSynchronizationOperation =
+	| "login"
+	| "logout"
+	| "saveCredential"
+	| "setRuntimeApiKey"
+	| "removeRuntimeApiKey";
+
+/** Credentials changed successfully, but local model state could not be synchronized. */
+export class CredentialSynchronizationError extends Error {
+	readonly providerId: string;
+	readonly operation: CredentialSynchronizationOperation;
+	readonly credential: Credential | undefined;
+
+	constructor(
+		providerId: string,
+		operation: CredentialSynchronizationOperation,
+		credential: Credential | undefined,
+		options: ErrorOptions,
+	) {
+		super(`Credential ${operation} committed for ${providerId}, but local synchronization failed`, options);
+		this.name = "CredentialSynchronizationError";
+		this.providerId = providerId;
+		this.operation = operation;
+		this.credential = credential;
+		Object.defineProperty(this, "credential", { enumerable: false });
+	}
+}
+
 function operationSignal(signal: AbortSignal | undefined): AbortSignal {
 	return signal ?? new AbortController().signal;
+}
+
+function raceWithAbortSignal<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+	if (signal.aborted)
+		return Promise.reject(signal.reason ?? new DOMException("The operation was aborted", "AbortError"));
+	return new Promise<T>((resolve, reject) => {
+		const onAbort = () => reject(signal.reason ?? new DOMException("The operation was aborted", "AbortError"));
+		signal.addEventListener("abort", onAbort, { once: true });
+		promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", onAbort));
+	});
 }
 
 /** Configured pi-ai Models collection used by coding-agent and SDK consumers. */
@@ -88,6 +126,7 @@ export class ModelRuntime implements Models {
 	private availabilityRefreshSeq = 0;
 	private availabilityErrorSeq = 0;
 	private readonly providerAvailabilitySeq = new Map<string, number>();
+	private readonly credentialOperations = new Map<string, Promise<unknown>>();
 	private availabilityError: string | undefined;
 	private constructor(
 		credentials: RuntimeCredentials,
@@ -397,9 +436,82 @@ export class ModelRuntime implements Models {
 		await this.queueAvailabilityRefresh();
 	}
 
+	private assertCredentialRefreshSucceeded(
+		providerId: string,
+		result: ModelsRefreshResult,
+		signal?: AbortSignal,
+	): void {
+		if (result.aborted) {
+			signal?.throwIfAborted();
+			throw new Error(`Model refresh aborted for ${providerId}`);
+		}
+		const refreshError = result.errors.get(providerId);
+		if (refreshError) throw refreshError;
+		const compositionError = this.compositionErrors.get(providerId);
+		if (compositionError) throw new Error(compositionError);
+	}
+
+	private enqueueCredentialOperation<T>(providerId: string, signal: AbortSignal, task: () => Promise<T>): Promise<T> {
+		const previous = this.credentialOperations.get(providerId) ?? Promise.resolve();
+		let markStarted: (() => void) | undefined;
+		const started = new Promise<void>((resolve) => {
+			markStarted = resolve;
+		});
+		const operation = (async () => {
+			await previous.catch(() => {});
+			signal.throwIfAborted();
+			markStarted?.();
+			return task();
+		})();
+		const tail = operation.catch(() => {});
+		this.credentialOperations.set(providerId, tail);
+		void tail.then(() => {
+			if (this.credentialOperations.get(providerId) === tail) this.credentialOperations.delete(providerId);
+		});
+		return raceWithAbortSignal(started, signal).then(() => operation);
+	}
+	private async synchronizeCredentialState(
+		providerId: string,
+		operation: CredentialSynchronizationOperation,
+		credential: Credential | undefined,
+		synchronize: () => void | Promise<void>,
+	): Promise<void> {
+		try {
+			await synchronize();
+		} catch (cause) {
+			if (cause instanceof CredentialSynchronizationError) throw cause;
+			throw new CredentialSynchronizationError(providerId, operation, credential, { cause });
+		}
+	}
+	private async refreshRemainingAuthAfterLogout(providerId: string, logoutGeneration: number): Promise<void> {
+		// Environment/runtime auth can remain after stored auth is removed. The
+		// probe is normally synchronous, but its deadline is authoritative because
+		// extension checks are third-party code and need not honor cancellation.
+		let timeout: number | undefined;
+		try {
+			const remainingAuth = await Promise.race([
+				this.checkAuth(providerId).catch(() => undefined),
+				new Promise<undefined>((resolve) => {
+					timeout = setTimeout(resolve, POST_LOGOUT_AUTH_CHECK_TIMEOUT_MS);
+				}),
+			]);
+			if (logoutGeneration === this.snapshotGeneration && !this.snapshot.storedProviders.has(providerId)) {
+				this.snapshot = removeStoredCredentialProvider(this.snapshot, providerId, remainingAuth);
+			}
+		} finally {
+			if (timeout) clearTimeout(timeout);
+		}
+	}
+
 	async saveCredential(providerId: string, credential: Credential): Promise<void> {
-		await this.credentials.modify(providerId, async () => credential);
-		await this.refresh();
+		const signal = operationSignal(undefined);
+		await this.enqueueCredentialOperation(providerId, signal, async () => {
+			await this.credentials.modify(providerId, async () => credential);
+			await this.synchronizeCredentialState(providerId, "saveCredential", credential, async () => {
+				const result = await this.refresh({ providers: [providerId] });
+				this.assertCredentialRefreshSucceeded(providerId, result);
+			});
+		});
 	}
 	/**
 	 * Apply a process-scoped API key override. This publishes the provider against
@@ -408,14 +520,24 @@ export class ModelRuntime implements Models {
 	 * separately.
 	 */
 	async setRuntimeApiKey(providerId: string, apiKey: string, options: AuthOperationOptions): Promise<void> {
-		options.signal?.throwIfAborted();
-		this.credentials.setRuntimeApiKey(providerId, apiKey);
-		this.snapshot = addRuntimeApiKeyProvider(this.snapshot, providerId);
+		const signal = operationSignal(options.signal);
+		await this.enqueueCredentialOperation(providerId, signal, async () => {
+			this.credentials.setRuntimeApiKey(providerId, apiKey);
+			await this.synchronizeCredentialState(providerId, "setRuntimeApiKey", { type: "api_key", key: apiKey }, () => {
+				this.snapshot = addRuntimeApiKeyProvider(this.snapshot, providerId);
+			});
+		});
 	}
 
-	async removeRuntimeApiKey(providerId: string): Promise<void> {
-		this.credentials.removeRuntimeApiKey(providerId);
-		await this.refresh({ allowNetwork: this.modelNetworkEnabled });
+	async removeRuntimeApiKey(providerId: string, options: AuthOperationOptions = {}): Promise<void> {
+		const signal = operationSignal(options.signal);
+		await this.enqueueCredentialOperation(providerId, signal, async () => {
+			this.credentials.removeRuntimeApiKey(providerId);
+			await this.synchronizeCredentialState(providerId, "removeRuntimeApiKey", undefined, async () => {
+				const result = await this.refresh({ allowNetwork: this.modelNetworkEnabled, signal });
+				this.assertCredentialRefreshSucceeded(providerId, result, signal);
+			});
+		});
 	}
 
 	listCredentials(): Promise<readonly CredentialInfo[]> {
@@ -485,44 +607,39 @@ export class ModelRuntime implements Models {
 	}
 
 	async login(providerId: string, type: AuthType, interaction: AuthInteraction): Promise<Credential> {
-		const credential = await this.models.login(providerId, type, interaction);
-		// Credential acquisition and persistence are the login transaction. Publish
-		// the provider against the current snapshot immediately; catalog restoration,
-		// ambient availability checks, and networking belong to /model's bounded
-		// background refresh and must never keep a successful login dialog open.
-		this.updateModelSnapshot();
-		this.externalProviderAuthStatuses.delete(providerId);
-		this.snapshot = addStoredCredentialProvider(this.snapshot, providerId, credential.type);
-		return credential;
+		const signal = operationSignal(interaction.signal);
+		return this.enqueueCredentialOperation(providerId, signal, async () => {
+			const credential = await this.models.login(providerId, type, { ...interaction, signal });
+			await this.synchronizeCredentialState(providerId, "login", credential, () => {
+				// Credential acquisition and persistence are the login transaction. Publish
+				// the provider against the current snapshot immediately; catalog restoration,
+				// ambient availability checks, and networking belong to /model's bounded
+				// background refresh and must never keep a successful login dialog open.
+				this.updateModelSnapshot();
+				this.externalProviderAuthStatuses.delete(providerId);
+				this.snapshot = addStoredCredentialProvider(this.snapshot, providerId, credential.type);
+			});
+			return credential;
+		});
 	}
 
-	async logout(providerId: string): Promise<void> {
-		await this.models.logout(providerId);
-		// Reset credential-dependent compatibility projections, then publish the
-		// persisted deletion without waiting for model stores or remote catalogs.
-		this.recomposeProvider(providerId);
-		this.updateModelSnapshot();
-		this.externalProviderAuthStatuses.delete(providerId);
-		this.snapshot = removeStoredCredentialProvider(this.snapshot, providerId);
-		const logoutGeneration = this.snapshotGeneration;
-
-		// Environment/runtime auth can remain after stored auth is removed. The
-		// probe is normally synchronous, but its deadline is authoritative because
-		// extension checks are third-party code and need not honor cancellation.
-		let timeout: number | undefined;
-		try {
-			const remainingAuth = await Promise.race([
-				this.checkAuth(providerId).catch(() => undefined),
-				new Promise<undefined>((resolve) => {
-					timeout = setTimeout(resolve, POST_LOGOUT_AUTH_CHECK_TIMEOUT_MS);
-				}),
-			]);
-			if (logoutGeneration === this.snapshotGeneration && !this.snapshot.storedProviders.has(providerId)) {
-				this.snapshot = removeStoredCredentialProvider(this.snapshot, providerId, remainingAuth);
-			}
-		} finally {
-			if (timeout) clearTimeout(timeout);
-		}
+	async logout(providerId: string, options: AuthOperationOptions = {}): Promise<void> {
+		const signal = operationSignal(options.signal);
+		const logoutGeneration = await this.enqueueCredentialOperation(providerId, signal, async () => {
+			await this.models.logout(providerId, { signal });
+			let generation = 0;
+			await this.synchronizeCredentialState(providerId, "logout", undefined, () => {
+				// Reset credential-dependent compatibility projections, then publish the
+				// persisted deletion without waiting for model stores or remote catalogs.
+				this.recomposeProvider(providerId);
+				this.updateModelSnapshot();
+				this.externalProviderAuthStatuses.delete(providerId);
+				this.snapshot = removeStoredCredentialProvider(this.snapshot, providerId);
+				generation = this.snapshotGeneration;
+			});
+			return generation;
+		});
+		await this.refreshRemainingAuthAfterLogout(providerId, logoutGeneration);
 	}
 
 	async refresh(options: ModelsRefreshOptions = {}): Promise<ModelsRefreshResult> {

--- a/packages/coding-agent/src/core/oauth-login.ts
+++ b/packages/coding-agent/src/core/oauth-login.ts
@@ -1,4 +1,5 @@
 import type { AuthInfoLink, AuthInteraction, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
+import { CredentialSynchronizationError } from "./model-runtime.ts";
 
 export interface AtomicOAuthLoginCallbacks extends OAuthLoginCallbacks {
 	onManualCodeCancel?(): void;
@@ -26,7 +27,7 @@ export function isOAuthLoginCancelled(
 	signal?: AbortSignal,
 	options: { includeActiveSignal?: boolean } = {},
 ): boolean {
-	if (error instanceof OAuthLoginTransactionError) return false;
+	if (error instanceof OAuthLoginTransactionError || error instanceof CredentialSynchronizationError) return false;
 	if (options.includeActiveSignal !== false && signal?.aborted) return true;
 	const reason = signal?.reason;
 	const seen = new Set<object>();

--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -58,6 +58,12 @@ const bashSchema = Type.Object(
 	{ ...bashBaseSchema.properties, async: Type.Optional(Type.Boolean({ description: "Run as a background job." })) },
 	{ additionalProperties: false },
 );
+export const bashToolSystemPromptContribution = Object.freeze({
+	snippet: "Execute a shell command.",
+	guidelines: Object.freeze([
+		"You can inspect ATOMIC_* or PI_* environment variables for current model and session details.",
+	] as const),
+} as const);
 export type BashToolInput = Static<typeof bashSchema>;
 export interface BashToolDetails {
 	truncation?: TruncationResult;
@@ -375,10 +381,8 @@ export function createBashToolDefinition(
 		name: "bash",
 		label: "bash",
 		description: "Execute a shell command in the session workspace, with optional PTY or background-job handling.",
-		promptSnippet: "Execute a shell command.",
-		promptGuidelines: exposeSessionEnvironment
-			? ["You can inspect ATOMIC_* or PI_* environment variables for current model and session details."]
-			: undefined,
+		promptSnippet: bashToolSystemPromptContribution.snippet,
+		promptGuidelines: exposeSessionEnvironment ? [...bashToolSystemPromptContribution.guidelines] : undefined,
 		parameters: asyncEnabled ? bashSchema : (bashBaseSchema as typeof bashSchema),
 		maxResultSizeChars: Infinity,
 		async execute(_toolCallId, bashCommand: BashToolInput, signal?: AbortSignal, onUpdate?, _ctx?) {
@@ -687,10 +691,5 @@ export function createBashToolDefinition(
 	};
 }
 export function createBashTool(cwd: string, options?: BashToolOptions): AgentTool<typeof bashSchema> {
-	const definition = createBashToolDefinition(cwd, options),
-		tool = wrapToolDefinition(definition);
-	return Object.assign(tool, {
-		promptSnippet: definition.promptSnippet,
-		promptGuidelines: definition.promptGuidelines,
-	});
+	return wrapToolDefinition(createBashToolDefinition(cwd, options));
 }

--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -38,6 +38,16 @@ const editSchema = Type.Object(
 	},
 	{ additionalProperties: false },
 );
+export const editToolSystemPromptContribution = Object.freeze({
+	snippet: "Apply source edits with hashline patch input",
+	guidelines: Object.freeze([
+		"hashline edit format: a header ending in ':' is followed by '+'TEXT body rows; 'delete' has no body. Every section starts with [PATH#TAG]; TAG is REQUIRED (the 4-hex snapshot tag from your latest read/search) — there is no hashless form. Use the write tool to create new files.",
+		"Ops: 'replace N..M:' replaces original lines N..M (INCLUSIVE — line M is consumed); 'replace block N:' replaces the whole syntactic block that BEGINS on line N (Atomic resolves the closing line with a brace/indent heuristic; point N at the opener); 'delete N..M' / 'delete block N' delete (no body); 'insert before N:' / 'insert after N:' insert relative to a line; 'insert after block N:' inserts after the END of the block beginning on N; 'insert head:' / 'insert tail:' insert at file start/end. Single line: 'replace N..N:' / 'delete N'. The range is the ORIGINAL lines you touch; body length is irrelevant.",
+		"Body rows appear only under a ':' header. Every row is '+TEXT' (adds a literal line, leading whitespace kept; '+' alone adds a blank line). There is NO other body row kind — never write '-old' or a bare/context line. To keep a line, leave it out of every range. For a literal line starting with '-' or '+', prefix it: '+-x', '++x'.",
+		"Numbers refer to the ORIGINAL file and do not shift as hunks apply; they die with the call — every applied edit mints a fresh #TAG and renumbers, so anchor the next edit on the edit response or a fresh read. Ranges are TIGHT: cover ONLY lines whose content changes; a stale wide range shreds everything it spans. Pure additions use 'insert', never a widened 'replace'. Whole construct → 'replace block N'; lines inside it → 'replace N..M'.",
+		"On a stale-tag rejection or any surprising result: STOP and re-read before further edits. Never start or end a range mid-expression/mid-block, and never span a hunk across an elided ('…') region — read it first. Never use edit to reformat/restyle code; run the project formatter instead.",
+	] as const),
+} as const);
 
 export type EditToolInput = Static<typeof editSchema>;
 
@@ -208,14 +218,8 @@ export function createEditToolDefinition(
 		label: "edit",
 		description:
 			"Edit existing files with the hashline patch language: each section starts with [PATH#TAG] (TAG is the 4-hex snapshot tag from your latest read/search), then hunk headers (replace N..M:, replace block N:, delete N..M, delete block N, insert before|after N:, insert after block N:, insert head:, insert tail:) followed by +TEXT body rows. Numbers refer to the original file. Use the write tool to create new files.",
-		promptSnippet: "Apply source edits with hashline patch input",
-		promptGuidelines: [
-			"hashline edit format: a header ending in ':' is followed by '+'TEXT body rows; 'delete' has no body. Every section starts with [PATH#TAG]; TAG is REQUIRED (the 4-hex snapshot tag from your latest read/search) — there is no hashless form. Use the write tool to create new files.",
-			"Ops: 'replace N..M:' replaces original lines N..M (INCLUSIVE — line M is consumed); 'replace block N:' replaces the whole syntactic block that BEGINS on line N (Atomic resolves the closing line with a brace/indent heuristic; point N at the opener); 'delete N..M' / 'delete block N' delete (no body); 'insert before N:' / 'insert after N:' insert relative to a line; 'insert after block N:' inserts after the END of the block beginning on N; 'insert head:' / 'insert tail:' insert at file start/end. Single line: 'replace N..N:' / 'delete N'. The range is the ORIGINAL lines you touch; body length is irrelevant.",
-			"Body rows appear only under a ':' header. Every row is '+TEXT' (adds a literal line, leading whitespace kept; '+' alone adds a blank line). There is NO other body row kind — never write '-old' or a bare/context line. To keep a line, leave it out of every range. For a literal line starting with '-' or '+', prefix it: '+-x', '++x'.",
-			"Numbers refer to the ORIGINAL file and do not shift as hunks apply; they die with the call — every applied edit mints a fresh #TAG and renumbers, so anchor the next edit on the edit response or a fresh read. Ranges are TIGHT: cover ONLY lines whose content changes; a stale wide range shreds everything it spans. Pure additions use 'insert', never a widened 'replace'. Whole construct → 'replace block N'; lines inside it → 'replace N..M'.",
-			"On a stale-tag rejection or any surprising result: STOP and re-read before further edits. Never start or end a range mid-expression/mid-block, and never span a hunk across an elided ('…') region — read it first. Never use edit to reformat/restyle code; run the project formatter instead.",
-		],
+		promptSnippet: editToolSystemPromptContribution.snippet,
+		promptGuidelines: [...editToolSystemPromptContribution.guidelines],
 		parameters: editSchema,
 		async execute(_toolCallId, input: EditToolInput, signal?: AbortSignal) {
 			if (typeof input.input !== "string" || input.input.trim() === "")

--- a/packages/coding-agent/src/core/tools/find.ts
+++ b/packages/coding-agent/src/core/tools/find.ts
@@ -35,6 +35,10 @@ const findSchema = Type.Object(
 	},
 	{ additionalProperties: false },
 );
+export const findToolSystemPromptContribution = Object.freeze({
+	snippet: "Find filesystem paths by glob.",
+	guidelines: Object.freeze([] as const),
+} as const);
 export type FindToolInput = Static<typeof findSchema>;
 const DEFAULT_LIMIT = 200;
 const MAX_LIMIT = 200;
@@ -381,7 +385,7 @@ export function createFindToolDefinition(
 		name: "find",
 		label: "find",
 		description: "Find filesystem paths by glob; use search when you need content matches instead of path matches.",
-		promptSnippet: "Find filesystem paths by glob.",
+		promptSnippet: findToolSystemPromptContribution.snippet,
 		parameters: findSchema,
 		async execute(_toolCallId, params: FindToolInput, signal?: AbortSignal, _onUpdate?, _ctx?) {
 			return new Promise((resolve, reject) => {

--- a/packages/coding-agent/src/core/tools/index.ts
+++ b/packages/coding-agent/src/core/tools/index.ts
@@ -6,6 +6,7 @@ export {
 	type BashToolDetails,
 	type BashToolInput,
 	type BashToolOptions,
+	bashToolSystemPromptContribution,
 	createBashTool,
 	createBashToolDefinition,
 	createLocalBashOperations,
@@ -17,6 +18,7 @@ export {
 	type EditToolDetails,
 	type EditToolInput,
 	type EditToolOptions,
+	editToolSystemPromptContribution,
 } from "./edit.ts";
 export { withFileMutationQueue } from "./file-mutation-queue.ts";
 export {
@@ -26,6 +28,7 @@ export {
 	type FindToolDetails,
 	type FindToolInput,
 	type FindToolOptions,
+	findToolSystemPromptContribution,
 } from "./find.ts";
 export {
 	createLsTool,
@@ -34,6 +37,7 @@ export {
 	type LsToolDetails,
 	type LsToolInput,
 	type LsToolOptions,
+	lsToolSystemPromptContribution,
 } from "./ls.ts";
 export {
 	createReadTool,
@@ -42,6 +46,7 @@ export {
 	type ReadToolDetails,
 	type ReadToolInput,
 	type ReadToolOptions,
+	readToolSystemPromptContribution,
 } from "./read.ts";
 export {
 	createSearchTool,
@@ -49,6 +54,7 @@ export {
 	type SearchToolDetails,
 	type SearchToolInput,
 	type SearchToolOptions,
+	searchToolSystemPromptContribution,
 } from "./search.ts";
 export {
 	createStructuredOutputCapture,
@@ -78,6 +84,7 @@ export {
 	type WriteOperations,
 	type WriteToolInput,
 	type WriteToolOptions,
+	writeToolSystemPromptContribution,
 } from "./write.ts";
 
 import type { AgentTool } from "@earendil-works/pi-agent-core";

--- a/packages/coding-agent/src/core/tools/ls.ts
+++ b/packages/coding-agent/src/core/tools/ls.ts
@@ -14,6 +14,10 @@ const lsSchema = Type.Object({
 	path: Type.Optional(Type.String({ description: "Directory to list (default: current directory)" })),
 	limit: Type.Optional(Type.Number({ description: "Maximum number of entries to return (default: 500)" })),
 });
+export const lsToolSystemPromptContribution = Object.freeze({
+	snippet: "List directory contents",
+	guidelines: Object.freeze([] as const),
+} as const);
 
 export type LsToolInput = Static<typeof lsSchema>;
 
@@ -106,7 +110,7 @@ export function createLsToolDefinition(
 		name: "ls",
 		label: "ls",
 		description: `List directory contents. Returns entries sorted alphabetically, with '/' suffix for directories. Includes dotfiles. Output is truncated to ${DEFAULT_LIMIT} entries or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first).`,
-		promptSnippet: "List directory contents",
+		promptSnippet: lsToolSystemPromptContribution.snippet,
 		parameters: lsSchema,
 		async execute(
 			_toolCallId,

--- a/packages/coding-agent/src/core/tools/read.ts
+++ b/packages/coding-agent/src/core/tools/read.ts
@@ -61,6 +61,12 @@ const readSchema = Type.Object(
 	},
 	{ additionalProperties: false },
 );
+export const readToolSystemPromptContribution = Object.freeze({
+	snippet: "Read a path selector.",
+	guidelines: Object.freeze([
+		"Use read to inspect file and resource contents; use path selectors for line ranges, raw output, and conflict views.",
+	] as const),
+} as const);
 export type ReadToolInput = Static<typeof readSchema>;
 const READ_TOOL_MAX_RESULT_CHARS = 50_000;
 export interface OversizedReadDetails {
@@ -308,10 +314,8 @@ export function createReadToolDefinition(
 		label: "read",
 		description:
 			"Read files, directories, archives, SQLite databases, internal resources, images, documents, and URLs through one path string.",
-		promptSnippet: "Read a path selector.",
-		promptGuidelines: [
-			"Use read to inspect file and resource contents; use path selectors for line ranges, raw output, and conflict views.",
-		],
+		promptSnippet: readToolSystemPromptContribution.snippet,
+		promptGuidelines: [...readToolSystemPromptContribution.guidelines],
 		parameters: readSchema,
 		maxResultSizeChars: Infinity,
 		async execute(_toolCallId, { path }: ReadToolInput, signal?: AbortSignal, _onUpdate?, ctx?) {

--- a/packages/coding-agent/src/core/tools/search.ts
+++ b/packages/coding-agent/src/core/tools/search.ts
@@ -65,6 +65,10 @@ const searchSchema = Type.Object(
 	},
 	{ additionalProperties: false },
 );
+export const searchToolSystemPromptContribution = Object.freeze({
+	snippet: "Search file contents with regex patterns.",
+	guidelines: Object.freeze([] as const),
+} as const);
 export type SearchToolInput = Static<typeof searchSchema>;
 export type SearchToolOptions = GrepToolOptions & {
 	hashlineStore?: HashlineSnapshotStore;
@@ -501,7 +505,7 @@ export function createSearchToolDefinition(
 		name: "search",
 		label: "search",
 		description: "Search file contents with a regex across files, directories, globs, and internal URLs.",
-		promptSnippet: "Search file contents with regex patterns.",
+		promptSnippet: searchToolSystemPromptContribution.snippet,
 		parameters: searchSchema,
 		async execute(toolCallId, params, signal, onUpdate, ctx) {
 			const resourceCtx = ctx as InternalResourceContext | undefined;

--- a/packages/coding-agent/src/core/tools/tool-definition-wrapper.ts
+++ b/packages/coding-agent/src/core/tools/tool-definition-wrapper.ts
@@ -36,6 +36,8 @@ export function wrapToolDefinition<TParams extends TSchema, TDetails = unknown>(
 		...(Object.hasOwn(definition, "constrainedSampling")
 			? { constrainedSampling: definition.constrainedSampling }
 			: {}),
+		promptSnippet: definition.promptSnippet,
+		promptGuidelines: definition.promptGuidelines ? [...definition.promptGuidelines] : undefined,
 		maxResultSizeChars: definition.maxResultSizeChars,
 		prepareArguments: definition.prepareArguments
 			? (args) =>

--- a/packages/coding-agent/src/core/tools/write.ts
+++ b/packages/coding-agent/src/core/tools/write.ts
@@ -53,6 +53,12 @@ const writeSchema = Type.Object(
 	{ additionalProperties: false },
 );
 
+export const writeToolSystemPromptContribution = Object.freeze({
+	snippet: "Create or overwrite a writable path selector.",
+	guidelines: Object.freeze([
+		"Use write when replacing the full content of a target; use edit for source edits anchored to existing hashline snapshots.",
+	] as const),
+} as const);
 export type WriteToolInput = Static<typeof writeSchema>;
 export interface WriteToolDetails {
 	resolvedPath?: string;
@@ -315,10 +321,8 @@ export function createWriteToolDefinition(
 		label: "write",
 		description:
 			"Create or overwrite a file, writable internal resource, archive entry, SQLite row, or merge-conflict resolution.",
-		promptSnippet: "Create or overwrite a writable path selector.",
-		promptGuidelines: [
-			"Use write when replacing the full content of a target; use edit for source edits anchored to existing hashline snapshots.",
-		],
+		promptSnippet: writeToolSystemPromptContribution.snippet,
+		promptGuidelines: [...writeToolSystemPromptContribution.guidelines],
 		parameters: writeSchema,
 		async execute(
 			_toolCallId,

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -138,7 +138,13 @@ export {
 	normalizeModelFailureSignal,
 } from "./core/model-fallback-failures.ts";
 export { ModelRegistry } from "./core/model-registry.ts";
-export { type CreateModelRuntimeOptions, ModelRuntime, type ModelRuntimeAuthOverrides } from "./core/model-runtime.ts";
+export {
+	type CreateModelRuntimeOptions,
+	CredentialSynchronizationError,
+	type CredentialSynchronizationOperation,
+	ModelRuntime,
+	type ModelRuntimeAuthOverrides,
+} from "./core/model-runtime.ts";
 export type {
 	PackageManager,
 	PathMetadata,
@@ -261,6 +267,7 @@ export {
 	type BashToolDetails,
 	type BashToolInput,
 	type BashToolOptions,
+	bashToolSystemPromptContribution,
 	createAskUserQuestionToolDefinition,
 	createBashToolDefinition,
 	createEditToolDefinition,
@@ -276,22 +283,27 @@ export {
 	type EditToolDetails,
 	type EditToolInput,
 	type EditToolOptions,
+	editToolSystemPromptContribution,
 	type FindOperations,
 	type FindToolDetails,
 	type FindToolInput,
 	type FindToolOptions,
+	findToolSystemPromptContribution,
 	formatSize,
 	type LsOperations,
 	type LsToolDetails,
 	type LsToolInput,
 	type LsToolOptions,
+	lsToolSystemPromptContribution,
 	type ReadOperations,
 	type ReadToolDetails,
 	type ReadToolInput,
 	type ReadToolOptions,
+	readToolSystemPromptContribution,
 	type SearchToolDetails,
 	type SearchToolInput,
 	type SearchToolOptions,
+	searchToolSystemPromptContribution,
 	type ToolsOptions,
 	type TruncationOptions,
 	type TruncationResult,
@@ -302,6 +314,7 @@ export {
 	type WriteToolInput,
 	type WriteToolOptions,
 	withFileMutationQueue,
+	writeToolSystemPromptContribution,
 } from "./core/tools/index.ts";
 export {
 	hasProjectTrustInputs,

--- a/packages/coding-agent/src/modes/interactive/interactive-auth-login.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-auth-login.ts
@@ -1,3 +1,4 @@
+import { CredentialSynchronizationError } from "../../core/model-runtime.ts";
 import { isOAuthLoginCancelled } from "../../core/oauth-login.ts";
 import { InteractiveModeBase } from "./interactive-mode-base.ts";
 import {
@@ -151,7 +152,11 @@ InteractiveModeBase.prototype.showApiKeyLoginDialog = async function (
 	} catch (error: unknown) {
 		restoreEditor();
 		const errorMsg = error instanceof Error ? error.message : String(error);
-		if (!isOAuthLoginCancelled(error)) {
+		if (error instanceof CredentialSynchronizationError) {
+			this.showError(
+				`Saved API key for ${providerName}, but local model state could not be synchronized: ${errorMsg}`,
+			);
+		} else if (!isOAuthLoginCancelled(error)) {
 			this.showError(`Failed to save API key for ${providerName}: ${errorMsg}`);
 		}
 	}
@@ -296,7 +301,9 @@ InteractiveModeBase.prototype.showLoginDialog = async function (
 	} catch (error: unknown) {
 		restoreEditor();
 		const errorMsg = error instanceof Error ? error.message : String(error);
-		if (loginSucceeded || !isOAuthLoginCancelled(error)) {
+		if (error instanceof CredentialSynchronizationError) {
+			this.showError(`Logged in to ${providerName}, but local model state could not be synchronized: ${errorMsg}`);
+		} else if (loginSucceeded || !isOAuthLoginCancelled(error)) {
 			this.showError(`Failed to login to ${providerName}: ${errorMsg}`);
 		}
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-auth-routing.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-auth-routing.ts
@@ -1,4 +1,5 @@
 import { builtinProviders } from "@earendil-works/pi-ai/providers/all";
+import { CredentialSynchronizationError } from "../../core/model-runtime.ts";
 import type { AuthStatus } from "../../core/provider-composer.ts";
 import { InteractiveModeBase } from "./interactive-mode-base.ts";
 import {
@@ -192,7 +193,12 @@ InteractiveModeBase.prototype.showOAuthSelector = async function (
 					this.setupAutocompleteProvider();
 					this.showStatus(formatLogoutStatus(providerOption.name, providerOption.authType, result.authStatus));
 				} catch (error: unknown) {
-					this.showError(`Logout failed: ${error instanceof Error ? error.message : String(error)}`);
+					const message = error instanceof Error ? error.message : String(error);
+					this.showError(
+						error instanceof CredentialSynchronizationError
+							? `Credentials removed for ${providerOption.name}, but local model state could not be synchronized: ${message}`
+							: `Logout failed: ${message}`,
+					);
 				}
 			},
 			() => {

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -1,6 +1,7 @@
 import type { ChildProcess } from "node:child_process";
 import type { ImageContent } from "@earendil-works/pi-ai/compat";
 import type { BashResult } from "../../core/bash-executor.ts";
+import { CredentialSynchronizationError } from "../../core/model-runtime.ts";
 import type { BashOutputChannel } from "../../core/tools/bash.ts";
 import { sleep } from "../../utils/sleep.ts";
 import type { ActivityWatchdogDiagnostic } from "../interactive-engine/activity-watchdog.ts";
@@ -525,7 +526,16 @@ export class RpcClient extends RpcClientApi {
 		return response;
 	}
 	private assertSuccess(response: RpcResponse): void {
-		if (!response.success) throw new Error(response.error);
+		if (response.success) return;
+		if (response.errorCode === "credential_synchronization" && response.errorDetails) {
+			throw new CredentialSynchronizationError(
+				response.errorDetails.providerId,
+				response.errorDetails.operation,
+				undefined,
+				{ cause: new Error(response.error) },
+			);
+		}
+		throw new Error(response.error);
 	}
 	protected data<T>(response: RpcResponse): T {
 		this.assertSuccess(response);

--- a/packages/coding-agent/src/modes/rpc/rpc-command-handler.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-command-handler.ts
@@ -73,7 +73,7 @@ export function createRpcCommandHandler({
 					})
 					.catch((promptError: unknown) => {
 						if (!preflightSucceeded) {
-							output(createRpcErrorResponse(id, "prompt", formatRpcErrorMessage(promptError)));
+							output(createRpcErrorResponse(id, "prompt", formatRpcErrorMessage(promptError), promptError));
 						}
 					});
 				return undefined;

--- a/packages/coding-agent/src/modes/rpc/rpc-input.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-input.ts
@@ -83,7 +83,7 @@ export function createRpcInputLineHandler({
 			await checkShutdownRequested();
 		} catch (commandError: unknown) {
 			const failed = getCommandIdentity(command);
-			output(createRpcErrorResponse(failed.id, failed.type, formatRpcErrorMessage(commandError)));
+			output(createRpcErrorResponse(failed.id, failed.type, formatRpcErrorMessage(commandError), commandError));
 			await waitForRawStdoutBackpressure();
 		}
 	};

--- a/packages/coding-agent/src/modes/rpc/rpc-provider-auth.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-provider-auth.ts
@@ -1,6 +1,7 @@
 import type { Credential } from "@earendil-works/pi-ai";
 import type { AgentSession } from "../../core/agent-session.ts";
 import type { HostInputFormRequest } from "../../core/extensions/ui-types.ts";
+import { CredentialSynchronizationError } from "../../core/model-runtime.ts";
 import { createAuthInteraction, isOAuthLoginCancelled } from "../../core/oauth-login.ts";
 import { createRpcOAuthCallbacks, type OAuthInteractionTransport } from "./rpc-oauth-interaction.ts";
 import type { RpcLoginProviderResult, RpcModelCatalog, RpcOAuthLoginProviderResult } from "./rpc-types.ts";
@@ -60,6 +61,7 @@ export class RpcProviderAuth {
 			// and never sent back down the stdout pipe.
 			return { provider, cancelled: false, type: "api_key", ...this.catalog(session) };
 		} catch (error) {
+			if (error instanceof CredentialSynchronizationError) throw error;
 			if (controller.signal.aborted || (error instanceof Error && error.message === "Login cancelled"))
 				return { provider, cancelled: true };
 			throw error;

--- a/packages/coding-agent/src/modes/rpc/rpc-responses.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-responses.ts
@@ -1,3 +1,4 @@
+import { CredentialSynchronizationError } from "../../core/model-runtime.ts";
 import type { RpcCommand, RpcExtensionUIRequest, RpcResponse } from "./rpc-types.ts";
 
 export type RpcOutputRecord = RpcResponse | RpcExtensionUIRequest | object;
@@ -14,7 +15,23 @@ export function createRpcSuccessResponse<T extends RpcCommand["type"]>(
 	return { id, type: "response", command, success: true, data } as RpcResponse;
 }
 
-export function createRpcErrorResponse(id: string | undefined, command: string, message: string): RpcResponse {
+export function createRpcErrorResponse(
+	id: string | undefined,
+	command: string,
+	message: string,
+	cause?: unknown,
+): RpcResponse {
+	if (cause instanceof CredentialSynchronizationError) {
+		return {
+			id,
+			type: "response",
+			command,
+			success: false,
+			error: message,
+			errorCode: "credential_synchronization",
+			errorDetails: { providerId: cause.providerId, operation: cause.operation },
+		};
+	}
 	return { id, type: "response", command, success: false, error: message };
 }
 

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -20,6 +20,7 @@ import type { BashResult } from "../../core/bash-executor.ts";
 import type { VerbatimCompactionResult } from "../../core/compaction/index.ts";
 import type { ResourceOverlap } from "../../core/diagnostics.ts";
 import type { ModelFallbackReason } from "../../core/model-resolver-types.ts";
+import type { CredentialSynchronizationOperation } from "../../core/model-runtime.ts";
 import type { OAuthProviderMetadata } from "../../core/oauth-login.ts";
 import type { AuthStatus } from "../../core/provider-composer.ts";
 import type { SessionEntry, SessionTreeNode } from "../../core/session-manager.ts";
@@ -378,7 +379,18 @@ export type RpcResponse =
 	  }
 
 	// Error response (any command can fail)
-	| { id?: string; type: "response"; command: string; success: false; error: string };
+	| {
+			id?: string;
+			type: "response";
+			command: string;
+			success: false;
+			error: string;
+			errorCode?: "credential_synchronization";
+			errorDetails?: {
+				providerId: string;
+				operation: CredentialSynchronizationOperation;
+			};
+	  };
 
 // ============================================================================
 // RPC Events (stdout)

--- a/packages/coding-agent/test/model-runtime-credential-sync.test.ts
+++ b/packages/coding-agent/test/model-runtime-credential-sync.test.ts
@@ -44,4 +44,19 @@ describe("ModelRuntime credential synchronization", () => {
 		expect(refresh).not.toHaveBeenCalled();
 		expect(await credentials.read("anthropic")).toBeUndefined();
 	});
+
+	test("does not leak the credential through enumeration or serialization", () => {
+		// The non-enumerable descriptor on `credential` is the only thing keeping a
+		// live secret out of JSON.stringify, console.log, and any structured error
+		// reporter that walks own enumerable properties. Nothing else pinned it, so
+		// a refactor of the constructor could silently make errors credential-bearing.
+		const secret = { type: "api_key", key: "sk-do-not-log-me" } as const;
+		const error = new CredentialSynchronizationError("anthropic", "saveCredential", secret, {});
+
+		expect(error.credential).toBe(secret);
+		expect(Object.propertyIsEnumerable.call(error, "credential")).toBe(false);
+		expect(Object.keys(error)).not.toContain("credential");
+		expect(JSON.stringify(error)).not.toContain("sk-do-not-log-me");
+		expect(JSON.stringify({ error })).not.toContain("sk-do-not-log-me");
+	});
 });

--- a/packages/coding-agent/test/model-runtime-credential-sync.test.ts
+++ b/packages/coding-agent/test/model-runtime-credential-sync.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AuthStorage } from "../src/core/auth-storage.ts";
+import { CredentialSynchronizationError, ModelRuntime } from "../src/core/model-runtime.ts";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllEnvs();
+});
+
+describe("ModelRuntime credential synchronization", () => {
+	it("reports a committed credential when local synchronization fails", async () => {
+		const credentials = AuthStorage.inMemory();
+		const runtime = await ModelRuntime.create({ credentials, modelsPath: null, allowModelNetwork: false });
+		const credential = { type: "api_key" as const, key: "persisted-key" };
+		const internals = runtime as unknown as {
+			models: { getAvailable(providerId?: string, options?: object): Promise<readonly never[]> };
+		};
+		vi.spyOn(internals.models, "getAvailable").mockRejectedValue(new Error("availability sync failed"));
+		const outcome = runtime.saveCredential("anthropic", credential);
+		await expect(outcome).rejects.toMatchObject({
+			name: "CredentialSynchronizationError",
+			providerId: "anthropic",
+			operation: "saveCredential",
+			credential,
+			cause: { message: "availability sync failed" },
+		});
+		await expect(outcome).rejects.toBeInstanceOf(CredentialSynchronizationError);
+		expect(await credentials.read("anthropic")).toEqual(credential);
+	});
+
+	it("keeps a credential save failure distinct from synchronization failure", async () => {
+		const credentials = AuthStorage.inMemory();
+		const runtime = await ModelRuntime.create({ credentials, modelsPath: null, allowModelNetwork: false });
+		const saveFailure = new Error("credential write failed");
+		vi.spyOn(credentials, "modify").mockRejectedValue(saveFailure);
+		const refresh = vi.spyOn(runtime, "refresh");
+
+		await expect(runtime.saveCredential("anthropic", { type: "api_key", key: "not-written" })).rejects.toBe(
+			saveFailure,
+		);
+		await expect(
+			runtime.saveCredential("anthropic", { type: "api_key", key: "not-written" }),
+		).rejects.not.toBeInstanceOf(CredentialSynchronizationError);
+		expect(refresh).not.toHaveBeenCalled();
+		expect(await credentials.read("anthropic")).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/post-tool-compaction-preflight.test.ts
+++ b/packages/coding-agent/test/post-tool-compaction-preflight.test.ts
@@ -432,6 +432,34 @@ describe("post-tool compaction preflight", () => {
 		expect(harness.sessionManager.getEntries().some((entry) => entry.type === "compaction")).toBe(false);
 	});
 
+	it("does not compact an all-blocked terminating batch", async () => {
+		const blockTerminatingTool: ExtensionFactory = (pi) => {
+			pi.on("tool_call", () => ({ block: true, reason: "blocked", terminate: true }));
+		};
+		const harness = await createHarnessWithExtensions({
+			contextWindow: 1_000,
+			settings: {
+				compaction: { enabled: true, reserveTokens: 200, compression_ratio: 0.5, preserve_recent: 2 },
+			},
+			responses: [
+				{
+					toolCalls: [{ id: "call-blocked-terminate", name: "large_result", args: {} }],
+					usage: { input: 700, output: 20, totalTokens: 720 },
+				},
+			],
+			baseToolsOverride: { large_result: largeResultTool },
+			extensionFactories: [compactOffline, blockTerminatingTool],
+		});
+		harnesses.push(harness);
+		await wireHarness(harness);
+
+		await harness.session.prompt(longPrompt);
+
+		expect(harness.faux.callCount).toBe(1);
+		expect(harness.eventsOfType("compaction_start")).toHaveLength(0);
+		expect(harness.sessionManager.getEntries().some((entry) => entry.type === "compaction")).toBe(false);
+	});
+
 	it("applies the hard-limit gate after context extensions transform the compacted messages", async () => {
 		const expandingContext: ExtensionFactory = (pi) => {
 			let compacted = false;

--- a/packages/coding-agent/test/rpc-credential-error.test.ts
+++ b/packages/coding-agent/test/rpc-credential-error.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { CredentialSynchronizationError } from "../src/core/model-runtime.ts";
+import { RpcClient } from "../src/modes/rpc/rpc-client.ts";
+import { createRpcErrorResponse } from "../src/modes/rpc/rpc-responses.ts";
+import type { RpcResponse } from "../src/modes/rpc/rpc-types.ts";
+
+class ProbeRpcClient extends RpcClient {
+	decode(response: RpcResponse): void {
+		this.data(response);
+	}
+}
+
+describe("RPC credential synchronization errors", () => {
+	it("preserves the synchronization discriminator without credential material", () => {
+		const error = new CredentialSynchronizationError(
+			"anthropic",
+			"login",
+			{ type: "api_key", key: "secret" },
+			{ cause: new Error("availability failed") },
+		);
+		const response = createRpcErrorResponse("login", "login_provider", error.message, error);
+
+		expect(response).toMatchObject({
+			success: false,
+			errorCode: "credential_synchronization",
+			errorDetails: { providerId: "anthropic", operation: "login" },
+		});
+		expect(JSON.stringify(error)).not.toContain("secret");
+		expect(JSON.stringify(response)).not.toContain("secret");
+	});
+
+	it("rehydrates the typed error at the isolated-runtime host", () => {
+		const response = createRpcErrorResponse(
+			"logout",
+			"logout_provider",
+			"Credential logout committed for anthropic, but local synchronization failed",
+			new CredentialSynchronizationError("anthropic", "logout", undefined, { cause: new Error("stale") }),
+		);
+		const client = new ProbeRpcClient();
+
+		expect(() => client.decode(response)).toThrow(CredentialSynchronizationError);
+		try {
+			client.decode(response);
+		} catch (error) {
+			expect(error).toMatchObject({
+				providerId: "anthropic",
+				operation: "logout",
+				credential: undefined,
+				cause: { message: "Credential logout committed for anthropic, but local synchronization failed" },
+			});
+		}
+	});
+});

--- a/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
@@ -142,9 +142,12 @@ describe("AgentSession model and extension characterization", () => {
 			],
 		});
 		harnesses.push(harness);
+		let followUpCalls = 0;
+
 		harness.setResponses([
 			fauxAssistantMessage([fauxToolCall("echo", { text: "hello" })], { stopReason: "toolUse" }),
 			(context) => {
+				followUpCalls += 1;
 				const toolResult = context.messages.find((message) => message.role === "toolResult");
 				const errorText =
 					toolResult?.role === "toolResult"
@@ -160,6 +163,48 @@ describe("AgentSession model and extension characterization", () => {
 		await harness.session.prompt("hi");
 
 		expect(getAssistantTexts(harness)).toContain("Blocked by test");
+		expect(followUpCalls).toBe(1);
+		expect(harness.getPendingResponseCount()).toBe(0);
+		expect(
+			harness.session.messages.find((message) => message.role === "toolResult" && message.isError),
+		).toBeDefined();
+	});
+	it("allows a blocked tool_call handler to terminate the batch without a follow-up model call", async () => {
+		const echoTool: AgentTool = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo text back",
+			parameters: Type.Object({ text: Type.String() }),
+			execute: async () => {
+				throw new Error("tool should have been blocked");
+			},
+		};
+		const harness = await createHarness({
+			tools: [echoTool],
+			extensionFactories: [
+				(pi) => {
+					pi.on("tool_call", async () => ({
+						block: true,
+						reason: "Blocked by terminating test",
+						terminate: true,
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage([fauxToolCall("echo", { text: "hello" }), fauxToolCall("echo", { text: "world" })], {
+				stopReason: "toolUse",
+			}),
+			fauxAssistantMessage("should not run"),
+		]);
+
+		await harness.session.prompt("hi");
+
+		expect(harness.getPendingResponseCount()).toBe(1);
+		expect(getAssistantTexts(harness)).not.toContain("should not run");
+		expect(harness.eventsOfType("tool_execution_end")).toHaveLength(2);
+		expect(harness.eventsOfType("tool_execution_end").map((event) => event.result?.terminate)).toEqual([true, true]);
 		expect(
 			harness.session.messages.find((message) => message.role === "toolResult" && message.isError),
 		).toBeDefined();

--- a/packages/coding-agent/test/suite/regressions/5998-blocked-tool-terminate.test.ts
+++ b/packages/coding-agent/test/suite/regressions/5998-blocked-tool-terminate.test.ts
@@ -1,0 +1,56 @@
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, getAssistantTexts, type Harness } from "../harness.ts";
+
+describe("#5998 blocked tool termination", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("lets a blocked tool_call handler terminate the run without a follow-up model call", async () => {
+		const echoTool: AgentTool = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo text back",
+			parameters: Type.Object({ text: Type.String() }),
+			execute: async () => {
+				throw new Error("tool should have been blocked");
+			},
+		};
+		const harness = await createHarness({
+			tools: [echoTool],
+			extensionFactories: [
+				(pi) => {
+					pi.on("tool_call", async () => ({
+						block: true,
+						reason: "Blocked by terminating policy",
+						terminate: true,
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		let followUpCalls = 0;
+		harness.setResponses([
+			fauxAssistantMessage([fauxToolCall("echo", { text: "hello" })], { stopReason: "toolUse" }),
+			() => {
+				followUpCalls += 1;
+				return fauxAssistantMessage("should not run");
+			},
+		]);
+
+		await harness.session.prompt("hi");
+
+		expect(followUpCalls).toBe(0);
+		expect(harness.getPendingResponseCount()).toBe(1);
+		expect(getAssistantTexts(harness)).not.toContain("should not run");
+		expect(harness.eventsOfType("tool_execution_end")[0]?.result).toHaveProperty("terminate", true);
+		expect(
+			harness.session.messages.find((message) => message.role === "toolResult" && message.isError),
+		).toBeDefined();
+	});
+});

--- a/packages/coding-agent/test/tool-definition-wrapper.test.ts
+++ b/packages/coding-agent/test/tool-definition-wrapper.test.ts
@@ -43,6 +43,15 @@ describe("tool definition wrappers", () => {
 		expect(updates).toEqual([4]);
 	});
 
+	test("preserves prompt metadata while wrapping builtin definitions", () => {
+		const definition = createReadToolDefinition("/workspace");
+		const wrapped = wrapToolDefinition(definition);
+
+		expect(wrapped.promptSnippet).toBe(definition.promptSnippet);
+		expect(wrapped.promptGuidelines).toEqual(definition.promptGuidelines);
+		expect(wrapped.promptGuidelines).not.toBe(definition.promptGuidelines);
+	});
+
 	test("preserves constrained sampling by identity in both wrapper directions", () => {
 		const definition: ToolDefinition<typeof parameters, { value: number }> = {
 			name: "grammar",

--- a/packages/coding-agent/test/tool-system-prompt-contributions.test.ts
+++ b/packages/coding-agent/test/tool-system-prompt-contributions.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "vitest";
+import { buildSystemPrompt } from "../src/core/system-prompt.ts";
+import { bashToolSystemPromptContribution, createBashToolDefinition } from "../src/core/tools/bash.ts";
+import { createEditToolDefinition, editToolSystemPromptContribution } from "../src/core/tools/edit.ts";
+import { createFindToolDefinition, findToolSystemPromptContribution } from "../src/core/tools/find.ts";
+import { createLsToolDefinition, lsToolSystemPromptContribution } from "../src/core/tools/ls.ts";
+import { createReadToolDefinition, readToolSystemPromptContribution } from "../src/core/tools/read.ts";
+import { createSearchToolDefinition, searchToolSystemPromptContribution } from "../src/core/tools/search.ts";
+import { createWriteToolDefinition, writeToolSystemPromptContribution } from "../src/core/tools/write.ts";
+
+const cases = [
+	["read", readToolSystemPromptContribution, createReadToolDefinition],
+	["bash", bashToolSystemPromptContribution, createBashToolDefinition],
+	["edit", editToolSystemPromptContribution, createEditToolDefinition],
+	["write", writeToolSystemPromptContribution, createWriteToolDefinition],
+	["search", searchToolSystemPromptContribution, createSearchToolDefinition],
+	["find", findToolSystemPromptContribution, createFindToolDefinition],
+	["ls", lsToolSystemPromptContribution, createLsToolDefinition],
+] as const;
+
+describe("built-in tool system prompt contributions", () => {
+	test.each(cases)(
+		"keeps the %s tool definition aligned with its immutable contribution",
+		(_name, contribution, createDefinition) => {
+			const definition = createDefinition("/workspace");
+
+			expect(definition.promptSnippet).toBe(contribution.snippet);
+			expect(definition.promptGuidelines ?? []).toEqual(contribution.guidelines);
+			expect(Object.isFrozen(contribution)).toBe(true);
+			expect(Object.isFrozen(contribution.guidelines)).toBe(true);
+			if (contribution.guidelines.length > 0) {
+				expect(definition.promptGuidelines).not.toBe(contribution.guidelines);
+				definition.promptGuidelines?.push("definition-only guideline");
+				expect(contribution.guidelines).not.toContain("definition-only guideline");
+			}
+		},
+	);
+
+	test.each(cases)(
+		"adds the %s contribution exactly once to the system prompt",
+		(_name, contribution, createDefinition) => {
+			const definition = createDefinition("/workspace");
+			const prompt = buildSystemPrompt({
+				selectedTools: [definition.name],
+				toolSnippets: { [definition.name]: definition.promptSnippet! },
+				promptGuidelines: definition.promptGuidelines,
+				contextFiles: [],
+				skills: [],
+				cwd: "/workspace",
+			});
+
+			expect(prompt.split(contribution.snippet)).toHaveLength(2);
+			for (const guideline of contribution.guidelines) expect(prompt.split(guideline)).toHaveLength(2);
+		},
+	);
+
+	test("keeps bash session-environment guidance conditional", () => {
+		const definition = createBashToolDefinition("/workspace", { exposeSessionEnvironment: false });
+
+		expect(definition.promptGuidelines).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Port the verified upstream 1eb988cf blocked-tool termination and 9ab91fb9 prompt-contribution contracts, mapping Atomic's public search tool and preserving Atomic's non-blocking auth snapshots. Add CredentialSynchronizationError through ModelRuntime, interactive auth, and RPC without sending credential material over the wire.

Confirmed upstream paths, symbols, and event behavior with git show/grep against v0.84.0 and v0.84.1.

Assistant-model: GPT-5.6 Luna

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788962988&installation_model_id=10562&pr_number=2288&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2288&signature=c7cd60af0bd76b14b55a6a2790eded73af6ac430154f678f12c7502f35bca8b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds credential synchronization error propagation across local, interactive, and RPC authentication flows, while updating blocked-tool termination and built-in tool prompt contributions. One maintainability issue remains in the RPC error helper: its untyped error cause weakens the compiler-checked boundary for credential synchronization errors.

<h3>Confidence Score: 4/5</h3>

Merge is safe after addressing the remaining P2 type-safety requirement.

The final findings contain one non-security P2 issue and no P0 or P1 findings, which maps to a score of 4.

**Files Needing Attention:** packages/coding-agent/src/modes/rpc/rpc-responses.ts

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/src/modes/rpc/rpc-responses.ts:21-22
**Ambiguous RPC error typing**

The new `cause?: unknown` parameter and related `unknown` double cast obscure the accepted credential-error and runtime test seams, weakening compile-time checking as these contracts evolve. Use concrete error and test-interface types instead.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(model-runtime): define the credentia..."](https://github.com/bastani-inc/atomic/commit/26fd8ced2c0a6df1af12f6a4cb01e59541ac6601) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52094562)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->