### PR TITLE
feat/2223 graph overlay

### DIFF
--- a/packages/coding-agent/src/core/extensions/loader-virtual-modules.ts
+++ b/packages/coding-agent/src/core/extensions/loader-virtual-modules.ts
@@ -409,16 +409,17 @@ function getAliases(): Record<string, string> {
 		}
 		const packageRoot = findPackageRoot(packageName);
 		const entryRelativePath = workspaceRelativePath.split("/").slice(1).join("/");
-		return path.join(packageRoot, entryRelativePath);
+		const packagePath = path.join(packageRoot, entryRelativePath);
+		if (!fs.existsSync(packagePath)) {
+			throw new Error(`Cannot locate ${workspaceRelativePath} in package "${packageName}"`);
+		}
+		return packagePath;
 	};
 
 	const piCodingAgentEntry = packageIndex;
 	const piAgentCoreEntry = resolveWorkspaceOrImport("agent/dist/index.js", "@earendil-works/pi-agent-core");
 	const piTuiEntry = resolveWorkspaceOrImport("tui/dist/index.js", "@earendil-works/pi-tui");
-	const piTuiLayoutEntry = path.join(path.dirname(piTuiEntry), "layout.js");
-	// The workspace path mirrors pi-ai 0.80.x's built dist layout. If an
-	// upstream layout change moves these files, this join needs updating to
-	// match the package's real dist paths.
+	const piTuiLayoutEntry = resolveWorkspaceOrImport("tui/dist/layout.js", "@earendil-works/pi-tui");
 	const piAiEntry = resolveWorkspaceOrImport("ai/dist/compat.js", "@earendil-works/pi-ai");
 	const piAiOauthEntry = resolveWorkspaceOrImport("ai/dist/oauth.js", "@earendil-works/pi-ai");
 	const piAiProvidersEntry = resolveWorkspaceOrImport("ai/dist/providers/all.js", "@earendil-works/pi-ai");

--- a/packages/coding-agent/src/core/extensions/loader-virtual-modules.ts
+++ b/packages/coding-agent/src/core/extensions/loader-virtual-modules.ts
@@ -15,13 +15,14 @@ let _virtualModules: Record<string, object> | null = null;
 let _virtualModulesPromise: Promise<Record<string, object>> | null = null;
 
 async function loadVirtualModules(): Promise<Record<string, object>> {
-	const [typebox, typeboxCompile, typeboxValue, piAgentCore, piTui, piAi, piAiOauth, piCodingAgent] =
+	const [typebox, typeboxCompile, typeboxValue, piAgentCore, piTui, piTuiLayout, piAi, piAiOauth, piCodingAgent] =
 		await Promise.all([
 			import("typebox"),
 			import("typebox/compile"),
 			import("typebox/value"),
 			import("@earendil-works/pi-agent-core"),
 			import("@earendil-works/pi-tui"),
+			import("@earendil-works/pi-tui/dist/layout.js"),
 			// pi 0.80.2: the old global pi-ai API moved off the root entrypoint onto
 			// `/compat` (a strict superset). Extensions still `import ... from
 			// "@earendil-works/pi-ai"`, so we load the compat module here and key it
@@ -42,12 +43,14 @@ async function loadVirtualModules(): Promise<Record<string, object>> {
 		"@sinclair/typebox/value": typeboxValue,
 		"@earendil-works/pi-agent-core": piAgentCore,
 		"@earendil-works/pi-tui": piTui,
+		"@earendil-works/pi-tui/dist/layout.js": piTuiLayout,
 		"@earendil-works/pi-ai": piAi,
 		"@earendil-works/pi-ai/compat": piAi,
 		"@earendil-works/pi-ai/oauth": piAiOauth,
 		"@bastani/atomic": piCodingAgent,
 		"@mariozechner/pi-agent-core": piAgentCore,
 		"@mariozechner/pi-tui": piTui,
+		"@mariozechner/pi-tui/dist/layout.js": piTuiLayout,
 		"@mariozechner/pi-ai": piAi,
 		"@mariozechner/pi-ai/compat": piAi,
 		"@mariozechner/pi-ai/oauth": piAiOauth,
@@ -412,6 +415,7 @@ function getAliases(): Record<string, string> {
 	const piCodingAgentEntry = packageIndex;
 	const piAgentCoreEntry = resolveWorkspaceOrImport("agent/dist/index.js", "@earendil-works/pi-agent-core");
 	const piTuiEntry = resolveWorkspaceOrImport("tui/dist/index.js", "@earendil-works/pi-tui");
+	const piTuiLayoutEntry = path.join(path.dirname(piTuiEntry), "layout.js");
 	// The workspace path mirrors pi-ai 0.80.x's built dist layout. If an
 	// upstream layout change moves these files, this join needs updating to
 	// match the package's real dist paths.
@@ -423,12 +427,14 @@ function getAliases(): Record<string, string> {
 		"@bastani/atomic": piCodingAgentEntry,
 		"@earendil-works/pi-coding-agent": piCodingAgentEntry,
 		"@earendil-works/pi-agent-core": piAgentCoreEntry,
+		"@earendil-works/pi-tui/dist/layout.js": piTuiLayoutEntry,
 		"@earendil-works/pi-tui": piTuiEntry,
 		"@earendil-works/pi-ai/oauth": piAiOauthEntry,
 		"@earendil-works/pi-ai/providers/all": piAiProvidersEntry,
 		"@earendil-works/pi-ai/compat": piAiEntry,
 		"@earendil-works/pi-ai": piAiEntry,
 		"@mariozechner/pi-agent-core": piAgentCoreEntry,
+		"@mariozechner/pi-tui/dist/layout.js": piTuiLayoutEntry,
 		"@mariozechner/pi-tui": piTuiEntry,
 		"@mariozechner/pi-ai/oauth": piAiOauthEntry,
 		"@mariozechner/pi-ai/providers/all": piAiProvidersEntry,

--- a/packages/coding-agent/src/core/extensions/loader-virtual-modules.ts
+++ b/packages/coding-agent/src/core/extensions/loader-virtual-modules.ts
@@ -409,17 +409,16 @@ function getAliases(): Record<string, string> {
 		}
 		const packageRoot = findPackageRoot(packageName);
 		const entryRelativePath = workspaceRelativePath.split("/").slice(1).join("/");
-		const packagePath = path.join(packageRoot, entryRelativePath);
-		if (!fs.existsSync(packagePath)) {
-			throw new Error(`Cannot locate ${workspaceRelativePath} in package "${packageName}"`);
-		}
-		return packagePath;
+		return path.join(packageRoot, entryRelativePath);
 	};
 
 	const piCodingAgentEntry = packageIndex;
 	const piAgentCoreEntry = resolveWorkspaceOrImport("agent/dist/index.js", "@earendil-works/pi-agent-core");
 	const piTuiEntry = resolveWorkspaceOrImport("tui/dist/index.js", "@earendil-works/pi-tui");
 	const piTuiLayoutEntry = resolveWorkspaceOrImport("tui/dist/layout.js", "@earendil-works/pi-tui");
+	// The workspace path mirrors pi-ai 0.80.x's built dist layout. If an
+	// upstream layout change moves these files, this join needs updating to
+	// match the package's real dist paths.
 	const piAiEntry = resolveWorkspaceOrImport("ai/dist/compat.js", "@earendil-works/pi-ai");
 	const piAiOauthEntry = resolveWorkspaceOrImport("ai/dist/oauth.js", "@earendil-works/pi-ai");
 	const piAiProvidersEntry = resolveWorkspaceOrImport("ai/dist/providers/all.js", "@earendil-works/pi-ai");

--- a/packages/coding-agent/test/extensions-loader-virtual-modules.test.ts
+++ b/packages/coding-agent/test/extensions-loader-virtual-modules.test.ts
@@ -11,6 +11,11 @@ type PiAiExports = {
 	getModel?: object;
 	StringEnum?: object;
 };
+type PiTuiLayoutExports = {
+	getScrollbarGeometry?: object;
+	getScrollViewBox?: object;
+	renderLayoutFrame?: object;
+};
 
 // Provider-owned OAuth is exposed through provider metadata; the removed global
 // OAuth registration bridge is intentionally not part of extension aliases.
@@ -40,6 +45,23 @@ describe("extension loader pi-ai compat aliases", () => {
 		expect(aliases["@mariozechner/pi-ai"]).toBe(aliases["@mariozechner/pi-ai/compat"]);
 		expect(aliases["@mariozechner/pi-ai"]).toBe(aliases["@earendil-works/pi-ai/compat"]);
 	});
+	it(
+		"maps pi-tui layout helpers through both loader resolution paths",
+		async () => {
+			const specifiers = ["@earendil-works/pi-tui/dist/layout.js", "@mariozechner/pi-tui/dist/layout.js"] as const;
+			const aliases = extensionLoaderTestHooks.getAliases();
+			const modules = await extensionLoaderTestHooks.loadVirtualModules();
+			for (const specifier of specifiers) {
+				expect(aliases[specifier]).toMatch(/[\\/]layout\.js$/);
+				const layout = modules[specifier] as PiTuiLayoutExports;
+				expect(typeof layout.getScrollbarGeometry).toBe("function");
+				expect(typeof layout.getScrollViewBox).toBe("function");
+				expect(typeof layout.renderLayoutFrame).toBe("function");
+			}
+			expect(modules[specifiers[0]]).toBe(modules[specifiers[1]]);
+		},
+		REAL_EXTENSION_LOADER_TEST_TIMEOUT_MS,
+	);
 
 	it("confirms compat is the legacy API surface while root stays core-only", async () => {
 		const root = (await import("@earendil-works/pi-ai")) as PiAiExports;

--- a/packages/coding-agent/test/extensions-loader-virtual-modules.test.ts
+++ b/packages/coding-agent/test/extensions-loader-virtual-modules.test.ts
@@ -53,6 +53,7 @@ describe("extension loader pi-ai compat aliases", () => {
 			const modules = await extensionLoaderTestHooks.loadVirtualModules();
 			for (const specifier of specifiers) {
 				expect(aliases[specifier]).toMatch(/[\\/]layout\.js$/);
+				expect(fs.existsSync(aliases[specifier]!)).toBe(true);
 				const layout = modules[specifier] as PiTuiLayoutExports;
 				expect(typeof layout.getScrollbarGeometry).toBe("function");
 				expect(typeof layout.getScrollViewBox).toBe("function");

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Fixed graph overlay rendering to keep its live vertical position in pi-tui's `ScrollView` and preserve OSC-8 hyperlink terminators when normalizing layout rows.
 
-- Fixed headless graph overlays growing with graph height, switcher wheel input scrolling an obscured graph, and the scrollbar covering the final graph column; overflow now reserves its scrollbar column and the switcher owns wheel selection ([#2223](https://github.com/bastani-inc/atomic/issues/2223)).
+- Fixed switcher wheel input scrolling an obscured graph and the scrollbar covering the final graph column; overflow now reserves its scrollbar column and the switcher owns wheel selection ([#2223](https://github.com/bastani-inc/atomic/issues/2223)).
 - Removed the unhosted graph overlay's fixed-height fallback and kept pi-tui's layout metadata aligned with sparse, deeply scrolled content, so large graphs track their natural geometry without corrupting OSC-8 rows ([#2223](https://github.com/bastani-inc/atomic/issues/2223)).
 
 - Fixed the inline workflow form editor not inheriting the host's `autocompleteMaxVisible` setting when Atomic installs it as a custom editor.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Updated the Ralph research stage model configuration. The primary model moves from `openai-codex/gpt-5.6-luna:max` to `anthropic/claude-opus-5:high`, and the fallback chain is rebuilt around high/xhigh thinking levels: GPT-5.6 Sol at `xhigh` replaces the Luna variants, Claude Fable 5 and Claude Opus 4.8 step up from `low`/`medium` to `high`, GPT-5.5 and GLM-5.2 step up to `xhigh`, and Kimi K3 (`kimi-coding`, `moonshotai`, `moonshotai-cn`, and OpenRouter) plus `openrouter/sakana/fugu-ultra:high` join the chain.
 
+- Rebuilt the workflow graph overlay on pi-tui 0.84.1's `VStack` and `ScrollView` layout primitives. The graph body now adapts to terminal height and resize, supports vertical wheel scrolling and a draggable scrollbar, and keeps wide-graph horizontal panning and existing prompt/navigation key handling ([#2223](https://github.com/bastani-inc/atomic/issues/2223)).
+
 - Workflow command, worktree Git/setup-hook, and Playwright CLI subprocesses now receive `AI_AGENT=atomic` for generic child-process attribution without mutating caller-supplied environment objects.
 
 ### Fixed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Fixed graph overlay rendering to keep its live vertical position in pi-tui's `ScrollView` and preserve OSC-8 hyperlink terminators when normalizing layout rows.
 
 - Fixed switcher wheel input scrolling an obscured graph and the scrollbar covering the final graph column; overflow now reserves its scrollbar column and the switcher owns wheel selection ([#2223](https://github.com/bastani-inc/atomic/issues/2223)).
-- Removed the unhosted graph overlay's fixed-height fallback and kept pi-tui's layout metadata aligned with sparse, deeply scrolled content, so large graphs track their natural geometry without corrupting OSC-8 rows ([#2223](https://github.com/bastani-inc/atomic/issues/2223)).
+- Restored natural graph geometry for unhosted overlays by removing the fixed-height fallback and kept pi-tui's layout metadata aligned with sparse, deeply scrolled content, so large graphs track their natural geometry without corrupting OSC-8 rows ([#2223](https://github.com/bastani-inc/atomic/issues/2223)).
 
 - Fixed the inline workflow form editor not inheriting the host's `autocompleteMaxVisible` setting when Atomic installs it as a custom editor.
 - Fixed late workflow messages and MCP scope cleanup that finish after an extension reload. Stale event-bus calls now no-op instead of throwing, while active routes keep their normal fallback behavior.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -15,7 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Workflow command, worktree Git/setup-hook, and Playwright CLI subprocesses now receive `AI_AGENT=atomic` for generic child-process attribution without mutating caller-supplied environment objects.
 
 ### Fixed
+
 - Fixed graph overlay rendering to keep its live vertical position in pi-tui's `ScrollView` and preserve OSC-8 hyperlink terminators when normalizing layout rows.
+
+- Fixed headless graph overlays growing with graph height, switcher wheel input scrolling an obscured graph, and the scrollbar covering the final graph column; overflow now reserves its scrollbar column and the switcher owns wheel selection ([#2223](https://github.com/bastani-inc/atomic/issues/2223)).
 
 - Fixed the inline workflow form editor not inheriting the host's `autocompleteMaxVisible` setting when Atomic installs it as a custom editor.
 - Fixed late workflow messages and MCP scope cleanup that finish after an extension reload. Stale event-bus calls now no-op instead of throwing, while active routes keep their normal fallback behavior.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Fixed graph overlay rendering to keep its live vertical position in pi-tui's `ScrollView` and preserve OSC-8 hyperlink terminators when normalizing layout rows.
 
 - Fixed headless graph overlays growing with graph height, switcher wheel input scrolling an obscured graph, and the scrollbar covering the final graph column; overflow now reserves its scrollbar column and the switcher owns wheel selection ([#2223](https://github.com/bastani-inc/atomic/issues/2223)).
+- Removed the unhosted graph overlay's fixed-height fallback and kept pi-tui's layout metadata aligned with sparse, deeply scrolled content, so large graphs track their natural geometry without corrupting OSC-8 rows ([#2223](https://github.com/bastani-inc/atomic/issues/2223)).
 
 - Fixed the inline workflow form editor not inheriting the host's `autocompleteMaxVisible` setting when Atomic installs it as a custom editor.
 - Fixed late workflow messages and MCP scope cleanup that finish after an extension reload. Stale event-bus calls now no-op instead of throwing, while active routes keep their normal fallback behavior.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Workflow command, worktree Git/setup-hook, and Playwright CLI subprocesses now receive `AI_AGENT=atomic` for generic child-process attribution without mutating caller-supplied environment objects.
 
 ### Fixed
+- Fixed graph overlay rendering to keep its live vertical position in pi-tui's `ScrollView` and preserve OSC-8 hyperlink terminators when normalizing layout rows.
 
 - Fixed the inline workflow form editor not inheriting the host's `autocompleteMaxVisible` setting when Atomic installs it as a custom editor.
 - Fixed late workflow messages and MCP scope cleanup that finish after an extension reload. Stale event-bus calls now no-op instead of throwing, while active routes keep their normal fallback behavior.

--- a/packages/workflows/src/tui/graph-view-constants.ts
+++ b/packages/workflows/src/tui/graph-view-constants.ts
@@ -18,20 +18,6 @@ export const COMPACT_HINT_KEYS: Array<{ key: string; label: string }> = [
 export const MODE_PILL_LABEL = "GRAPH";
 
 /**
- * Fixed line count emitted by `_renderOverlay`. pi-tui paints the
- * overlay in the same buffer as the chat, so a *variable* line count
- * causes the chat to scroll every time the focused-stage section grows
- * or shrinks — that's exactly the duplicate-rows bug we hit when
- * navigating with j/k. Padding to a constant height keeps the overlay
- * a stable rectangle that pi-tui can diff cell-by-cell.
- *
- * Mirrors the doom-overlay reference extension, which always emits the
- * same number of lines per frame regardless of game state.
- */
-export const OVERLAY_LINE_COUNT = 32;
-export const OVERLAY_VERTICAL_MARGIN_ROWS = 1;
-
-/**
  * Animation tick period. Overlay re-renders fire on this cadence so
  * duration counters tick from active elapsed time (freezing while paused)
  * and the running-stage border lerps between `borderDim` and
@@ -50,4 +36,3 @@ export const ANIMATION_TICK_MS = 100;
  */
 export const PULSE_PERIOD_MS = 2000;
 export const GRAPH_SCROLL_STEP_COLS = 4;
-export const GRAPH_SCROLL_STEP_ROWS = 4;

--- a/packages/workflows/src/tui/graph-view-graph-render.ts
+++ b/packages/workflows/src/tui/graph-view-graph-render.ts
@@ -132,7 +132,7 @@ export abstract class GraphViewGraphRenderer extends GraphViewRenderHelpers {
 		const viewportLeft = viewport.leftMargin;
 		const viewportRight = viewport.leftMargin + viewport.viewportWidth;
 		const rects: typeof this.graphNodeHitRects = [];
-		const viewportTop = this.graphScrollOffset;
+		const viewportTop = this._graphScrollTop();
 		const viewportBottom = Math.min(this.cachedRenderGeometry.totalRows, viewportTop + visibleRowCount);
 		const { bands } = this.cachedRenderGeometry;
 		for (let bandIndex = this._firstVisibleLayoutBand(viewportTop); bandIndex < bands.length; bandIndex++) {

--- a/packages/workflows/src/tui/graph-view-graph-render.ts
+++ b/packages/workflows/src/tui/graph-view-graph-render.ts
@@ -1,3 +1,4 @@
+import type { RunSnapshot } from "../shared/store-types.js";
 import { hexBg, hexToAnsi, RESET } from "./color-utils.js";
 import { GraphCanvas } from "./graph-canvas.js";
 import { PULSE_PERIOD_MS } from "./graph-view-constants.js";
@@ -11,46 +12,51 @@ interface Placement {
 	line: string;
 }
 
-/** Graph body rendering and vertical/horizontal viewport management. */
+/** Graph body rendering and horizontal canvas management. */
 export abstract class GraphViewGraphRenderer extends GraphViewRenderHelpers {
-	protected _renderGraph(width: number): string[] {
-		const run = this._getCurrentRun();
+	protected _renderGraph(
+		width: number,
+		viewportTop: number,
+		viewportRows: number,
+		renderRun?: RunSnapshot | null,
+	): string[] {
+		const safeRows = Math.max(0, Math.floor(viewportRows));
+		const run = renderRun !== undefined ? renderRun : this._getCurrentRun();
 		if (!run || this.cachedLayout.length === 0) {
 			this.lastGraphViewport = null;
 			this.graphNodeHitRects = [];
-			this.lastGraphTotalRows = 1;
-			const dim = hexToAnsi(this.graphTheme.dim);
-			return [this._centerCanvasContent(`${dim}waiting for stage events…${RESET}`, width)];
+			this.lastGraphTopPad = 0;
+			this.lastGraphVisibleRows = safeRows;
+			const lines = Array.from({ length: safeRows }, () => "");
+			if (safeRows > 0) {
+				const dim = hexToAnsi(this.graphTheme.dim);
+				lines[Math.floor((safeRows - 1) / 2)] = this._centerCanvasContent(
+					`${dim}waiting for stage events…${RESET}`,
+					width,
+				);
+			}
+			return lines;
 		}
 
 		const graphInner = Math.max(1, width - 4);
 		const { canvasWidth, totalRows, bands, edges } = this.cachedRenderGeometry;
-		this.lastGraphTotalRows = totalRows;
 		const leftMargin = Math.max(2, canvasWidth <= graphInner ? Math.floor((graphInner - canvasWidth) / 2) : 2);
 		const viewportWidth = Math.max(1, width - leftMargin);
 		const fullCanvasWidth = Math.max(canvasWidth, viewportWidth);
 		this.lastGraphViewport = { leftMargin, viewportWidth };
+
+		const safeTop = Math.max(0, Math.min(totalRows, Math.floor(viewportTop)));
+		const graphRows = Math.max(0, Math.min(safeRows, totalRows - safeTop));
+		const viewportBottom = safeTop + graphRows;
 		this._clampGraphHorizontalScroll(fullCanvasWidth, viewportWidth);
-		if (this.pendingEnsureFocusedVisible) {
-			this._scrollFocusedColumnIntoView(viewportWidth, fullCanvasWidth);
-		}
-
-		const bodyRows = this._overlayBodyRows(this._overlayPanelLineCount());
-		if (totalRows > bodyRows) {
-			this._clampGraphScroll(totalRows, bodyRows);
-			if (this.pendingEnsureFocusedVisible) this._scrollFocusedIntoView(width, bodyRows, totalRows);
-			this._clampGraphScroll(totalRows, bodyRows);
-		} else {
-			this.graphScrollOffset = 0;
-		}
-
-		const viewportTop = this.graphScrollOffset;
-		const viewportBottom = Math.min(totalRows, viewportTop + bodyRows);
+		const topPad = safeTop === 0 && totalRows <= safeRows ? Math.min(3, Math.floor((safeRows - totalRows) / 2)) : 0;
+		this.lastGraphTopPad = topPad;
+		this.lastGraphVisibleRows = graphRows;
 		const viewportLeft = this.graphScrollColOffset;
 		const viewportRight = viewportLeft + viewportWidth;
 		const pulsePhase = (Date.now() % PULSE_PERIOD_MS) / PULSE_PERIOD_MS;
 		const edgeCanvas = new GraphCanvas({
-			top: viewportTop,
+			top: safeTop,
 			bottom: viewportBottom,
 			left: viewportLeft,
 			right: viewportRight,
@@ -58,7 +64,7 @@ export abstract class GraphViewGraphRenderer extends GraphViewRenderHelpers {
 		const edgeColor = this.graphTheme.borderDim;
 		for (const edge of edges) {
 			if (
-				edge.bottom <= viewportTop ||
+				edge.bottom <= safeTop ||
 				edge.top >= viewportBottom ||
 				edge.right <= viewportLeft ||
 				edge.left >= viewportRight
@@ -69,7 +75,7 @@ export abstract class GraphViewGraphRenderer extends GraphViewRenderHelpers {
 		}
 		const edgeLines = edgeCanvas.toLines();
 		const placements = new Map<number, Placement[]>();
-		for (let bandIndex = this._firstVisibleLayoutBand(viewportTop); bandIndex < bands.length; bandIndex++) {
+		for (let bandIndex = this._firstVisibleLayoutBand(safeTop); bandIndex < bands.length; bandIndex++) {
 			const band = bands[bandIndex]!;
 			if (band.top >= viewportBottom) break;
 			for (const ni of band.nodeIndices) {
@@ -88,8 +94,8 @@ export abstract class GraphViewGraphRenderer extends GraphViewRenderHelpers {
 				const visibleRight = Math.min(node.x + NODE_W, viewportRight);
 				for (let li = 0; li < cardLines.length; li++) {
 					const globalRow = node.y + li;
-					if (globalRow < viewportTop || globalRow >= viewportBottom) continue;
-					const localRow = globalRow - viewportTop;
+					if (globalRow < safeTop || globalRow >= viewportBottom) continue;
+					const localRow = globalRow - safeTop;
 					let bucket = placements.get(localRow);
 					if (!bucket) {
 						bucket = [];
@@ -106,10 +112,10 @@ export abstract class GraphViewGraphRenderer extends GraphViewRenderHelpers {
 
 		const bg = hexBg(this.graphTheme.bg);
 		const leftPad = `${bg}${" ".repeat(leftMargin)}${RESET}`;
-		const composed: string[] = [];
-		for (let localRow = 0; localRow < viewportBottom - viewportTop; localRow++) {
+		const composed = Array.from({ length: safeRows }, () => "");
+		for (let localRow = 0; localRow < graphRows; localRow++) {
 			const line = this._composeRow(edgeLines[localRow] ?? "", placements.get(localRow) ?? [], edgeColor);
-			composed.push(`${leftPad}${this._padCanvas(line, viewportWidth)}`);
+			composed[topPad + localRow] = `${leftPad}${this._padCanvas(line, viewportWidth)}`;
 		}
 		return composed;
 	}
@@ -127,7 +133,7 @@ export abstract class GraphViewGraphRenderer extends GraphViewRenderHelpers {
 		const viewportRight = viewport.leftMargin + viewport.viewportWidth;
 		const rects: typeof this.graphNodeHitRects = [];
 		const viewportTop = this.graphScrollOffset;
-		const viewportBottom = viewportTop + visibleRowCount;
+		const viewportBottom = Math.min(this.cachedRenderGeometry.totalRows, viewportTop + visibleRowCount);
 		const { bands } = this.cachedRenderGeometry;
 		for (let bandIndex = this._firstVisibleLayoutBand(viewportTop); bandIndex < bands.length; bandIndex++) {
 			const band = bands[bandIndex]!;
@@ -147,20 +153,5 @@ export abstract class GraphViewGraphRenderer extends GraphViewRenderHelpers {
 			}
 		}
 		this.graphNodeHitRects = rects;
-	}
-
-	protected _visibleGraphLines(
-		graphLines: string[],
-		_frameWidth: number,
-		bodyRows: number,
-	): { lines: string[]; topPad: number } {
-		this.pendingEnsureFocusedVisible = false;
-		return {
-			lines: graphLines,
-			topPad:
-				this.lastGraphTotalRows <= bodyRows
-					? Math.min(3, Math.max(0, Math.floor((bodyRows - this.lastGraphTotalRows) / 2)))
-					: 0,
-		};
 	}
 }

--- a/packages/workflows/src/tui/graph-view-input.ts
+++ b/packages/workflows/src/tui/graph-view-input.ts
@@ -78,7 +78,6 @@ export abstract class GraphViewInputController extends GraphViewRenderer {
 		const stageCount = this.cachedLayout.length;
 		if (this.graphLayout.handleScrollbarInput(data)) {
 			this.pendingEnsureFocusedVisible = false;
-			this.graphScrollOffset = this.graphLayout.scrollView.scrollTop;
 			return true;
 		}
 		const wheelDelta = this._mouseWheelDelta(data);
@@ -265,7 +264,6 @@ export abstract class GraphViewInputController extends GraphViewRenderer {
 	private _scrollGraphVertically(deltaRows: number): void {
 		this.pendingEnsureFocusedVisible = false;
 		this.graphLayout.scrollView.scrollBy(deltaRows);
-		this.graphScrollOffset = this.graphLayout.scrollView.scrollTop;
 	}
 
 	private _handleWheelDelta(delta: MouseWheelDelta): boolean {
@@ -323,7 +321,7 @@ export abstract class GraphViewInputController extends GraphViewRenderer {
 		return this.switcherState;
 	}
 	get _graphScrollOffset(): number {
-		return this.graphScrollOffset;
+		return this._graphScrollTop();
 	}
 	get _graphScrollColOffset(): number {
 		return this.graphScrollColOffset;

--- a/packages/workflows/src/tui/graph-view-input.ts
+++ b/packages/workflows/src/tui/graph-view-input.ts
@@ -1,4 +1,4 @@
-import { GRAPH_SCROLL_STEP_COLS, GRAPH_SCROLL_STEP_ROWS } from "./graph-view-constants.js";
+import { GRAPH_SCROLL_STEP_COLS } from "./graph-view-constants.js";
 import { GraphViewRenderer } from "./graph-view-render.js";
 import { isKeybindingsLike, type KeybindingsLike } from "./keybindings-adapter.js";
 import { isTerminalLeftMousePress, parseTerminalMouseInput, terminalMouseWheelDirection } from "./mouse-input.js";
@@ -11,6 +11,8 @@ interface MouseWheelDelta {
 	rows: number;
 }
 
+const GRAPH_SCROLL_WHEEL_LINES = 4;
+
 /** Keyboard, mouse, switcher, prompt, and focus navigation handling. */
 export abstract class GraphViewInputController extends GraphViewRenderer {
 	/** Returns true if consumed. */
@@ -19,31 +21,22 @@ export abstract class GraphViewInputController extends GraphViewRenderer {
 			this._returnToMainChat();
 			return true;
 		}
-		if (this.switcherOpen) {
-			return this._handleSwitcherInput(data);
-		}
+		if (this.graphLayout.isScrollbarInput(data)) return this._handleGraphInput(data);
+		const wheelDelta = this._mouseWheelDelta(data);
+		if (wheelDelta) return this._handleWheelDelta(wheelDelta);
+		if (this.switcherOpen) return this._handleSwitcherInput(data);
 		// Stage-local HIL is represented by graph nodes and remains graph-first;
 		// only the legacy run-level prompt card sets `promptState`. Keep that
-		// fallback answerable, but let a narrow set of non-text graph controls
-		// through first so the workflow overlay can still be detached or scrolled
-		// instead of feeling modal while a prompt is visible. Printable keys such
-		// as "/" belong to the prompt card while legacy run-level text/editor
-		// prompts own input.
-		if (this.promptState) {
-			if (this._isNonTextGraphControlBeforePrompt(data)) {
-				return this._handleGraphInput(data);
-			}
-			return this._handlePromptInput(data);
-		}
+		// fallback answerable, but let the scrollbar and wheel controls above
+		// continue to belong to the graph instead of leaking to the transcript.
+		// Printable keys such as "/" belong to the prompt card while legacy
+		// run-level text/editor prompts own input.
+		if (this.promptState) return this._handlePromptInput(data);
 		return this._handleGraphInput(data);
 	}
 
 	private _promptKeybindings(): KeybindingsLike | undefined {
 		return isKeybindingsLike(this.piKeybindings) ? this.piKeybindings : undefined;
-	}
-
-	private _isNonTextGraphControlBeforePrompt(data: string): boolean {
-		return this._mouseWheelDelta(data) !== null;
 	}
 
 	private _isReturnToMainChatInput(data: string): boolean {
@@ -83,12 +76,13 @@ export abstract class GraphViewInputController extends GraphViewRenderer {
 
 	private _handleGraphInput(data: string): boolean {
 		const stageCount = this.cachedLayout.length;
-		const wheelDelta = this._mouseWheelDelta(data);
-		if (wheelDelta) {
-			if (wheelDelta.rows !== 0) this._scrollGraphBy(wheelDelta.rows);
-			if (wheelDelta.cols !== 0) this._scrollGraphHorizontallyBy(wheelDelta.cols);
+		if (this.graphLayout.handleScrollbarInput(data)) {
+			this.pendingEnsureFocusedVisible = false;
+			this.graphScrollOffset = this.graphLayout.scrollView.scrollTop;
 			return true;
 		}
+		const wheelDelta = this._mouseWheelDelta(data);
+		if (wheelDelta) return this._handleWheelDelta(wheelDelta);
 
 		const clickedNodeIndex = this._graphNodeIndexForClick(data);
 		if (clickedNodeIndex !== undefined) {
@@ -268,10 +262,16 @@ export abstract class GraphViewInputController extends GraphViewRenderer {
 		this.focusedIndex = next;
 		this.pendingEnsureFocusedVisible = true;
 	}
-
-	private _scrollGraphBy(deltaRows: number): void {
+	private _scrollGraphVertically(deltaRows: number): void {
 		this.pendingEnsureFocusedVisible = false;
-		this.graphScrollOffset = Math.max(0, this.graphScrollOffset + deltaRows);
+		this.graphLayout.scrollView.scrollBy(deltaRows);
+		this.graphScrollOffset = this.graphLayout.scrollView.scrollTop;
+	}
+
+	private _handleWheelDelta(delta: MouseWheelDelta): boolean {
+		if (delta.rows !== 0) this._scrollGraphVertically(delta.rows);
+		if (delta.cols !== 0) this._scrollGraphHorizontallyBy(delta.cols);
+		return true;
 	}
 
 	private _scrollGraphHorizontallyBy(deltaCols: number): void {
@@ -292,7 +292,6 @@ export abstract class GraphViewInputController extends GraphViewRenderer {
 		}
 		return null;
 	}
-
 	private _sgrLeftMousePress(data: string): { col: number; row: number } | null {
 		const event = parseTerminalMouseInput(data);
 		if (event?.protocol !== "sgr" || !isTerminalLeftMousePress(event)) return null;
@@ -303,11 +302,14 @@ export abstract class GraphViewInputController extends GraphViewRenderer {
 		const event = parseTerminalMouseInput(data);
 		if (!event) return null;
 		const direction = terminalMouseWheelDirection(event);
-		if (direction === "up") return { cols: 0, rows: -GRAPH_SCROLL_STEP_ROWS };
-		if (direction === "down") return { cols: 0, rows: GRAPH_SCROLL_STEP_ROWS };
+		if (direction === "up") return { cols: 0, rows: -GRAPH_SCROLL_WHEEL_LINES };
+		if (direction === "down") return { cols: 0, rows: GRAPH_SCROLL_WHEEL_LINES };
 		if (direction === "left") return { cols: -GRAPH_SCROLL_STEP_COLS, rows: 0 };
 		if (direction === "right") return { cols: GRAPH_SCROLL_STEP_COLS, rows: 0 };
 		return null;
+	}
+	get _graphScrollbarGeometry() {
+		return this.graphLayout.scrollbarGeometry;
 	}
 
 	// ---- test seams ----

--- a/packages/workflows/src/tui/graph-view-input.ts
+++ b/packages/workflows/src/tui/graph-view-input.ts
@@ -22,9 +22,9 @@ export abstract class GraphViewInputController extends GraphViewRenderer {
 			return true;
 		}
 		if (this.graphLayout.isScrollbarInput(data)) return this._handleGraphInput(data);
+		if (this.switcherOpen) return this._handleSwitcherInput(data);
 		const wheelDelta = this._mouseWheelDelta(data);
 		if (wheelDelta) return this._handleWheelDelta(wheelDelta);
-		if (this.switcherOpen) return this._handleSwitcherInput(data);
 		// Stage-local HIL is represented by graph nodes and remains graph-first;
 		// only the legacy run-level prompt card sets `promptState`. Keep that
 		// fallback answerable, but let the scrollbar and wheel controls above
@@ -161,21 +161,13 @@ export abstract class GraphViewInputController extends GraphViewRenderer {
 			this.switcherOpen = false;
 			return true;
 		}
-		if (matchesKey(data, Key.down)) {
-			const filtered = filterStages(stages, this.switcherState.query);
-			this.switcherState = {
-				...this.switcherState,
-				selectedIndex: Math.min(this.switcherState.selectedIndex + 1, filtered.length - 1),
-			};
-			return true;
-		}
-		if (matchesKey(data, Key.up)) {
-			this.switcherState = {
-				...this.switcherState,
-				selectedIndex: Math.max(this.switcherState.selectedIndex - 1, 0),
-			};
-			return true;
-		}
+		const wheelEvent = parseTerminalMouseInput(data);
+		const wheelDirection = wheelEvent ? terminalMouseWheelDirection(wheelEvent) : null;
+		if (wheelDirection === "down") return this._moveSwitcherSelection(1);
+		if (wheelDirection === "up") return this._moveSwitcherSelection(-1);
+		if (wheelDirection !== null) return true;
+		if (matchesKey(data, Key.down)) return this._moveSwitcherSelection(1);
+		if (matchesKey(data, Key.up)) return this._moveSwitcherSelection(-1);
 		if (matchesKey(data, Key.backspace)) {
 			this.switcherState = {
 				query: this.switcherState.query.slice(0, -1),
@@ -191,6 +183,17 @@ export abstract class GraphViewInputController extends GraphViewRenderer {
 			return true;
 		}
 		return false;
+	}
+
+	private _moveSwitcherSelection(step: number): boolean {
+		const stages = this.cachedLayout.map((layoutNode) => layoutNode.stage);
+		const filtered = filterStages(stages, this.switcherState.query);
+		const maxIndex = Math.max(0, filtered.length - 1);
+		this.switcherState = {
+			...this.switcherState,
+			selectedIndex: Math.max(0, Math.min(this.switcherState.selectedIndex + step, maxIndex)),
+		};
+		return true;
 	}
 
 	/**

--- a/packages/workflows/src/tui/graph-view-layout.ts
+++ b/packages/workflows/src/tui/graph-view-layout.ts
@@ -43,7 +43,20 @@ export interface GraphViewLayoutFrame {
 	bodyBox: LayoutBox | undefined;
 	topMarginRows: number;
 	bottomMarginRows: number;
+	wrappedRows: boolean[];
 	scrollbar: ScrollbarGeometry | undefined;
+}
+
+function collectWrappedRows(box: LayoutBox, height: number, wrappedRows: boolean[]): void {
+	if (box.lines) {
+		const offset = box.lineOffset ?? 0;
+		const firstRow = Math.max(box.rect.y, box.clip.y, 0);
+		const lastRow = Math.min(box.rect.y + box.rect.height, box.clip.y + box.clip.height, height);
+		for (let row = firstRow; row < lastRow; row++) {
+			if (box.lines[offset + row - box.rect.y] !== undefined) wrappedRows[row] = true;
+		}
+	}
+	for (const child of box.children) collectWrappedRows(child, height, wrappedRows);
 }
 
 class CallbackComponent implements Component {
@@ -117,14 +130,18 @@ export class GraphViewLayout {
 		const bodyBox = getScrollViewBox(frame, this.scrollView);
 		this.scrollbar = bodyBox ? getScrollbarGeometry(bodyBox) : undefined;
 		if (!this.scrollbar) this.draggingScrollbar = undefined;
+		const wrappedRows = Array.from({ length: safeHeight }, () => false);
+		collectWrappedRows(frame.root, safeHeight, wrappedRows);
 		return {
 			frame,
 			bodyBox,
 			topMarginRows: marginRows,
 			bottomMarginRows: marginRows,
+			wrappedRows,
 			scrollbar: this.scrollbar,
 		};
 	}
+
 	/** Repaint the thumb after overlays that cover the body rows. */
 	paintScrollbar(lines: string[], width: number): void {
 		const geometry = this.scrollbar;
@@ -224,6 +241,10 @@ export class GraphViewLayout {
 		for (let index = 0; index < visible.length && index < rows; index++) {
 			lines[top + index] = visible[index]!;
 		}
+		// pi-tui scans upward from scrollTop for an image that crosses the
+		// viewport edge. A non-empty sentinel stops that scan at the first
+		// hidden row instead of making every frame walk the whole graph.
+		if (top > 0) lines[top - 1] = " ";
 		return lines;
 	}
 

--- a/packages/workflows/src/tui/graph-view-layout.ts
+++ b/packages/workflows/src/tui/graph-view-layout.ts
@@ -86,7 +86,7 @@ export class GraphViewLayout {
 			axis: "vertical",
 			follow: "none",
 			overscroll: "contain",
-			scrollbar: "auto",
+			scrollbar: "hidden",
 		});
 
 		const marginVisible = ({ height }: { height: number }): boolean => graphLayoutMarginRows(height) > 0;
@@ -110,7 +110,7 @@ export class GraphViewLayout {
 		);
 		const requestRender = this.callbacks.requestRender ?? EMPTY_RENDER;
 		this.scrollView.updateLayout(this.bodyContentRows, this.bodyViewportRows, requestRender);
-		this.scrollView.setScrollbarActive(this.bodyContentRows > this.bodyViewportRows);
+		this.scrollView.setScrollbar(this.bodyContentRows > this.bodyViewportRows ? "always" : "hidden");
 		this.callbacks.beforeFrame?.(this.scrollView, this.bodyViewportRows, this.bodyContentRows, safeWidth);
 
 		const frame = renderLayoutFrame(this.root, safeWidth, safeHeight, requestRender);

--- a/packages/workflows/src/tui/graph-view-layout.ts
+++ b/packages/workflows/src/tui/graph-view-layout.ts
@@ -1,0 +1,245 @@
+import { type Component, ScrollView, VStack } from "@earendil-works/pi-tui";
+import {
+	getScrollbarGeometry,
+	getScrollViewBox,
+	type LayoutBox,
+	type LayoutFrame,
+	renderLayoutFrame,
+	type ScrollbarGeometry,
+} from "@earendil-works/pi-tui/dist/layout.js";
+import { isTerminalLeftMousePress, parseTerminalMouseInput } from "./mouse-input.js";
+import { sliceColumns, visibleWidth } from "./text-helpers.js";
+
+const EMPTY_RENDER: () => void = () => {};
+export const GRAPH_HEADER_ROWS = 3;
+export const GRAPH_FOOTER_ROWS = 3;
+
+export function graphLayoutMarginRows(height: number): number {
+	return Math.max(1, Math.floor(height)) >= 9 ? 1 : 0;
+}
+
+export function graphLayoutBodyRows(height: number): number {
+	const safeHeight = Math.max(1, Math.floor(height));
+	return Math.max(0, safeHeight - GRAPH_HEADER_ROWS - GRAPH_FOOTER_ROWS - graphLayoutMarginRows(safeHeight) * 2);
+}
+
+export function graphLayoutNaturalHeight(bodyRows: number): number {
+	const safeBodyRows = Math.max(1, Math.floor(bodyRows));
+	const base = GRAPH_HEADER_ROWS + GRAPH_FOOTER_ROWS + safeBodyRows;
+	return base >= GRAPH_HEADER_ROWS + GRAPH_FOOTER_ROWS + 3 ? base + 2 : base;
+}
+
+export interface GraphViewLayoutCallbacks {
+	renderHeader: (width: number) => string[];
+	renderBody: (width: number, top: number, rows: number, contentRows: number) => string[];
+	renderFooter: (width: number) => string[];
+	bodyContentHeight: (width: number, viewportRows: number) => number;
+	beforeFrame?: (scrollView: ScrollView, viewportRows: number, contentRows: number, width: number) => void;
+	requestRender?: () => void;
+}
+
+export interface GraphViewLayoutFrame {
+	frame: LayoutFrame;
+	bodyBox: LayoutBox | undefined;
+	topMarginRows: number;
+	bottomMarginRows: number;
+	scrollbar: ScrollbarGeometry | undefined;
+}
+
+class CallbackComponent implements Component {
+	constructor(private readonly renderLines: (width: number) => string[]) {}
+
+	render(width: number): string[] {
+		return this.renderLines(width);
+	}
+
+	invalidate(): void {}
+}
+
+/**
+ * Layout root for the graph overlay.
+ *
+ * pi-tui mounts extension overlays as ordinary components, while its
+ * ScrollView/VStack sizing pass belongs to TuiAltScreen. This small bridge
+ * runs that same installed pi-tui layout pass for the overlay component, so
+ * the graph body still gets a real constrained ScrollView without changing
+ * the host TUI or the transcript surface.
+ */
+export class GraphViewLayout {
+	readonly scrollView: ScrollView;
+
+	private readonly root: VStack;
+	private readonly callbacks: GraphViewLayoutCallbacks;
+	private bodyViewportRows = 0;
+	private bodyContentRows = 0;
+	private scrollbar: ScrollbarGeometry | undefined;
+	private draggingScrollbar: { grabOffset: number } | undefined;
+
+	constructor(callbacks: GraphViewLayoutCallbacks) {
+		this.callbacks = callbacks;
+
+		const margin = new CallbackComponent(() => [""]);
+		const header = new CallbackComponent((width) => this.callbacks.renderHeader(width));
+		const body = new CallbackComponent((width) => this.renderBody(width));
+		const footer = new CallbackComponent((width) => this.callbacks.renderFooter(width));
+		this.scrollView = new ScrollView(body, {
+			axis: "vertical",
+			follow: "none",
+			overscroll: "contain",
+			scrollbar: "auto",
+		});
+
+		const marginVisible = ({ height }: { height: number }): boolean => graphLayoutMarginRows(height) > 0;
+		this.root = new VStack([
+			{ component: margin, basis: 1, grow: 0, shrink: 0, minSize: 0, visible: marginVisible },
+			{ component: header, basis: GRAPH_HEADER_ROWS, grow: 0, shrink: 1, minSize: 0 },
+			{ component: this.scrollView, basis: 0, grow: 1, shrink: 1, minSize: 0 },
+			{ component: footer, basis: GRAPH_FOOTER_ROWS, grow: 0, shrink: 1, minSize: 1 },
+			{ component: margin, basis: 1, grow: 0, shrink: 0, minSize: 0, visible: marginVisible },
+		]);
+	}
+
+	render(width: number, height: number): GraphViewLayoutFrame {
+		const safeWidth = Math.max(1, Math.floor(width));
+		const safeHeight = Math.max(1, Math.floor(height));
+		const marginRows = graphLayoutMarginRows(safeHeight);
+		this.bodyViewportRows = graphLayoutBodyRows(safeHeight);
+		this.bodyContentRows = Math.max(
+			0,
+			Math.floor(this.callbacks.bodyContentHeight(safeWidth, this.bodyViewportRows)),
+		);
+		const requestRender = this.callbacks.requestRender ?? EMPTY_RENDER;
+		this.scrollView.updateLayout(this.bodyContentRows, this.bodyViewportRows, requestRender);
+		this.scrollView.setScrollbarActive(this.bodyContentRows > this.bodyViewportRows);
+		this.callbacks.beforeFrame?.(this.scrollView, this.bodyViewportRows, this.bodyContentRows, safeWidth);
+
+		const frame = renderLayoutFrame(this.root, safeWidth, safeHeight, requestRender);
+		const bodyBox = getScrollViewBox(frame, this.scrollView);
+		this.scrollbar = bodyBox ? getScrollbarGeometry(bodyBox) : undefined;
+		if (!this.scrollbar) this.draggingScrollbar = undefined;
+		return {
+			frame,
+			bodyBox,
+			topMarginRows: marginRows,
+			bottomMarginRows: marginRows,
+			scrollbar: this.scrollbar,
+		};
+	}
+	/** Repaint the thumb after overlays that cover the body rows. */
+	paintScrollbar(lines: string[], width: number): void {
+		const geometry = this.scrollbar;
+		if (!geometry) return;
+		for (let offset = 0; offset < geometry.thumbHeight; offset++) {
+			const row = geometry.thumbTop + offset;
+			if (row < 0 || row >= lines.length || geometry.column < 0 || geometry.column >= width) continue;
+			const line = lines[row] ?? " ".repeat(width);
+			const before = sliceColumns(line, 0, geometry.column, true);
+			const after = sliceColumns(line, geometry.column + 1, width - geometry.column - 1, true);
+			const beforePad = " ".repeat(Math.max(0, geometry.column - visibleWidth(before)));
+			const afterPad = " ".repeat(Math.max(0, width - geometry.column - 1 - visibleWidth(after)));
+			lines[row] = `${before}${beforePad}${this.scrollView.scrollbarStyle(" ")}${after}${afterPad}`;
+		}
+	}
+
+	dispose(): void {
+		this.draggingScrollbar = undefined;
+		this.scrollbar = undefined;
+		this.scrollView.updateLayout(this.bodyContentRows, this.bodyViewportRows, EMPTY_RENDER);
+		this.scrollView.setScrollbarActive(false);
+		this.scrollView.setScrollbar("hidden");
+	}
+
+	get viewportRows(): number {
+		return this.bodyViewportRows;
+	}
+
+	get contentRows(): number {
+		return this.bodyContentRows;
+	}
+
+	get scrollbarGeometry(): ScrollbarGeometry | undefined {
+		return this.scrollbar;
+	}
+	/** Return whether an event belongs to the graph scrollbar without mutating it. */
+	isScrollbarInput(data: string): boolean {
+		const event = parseTerminalMouseInput(data);
+		if (!event) return false;
+		if (this.draggingScrollbar) {
+			return event.action === "release" || ((event.buttonCode & 32) !== 0 && (event.buttonCode & 3) === 0);
+		}
+		const geometry = this.scrollbar;
+		return (
+			geometry !== undefined &&
+			event.action === "press" &&
+			(event.buttonCode & 64) === 0 &&
+			(event.buttonCode & 32) === 0 &&
+			(event.buttonCode & 3) === 0 &&
+			event.col === geometry.column &&
+			event.row >= geometry.trackTop &&
+			event.row < geometry.trackTop + geometry.trackHeight
+		);
+	}
+
+	/** Route a scrollbar press, drag, or release to the graph ScrollView. */
+	handleScrollbarInput(data: string): boolean {
+		const event = parseTerminalMouseInput(data);
+		if (!event) return false;
+
+		if (event.action === "release") {
+			if (!this.draggingScrollbar) return false;
+			this.draggingScrollbar = undefined;
+			return true;
+		}
+
+		const moving = (event.buttonCode & 32) !== 0;
+		const leftButton = (event.buttonCode & 3) === 0;
+		if (this.draggingScrollbar && moving && leftButton) {
+			this.scrollToScrollbarRow(event.row);
+			return true;
+		}
+
+		const geometry = this.scrollbar;
+		if (!geometry) return false;
+		if (!isTerminalLeftMousePress(event) || event.col !== geometry.column) return false;
+		if (event.row < geometry.trackTop || event.row >= geometry.trackTop + geometry.trackHeight) return false;
+
+		if (event.row >= geometry.thumbTop && event.row < geometry.thumbTop + geometry.thumbHeight) {
+			this.draggingScrollbar = { grabOffset: event.row - geometry.thumbTop };
+		} else {
+			this.scrollToScrollbarRow(event.row - Math.floor(geometry.thumbHeight / 2));
+		}
+		return true;
+	}
+
+	invalidate(): void {
+		this.root.invalidate();
+	}
+
+	private renderBody(width: number): string[] {
+		const contentRows = this.bodyContentRows;
+		const lines = new Array<string>(contentRows);
+		const top = Math.max(0, Math.min(contentRows, this.scrollView.scrollTop));
+		const rows = Math.max(0, Math.min(this.bodyViewportRows, contentRows - top));
+		const visible = this.callbacks.renderBody(width, top, rows, contentRows);
+		for (let index = 0; index < visible.length && index < rows; index++) {
+			lines[top + index] = visible[index]!;
+		}
+		return lines;
+	}
+
+	private scrollToScrollbarRow(row: number): void {
+		const geometry = this.scrollbar;
+		if (!geometry || geometry.maxScrollTop <= 0) return;
+		const maxThumbTop = Math.max(0, geometry.trackHeight - geometry.thumbHeight);
+		if (maxThumbTop === 0) {
+			this.scrollView.scrollTo(0);
+			return;
+		}
+		const thumbTop = Math.max(
+			geometry.trackTop,
+			Math.min(geometry.trackTop + maxThumbTop, row - (this.draggingScrollbar?.grabOffset ?? 0)),
+		);
+		const ratio = (thumbTop - geometry.trackTop) / maxThumbTop;
+		this.scrollView.scrollTo(Math.round(ratio * geometry.maxScrollTop));
+	}
+}

--- a/packages/workflows/src/tui/graph-view-render-helpers.ts
+++ b/packages/workflows/src/tui/graph-view-render-helpers.ts
@@ -1,12 +1,6 @@
 import { BOLD, hexBg, hexToAnsi, RESET } from "./color-utils.js";
 import type { GraphCanvas } from "./graph-canvas.js";
-import {
-	COMPACT_HINT_KEYS,
-	HINT_KEYS,
-	MODE_PILL_LABEL,
-	OVERLAY_LINE_COUNT,
-	OVERLAY_VERTICAL_MARGIN_ROWS,
-} from "./graph-view-constants.js";
+import { COMPACT_HINT_KEYS, HINT_KEYS, MODE_PILL_LABEL } from "./graph-view-constants.js";
 import { GraphViewState } from "./graph-view-state.js";
 import { renderOutlinePill } from "./header.js";
 import { NODE_H, NODE_W } from "./layout.js";
@@ -15,62 +9,6 @@ import { OVERLAY_HIDDEN_STATUS_KEYS, WORKFLOW_STATUS_KEY } from "./workflow-stat
 
 /** Low-level overlay geometry, chrome, ANSI canvas, and edge helpers. */
 export abstract class GraphViewRenderHelpers extends GraphViewState {
-	/**
-	 * Number of rows the overlay frame must paint. Pi-tui anchors the
-	 * overlay vertically by counting rendered lines, so to truly fill the
-	 * terminal under `maxHeight: "100%"` the component must emit
-	 * approximately `terminal.rows` lines. When a host reports fewer
-	 * than the legacy 32 rows, honour that shorter viewport where the
-	 * graph chrome can still fit so the bottom status controls are not
-	 * clipped by pi-tui's overlay max-height slicing. A host that doesn't
-	 * surface terminal dimensions keeps the previous stable rectangle.
-	 */
-	protected _overlayLineCount(): number {
-		const reported = this.getViewportRows?.();
-		if (typeof reported !== "number" || !Number.isFinite(reported)) {
-			return OVERLAY_LINE_COUNT;
-		}
-		// Header (3) + one body row + statusline (3) is the absolute
-		// minimum useful frame. Margins are dropped automatically at this
-		// size by `_overlayVerticalMarginRows`.
-		return Math.max(7, Math.floor(reported));
-	}
-
-	/** Rows available for the graph body (between header and statusline). */
-	protected _overlayBodyRows(lineCount: number): number {
-		return Math.max(1, lineCount - 3 /* header */ - 3 /* statusline */);
-	}
-
-	protected _overlayVerticalMarginRows(lineCount = this._overlayLineCount()): number {
-		return lineCount >= 9 ? OVERLAY_VERTICAL_MARGIN_ROWS : 0;
-	}
-
-	protected _overlayPanelLineCount(): number {
-		const lineCount = this._overlayLineCount();
-		const margins = this._overlayVerticalMarginRows(lineCount) * 2;
-		return Math.max(7, lineCount - margins);
-	}
-
-	protected _marginRow(width: number): string {
-		return " ".repeat(width);
-	}
-
-	protected _withVerticalMargins(panelLines: string[], width: number): string[] {
-		const expected = this._overlayLineCount();
-		const marginRows = this._overlayVerticalMarginRows(expected);
-		const panelTarget = this._overlayPanelLineCount();
-		const body = panelLines.slice(0, panelTarget);
-		while (body.length < panelTarget) body.push(this._blankRow(width));
-		const margins = Array.from({ length: marginRows }, () => this._marginRow(width));
-		const lines = [...margins, ...body, ...margins];
-		if (lines.length > expected) return lines.slice(0, expected);
-		while (lines.length < expected) {
-			const insertAt = marginRows > 0 ? Math.max(0, lines.length - marginRows) : lines.length;
-			lines.splice(insertAt, 0, this._blankRow(width));
-		}
-		return lines;
-	}
-
 	/**
 	 * Three-row statusline pinned to the bottom of the overlay. Mirrors
 	 * the header band: `backgroundPanel` chrome, outlined accent pill
@@ -182,11 +120,6 @@ export abstract class GraphViewRenderHelpers extends GraphViewState {
 		return `${bg}${" ".repeat(leftPad)}${RESET}${cardLine}${bg}${" ".repeat(rightPadLen)}${RESET}`;
 	}
 
-	protected _clampGraphScroll(totalRows: number, bodyRows: number): void {
-		const maxOffset = Math.max(0, totalRows - bodyRows);
-		this.graphScrollOffset = Math.max(0, Math.min(maxOffset, this.graphScrollOffset));
-	}
-
 	protected _clampGraphHorizontalScroll(totalCols: number, viewportCols: number): void {
 		const maxOffset = Math.max(0, totalCols - viewportCols);
 		this.graphScrollColOffset = Math.max(0, Math.min(maxOffset, this.graphScrollColOffset));
@@ -204,24 +137,6 @@ export abstract class GraphViewRenderHelpers extends GraphViewState {
 		}
 		this._clampGraphHorizontalScroll(totalCols, viewportCols);
 	}
-
-	protected _scrollFocusedIntoView(frameWidth: number, bodyRows: number, totalRows: number): void {
-		const range = this._focusedGraphRowRange(frameWidth);
-		if (!range) return;
-		if (range.start < this.graphScrollOffset) {
-			this.graphScrollOffset = range.start;
-		} else if (range.end >= this.graphScrollOffset + bodyRows) {
-			this.graphScrollOffset = range.end - bodyRows + 1;
-		}
-		this._clampGraphScroll(totalRows, bodyRows);
-	}
-
-	protected _focusedGraphRowRange(_frameWidth: number): { start: number; end: number } | null {
-		const node = this.cachedLayout[this.focusedIndex];
-		if (!node) return null;
-		return { start: node.y, end: node.y + NODE_H - 1 };
-	}
-
 	/**
 	 * Plot a parent → child edge for the vertical orientation. The edge
 	 * exits from the parent's bottom-centre, runs through a horizontal

--- a/packages/workflows/src/tui/graph-view-render.ts
+++ b/packages/workflows/src/tui/graph-view-render.ts
@@ -9,7 +9,12 @@ import { renderPromptCard } from "./prompt-card.js";
 import { renderSwitcher } from "./switcher.js";
 import { truncateToWidth, visibleWidth } from "./text-helpers.js";
 
-const LAYOUT_OSC_RESET = /\x1b\]8;;(?:\x07|\x1b\\)/g;
+/**
+ * `renderLayoutFrame` adds its own reset plus an OSC-8 terminator around each
+ * row. Strip only that wrapper; OSC-8 terminators emitted by graph content
+ * must remain so a hyperlink cannot bleed into later rows.
+ */
+const LAYOUT_OSC_RESET = /\x1b\[0m\x1b\]8;;(?:\x07|\x1b\\)/g;
 
 /** Overlay/widget rendering orchestration for GraphView. */
 export abstract class GraphViewRenderer extends GraphViewGraphRenderer {
@@ -29,6 +34,9 @@ export abstract class GraphViewRenderer extends GraphViewGraphRenderer {
 				this._prepareGraphScroll(scrollView, viewportRows, contentRows, width),
 			requestRender: () => this.requestRender?.(),
 		});
+	}
+	protected override _graphScrollTop(): number {
+		return this.graphLayout.scrollView.scrollTop;
 	}
 
 	/** Render to string lines. width = terminal columns. */
@@ -65,7 +73,6 @@ export abstract class GraphViewRenderer extends GraphViewGraphRenderer {
 		try {
 			const frameHeight = this._overlayFrameHeight(run);
 			const layoutFrame = this.graphLayout.render(frameWidth, frameHeight);
-			this.graphScrollOffset = this.graphLayout.scrollView.scrollTop;
 			const lines = this._normalizeLayoutLines(
 				layoutFrame.frame.lines,
 				frameWidth,
@@ -125,14 +132,10 @@ export abstract class GraphViewRenderer extends GraphViewGraphRenderer {
 		if (viewportRows <= 0) return;
 		if (!run || this.cachedRenderGeometry.totalRows <= 0) {
 			scrollView.scrollToStart();
-			this.graphScrollOffset = 0;
 			this.pendingEnsureFocusedVisible = false;
 			return;
 		}
 
-		if (!this.pendingEnsureFocusedVisible && scrollView.scrollTop !== this.graphScrollOffset) {
-			scrollView.scrollTo(this.graphScrollOffset);
-		}
 		if (this.pendingEnsureFocusedVisible) {
 			const node = this.cachedLayout[this.focusedIndex];
 			if (node) {
@@ -154,7 +157,6 @@ export abstract class GraphViewRenderer extends GraphViewGraphRenderer {
 			}
 			this.pendingEnsureFocusedVisible = false;
 		}
-		this.graphScrollOffset = scrollView.scrollTop;
 	}
 
 	private _renderHeader(width: number): string[] {
@@ -197,7 +199,7 @@ export abstract class GraphViewRenderer extends GraphViewGraphRenderer {
 		return lines;
 	}
 
-	private _normalizeLayoutLines(
+	protected _normalizeLayoutLines(
 		lines: readonly string[],
 		width: number,
 		height: number,

--- a/packages/workflows/src/tui/graph-view-render.ts
+++ b/packages/workflows/src/tui/graph-view-render.ts
@@ -1,25 +1,50 @@
 import type { RunSnapshot } from "../shared/store-types.js";
 import { hexBg, hexToAnsi, RESET } from "./color-utils.js";
 import { GraphViewGraphRenderer } from "./graph-view-graph-render.js";
+import { GRAPH_HEADER_ROWS, GraphViewLayout, graphLayoutNaturalHeight } from "./graph-view-layout.js";
+import type { GraphViewOpts } from "./graph-view-types.js";
 import { renderHeader, renderOutlinePill } from "./header.js";
+import { NODE_H } from "./layout.js";
 import { renderPromptCard } from "./prompt-card.js";
 import { renderSwitcher } from "./switcher.js";
+import { truncateToWidth, visibleWidth } from "./text-helpers.js";
+
+const LAYOUT_OSC_RESET = /\x1b\]8;;(?:\x07|\x1b\\)/g;
 
 /** Overlay/widget rendering orchestration for GraphView. */
 export abstract class GraphViewRenderer extends GraphViewGraphRenderer {
+	protected readonly graphLayout: GraphViewLayout;
+	private lastOverlayFrameHeight = 0;
+	private hasReportedViewportRows = false;
+	private renderRun: RunSnapshot | null | undefined;
+
+	constructor(opts: GraphViewOpts) {
+		super(opts);
+		this.graphLayout = new GraphViewLayout({
+			renderHeader: (width) => this._renderHeader(width),
+			renderBody: (width, top, rows, contentRows) => this._renderBody(width, top, rows, contentRows),
+			renderFooter: (width) => this._renderStatusline(width),
+			bodyContentHeight: (_width, viewportRows) => this._graphBodyContentHeight(viewportRows),
+			beforeFrame: (scrollView, viewportRows, contentRows, width) =>
+				this._prepareGraphScroll(scrollView, viewportRows, contentRows, width),
+			requestRender: () => this.requestRender?.(),
+		});
+	}
+
 	/** Render to string lines. width = terminal columns. */
 	render(width: number): string[] {
-		if (this.mode === "widget") {
-			return this._renderWidget(width);
-		}
+		if (this.mode === "widget") return this._renderWidget(width);
 		return this._renderOverlay(width);
+	}
+
+	override dispose(): void {
+		this.graphLayout.dispose();
+		super.dispose();
 	}
 
 	protected _renderWidget(width: number): string[] {
 		const run = this._getCurrentRun();
-		if (!run) {
-			return [`${hexToAnsi(this.graphTheme.dim)}no active workflow${RESET}`];
-		}
+		if (!run) return [`${hexToAnsi(this.graphTheme.dim)}no active workflow${RESET}`];
 		const displayStages = this._displayStages(run);
 		const headerLines = renderHeader({ ...run, stages: displayStages }, { width, theme: this.graphTheme });
 		const counts = this._counts(displayStages);
@@ -35,115 +60,192 @@ export abstract class GraphViewRenderer extends GraphViewGraphRenderer {
 
 	protected _renderOverlay(width: number): string[] {
 		const frameWidth = Math.max(40, width);
-		this.lastOverlayFrameWidth = frameWidth;
-		const lines: string[] = [];
 		const run = this._getCurrentRun();
+		this.renderRun = run;
+		try {
+			const frameHeight = this._overlayFrameHeight(run);
+			const layoutFrame = this.graphLayout.render(frameWidth, frameHeight);
+			this.graphScrollOffset = this.graphLayout.scrollView.scrollTop;
+			const lines = this._normalizeLayoutLines(
+				layoutFrame.frame.lines,
+				frameWidth,
+				frameHeight,
+				layoutFrame.topMarginRows,
+				layoutFrame.bottomMarginRows,
+			);
+			const bodyStart = layoutFrame.bodyBox?.rect.y ?? layoutFrame.topMarginRows + GRAPH_HEADER_ROWS;
+			const bodyRows = layoutFrame.bodyBox?.rect.height ?? this.graphLayout.viewportRows;
+			if (run) {
+				this._recordGraphNodeHitRects(bodyStart + this.lastGraphTopPad, this.lastGraphVisibleRows);
+				this._renderSwitcherOverlay(lines, run, frameWidth, bodyStart, bodyRows);
+				this._renderPromptOverlay(lines, frameWidth, bodyStart, bodyRows);
+			} else {
+				this.graphNodeHitRects = [];
+				this.lastGraphViewport = null;
+			}
+			this.graphLayout.paintScrollbar(lines, frameWidth);
 
-		if (!run) {
-			return this._renderEmptyState(frameWidth);
+			return lines;
+		} finally {
+			this.renderRun = undefined;
 		}
-
-		// 1. Header chrome (3 rows: outline pill + session name + counts).
-		lines.push(
-			...renderHeader({ ...run, stages: this._displayStages(run) }, { width: frameWidth, theme: this.graphTheme }),
-		);
-
-		// 2. Graph occupies the full body. No section labels, no focused-
-		//    stage panel — status colour on each card carries that signal.
-		const graphLines = this._renderGraph(frameWidth);
-		const bodyTarget = this._overlayBodyRows(this._overlayPanelLineCount());
-		const visibleGraph = this._visibleGraphLines(graphLines, frameWidth, bodyTarget);
-		this._recordGraphNodeHitRects(
-			this._overlayVerticalMarginRows() + 3 + visibleGraph.topPad,
-			visibleGraph.lines.length,
-		);
-		for (let i = 0; i < visibleGraph.topPad; i++) lines.push(this._blankRow(frameWidth));
-		for (const line of visibleGraph.lines) {
-			lines.push(this._canvasRow(line, frameWidth));
-		}
-		while (lines.length < 3 + bodyTarget) lines.push(this._blankRow(frameWidth));
-		if (lines.length > 3 + bodyTarget) lines.length = 3 + bodyTarget;
-
-		this._renderSwitcherOverlay(lines, run, frameWidth, bodyTarget);
-		this._renderPromptOverlay(lines, frameWidth, bodyTarget);
-
-		// 5. Three-row statusline pinned to the bottom.
-		lines.push(...this._renderStatusline(frameWidth));
-
-		return this._withVerticalMargins(lines, frameWidth);
 	}
 
-	protected _renderEmptyState(width: number): string[] {
-		this.graphNodeHitRects = [];
-		this.lastGraphViewport = null;
+	protected _overlayFrameHeight(run: RunSnapshot | null = this._currentRenderRun()): number {
+		const reported = this.getViewportRows?.();
+		if (typeof reported === "number" && Number.isFinite(reported) && reported > 0) {
+			this.hasReportedViewportRows = true;
+			this.lastOverlayFrameHeight = Math.max(1, Math.floor(reported));
+			return this.lastOverlayFrameHeight;
+		}
+		if (this.hasReportedViewportRows && this.lastOverlayFrameHeight > 0) return this.lastOverlayFrameHeight;
+
+		const bodyRows = run ? Math.max(1, this.cachedRenderGeometry.totalRows) : 2;
+		this.lastOverlayFrameHeight = graphLayoutNaturalHeight(bodyRows);
+		return this.lastOverlayFrameHeight;
+	}
+
+	private _currentRenderRun(): RunSnapshot | null {
+		return this.renderRun !== undefined ? this.renderRun : this._getCurrentRun();
+	}
+
+	private _graphBodyContentHeight(viewportRows: number): number {
+		const rows = Math.max(0, Math.floor(viewportRows));
+		if (!this._currentRenderRun() || this.cachedRenderGeometry.totalRows <= 0) return rows;
+		return Math.max(rows, this.cachedRenderGeometry.totalRows);
+	}
+
+	private _prepareGraphScroll(
+		scrollView: GraphViewLayout["scrollView"],
+		viewportRows: number,
+		_contentRows: number,
+		width: number,
+	): void {
+		const run = this._currentRenderRun();
+		if (viewportRows <= 0) return;
+		if (!run || this.cachedRenderGeometry.totalRows <= 0) {
+			scrollView.scrollToStart();
+			this.graphScrollOffset = 0;
+			this.pendingEnsureFocusedVisible = false;
+			return;
+		}
+
+		if (!this.pendingEnsureFocusedVisible && scrollView.scrollTop !== this.graphScrollOffset) {
+			scrollView.scrollTo(this.graphScrollOffset);
+		}
+		if (this.pendingEnsureFocusedVisible) {
+			const node = this.cachedLayout[this.focusedIndex];
+			if (node) {
+				let next = scrollView.scrollTop;
+				if (node.y < next) next = node.y;
+				else if (node.y + NODE_H > next + viewportRows) next = node.y + NODE_H - viewportRows;
+				scrollView.scrollTo(next);
+
+				const graphInner = Math.max(1, width - 4);
+				const leftMargin = Math.max(
+					2,
+					this.cachedRenderGeometry.canvasWidth <= graphInner
+						? Math.floor((graphInner - this.cachedRenderGeometry.canvasWidth) / 2)
+						: 2,
+				);
+				const viewportWidth = Math.max(1, width - leftMargin);
+				const fullCanvasWidth = Math.max(this.cachedRenderGeometry.canvasWidth, viewportWidth);
+				this._scrollFocusedColumnIntoView(viewportWidth, fullCanvasWidth);
+			}
+			this.pendingEnsureFocusedVisible = false;
+		}
+		this.graphScrollOffset = scrollView.scrollTop;
+	}
+
+	private _renderHeader(width: number): string[] {
+		const run = this._currentRenderRun();
+		if (run) return renderHeader({ ...run, stages: this._displayStages(run) }, { width, theme: this.graphTheme });
+
 		const t = this.graphTheme;
 		const muted = hexToAnsi(t.textMuted);
-		const dim = hexToAnsi(t.dim);
-		const accent = hexToAnsi(t.accent);
 		const chromeBg = hexBg(t.backgroundPanel);
-
 		const { top, mid, bot, visibleWidth: pillW } = renderOutlinePill("ORCHESTRATOR", t.accent, chromeBg);
-		const idleLabel = `  ${muted}idle${RESET}`;
-		const fillerVisible = Math.max(0, width - 1 - pillW - 6 /* "  idle" */ - 2);
+		const fillerVisible = Math.max(0, width - 1 - pillW - 6 - 2);
 		const filler = " ".repeat(fillerVisible);
-		const lines: string[] = [
+		return [
 			`${chromeBg} ${RESET}${top}${chromeBg}${" ".repeat(6 + fillerVisible)}${" ".repeat(2)}${RESET}`,
-			`${chromeBg} ${RESET}${mid}${chromeBg}${idleLabel}${filler}${" ".repeat(2)}${RESET}`,
+			`${chromeBg} ${RESET}${mid}${chromeBg}  ${muted}idle${RESET}${filler}${" ".repeat(2)}${RESET}`,
 			`${chromeBg} ${RESET}${bot}${chromeBg}${" ".repeat(6 + fillerVisible)}${" ".repeat(2)}${RESET}`,
 		];
-		const bodyTarget = this._overlayBodyRows(this._overlayPanelLineCount());
-		const body: string[] = [
-			this._canvasRow(`  ${muted}No active workflow run.${RESET}`, width),
-			this._canvasRow(
-				`  ${dim}Start one with ${accent}/workflow <name>${RESET}${dim} or press ${accent}F2${RESET}${dim} on an active run.${RESET}`,
+	}
+
+	private _renderBody(width: number, top: number, rows: number, _contentRows: number): string[] {
+		const run = this._currentRenderRun();
+		const raw = run ? this._renderGraph(width, top, rows, run) : this._renderEmptyBody(width, rows);
+		return raw.map((line) => this._canvasRow(line, width));
+	}
+
+	private _renderEmptyBody(width: number, rows: number): string[] {
+		const body = [
+			this._centerCanvasContent(`  ${hexToAnsi(this.graphTheme.textMuted)}No active workflow run.${RESET}`, width),
+			this._centerCanvasContent(
+				`  ${hexToAnsi(this.graphTheme.dim)}Start one with ${hexToAnsi(this.graphTheme.accent)}/workflow <name>${RESET}${hexToAnsi(this.graphTheme.dim)} or press ${hexToAnsi(this.graphTheme.accent)}F2${RESET}${hexToAnsi(this.graphTheme.dim)} on an active run.${RESET}`,
 				width,
 			),
 		];
-		const topPad = Math.max(0, Math.floor((bodyTarget - body.length) / 2));
-		for (let i = 0; i < topPad; i++) lines.push(this._blankRow(width));
-		for (const l of body) lines.push(l);
-		while (lines.length < 3 + bodyTarget) lines.push(this._blankRow(width));
-		lines.push(...this._renderStatusline(width));
-		return this._withVerticalMargins(lines, width);
+		const lines = Array.from({ length: rows }, () => "");
+		const topPad = Math.max(0, Math.floor((rows - body.length) / 2));
+		for (let index = 0; index < body.length; index++) {
+			const target = topPad + index;
+			if (target < lines.length) lines[target] = body[index]!;
+		}
+		return lines;
 	}
 
-	private _renderSwitcherOverlay(lines: string[], run: RunSnapshot, frameWidth: number, bodyTarget: number): void {
-		// Switcher overlay — floats over the body when open.
-		if (!this.switcherOpen) return;
+	private _normalizeLayoutLines(
+		lines: readonly string[],
+		width: number,
+		height: number,
+		topMarginRows: number,
+		bottomMarginRows: number,
+	): string[] {
+		return Array.from({ length: height }, (_, row) => {
+			if (row < topMarginRows || row >= height - bottomMarginRows) return " ".repeat(width);
+			const clean = (lines[row] ?? "").replace(LAYOUT_OSC_RESET, "");
+			if (visibleWidth(clean) === 0) return this._blankRow(width);
+			if (visibleWidth(clean) > width) return truncateToWidth(clean, width, "…", true);
+			return `${clean}${" ".repeat(width - visibleWidth(clean))}`;
+		});
+	}
 
-		const bodyStart = 3;
-		const bodyEnd = 3 + bodyTarget;
-		for (let row = bodyStart; row < bodyEnd; row++) {
-			lines[row] = this._blankRow(frameWidth);
-		}
+	private _renderSwitcherOverlay(
+		lines: string[],
+		run: RunSnapshot,
+		frameWidth: number,
+		bodyStart: number,
+		bodyRows: number,
+	): void {
+		if (!this.switcherOpen) return;
+		const bodyEnd = bodyStart + bodyRows;
+		for (let row = bodyStart; row < bodyEnd; row++) lines[row] = this._blankRow(frameWidth);
 		const switcherWidth = Math.min(60, Math.max(40, frameWidth - 8));
 		const switcherLines = renderSwitcher(this._displayStages(run), this.switcherState, {
 			width: switcherWidth,
 			theme: this.graphTheme,
 			canOpenStageChat: (stage) => this._stageChatTarget(stage) !== undefined,
 		});
-		const insertAt = Math.max(
-			bodyStart,
-			bodyStart + Math.min(2, Math.floor((bodyTarget - switcherLines.length) / 3)),
-		);
+		const insertAt = Math.max(bodyStart, bodyStart + Math.min(2, Math.floor((bodyRows - switcherLines.length) / 3)));
 		const switcherLeft = Math.max(2, Math.floor((frameWidth - switcherWidth) / 2));
-		for (let i = 0; i < switcherLines.length; i++) {
-			const lineIdx = insertAt + i;
-			if (lineIdx >= bodyEnd) break;
-			const base = lines[lineIdx] ?? this._blankRow(frameWidth);
-			const merged = this._overlayCard(base, switcherLines[i]!, switcherLeft, frameWidth);
-			if (lineIdx < lines.length) lines[lineIdx] = merged;
-			else lines.push(merged);
+		for (let index = 0; index < switcherLines.length; index++) {
+			const lineIndex = insertAt + index;
+			if (lineIndex >= bodyEnd) break;
+			lines[lineIndex] = this._overlayCard(
+				lines[lineIndex] ?? this._blankRow(frameWidth),
+				switcherLines[index]!,
+				switcherLeft,
+				frameWidth,
+			);
 		}
 	}
 
-	private _renderPromptOverlay(lines: string[], frameWidth: number, bodyTarget: number): void {
-		// Pending HIL prompt — floats over the graph body, centred. The
-		// chat editor remains free regardless: the overlay is the only
-		// surface that interacts with the prompt. When the stage switcher is
-		// open it owns the body/input, so hide the prompt card until it closes.
+	private _renderPromptOverlay(lines: string[], frameWidth: number, bodyStart: number, bodyRows: number): void {
 		if (!this.promptState || this.switcherOpen) return;
-		const run = this._getCurrentRun();
+		const run = this._currentRenderRun();
 		const cardWidth = Math.min(72, Math.max(40, frameWidth - 6));
 		const cardLines = renderPromptCard({
 			state: this.promptState,
@@ -151,19 +253,20 @@ export abstract class GraphViewRenderer extends GraphViewGraphRenderer {
 			width: cardWidth,
 			cursorOn: ((Date.now() / 530) | 0) % 2 === 0,
 			identity: run ? { runId: run.id, name: run.name } : undefined,
-			maxRows: bodyTarget,
+			maxRows: bodyRows,
 		});
-		const bodyStart = 3;
-		const bodyEnd = bodyStart + bodyTarget;
-		const slot = Math.max(bodyStart, bodyStart + Math.floor((bodyTarget - cardLines.length) / 2));
-		// The card renderer owns row budgeting, but keep this composition boundary
-		// defensive: a complete card fits wholly in the body or is not painted.
-		if (cardLines.length > bodyTarget || slot + cardLines.length > bodyEnd) return;
+		const bodyEnd = bodyStart + bodyRows;
+		const slot = Math.max(bodyStart, bodyStart + Math.floor((bodyRows - cardLines.length) / 2));
+		if (cardLines.length > bodyRows || slot + cardLines.length > bodyEnd) return;
 		const leftPad = Math.max(0, Math.floor((frameWidth - cardWidth) / 2));
-		for (let i = 0; i < cardLines.length; i++) {
-			const lineIdx = slot + i;
-			const base = lines[lineIdx] ?? this._blankRow(frameWidth);
-			lines[lineIdx] = this._overlayCard(base, cardLines[i]!, leftPad, frameWidth);
+		for (let index = 0; index < cardLines.length; index++) {
+			const lineIndex = slot + index;
+			lines[lineIndex] = this._overlayCard(
+				lines[lineIndex] ?? this._blankRow(frameWidth),
+				cardLines[index]!,
+				leftPad,
+				frameWidth,
+			);
 		}
 	}
 }

--- a/packages/workflows/src/tui/graph-view-render.ts
+++ b/packages/workflows/src/tui/graph-view-render.ts
@@ -11,11 +11,19 @@ import { truncateToWidth, visibleWidth } from "./text-helpers.js";
 
 /**
  * `renderLayoutFrame` adds its own reset plus an OSC-8 terminator around each
- * row. Strip only that wrapper; OSC-8 terminators emitted by graph content
+ * row. Strip only the outer wrapper; OSC-8 terminators emitted by graph content
  * must remain so a hyperlink cannot bleed into later rows.
  */
-const LAYOUT_OSC_RESET = /\x1b\[0m\x1b\]8;;(?:\x07|\x1b\\)/g;
+const LAYOUT_OSC_RESET = "\x1b[0m\x1b]8;;\x07";
+const MAX_UNHOSTED_BODY_ROWS = 24;
 
+function stripLayoutWrapper(line: string): string {
+	const startsWithWrapper = line.startsWith(LAYOUT_OSC_RESET);
+	const endsWithWrapper = line.endsWith(LAYOUT_OSC_RESET);
+	const start = startsWithWrapper ? LAYOUT_OSC_RESET.length : 0;
+	const end = endsWithWrapper ? line.length - LAYOUT_OSC_RESET.length : line.length;
+	return line.slice(start, Math.max(start, end));
+}
 /** Overlay/widget rendering orchestration for GraphView. */
 export abstract class GraphViewRenderer extends GraphViewGraphRenderer {
 	protected readonly graphLayout: GraphViewLayout;
@@ -107,7 +115,7 @@ export abstract class GraphViewRenderer extends GraphViewGraphRenderer {
 		}
 		if (this.hasReportedViewportRows && this.lastOverlayFrameHeight > 0) return this.lastOverlayFrameHeight;
 
-		const bodyRows = run ? Math.max(1, this.cachedRenderGeometry.totalRows) : 2;
+		const bodyRows = run ? Math.min(Math.max(1, this.cachedRenderGeometry.totalRows), MAX_UNHOSTED_BODY_ROWS) : 2;
 		this.lastOverlayFrameHeight = graphLayoutNaturalHeight(bodyRows);
 		return this.lastOverlayFrameHeight;
 	}
@@ -208,7 +216,7 @@ export abstract class GraphViewRenderer extends GraphViewGraphRenderer {
 	): string[] {
 		return Array.from({ length: height }, (_, row) => {
 			if (row < topMarginRows || row >= height - bottomMarginRows) return " ".repeat(width);
-			const clean = (lines[row] ?? "").replace(LAYOUT_OSC_RESET, "");
+			const clean = stripLayoutWrapper(lines[row] ?? "");
 			if (visibleWidth(clean) === 0) return this._blankRow(width);
 			if (visibleWidth(clean) > width) return truncateToWidth(clean, width, "…", true);
 			return `${clean}${" ".repeat(width - visibleWidth(clean))}`;

--- a/packages/workflows/src/tui/graph-view-render.ts
+++ b/packages/workflows/src/tui/graph-view-render.ts
@@ -10,12 +10,11 @@ import { renderSwitcher } from "./switcher.js";
 import { truncateToWidth, visibleWidth } from "./text-helpers.js";
 
 /**
- * `renderLayoutFrame` adds its own reset plus an OSC-8 terminator around each
- * row. Strip only the outer wrapper; OSC-8 terminators emitted by graph content
- * must remain so a hyperlink cannot bleed into later rows.
+ * `renderLayoutFrame` wraps each painted row with its segment reset. The
+ * layout bridge records which rows were painted, so content that was not
+ * wrapped cannot be mistaken for a layout seam during normalization.
  */
 const LAYOUT_OSC_RESET = "\x1b[0m\x1b]8;;\x07";
-const MAX_UNHOSTED_BODY_ROWS = 24;
 
 function stripLayoutWrapper(line: string): string {
 	const startsWithWrapper = line.startsWith(LAYOUT_OSC_RESET);
@@ -83,6 +82,7 @@ export abstract class GraphViewRenderer extends GraphViewGraphRenderer {
 			const layoutFrame = this.graphLayout.render(frameWidth, frameHeight);
 			const lines = this._normalizeLayoutLines(
 				layoutFrame.frame.lines,
+				layoutFrame.wrappedRows,
 				frameWidth,
 				frameHeight,
 				layoutFrame.topMarginRows,
@@ -113,9 +113,12 @@ export abstract class GraphViewRenderer extends GraphViewGraphRenderer {
 			this.lastOverlayFrameHeight = Math.max(1, Math.floor(reported));
 			return this.lastOverlayFrameHeight;
 		}
+		// A custom overlay may lose its terminal while the host tears down the
+		// TUI. Keep the last hosted frame until a new row count arrives, so the
+		// disappearing overlay does not jump to a different natural height.
 		if (this.hasReportedViewportRows && this.lastOverlayFrameHeight > 0) return this.lastOverlayFrameHeight;
 
-		const bodyRows = run ? Math.min(Math.max(1, this.cachedRenderGeometry.totalRows), MAX_UNHOSTED_BODY_ROWS) : 2;
+		const bodyRows = run ? Math.max(1, this.cachedRenderGeometry.totalRows) : 2;
 		this.lastOverlayFrameHeight = graphLayoutNaturalHeight(bodyRows);
 		return this.lastOverlayFrameHeight;
 	}
@@ -209,6 +212,7 @@ export abstract class GraphViewRenderer extends GraphViewGraphRenderer {
 
 	protected _normalizeLayoutLines(
 		lines: readonly string[],
+		wrappedRows: readonly boolean[],
 		width: number,
 		height: number,
 		topMarginRows: number,
@@ -216,7 +220,8 @@ export abstract class GraphViewRenderer extends GraphViewGraphRenderer {
 	): string[] {
 		return Array.from({ length: height }, (_, row) => {
 			if (row < topMarginRows || row >= height - bottomMarginRows) return " ".repeat(width);
-			const clean = stripLayoutWrapper(lines[row] ?? "");
+			const source = lines[row] ?? "";
+			const clean = wrappedRows[row] === true ? stripLayoutWrapper(source) : source;
 			if (visibleWidth(clean) === 0) return this._blankRow(width);
 			if (visibleWidth(clean) > width) return truncateToWidth(clean, width, "…", true);
 			return `${clean}${" ".repeat(width - visibleWidth(clean))}`;

--- a/packages/workflows/src/tui/graph-view-state.ts
+++ b/packages/workflows/src/tui/graph-view-state.ts
@@ -103,7 +103,7 @@ export abstract class GraphViewState {
 		targets: new Map(),
 	};
 	protected currentSnapshot: StoreSnapshot | null = null;
-	protected graphScrollOffset = 0;
+	protected abstract _graphScrollTop(): number;
 	protected graphScrollColOffset = 0;
 	protected graphNodeHitRects: GraphNodeHitRect[] = [];
 	protected lastGraphViewport: GraphViewportGeometry | null = null;
@@ -187,7 +187,6 @@ export abstract class GraphViewState {
 			this.cachedRenderGeometry = { canvasWidth: 0, totalRows: 0, bands: [], edges: [] };
 			this.expandedGraph = { stages: [], renderStages: [], tools: [], nodes: [], targets: new Map() };
 			this.focusedIndex = 0;
-			this.graphScrollOffset = 0;
 			this.graphScrollColOffset = 0;
 			this.graphNodeHitRects = [];
 			this.lastGraphViewport = null;
@@ -340,7 +339,6 @@ export abstract class GraphViewState {
 
 		if (this.cachedLayout.length === 0) {
 			this.focusedIndex = 0;
-			this.graphScrollOffset = 0;
 			this.graphScrollColOffset = 0;
 		} else if (this.focusedIndex >= this.cachedLayout.length) {
 			this.focusedIndex = this.cachedLayout.length - 1;

--- a/packages/workflows/src/tui/graph-view-state.ts
+++ b/packages/workflows/src/tui/graph-view-state.ts
@@ -107,8 +107,8 @@ export abstract class GraphViewState {
 	protected graphScrollColOffset = 0;
 	protected graphNodeHitRects: GraphNodeHitRect[] = [];
 	protected lastGraphViewport: GraphViewportGeometry | null = null;
-	protected lastGraphTotalRows = 0;
-	protected lastOverlayFrameWidth = 80;
+	protected lastGraphTopPad = 0;
+	protected lastGraphVisibleRows = 0;
 	protected pendingEnsureFocusedVisible = true;
 	protected lastAutoFocusedAwaitingInputKey: string | null = null;
 	protected lastBuiltSnapshotVersion: number | null = null;

--- a/packages/workflows/src/tui/graph-view-types.ts
+++ b/packages/workflows/src/tui/graph-view-types.ts
@@ -42,12 +42,9 @@ export interface GraphViewOpts {
 	initialFocusedStageId?: string;
 	initialFocusedRunId?: string;
 	/**
-	 * Optional accessor returning the current terminal row count. When
-	 * present in overlay mode the renderer expands the frame to roughly
-	 * `viewportRows` lines (clamped to at least the header + statusline
-	 * budget) so the popup fills the terminal under pi-tui's
-	 * `width: "100%" / maxHeight: "100%"` geometry. Returning `undefined`
-	 * falls back to the constant `OVERLAY_LINE_COUNT` rectangle.
+	 * Optional terminal row accessor used by the custom-overlay bridge. The
+	 * graph layout root consumes the current height on every render so a resize
+	 * changes the ScrollView viewport instead of a fixed rectangle.
 	 */
 	getViewportRows?: () => number | undefined;
 	/**

--- a/packages/workflows/src/tui/overlay-adapter.ts
+++ b/packages/workflows/src/tui/overlay-adapter.ts
@@ -81,24 +81,13 @@ export interface GraphOverlayPort {
 }
 
 /**
- * Aspirational full-screen overlay geometry. In a future host that
- * forwards `overlayOptions` to pi-tui's `resolveOverlayLayout`,
- * `width`/`maxHeight` would expand against terminal dimensions so the
- * popup fills the entire frame, with `margin: 0` removing the breathing
- * room a centered popup needs.
+ * Full-screen overlay geometry. The custom-overlay host supplies terminal rows
+ * to the graph layout bridge, which reuses pi-tui's installed VStack/ScrollView
+ * frame pass before the component is painted.
  *
- * Current pi interactive `ExtensionUiController.custom` ignores
- * this object: it always mounts overlays with `{ anchor:
- * "bottom-center", width: "100%", maxHeight: "100%", margin: 0 }`. The
- * value is retained for `onHandle`-based toggle support and forward
- * compatibility — see `PiCustomOverlayOptions` for the host-compat
- * note.
- *
- * Note: percent geometry is necessary but not sufficient for a true
- * full-screen overlay — pi-tui positions the popup based on the
- * rendered overlay line count, so the mounted component must also
- * emit `terminal.rows` lines per frame. That row count is threaded
- * through `WorkflowAttachPane.getViewportRows` below.
+ * Keep the percentage geometry here so the host gives the overlay the complete
+ * terminal width and height; the graph component still owns its body viewport,
+ * scrollbar, and resize response.
  */
 const FULLSCREEN_OVERLAY_OPTIONS: PiOverlayOptions = {
 	anchor: "center",
@@ -386,11 +375,9 @@ export function buildGraphOverlayAdapter(
 				getToolsExpanded: ui?.getToolsExpanded,
 				setToolsExpanded: ui?.setToolsExpanded,
 				footerData: ui?.getFooterDataProvider?.(),
-				// Pi-tui owns terminal dimensions; thread its row count down
-				// so the overlay frame fills the actual viewport rather than
-				// a hard-coded 32-row rectangle. Returning `undefined` keeps
-				// the existing fallback for hosts that don't expose
-				// `tui.terminal`.
+				// Pi-tui owns terminal dimensions; the graph layout bridge consumes
+				// the current row count on every render so resize changes its
+				// ScrollView viewport. Hosts without a terminal use natural content size.
 				getViewportRows: () => tui.terminal?.rows,
 				// Drive the graph-view animation tick. Short-circuit when the
 				// overlay is hidden so a `setHidden(true)`-ed overlay does

--- a/packages/workflows/src/tui/workflow-attach-pane-types.ts
+++ b/packages/workflows/src/tui/workflow-attach-pane-types.ts
@@ -58,10 +58,9 @@ export interface WorkflowAttachPaneOpts {
 	initialAttachRunId?: string;
 	/**
 	 * Optional accessor returning the current terminal row count. Threaded
-	 * into both `GraphView` and `StageChatView` so the overlay renders a
-	 * frame that fills the full viewport instead of a fixed 32-row pane.
-	 * Returns `undefined` when the host has not surfaced terminal
-	 * dimensions; views fall back to their constant row budget.
+	 * into the graph overlay so its VStack root gets the live terminal height
+	 * on every frame; attached stage chat keeps its existing frame budget when
+	 * the host does not surface terminal dimensions.
 	 */
 	getViewportRows?: () => number | undefined;
 	/**

--- a/test/integration/overlay-entrypoints-open-prompts.test.ts
+++ b/test/integration/overlay-entrypoints-open-prompts.test.ts
@@ -438,14 +438,15 @@ describe("buildGraphOverlayAdapter — open with pi.ui.custom", () => {
 		assert.equal(lines.length, 50, "should fill the terminal-row viewport");
 	});
 
-	test("falls back to 32-row frame when tui.terminal is absent", () => {
+	test("sizes the graph overlay from its natural layout when tui.terminal is absent", () => {
 		const { ui, calls } = buildMockUi();
 		const store = createStore();
 		const adapter = buildGraphOverlayAdapter({ ui }, store);
 
 		adapter.open("run-fallback");
 		const lines = calls[0]!.component.render(120);
-		assert.equal(lines.length, 32, "fallback line count keeps the legacy rectangle");
+		assert.ok(lines.length > 0);
+		assert.ok(lines.length < 32, "fallback must not restore the old fixed rectangle");
 	});
 });
 

--- a/test/unit/overlay-adapter-autowrap.test.ts
+++ b/test/unit/overlay-adapter-autowrap.test.ts
@@ -13,10 +13,15 @@ async function registerIsolatedTests(): Promise<void> {
 	// `bun:test`'s module registry is the real one. vitest has no equivalent.
 	const { mock } = await import("bun:test");
 	class TestComponent {}
-
+	const [{ ScrollView }, { VStack }] = await Promise.all([
+		import("@earendil-works/pi-tui/dist/components/scroll-view.js"),
+		import("@earendil-works/pi-tui/dist/components/v-stack.js"),
+	]);
 	mock.module("@earendil-works/pi-tui", () => ({
 		Box: TestComponent,
 		Editor: TestComponent,
+		ScrollView,
+		VStack,
 		SelectList: TestComponent,
 		Text: TestComponent,
 		Key: {

--- a/test/unit/overlay-adapter-hidden-render.test.ts
+++ b/test/unit/overlay-adapter-hidden-render.test.ts
@@ -29,10 +29,15 @@ async function registerIsolatedTests(): Promise<void> {
 	// `bun:test`'s module registry is the real one. vitest has no equivalent.
 	const { mock } = await import("bun:test");
 	class TestComponent {}
-
+	const [{ ScrollView }, { VStack }] = await Promise.all([
+		import("@earendil-works/pi-tui/dist/components/scroll-view.js"),
+		import("@earendil-works/pi-tui/dist/components/v-stack.js"),
+	]);
 	mock.module("@earendil-works/pi-tui", () => ({
 		Box: TestComponent,
 		Editor: TestComponent,
+		ScrollView,
+		VStack,
 		SelectList: TestComponent,
 		Text: TestComponent,
 		Key: {

--- a/test/unit/overlay-graph-navigation-02.test.ts
+++ b/test/unit/overlay-graph-navigation-02.test.ts
@@ -158,17 +158,18 @@ describe("GraphView keyboard navigation", () => {
 		const view = makeView([...stages]);
 		const lines = view.render(96);
 		assert.equal(lines.length, 21);
+		assert.ok(lines.length < 32, "a short graph must not use the old fixed rectangle");
 		view.dispose();
 	});
-
-	it("caps an unhosted frame for a large graph while keeping the body scrollable", () => {
+	it("tracks unhosted frame height with a large graph while keeping the body scrollable", () => {
 		const stages = Array.from({ length: 400 }, (_, index) =>
 			makeStage(`stage-${index}`, index === 0 ? [] : [`stage-${index - 1}`]),
 		);
 		const view = makeView(stages);
 		const lines = view.render(96);
-		assert.equal(lines.length, 32);
-		assert.ok(lines.length < stages.length);
+		assert.ok(lines.length >= 32, "a large graph must not collapse to a short fixed frame");
+		assert.ok(lines.length > stages.length, "the natural frame must track graph content");
+		assert.ok(lines.length < stages.length * 10, "the frame should use graph geometry, not one row per stage");
 		view.dispose();
 	});
 
@@ -223,17 +224,44 @@ describe("GraphView keyboard navigation", () => {
 			layout.dispose();
 		}
 	});
+	it("terminates pi-tui's above-viewport image scan after one hidden row", () => {
+		const layout = new GraphViewLayout({
+			renderHeader: () => ["", "", ""],
+			renderBody: (_width, _top, rows) => Array.from({ length: rows }, () => "row"),
+			renderFooter: () => ["", "", ""],
+			bodyContentHeight: () => 5_000,
+		});
+		try {
+			layout.render(96, 24);
+			layout.scrollView.scrollTo(4_000);
+			const frame = layout.render(96, 24);
+			const content = frame.bodyBox?.scrollContentLines;
+			const scrollTop = layout.scrollView.scrollTop;
+			assert.ok(content && scrollTop > 0);
+			assert.equal(content[scrollTop - 1], " ", "the sentinel must stop the scan at the viewport edge");
+			assert.equal(content[scrollTop - 2], undefined, "rows above the sentinel remain unmaterialized");
+			assert.equal(content.length, 5_000);
+			assert.equal(frame.wrappedRows[frame.bodyBox!.rect.y], true, "painted body rows are tagged for normalization");
+		} finally {
+			layout.dispose();
+		}
+	});
 	it("preserves content OSC-8 terminators and composite seam resets", () => {
 		const view = makeView([makeStage("A")]);
 		const wrapper = "\x1b[0m\x1b]8;;\x07";
 		const content = "\x1b]8;;https://example.com\x07label\x1b[0m\x1b]8;;\x07";
-		const [line] = view._normalizeLayoutLines([`${wrapper}${content}${wrapper}`], 96, 1, 0, 0);
+		const [line] = view._normalizeLayoutLines([`${wrapper}${content}${wrapper}`], [true], 96, 1, 0, 0);
 		assert.match(line, /\x1b\]8;;https:\/\/example\.com\x07label\x1b\[0m\x1b\]8;;\x07/);
 		assert.equal((line.match(/\x1b\[0m\x1b\]8;;\x07/g) ?? []).length, 1);
 
 		const sideBySide = `${wrapper}\x1b[41mleft${wrapper}\x1b[42mright${wrapper}`;
-		const [composited] = view._normalizeLayoutLines([sideBySide], 96, 1, 0, 0);
+		const [composited] = view._normalizeLayoutLines([sideBySide], [true], 96, 1, 0, 0);
 		assert.match(composited, /\x1b\[41mleft\x1b\[0m\x1b\]8;;\x07\x1b\[42mright/);
+
+		const unwrapped = "\x1b]8;;https://example.com\x07label\x1b[0m\x1b]8;;\x07";
+		const [kept] = view._normalizeLayoutLines([unwrapped], [false], 96, 1, 0, 0);
+		assert.ok(kept.startsWith(unwrapped), "unwrapped content keeps its own OSC-8 terminator");
+		assert.equal((kept.match(/\x1b\[0m\x1b\]8;;\x07/g) ?? []).length, 1);
 		view.dispose();
 	});
 
@@ -331,6 +359,23 @@ describe("GraphView keyboard navigation", () => {
 		view.dispose();
 	});
 
+	it("keeps the last hosted frame height while the host terminal disappears", () => {
+		let terminalRows: number | undefined = 40;
+		const view = new GraphView({
+			mode: "overlay",
+			runId: "run-1",
+			store: makeStore(makeSnap([makeStage("lifecycle")])),
+			graphTheme: defaultTheme,
+			getViewportRows: () => terminalRows,
+		});
+
+		assert.equal(view.render(96).length, 40);
+		terminalRows = undefined;
+		assert.equal(view.render(96).length, 40, "a torn-down terminal keeps the last hosted frame height");
+		terminalRows = 12;
+		assert.equal(view.render(96).length, 12, "a returning host resizes immediately");
+		view.dispose();
+	});
 	it("hides unstarted placeholder stages while a prompt stage is awaiting input", () => {
 		const stages = [
 			makeStage("capture"),

--- a/test/unit/overlay-graph-navigation-02.test.ts
+++ b/test/unit/overlay-graph-navigation-02.test.ts
@@ -161,6 +161,17 @@ describe("GraphView keyboard navigation", () => {
 		view.dispose();
 	});
 
+	it("caps an unhosted frame for a large graph while keeping the body scrollable", () => {
+		const stages = Array.from({ length: 400 }, (_, index) =>
+			makeStage(`stage-${index}`, index === 0 ? [] : [`stage-${index - 1}`]),
+		);
+		const view = makeView(stages);
+		const lines = view.render(96);
+		assert.equal(lines.length, 32);
+		assert.ok(lines.length < stages.length);
+		view.dispose();
+	});
+
 	it("keeps unpainted margin rows around the layout root", () => {
 		const stages = [makeStage("A"), makeStage("B", ["A"])] as const;
 		const view = makeView([...stages]);
@@ -189,13 +200,40 @@ describe("GraphView keyboard navigation", () => {
 			layout.dispose();
 		}
 	});
-	it("preserves content OSC-8 terminators while removing layout wrappers", () => {
+	it("reserves the scrollbar column only while the body overflows", () => {
+		let overflowing = true;
+		const layout = new GraphViewLayout({
+			renderHeader: () => ["", "", ""],
+			renderBody: (_width, _top, rows) => Array.from({ length: rows }, () => ""),
+			renderFooter: () => ["", "", ""],
+			bodyContentHeight: (_width, rows) => (overflowing ? rows + 1 : rows),
+		});
+		try {
+			const overflowingFrame = layout.render(96, 20);
+			assert.ok(overflowingFrame.bodyBox);
+			assert.equal(overflowingFrame.bodyBox.children[0]?.rect.width, 95);
+			assert.equal(overflowingFrame.scrollbar?.column, 95);
+
+			overflowing = false;
+			const fittedFrame = layout.render(96, 20);
+			assert.ok(fittedFrame.bodyBox);
+			assert.equal(fittedFrame.bodyBox.children[0]?.rect.width, 96);
+			assert.equal(fittedFrame.scrollbar, undefined);
+		} finally {
+			layout.dispose();
+		}
+	});
+	it("preserves content OSC-8 terminators and composite seam resets", () => {
 		const view = makeView([makeStage("A")]);
-		const wrapped =
-			"\x1b[0m\x1b]8;;\x07" + "\x1b]8;;https://example.com\x07label\x1b]8;;\x07" + "\x1b[0m\x1b]8;;\x07";
-		const [line] = view._normalizeLayoutLines([wrapped], 96, 1, 0, 0);
-		assert.match(line, /\x1b\]8;;https:\/\/example\.com\x07label\x1b\]8;;\x07/);
-		assert.doesNotMatch(line, /\x1b\[0m\x1b\]8;;/);
+		const wrapper = "\x1b[0m\x1b]8;;\x07";
+		const content = "\x1b]8;;https://example.com\x07label\x1b[0m\x1b]8;;\x07";
+		const [line] = view._normalizeLayoutLines([`${wrapper}${content}${wrapper}`], 96, 1, 0, 0);
+		assert.match(line, /\x1b\]8;;https:\/\/example\.com\x07label\x1b\[0m\x1b\]8;;\x07/);
+		assert.equal((line.match(/\x1b\[0m\x1b\]8;;\x07/g) ?? []).length, 1);
+
+		const sideBySide = `${wrapper}\x1b[41mleft${wrapper}\x1b[42mright${wrapper}`;
+		const [composited] = view._normalizeLayoutLines([sideBySide], 96, 1, 0, 0);
+		assert.match(composited, /\x1b\[41mleft\x1b\[0m\x1b\]8;;\x07\x1b\[42mright/);
 		view.dispose();
 	});
 

--- a/test/unit/overlay-graph-navigation-02.test.ts
+++ b/test/unit/overlay-graph-navigation-02.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import { describe, it, vi } from "vitest";
 import { createStore } from "../../packages/workflows/src/shared/store.js";
 import { GraphView } from "../../packages/workflows/src/tui/graph-view.js";
+import { GraphViewLayout, graphLayoutBodyRows } from "../../packages/workflows/src/tui/graph-view-layout.js";
 import { visibleWidth } from "../../packages/workflows/src/tui/text-helpers.js";
 import { makeFakeKeybindings } from "../support/fake-keybindings.js";
 import * as h from "./overlay-graph-helpers.js";
@@ -156,8 +157,7 @@ describe("GraphView keyboard navigation", () => {
 		const stages = [makeStage("A"), makeStage("B", ["A"])] as const;
 		const view = makeView([...stages]);
 		const lines = view.render(96);
-		assert.ok(lines.length > 0);
-		assert.ok(lines.length < 32, `natural layout should not restore the old 32-row frame: ${lines.length}`);
+		assert.equal(lines.length, 21);
 		view.dispose();
 	});
 
@@ -166,9 +166,36 @@ describe("GraphView keyboard navigation", () => {
 		const view = makeView([...stages]);
 		const lines = view.render(96);
 		assert.equal(lines[0], " ".repeat(96));
+		assert.equal(lines.length, 21);
 		assert.equal(lines.at(-1), " ".repeat(96));
 		assert.match(visibleText(lines.slice(1, 4)), /ORCHESTRATOR/);
 		assert.match(visibleText(lines.slice(-4, -1)), /GRAPH/);
+		view.dispose();
+	});
+	it("keeps the ScrollView body box aligned with its viewport formula", () => {
+		const layout = new GraphViewLayout({
+			renderHeader: () => ["", "", ""],
+			renderBody: (_width, _top, rows) => Array.from({ length: rows }, () => ""),
+			renderFooter: () => ["", "", ""],
+			bodyContentHeight: (_width, rows) => rows,
+		});
+		try {
+			for (let height = 1; height <= 60; height++) {
+				const frame = layout.render(96, height);
+				assert.ok(frame.bodyBox, `layout should expose a body box at height ${height}`);
+				assert.equal(frame.bodyBox.rect.height, graphLayoutBodyRows(height), `body height at ${height}`);
+			}
+		} finally {
+			layout.dispose();
+		}
+	});
+	it("preserves content OSC-8 terminators while removing layout wrappers", () => {
+		const view = makeView([makeStage("A")]);
+		const wrapped =
+			"\x1b[0m\x1b]8;;\x07" + "\x1b]8;;https://example.com\x07label\x1b]8;;\x07" + "\x1b[0m\x1b]8;;\x07";
+		const [line] = view._normalizeLayoutLines([wrapped], 96, 1, 0, 0);
+		assert.match(line, /\x1b\]8;;https:\/\/example\.com\x07label\x1b\]8;;\x07/);
+		assert.doesNotMatch(line, /\x1b\[0m\x1b\]8;;/);
 		view.dispose();
 	});
 

--- a/test/unit/overlay-graph-navigation-02.test.ts
+++ b/test/unit/overlay-graph-navigation-02.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import { describe, it, vi } from "vitest";
 import { createStore } from "../../packages/workflows/src/shared/store.js";
 import { GraphView } from "../../packages/workflows/src/tui/graph-view.js";
+import { visibleWidth } from "../../packages/workflows/src/tui/text-helpers.js";
 import { makeFakeKeybindings } from "../support/fake-keybindings.js";
 import * as h from "./overlay-graph-helpers.js";
 
@@ -151,21 +152,19 @@ describe("GraphView keyboard navigation", () => {
 		view.dispose();
 	});
 
-	it("renders the constant 32-line frame when no viewport provider is wired", () => {
-		// Fallback path: direct unit renders without a host-provided
-		// viewport accessor get the legacy OVERLAY_LINE_COUNT rectangle.
-		const stages = [makeStage("A"), makeStage("B", ["A"])];
-		const view = makeView(stages);
+	it("sizes an unhosted overlay from its layout content instead of a fixed frame", () => {
+		const stages = [makeStage("A"), makeStage("B", ["A"])] as const;
+		const view = makeView([...stages]);
 		const lines = view.render(96);
-		assert.equal(lines.length, 32);
+		assert.ok(lines.length > 0);
+		assert.ok(lines.length < 32, `natural layout should not restore the old 32-row frame: ${lines.length}`);
 		view.dispose();
 	});
 
-	it("leaves unpainted top and bottom margin rows around the orchestrator panel", () => {
-		const stages = [makeStage("A"), makeStage("B", ["A"])];
-		const view = makeView(stages);
+	it("keeps unpainted margin rows around the layout root", () => {
+		const stages = [makeStage("A"), makeStage("B", ["A"])] as const;
+		const view = makeView([...stages]);
 		const lines = view.render(96);
-		assert.equal(lines.length, 32);
 		assert.equal(lines[0], " ".repeat(96));
 		assert.equal(lines.at(-1), " ".repeat(96));
 		assert.match(visibleText(lines.slice(1, 4)), /ORCHESTRATOR/);
@@ -206,6 +205,64 @@ describe("GraphView keyboard navigation", () => {
 		const lines = view.render(96);
 		assert.equal(lines.length, 10);
 		assert.match(visibleText(lines.slice(-4)), /GRAPH/);
+		view.dispose();
+	});
+
+	it("keeps tiny terminal frames bounded while shrinking chrome", () => {
+		let rows = 5;
+		const view = new GraphView({
+			mode: "overlay",
+			runId: "run-1",
+			store: makeStore(makeSnap([makeStage("tiny")])),
+			graphTheme: defaultTheme,
+			getViewportRows: () => rows,
+		});
+		for (rows of [5, 3, 1]) {
+			const lines = view.render(96);
+			assert.equal(lines.length, rows);
+			assert.ok(lines.every((line) => visibleWidth(line) === 96));
+		}
+		view.dispose();
+	});
+
+	it("reflows the ScrollView body across terminal resize without losing graph scrolling", () => {
+		const stages = Array.from({ length: 12 }, (_, index) =>
+			makeStage(`resize-${index}`, index === 0 ? [] : [`resize-${index - 1}`]),
+		);
+		const store = makeStore(makeSnap(stages));
+		let terminalRows = 10;
+		const view = new GraphView({
+			mode: "overlay",
+			runId: "run-1",
+			store,
+			graphTheme: defaultTheme,
+			getViewportRows: () => terminalRows,
+		});
+
+		assert.equal(view.render(96).length, 10);
+		const shortScrollbar = view._graphScrollbarGeometry;
+		assert.ok(shortScrollbar, "the short graph viewport has a ScrollView scrollbar");
+		assert.equal(view.handleInput("\x1b[<65;1;1M"), true);
+		view.render(96);
+		assert.ok(view._graphScrollOffset > 0);
+
+		terminalRows = 40;
+		const tallLines = view.render(96);
+		const tallScrollbar = view._graphScrollbarGeometry;
+		assert.equal(tallLines.length, 40);
+		assert.ok(tallScrollbar, "the taller graph viewport keeps a ScrollView scrollbar");
+		assert.ok(tallScrollbar.trackHeight > shortScrollbar.trackHeight, "the scrollbar track follows the resized body");
+		assert.match(visibleText(tallLines.slice(-4)), /GRAPH/);
+		assert.ok(view._graphScrollOffset > 0, "a taller viewport keeps the still-valid ScrollView offset");
+		assert.ok(view._graphScrollOffset <= tallScrollbar.maxScrollTop);
+
+		terminalRows = 8;
+		const shortLines = view.render(96);
+		const resizedShortScrollbar = view._graphScrollbarGeometry;
+		assert.equal(shortLines.length, 8);
+		assert.ok(resizedShortScrollbar, "the short resized graph viewport keeps a scrollbar");
+		assert.match(visibleText(shortLines.slice(-4)), /GRAPH/);
+		assert.ok(view._graphScrollOffset <= resizedShortScrollbar.maxScrollTop);
 		view.dispose();
 	});
 
@@ -311,6 +368,9 @@ describe("GraphView keyboard navigation", () => {
 		assert.equal(view.handleInput("d"), true);
 		assert.deepEqual(resolved, []);
 		assert.equal(store.runs()[0]?.pendingPrompt?.id, prompt.id);
+
+		assert.equal(view.handleInput("\x1b[6~"), true, "raw PageDown remains owned by the select prompt");
+		assert.equal(view.handleInput("\x1b[5~"), true, "raw PageUp remains owned by the select prompt");
 
 		assert.equal(view.handleInput("s"), true);
 		assert.deepEqual(resolved, [{ runId: "run-1", promptId: prompt.id, response: "beta" }]);

--- a/test/unit/overlay-graph-navigation-03.test.ts
+++ b/test/unit/overlay-graph-navigation-03.test.ts
@@ -387,7 +387,7 @@ describe("GraphView keyboard navigation", () => {
 		view.dispose();
 	});
 
-	it("contains graph wheel input while the stage switcher is open", () => {
+	it("keeps graph wheel input inside the stage switcher", () => {
 		const stages = Array.from({ length: 12 }, (_, index) =>
 			makeStage(`switcher-scroll-${index}`, index === 0 ? [] : [`switcher-scroll-${index - 1}`]),
 		);
@@ -401,9 +401,13 @@ describe("GraphView keyboard navigation", () => {
 
 		view.render(96);
 		assert.equal(view.handleInput("/"), true);
+		const beforeWheel = view.render(96).join("\n");
+		const initialOffset = view._graphScrollOffset;
 		assert.equal(view.handleInput(SGR_MOUSE_WHEEL_DOWN), true);
-		view.render(96);
-		assert.ok(view._graphScrollOffset > 0);
+		const afterWheel = view.render(96).join("\n");
+		assert.equal(view._graphScrollOffset, initialOffset);
+		assert.equal(view._switcherState.selectedIndex, 1);
+		assert.notEqual(afterWheel, beforeWheel);
 		view.dispose();
 	});
 

--- a/test/unit/overlay-graph-navigation-03.test.ts
+++ b/test/unit/overlay-graph-navigation-03.test.ts
@@ -3,6 +3,11 @@
 import assert from "node:assert/strict";
 import { describe, it } from "vitest";
 import { GraphView } from "../../packages/workflows/src/tui/graph-view.js";
+import {
+	GRAPH_HEADER_ROWS,
+	graphLayoutBodyRows,
+	graphLayoutMarginRows,
+} from "../../packages/workflows/src/tui/graph-view-layout.js";
 import { renderHeader } from "../../packages/workflows/src/tui/header.js";
 import { computeLayout, NODE_H, NODE_W } from "../../packages/workflows/src/tui/layout.js";
 import { renderNodeCard } from "../../packages/workflows/src/tui/node-card.js";
@@ -40,16 +45,18 @@ function graphNodeClick(
 	const scrollCols = opts.scrollCols ?? 0;
 	const layout = computeLayout(stages, { orientation: "vertical" });
 	const node = layout[index]!;
-	const marginRows = rows >= 9 ? 1 : 0;
-	const panelRows = Math.max(7, rows - marginRows * 2);
-	const bodyRows = Math.max(1, panelRows - 6);
+	const marginRows = graphLayoutMarginRows(rows);
+	const bodyRows = graphLayoutBodyRows(rows);
 	const totalGraphRows = Math.max(1, ...layout.map((n) => n.y + NODE_H));
 	const topPad =
 		totalGraphRows <= bodyRows ? Math.min(3, Math.max(0, Math.floor((bodyRows - totalGraphRows) / 2))) : 0;
 	const graphInner = Math.max(1, Math.max(40, width) - 4);
 	const canvasWidth = layout.reduce((max, n) => Math.max(max, n.x + NODE_W), 0);
 	const leftMargin = Math.max(2, canvasWidth <= graphInner ? Math.floor((graphInner - canvasWidth) / 2) : 2);
-	return sgrMousePress(leftMargin + node.x - scrollCols + 2, marginRows + 3 + topPad + node.y - scrollRows + 2);
+	return sgrMousePress(
+		leftMargin + node.x - scrollCols + 2,
+		marginRows + GRAPH_HEADER_ROWS + topPad + node.y - scrollRows + 2,
+	);
 }
 
 describe("GraphView keyboard navigation", () => {
@@ -377,6 +384,79 @@ describe("GraphView keyboard navigation", () => {
 		view.render(96);
 		assert.equal(view._focusedIndex, 0);
 		assert.ok(view._graphScrollOffset > 0);
+		view.dispose();
+	});
+
+	it("contains graph wheel input while the stage switcher is open", () => {
+		const stages = Array.from({ length: 12 }, (_, index) =>
+			makeStage(`switcher-scroll-${index}`, index === 0 ? [] : [`switcher-scroll-${index - 1}`]),
+		);
+		const view = new GraphView({
+			mode: "overlay",
+			runId: "run-1",
+			store: makeStore(makeSnap(stages)),
+			graphTheme: defaultTheme,
+			getViewportRows: () => 16,
+		});
+
+		view.render(96);
+		assert.equal(view.handleInput("/"), true);
+		assert.equal(view.handleInput(SGR_MOUSE_WHEEL_DOWN), true);
+		view.render(96);
+		assert.ok(view._graphScrollOffset > 0);
+		view.dispose();
+	});
+
+	it("drags the pi-tui scrollbar without changing focus or leaking to the graph click handler", () => {
+		const stages = Array.from({ length: 12 }, (_, index) =>
+			makeStage(`scrollbar-${index}`, index === 0 ? [] : [`scrollbar-${index - 1}`]),
+		);
+		const view = new GraphView({
+			mode: "overlay",
+			runId: "run-1",
+			store: makeStore(makeSnap(stages)),
+			graphTheme: defaultTheme,
+			getViewportRows: () => 16,
+		});
+
+		view.render(96);
+		const initiallyVisible = view._graphScrollbarGeometry;
+		assert.ok(initiallyVisible, "an overflowing graph exposes its scrollbar on first layout");
+		view.handleInput(SGR_MOUSE_WHEEL_DOWN);
+		view.render(96);
+		const scrollbar = view._graphScrollbarGeometry;
+		assert.ok(scrollbar, "a scrolled graph exposes a scrollbar geometry");
+		const before = view._graphScrollOffset;
+		const col = scrollbar.column + 1;
+		const thumbRow = scrollbar.thumbTop + 1;
+		assert.equal(view.handleInput(`\x1b[<0;${col};${thumbRow + 1}M`), true);
+		assert.equal(view.handleInput(`\x1b[<32;${col};${scrollbar.trackTop + scrollbar.trackHeight}M`), true);
+		assert.equal(view.handleInput(`\x1b[<0;${col};${scrollbar.trackTop + scrollbar.trackHeight}m`), true);
+		view.render(96);
+		assert.ok(view._graphScrollOffset > before);
+		assert.equal(view._focusedIndex, 0);
+		assert.equal(view.handleInput("\x1b[5~"), false, "PageUp remains available to the host transcript");
+		assert.equal(view.handleInput("\x1b[6~"), false, "PageDown remains available to the host transcript");
+		view.dispose();
+	});
+	it("keeps the ScrollView thumb visible after a prompt card covers the body", () => {
+		const stages = Array.from({ length: 12 }, (_, index) =>
+			makeStage(`prompt-scrollbar-${index}`, index === 0 ? [] : [`prompt-scrollbar-${index - 1}`]),
+		);
+		const view = new GraphView({
+			mode: "overlay",
+			runId: "run-1",
+			store: makeStore(makeRunPromptSnap(stages, makePendingPrompt({ message: "Continue?" }))),
+			graphTheme: defaultTheme,
+			getViewportRows: () => 16,
+		});
+
+		const lines = view.render(96);
+		const scrollbar = view._graphScrollbarGeometry;
+		assert.ok(scrollbar);
+		for (let row = scrollbar.thumbTop; row < scrollbar.thumbTop + scrollbar.thumbHeight; row++) {
+			assert.match(lines[row]!, /\x1b\[100m/, `thumb row ${row} remains painted over the prompt card`);
+		}
 		view.dispose();
 	});
 

--- a/test/unit/overlay-graph-perf.test.ts
+++ b/test/unit/overlay-graph-perf.test.ts
@@ -8,6 +8,7 @@ import type {
 } from "../../packages/workflows/src/shared/store-types.js";
 import { GraphCanvas } from "../../packages/workflows/src/tui/graph-canvas.js";
 import { GraphView } from "../../packages/workflows/src/tui/graph-view.js";
+import { graphLayoutBodyRows } from "../../packages/workflows/src/tui/graph-view-layout.js";
 import { NODE_H } from "../../packages/workflows/src/tui/layout.js";
 import { defaultTheme, makeSnap, makeStage, makeStore, visibleText } from "./overlay-graph-helpers.js";
 
@@ -115,11 +116,11 @@ class InstrumentedGraphView extends GraphView {
 	}
 
 	bodyRowsForTest(): number {
-		return this.graphLayout.viewportRows;
+		return graphLayoutBodyRows(24);
 	}
 
 	graphScrollOffsetForTest(): number {
-		return this.graphScrollOffset;
+		return this._graphScrollTop();
 	}
 
 	countRenderReadsForTest(): void {
@@ -311,9 +312,7 @@ describe("GraphView many-stage performance (#2100)", () => {
 			initialFocusedStageId: "s0",
 		});
 		try {
-			view.render(96);
 			const { viewportScoped } = perFrameReadBudgets(view);
-			view.paintedCards = 0;
 			view.countRenderReadsForTest();
 			const text = visibleText(view.render(96));
 			const reads = view.renderReadCountsForTest();

--- a/test/unit/overlay-graph-perf.test.ts
+++ b/test/unit/overlay-graph-perf.test.ts
@@ -115,7 +115,7 @@ class InstrumentedGraphView extends GraphView {
 	}
 
 	bodyRowsForTest(): number {
-		return this._overlayBodyRows(this._overlayPanelLineCount());
+		return this.graphLayout.viewportRows;
 	}
 
 	graphScrollOffsetForTest(): number {
@@ -311,7 +311,9 @@ describe("GraphView many-stage performance (#2100)", () => {
 			initialFocusedStageId: "s0",
 		});
 		try {
+			view.render(96);
 			const { viewportScoped } = perFrameReadBudgets(view);
+			view.paintedCards = 0;
 			view.countRenderReadsForTest();
 			const text = visibleText(view.render(96));
 			const reads = view.renderReadCountsForTest();

--- a/test/unit/overlay-graph-perf.test.ts
+++ b/test/unit/overlay-graph-perf.test.ts
@@ -116,7 +116,7 @@ class InstrumentedGraphView extends GraphView {
 	}
 
 	bodyRowsForTest(): number {
-		return graphLayoutBodyRows(24);
+		return graphLayoutBodyRows(this._overlayFrameHeight());
 	}
 
 	graphScrollOffsetForTest(): number {


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788992163&installation_model_id=10562&pr_number=2298&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2298&signature=1a9a9f79fb3f70df32806a899ec6461bf042dd11b4eeba24ee9acadbbfaf8077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR rebuilds the workflow graph overlay around pi-tui layout primitives, adds viewport-aware vertical scrolling and scrollbar interaction, and preserves graph navigation through terminal resizes. A focused execution using an 80-node workflow exercised wheel scrolling, scrollbar movement, viewport expansion and contraction, and fixed header/footer placement at 9-, 12-, and 48-row terminal heights. The potential inaccessible-content or overlapping-chrome regression was disproved: scrolling reached valid bounds, offsets stayed clamped after resize, and output retained the expected terminal dimensions.

<h3>Confidence Score: 5/5</h3>

The graph overlay’s primary tall-content scrolling and resize behavior operated correctly in the exercised rendering and input flow.

No final defects remain. The focused test drove the actual graph view through vertical wheel input, scrollbar navigation, offset clamping, and multiple terminal heights, confirming that content remains reachable while header and footer chrome remain fixed.

**Files Needing Attention:** No files require corrective changes. The most behaviorally significant implementation remains packages/workflows/src/tui/graph-view-layout.ts, with rendering coordination in packages/workflows/src/tui/graph-view-render.ts and input routing in packages/workflows/src/tui/graph-view-input.ts.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused GraphView layout validation harness against an 80-node overlay graph at terminal rows 12, 48, and 9.
- Exercised wheel scrolling, moved the scrollbar track to the maximum offset, and performed resize expansion and contraction to exercise fixed-chrome and dynamic layout paths.
- Observed that scroll offsets stayed within ScrollView bounds, every rendered frame matched the reported terminal height and width, the header remained in rows 1–3, and the footer occupied the final non-margin rows.
- The current bridge passed the GraphView path, with scrolling reaching the maximum and remaining valid after resize; the before/after captures verified the baseline against the executed validation.

<a href="https://app.greptile.com/trex/runs/18252948/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(workflows): clarify natural graph s..."](https://github.com/bastani-inc/atomic/commit/9f6fd74e1b4cd56d4cefc30a1640812a41dff9c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52094762)</sub>

<!-- /greptile_comment -->