### PR TITLE
fix(web-access): restore background fetch error notifications

### DIFF
--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Fixed background content fetch notifications that completed after an extension reload from throwing through stale runtime handles.
 - Fixed background fetch stale-context checks by consuming the host's exported predicate instead of copying its error-message marker.
+- Restored visible background content-fetch error notifications for non-stale success-path failures while keeping stale runtime errors contained and pending state alive until notification admission settles.
 
 - Routed query rewriting and summary-review model calls through Atomic's model runtime so registered custom providers and resolved request authentication apply.
 - Fixed frames and thumbnails returned by `fetch_content` bypassing the host's `images.autoResize` processing before they enter session history.

--- a/packages/web-access/web-search-features.ts
+++ b/packages/web-access/web-search-features.ts
@@ -77,6 +77,8 @@ export function registerWebSearchFeatures(pi: ExtensionAPI, initConfig: WebSearc
 				try {
 					pi.appendEntry("web-search-results", data);
 					const ok = fetched.filter(f => !f.error).length;
+					// Keep the fetch pending until notification admission settles so session
+					// changes can still clear the entry and abort its controller while admission is in flight.
 					await pi.sendMessage(
 						{
 							customType: "web-search-content-ready",
@@ -88,7 +90,8 @@ export function registerWebSearchFeatures(pi: ExtensionAPI, initConfig: WebSearc
 				} catch (error) {
 					if (!isStaleExtensionContextError(error)) throw error;
 				}
-			}, async (err) => {
+			})
+			.catch(async (err) => {
 				if (isStaleExtensionContextError(err)) return;
 				if (!runtimeState.sessionActive || !pendingFetches.has(fetchId)) return;
 				const message = err instanceof Error ? err.message : String(err);

--- a/test/unit/web-search-features-error-path.test.ts
+++ b/test/unit/web-search-features-error-path.test.ts
@@ -1,0 +1,276 @@
+import assert from "node:assert/strict";
+import type { ExtensionAPI, ExtensionContext } from "@bastani/atomic";
+import { afterEach, beforeEach, test, vi } from "vitest";
+import { STALE_EXTENSION_CONTEXT_MESSAGE } from "../../packages/coding-agent/src/core/extensions/stale-context.js";
+
+interface WebSearchConfig {
+	shortcuts?: {
+		curate?: string;
+		activity?: string;
+	};
+}
+
+interface ExtractedContent {
+	url: string;
+	title: string;
+	content: string;
+	error: string | null;
+}
+
+interface SearchReturnOptions {
+	queryList: string[];
+	results: Array<{ query: string }>;
+	urls: string[];
+	includeContent: boolean;
+}
+
+interface SearchReturnPayload {
+	content: Array<{ type: "text"; text: string }>;
+	details: Record<string, string | null>;
+}
+
+type SearchReturnBuilder = (opts: SearchReturnOptions) => SearchReturnPayload;
+
+interface WebSearchFeaturesModule {
+	registerWebSearchFeatures(pi: ExtensionAPI, initConfig: WebSearchConfig): void;
+}
+
+type EventHandler = (event: object, ctx: ExtensionContext) => Promise<void> | void;
+
+type Deferred<T> = {
+	promise: Promise<T>;
+	resolve(value: T): void;
+};
+
+interface MessageObservation {
+	customType: string;
+	content: string | undefined;
+	triggerTurn: boolean | undefined;
+}
+
+interface RegisteredState {
+	fetchAllContent: ReturnType<typeof vi.fn>;
+	handlers: Map<string, EventHandler>;
+	buildReturn: SearchReturnBuilder | null;
+	messages: MessageObservation[];
+	fetchSignal: AbortSignal | null;
+	nextFetchId: number;
+}
+
+const state = vi.hoisted(
+	(): RegisteredState => ({
+		fetchAllContent: vi.fn(),
+		handlers: new Map(),
+		buildReturn: null,
+		messages: [],
+		fetchSignal: null,
+		nextFetchId: 0,
+	}),
+);
+
+vi.mock("../../packages/web-access/extract.js", () => ({
+	fetchAllContent: state.fetchAllContent,
+}));
+
+vi.mock("../../packages/web-access/github-extract.js", () => ({
+	clearCloneCache: vi.fn(),
+}));
+
+vi.mock("../../packages/web-access/content-tools.js", () => ({
+	registerContentTools: vi.fn(),
+}));
+
+vi.mock("../../packages/web-access/storage.js", () => ({
+	clearResults: vi.fn(),
+	generateId: () => `fetch-${++state.nextFetchId}`,
+	restoreFromSession: vi.fn(),
+	storeResult: () => {},
+}));
+
+vi.mock("../../packages/web-access/web-search-activity.js", () => ({
+	createActivityWidgetState: () => ({}),
+	refreshActivityForSession: vi.fn(),
+	shutdownActivityWidget: vi.fn(),
+	toggleActivityWidget: vi.fn(),
+}));
+
+vi.mock("../../packages/web-access/web-search-curator.js", () => ({
+	openCuratorBrowser: vi.fn(async () => {}),
+}));
+
+vi.mock("../../packages/web-access/web-search-formatting.js", () => ({
+	MAX_INLINE_CONTENT: 10_000,
+	formatFullResults: vi.fn(),
+	stripThumbnails: (results: ExtractedContent[]) => results,
+}));
+
+vi.mock("../../packages/web-access/web-search-config.js", () => ({
+	DEFAULT_SHORTCUTS: { curate: "ctrl-c", activity: "ctrl-a" },
+}));
+
+vi.mock("../../packages/web-access/web-search-command.js", () => ({
+	registerWebSearchCommand: vi.fn(),
+}));
+
+vi.mock("../../packages/web-access/web-search-tool.js", () => ({
+	registerWebSearchTool: (_pi: ExtensionAPI, deps: { buildSearchReturn: SearchReturnBuilder }) => {
+		state.buildReturn = deps.buildSearchReturn;
+	},
+}));
+
+vi.mock("../../packages/web-access/web-search-return.js", () => ({
+	buildSearchReturn: (
+		_opts: SearchReturnOptions,
+		deps: { startBackgroundFetch(urls: string[]): string | null },
+	): SearchReturnPayload => {
+		const fetchId = deps.startBackgroundFetch(["https://example.test/article"]);
+		return {
+			content: [{ type: "text", text: "background fetch started" }],
+			details: { fetchId },
+		};
+	},
+}));
+
+const { registerWebSearchFeatures } = await vi.importActual<WebSearchFeaturesModule>(
+	"../../packages/web-access/web-search-features.js",
+);
+
+function deferred<T>(): Deferred<T> {
+	let resolvePromise: (value: T) => void = () => {};
+	const promise = new Promise<T>((resolve) => {
+		resolvePromise = resolve;
+	});
+	return { promise, resolve: resolvePromise };
+}
+
+function createPi(options: { appendError?: Error; contentAdmission?: Promise<void> } = {}): ExtensionAPI {
+	const on = (event: string, handler: EventHandler): void => {
+		state.handlers.set(event, handler);
+	};
+	const appendEntry = (_customType: string, _data: Record<string, string | number | null>): void => {
+		if (options.appendError) throw options.appendError;
+	};
+	const sendMessage = (
+		message: { customType: string; content?: string },
+		sendOptions?: { triggerTurn?: boolean },
+	): void | Promise<void> => {
+		state.messages.push({
+			customType: message.customType,
+			content: message.content,
+			triggerTurn: sendOptions?.triggerTurn,
+		});
+		if (message.customType === "web-search-content-ready") return options.contentAdmission;
+		return undefined;
+	};
+	return {
+		on,
+		registerShortcut: () => {},
+		registerTool: () => {},
+		registerCommand: () => {},
+		appendEntry,
+		sendMessage,
+	} as unknown as ExtensionAPI;
+}
+
+function setup(options: Parameters<typeof createPi>[0] = {}): ExtensionAPI {
+	state.fetchAllContent.mockReset();
+	state.fetchSignal = null;
+	state.handlers.clear();
+	state.buildReturn = null;
+	state.messages.length = 0;
+	state.nextFetchId = 0;
+	state.fetchAllContent.mockImplementation((_urls: string[], signal: AbortSignal) => {
+		state.fetchSignal = signal;
+		return Promise.resolve([
+			{
+				url: "https://example.test/article",
+				title: "Example",
+				content: "Example content",
+				error: null,
+			},
+		] satisfies ExtractedContent[]);
+	});
+	const pi = createPi(options);
+	registerWebSearchFeatures(pi, {} as WebSearchConfig);
+	return pi;
+}
+
+async function startSession(): Promise<void> {
+	const handler = state.handlers.get("session_start");
+	assert.ok(handler, "session_start handler should be registered");
+	await handler({}, {} as ExtensionContext);
+}
+
+async function shutdownSession(): Promise<void> {
+	const handler = state.handlers.get("session_shutdown");
+	assert.ok(handler, "session_shutdown handler should be registered");
+	await handler({}, {} as ExtensionContext);
+}
+
+async function waitForNotifications(): Promise<void> {
+	await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+function buildBackgroundFetch(): SearchReturnPayload {
+	assert.ok(state.buildReturn, "web search return builder should be registered");
+	const options: SearchReturnOptions = {
+		queryList: ["example"],
+		results: [],
+		urls: ["https://example.test/article"],
+		includeContent: true,
+	};
+	return state.buildReturn(options);
+}
+
+beforeEach(() => {
+	vi.restoreAllMocks();
+});
+
+afterEach(async () => {
+	if (state.handlers.has("session_shutdown")) await shutdownSession();
+});
+
+test("a non-stale appendEntry failure posts a visible web-search-error entry", async () => {
+	setup({ appendError: new Error("append failed") });
+	await startSession();
+
+	buildBackgroundFetch();
+	await waitForNotifications();
+
+	assert.deepEqual(state.messages, [
+		{
+			customType: "web-search-error",
+			content: "Content fetch failed [fetch-1]: append failed",
+			triggerTurn: false,
+		},
+	]);
+});
+
+test("a stale appendEntry failure is contained without posting a web-search-error entry", async () => {
+	const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+	setup({ appendError: new Error(STALE_EXTENSION_CONTEXT_MESSAGE) });
+	await startSession();
+
+	buildBackgroundFetch();
+	await waitForNotifications();
+
+	assert.deepEqual(state.messages, []);
+	assert.equal(errorSpy.mock.calls.length, 0);
+});
+
+test("pending fetch cleanup waits for content-ready message admission", async () => {
+	const admission = deferred<void>();
+	setup({ contentAdmission: admission.promise });
+	await startSession();
+
+	buildBackgroundFetch();
+	await waitForNotifications();
+	assert.equal(state.messages[0]?.customType, "web-search-content-ready");
+	assert.ok(state.fetchSignal, "fetch signal should be captured");
+
+	await shutdownSession();
+	assert.equal(state.fetchSignal.aborted, true);
+
+	admission.resolve();
+	await waitForNotifications();
+});


### PR DESCRIPTION
Route failures from the success handler through the chained catch so non-stale appendEntry or notification errors still publish web-search-error, while stale runtime failures remain contained by the host predicate. Reject the then(f, g) alternative because it cannot catch failures from f.

Keep pi.sendMessage awaited before pendingFetches cleanup so notification admission completes while the fetch remains pending and session lifecycle can still clear its controller. Reject fire-and-forget cleanup because it clears pending state before admission settles.

Refs: #2272
Assistant-model: GPT-5.6 Luna

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789043394&installation_model_id=10562&pr_number=2312&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2312&signature=4fbb6a75c48e85d1e32e54e52b3439b5eaa852bc6123f7ad659c9517a320f2f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change restores visible error notifications when background content-fetch success handling fails, while retaining stale-context suppression and pending notification admission behavior. The focused error-path coverage is in place, but its `ExtensionAPI` fake bypasses TypeScript structural checking and should be made type-safe before merge.

<h3>Confidence Score: 4/5</h3>

Runtime behavior appears safe, but the test double should be corrected to preserve compile-time API-contract coverage.

The final findings contain one non-security P2 style issue, which maps to a score of 4.

**Files Needing Attention:** test/unit/web-search-features-error-path.test.ts: the `createPi` mock uses an `unknown` cast to satisfy `ExtensionAPI`.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
test/unit/web-search-features-error-path.test.ts:172
**ExtensionAPI mock bypasses type checking**

Casting the partial test double through `unknown` disables structural validation against `ExtensionAPI`, so future API drift or an incorrectly shaped mock can remain hidden from TypeScript and reduce this regression test's reliability.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web-access): restore background fetc..."](https://github.com/bastani-inc/atomic/commit/a79c0e38aa5b45094ed62540fcbd8ce650cf0247) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52253587)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->