### PR TITLE
test(coding-agent): tighten test assertions and fixture types

### DIFF
--- a/packages/coding-agent/test/baseten-qwen-provider.test.ts
+++ b/packages/coding-agent/test/baseten-qwen-provider.test.ts
@@ -1,6 +1,8 @@
+import assert from "node:assert/strict";
+import { isDeepStrictEqual } from "node:util";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { getSupportedThinkingLevels } from "@earendil-works/pi-ai/compat";
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, test } from "vitest";
 import type { AgentSessionInternalSurface } from "../src/core/agent-session-methods.ts";
 import { _getRequiredRequestAuth } from "../src/core/agent-session-models.ts";
 import { AuthStorage } from "../src/core/auth-storage.ts";
@@ -100,19 +102,23 @@ describe("Baseten and Qwen Token Plan Individual providers", () => {
 			const model = getProviderModel(runtime, provider);
 			const models = runtime.getModels().filter((candidate) => candidate.provider === provider.provider);
 
-			expect(models.map((candidate) => candidate.id)).toEqual(provider.modelIds);
-			expect(defaultModelPerProvider[provider.provider]).toBe(provider.defaultModel);
-			expect(models).toContainEqual(model);
-			expect(getSupportedThinkingLevels(model)).toEqual(provider.thinkingLevels);
-			expect(runtime.getProvider(provider.provider)?.name).toBe(
+			assert.deepEqual(
+				models.map((candidate) => candidate.id),
+				provider.modelIds,
+			);
+			assert.equal(defaultModelPerProvider[provider.provider], provider.defaultModel);
+			assert.ok(models.some((candidate) => isDeepStrictEqual(candidate, model)));
+			assert.deepEqual(getSupportedThinkingLevels(model), provider.thinkingLevels);
+			assert.equal(
+				runtime.getProvider(provider.provider)?.name,
 				provider.provider === "baseten" ? "Baseten" : "Qwen Token Plan Individual",
 			);
-			expect(runtime.getProviderAuthStatus(provider.provider)).toEqual({
+			assert.deepEqual(runtime.getProviderAuthStatus(provider.provider), {
 				configured: true,
 				source: "environment",
 				label: provider.envVar,
 			});
-			expect((await runtime.getAuth(model))?.auth.apiKey).toBe(`test-${provider.provider}-key`);
+			assert.equal((await runtime.getAuth(model))?.auth.apiKey, `test-${provider.provider}-key`);
 		},
 	);
 
@@ -121,12 +127,16 @@ describe("Baseten and Qwen Token Plan Individual providers", () => {
 		const runtime = await createRuntime();
 		const model = getProviderModel(runtime, provider);
 
-		expect(runtime.getProviderAuthStatus(provider.provider)).toEqual({ configured: false });
-		expect(runtime.getAvailableSnapshot().some((candidate) => candidate.provider === provider.provider)).toBe(false);
-		expect(await runtime.getAuth(model)).toBeUndefined();
+		assert.deepEqual(runtime.getProviderAuthStatus(provider.provider), { configured: false });
+		assert.equal(
+			runtime.getAvailableSnapshot().some((candidate) => candidate.provider === provider.provider),
+			false,
+		);
+		assert.equal(await runtime.getAuth(model), undefined);
 		const session = { _modelRuntime: runtime } as AgentSessionInternalSurface;
-		await expect(_getRequiredRequestAuth.call(session, model)).rejects.toThrow(
-			`No API key found for ${provider.provider}.`,
+		await assert.rejects(
+			_getRequiredRequestAuth.call(session, model),
+			new RegExp(`No API key found for ${provider.provider}\\.`, "u"),
 		);
 	});
 
@@ -142,7 +152,7 @@ describe("Baseten and Qwen Token Plan Individual providers", () => {
 			});
 			const model = getProviderModel(runtime, provider);
 
-			await expect(runtime.getAuth(model)).rejects.toThrow(`for ${provider.provider}`);
+			await assert.rejects(runtime.getAuth(model), new RegExp(`for ${provider.provider}`, "u"));
 		},
 	);
 });

--- a/packages/coding-agent/test/interactive-tui.test.ts
+++ b/packages/coding-agent/test/interactive-tui.test.ts
@@ -67,17 +67,15 @@ function createPng(width: number, height: number): Buffer {
 
 function registerFetchContentTool(): ToolDefinition {
 	const tools: ToolDefinition[] = [];
-	registerContentTools(
-		{
-			registerTool: (tool: ToolDefinition) => tools.push(tool),
-			appendEntry: () => {},
-		} as unknown as ExtensionAPI,
-		{
-			maxInlineContent: 100_000,
-			stripThumbnails: (results) => results,
-			formatFullResults: () => "",
-		},
-	);
+	const extensionApi: Pick<ExtensionAPI, "registerTool" | "appendEntry"> = {
+		registerTool: (tool: ToolDefinition) => tools.push(tool),
+		appendEntry: () => {},
+	};
+	registerContentTools(extensionApi as ExtensionAPI, {
+		maxInlineContent: 100_000,
+		stripThumbnails: (results) => results,
+		formatFullResults: () => "",
+	});
 	const tool = tools.find(({ name }) => name === "fetch_content");
 	if (!tool) throw new Error("content-tools did not register fetch_content");
 	return tool;
@@ -282,7 +280,7 @@ describe("interactive TUI renderer", () => {
 			await new Promise<void>((resolve) => setImmediate(resolve));
 			tui.renderNow();
 			const fetchContent = registerFetchContentTool();
-			const content: AgentToolResult<unknown>["content"] = [
+			const content: Pick<AgentToolResult<never>, "content">["content"] = [
 				{ type: "image", data: imageData, mimeType: "image/png" },
 				{ type: "text", text: "Frame at 0:01" },
 			];
@@ -389,11 +387,9 @@ interface CopyCommandContext {
 	showError(message: string): void;
 }
 
-interface CopyCommandPrototype {
-	handleCopyCommand(this: CopyCommandContext, options?: { flashConfirmation?: boolean }): Promise<void>;
-}
+type CopyCommandPrototype = Pick<InteractiveMode, "handleCopyCommand">;
 
-const copyCommandPrototype = InteractiveMode.prototype as unknown as CopyCommandPrototype;
+const copyCommandPrototype: CopyCommandPrototype = InteractiveMode.prototype;
 
 describe("InteractiveMode copy confirmation", () => {
 	beforeEach(() => {

--- a/test/support/fake-tui.ts
+++ b/test/support/fake-tui.ts
@@ -4,13 +4,20 @@ import type { TUI } from "@earendil-works/pi-tui";
 
 export function makeTestTui(rows: number | (() => number | undefined)): TUI {
 	const readRows = typeof rows === "function" ? rows : () => rows;
-	return {
+	// The members consumers actually read stay structurally checked; only the
+	// final widening to the full TUI class is asserted, at one boundary
+	// (Greptile P2 on PR #2315). `terminal` is itself narrowed to the two
+	// geometry members the graph and stage-chat views consume.
+	const fixture: Pick<TUI, "requestRender"> & {
+		terminal: Pick<TUI["terminal"], "rows" | "columns">;
+	} = {
 		requestRender: () => {},
 		terminal: {
 			get rows() {
-				return readRows();
+				return readRows() as number;
 			},
 			columns: 80,
 		},
-	} as unknown as TUI;
+	};
+	return fixture as TUI;
 }

--- a/test/unit/subagents-completion-notification.test.ts
+++ b/test/unit/subagents-completion-notification.test.ts
@@ -365,6 +365,51 @@ test("delivers completions through a replacement API after invalidation", async 
 	assert.equal(registry.get(replacement.pi), undefined);
 });
 
+test("wraps a double failure in AggregateError with the registry already rolled back", () => {
+	// Greptile P2 on PR #2306: the both-cleanups-fail branch promised
+	// "preserve both errors if rollback also fails" and nothing entered it.
+	// The prior subscription's unsubscribe AND the new handler's rollback
+	// unsubscribe both throw non-stale errors here.
+	const listeners = new Map<string, Set<(data: unknown) => void>>();
+	let onCalls = 0;
+	const events = {
+		on(event: string, handler: (data: unknown) => void) {
+			onCalls += 1;
+			const set = listeners.get(event) ?? new Set();
+			set.add(handler);
+			listeners.set(event, set);
+			const subscriptionCall = onCalls;
+			return () => {
+				if (subscriptionCall === 1) throw new Error("injected replacement cleanup failure");
+				throw new Error("injected rollback failure");
+			};
+		},
+		emit(event: string, payload: unknown) {
+			for (const handler of listeners.get(event) ?? []) handler(payload);
+		},
+	};
+	const pi = { events, sendMessage: () => {} };
+	registerSubagentNotify(pi as never);
+	const registry = (globalThis as Record<string, unknown>).__piSubagentsNotifyRegistrations as WeakMap<
+		object,
+		{ unsubscribe: () => void }
+	>;
+	assert.ok(registry.get(pi), "the first subscription is registered");
+
+	let caught: unknown;
+	try {
+		registerSubagentNotify(pi as never);
+	} catch (error) {
+		caught = error;
+	}
+	assert.ok(caught instanceof AggregateError, "double failure surfaces as AggregateError");
+	assert.match(caught.message, /Failed to roll back notification registration/);
+	assert.equal(caught.errors.length, 2, "both errors are preserved");
+	assert.match(String(caught.errors[0]), /injected replacement cleanup failure/);
+	assert.match(String(caught.errors[1]), /injected rollback failure/);
+	assert.equal(registry.get(pi), undefined, "registry is rolled back before the AggregateError escapes");
+});
+
 test("rolls back a failed replacement before activation can expose a registry entry", () => {
 	const listeners = new Map<string, Set<(data: unknown) => void>>();
 	const activeHandlers = new Set<(data: unknown) => void>();

--- a/test/unit/web-search-features-error-path.test.ts
+++ b/test/unit/web-search-features-error-path.test.ts
@@ -162,14 +162,25 @@ function createPi(options: { appendError?: Error; contentAdmission?: Promise<voi
 		if (message.customType === "web-search-content-ready") return options.contentAdmission;
 		return undefined;
 	};
-	return {
-		on,
+	// The supplied members stay structurally checked against ExtensionAPI; the
+	// single widening cast sits at the return boundary because the production
+	// signature demands the full interface (Greptile P2 on PR #2312).
+	const fixture: Pick<
+		ExtensionAPI,
+		"on" | "registerShortcut" | "registerTool" | "registerCommand" | "appendEntry" | "sendMessage"
+	> = {
+		// Member-scoped casts for the three members whose production signatures
+		// are overloaded/generic; the simplified doubles cannot satisfy them
+		// structurally, and the narrowing made that visible (it was hidden by
+		// the blanket unknown cast). Every other member stays fully checked.
+		on: on as ExtensionAPI["on"],
 		registerShortcut: () => {},
 		registerTool: () => {},
 		registerCommand: () => {},
-		appendEntry,
-		sendMessage,
-	} as unknown as ExtensionAPI;
+		appendEntry: appendEntry as ExtensionAPI["appendEntry"],
+		sendMessage: sendMessage as ExtensionAPI["sendMessage"],
+	};
+	return fixture as ExtensionAPI;
 }
 
 function setup(options: Parameters<typeof createPi>[0] = {}): ExtensionAPI {


### PR DESCRIPTION
Use node:assert/strict for all 12 assertions in baseten-qwen-provider.test.ts and narrow the interactive fixture types without changing its 67 assertions.

Assertion counts:
- packages/coding-agent/test/baseten-qwen-provider.test.ts: 12 before, 12 after
- packages/coding-agent/test/interactive-tui.test.ts: 67 before, 67 after

Assistant-model: GPT-5.6 Luna

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789054884&installation_model_id=10562&pr_number=2316&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2316&signature=09214edf0935a2729d5631d06a9de8dec3cb89b049b16bfcf19ae62a012fc439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The update strengthens test assertions and narrows test fixture interfaces while retaining coverage for provider behavior, interactive terminal behavior, web-search error handling, and subagent notification cleanup.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The focused root and coding-agent test suites completed successfully, including the exercised cleanup error path.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the changes in commits 84b50794 and 65b24888 and completed whitespace checks.
- Verified the root notification and web-search suites; all tests passed (14 total).
- Verified the Coding-agent Baseten/Qwen provider and interactive-TUI suites; all tests passed (14 total).
- Validated the AggregateError cleanup-path test with verbose reporting; the named test passed.
- Compared before and after run evidence and confirmed no code changes were made; test outputs are captured in artifacts.

<a href="https://app.greptile.com/trex/runs/18331619/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["test: address Greptile findings across t..."](https://github.com/bastani-inc/atomic/commit/65b24888a63ff302854542a45da2b59d04e6aecb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52253627)</sub>

<!-- /greptile_comment -->