### PR TITLE
deps: apply dependabot bumps and fix npm audit vulnerability

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Install cargo-zigbuild for portable Linux builds
         if: matrix.platform == 'linux'
         timeout-minutes: 3
-        uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2.85.5
+        uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
         with:
           tool: cargo-zigbuild@0.23.0
       - name: Install Windows cross-compile tooling
@@ -192,7 +192,7 @@ jobs:
       - name: Install cargo-xwin
         if: matrix.platform == 'win32'
         timeout-minutes: 3
-        uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2.85.5
+        uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
         with:
           tool: cargo-xwin@0.23.0
       # Pinned so the populate step, the build step, and actions/cache agree

--- a/.github/workflows/warm-toolchain-cache.yml
+++ b/.github/workflows/warm-toolchain-cache.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: Install cargo-xwin
         timeout-minutes: 3
-        uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2.85.5
+        uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
         with:
           tool: cargo-xwin@0.23.0
       - name: Resolve MSVC CRT cache directory

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "globset"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -355,9 +355,9 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "ignore"
-version = "0.4.28"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adf14691c72bcfc1058740436a35bdd3ae9c07d1a941ef00b749e9ea16aefa7"
+checksum = "0b17771570a2b94107741a7b033f19132c2eee21d59d21b24d2ced26500bd66e"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -472,9 +472,9 @@ checksum = "5282704fbe8d49b0cf8b08e3f33233416a528658f205c7e5ace63b582de0b11c"
 
 [[package]]
 name = "napi-derive"
-version = "3.6.1"
+version = "3.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d5c9c02556ea6dc99dffd36c1ce60141411657438501a125b675776d011ce92"
+checksum = "6d9002b2940f0184444754546e0fcd15182f56948e6f381968b019d549387c42"
 dependencies = [
  "convert_case",
  "ctor",
@@ -486,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "6.1.0"
+version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9d8365cf97f54d9b6d6dbf83a25ca227ad7d6e920717426c599225aca6740b"
+checksum = "d60b5d773ad46c698c8cc2cd9fde0b283d39cbb7f71c04bee633c7bdba4423bd"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -631,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -846,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.11"
+version = "0.26.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
+checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
 dependencies = [
  "cc",
  "regex",

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -786,15 +786,15 @@ wheels = [
 
 [[package]]
 name = "h2"
-version = "4.3.0"
+version = "4.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hpack" },
     { name = "hyperframe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/85/7c366e69d84c17bb778fe41419e1fbcce3033d5b7ce29bbffff0a98b859f/h2-4.4.1.tar.gz", hash = "sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516", size = 2157281, upload-time = "2026-08-03T11:45:09.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/e85faf23bd72a92d1921e37d674ca56eb298a3c8be31fdecef0ff2b3aaac/h2-4.4.1-py3-none-any.whl", hash = "sha256:0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6", size = 62636, upload-time = "2026-08-03T11:44:59.164Z" },
 ]
 
 [[package]]

--- a/package-lock.json
+++ b/package-lock.json
@@ -7278,9 +7278,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -7487,9 +7487,9 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
-      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.1.tgz",
+      "integrity": "sha512-0trZaiG7Y7kN/Egy9a8j47t9osC0Tch4PaIWd9yGF6bvmlk7muExRvGNYb8sXBwEKMoNKsbNN9P8EefuQekE4Q==",
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^1.2.1"
@@ -9265,7 +9265,7 @@
         "markit-ai": "0.5.3",
         "minimatch": "10.2.5",
         "open": "^11.0.0",
-        "p-limit": "^7.3.0",
+        "p-limit": "^7.3.1",
         "proper-lockfile": "4.1.2",
         "semver": "7.8.0",
         "turndown": "^7.2.0",
@@ -9359,7 +9359,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@napi-rs/cli": "3.8.1"
+        "@napi-rs/cli": "3.8.2"
       },
       "engines": {
         "bun": ">=1.3.14",
@@ -9367,9 +9367,9 @@
       }
     },
     "packages/natives/node_modules/@napi-rs/cli": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-3.8.1.tgz",
-      "integrity": "sha512-XDtwn0o6XGLxzMoL7FrTDA7jz7t6UUAI+QreICK5QgDOqeZJODmLv0p77kzQNyfKbXVomAw1u2SC5Zzsr07gig==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-3.8.2.tgz",
+      "integrity": "sha512-iFmp3Lo/ipXoJI1I/6V/xU4hQV42bXS3A7j8C+Wt3LOtYY7HFCilkhyUkN1igLJFXWMICq95kNxhNcwzNRd+Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9488,7 +9488,7 @@
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.18.13",
-        "p-limit": "^7.3.0",
+        "p-limit": "^7.3.1",
         "turndown": "^7.2.0",
         "unpdf": "1.7.0"
       },

--- a/packages/coding-agent/npm-shrinkwrap.json
+++ b/packages/coding-agent/npm-shrinkwrap.json
@@ -35,7 +35,7 @@
 				"markit-ai": "0.5.3",
 				"minimatch": "10.2.5",
 				"open": "^11.0.0",
-				"p-limit": "^7.3.0",
+				"p-limit": "^7.3.1",
 				"proper-lockfile": "4.1.2",
 				"semver": "7.8.0",
 				"turndown": "^7.2.0",
@@ -3474,9 +3474,9 @@
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/p-limit": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
-			"integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.1.tgz",
+			"integrity": "sha512-0trZaiG7Y7kN/Egy9a8j47t9osC0Tch4PaIWd9yGF6bvmlk7muExRvGNYb8sXBwEKMoNKsbNN9P8EefuQekE4Q==",
 			"license": "MIT",
 			"dependencies": {
 				"yocto-queue": "^1.2.1"

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -108,7 +108,7 @@
     "markit-ai": "0.5.3",
     "minimatch": "10.2.5",
     "open": "^11.0.0",
-    "p-limit": "^7.3.0",
+    "p-limit": "^7.3.1",
     "proper-lockfile": "4.1.2",
     "semver": "7.8.0",
     "turndown": "^7.2.0",

--- a/packages/natives/package.json
+++ b/packages/natives/package.json
@@ -28,7 +28,7 @@
     "prepublish:native": "napi prepublish --npm-dir npm --tag-style npm --no-gh-release"
   },
   "devDependencies": {
-    "@napi-rs/cli": "3.8.1"
+    "@napi-rs/cli": "3.8.2"
   },
   "engines": {
     "bun": ">=1.3.14",

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@mozilla/readability": "^0.6.0",
     "linkedom": "^0.18.13",
-    "p-limit": "^7.3.0",
+    "p-limit": "^7.3.1",
     "turndown": "^7.2.0",
     "unpdf": "1.7.0"
   }

--- a/test/unit/semver-7.8.0-pin-regression.test.ts
+++ b/test/unit/semver-7.8.0-pin-regression.test.ts
@@ -122,7 +122,7 @@ interface SemverApi {
 const pinned: SemverApi = { compare, maxSatisfying, rcompare, satisfies, valid, validRange };
 
 /**
- * `@napi-rs/cli` 3.8.1 declares `semver@^7.8.2`, which the pin does not satisfy.
+ * `@napi-rs/cli` 3.8.2 declares `semver@^7.8.2`, which the pin does not satisfy.
  * A flat `semver` override held it below that range and `npm ls` reported the
  * edge invalid, so the override is scoped instead: everything collapses onto
  * 7.8.0 except the CLI, which keeps 7.8.5. The CLI is a build-time
@@ -626,9 +626,11 @@ describe("semver pinned at 7.8.0", () => {
 		assert.equal(natives.devDependencies.semver, undefined, "packages/natives must not declare a semver dependency");
 
 		// The declared range this measurement is about. If @napi-rs/cli moves off
-		// 3.8.1 its semver surface has to be re-measured, so pin the version the
-		// table above was taken against.
-		assert.equal(natives.devDependencies["@napi-rs/cli"], "3.8.1");
+		// 3.8.2 its semver surface has to be re-measured, so pin the version the
+		// table above was taken against. 3.8.2 was diffed against 3.8.1: its
+		// dependency table, semver imports and restrictWasiNodeEngine body are
+		// byte-identical, so the 3.8.1 measurement carries over unchanged.
+		assert.equal(natives.devDependencies["@napi-rs/cli"], "3.8.2");
 		assert.ok(
 			BASELINE_NAPI_WASI_ENGINE.has(natives.engines.node),
 			`packages/natives engines.node ${natives.engines.node} is not in BASELINE_NAPI_WASI_ENGINE`,


### PR DESCRIPTION
## Summary

Consolidated dependency/security sweep, replacing the open dependabot PRs that are safe to take and resolving the npm audit finding.

### Dependabot bumps applied
| PR | Update |
|---|---|
| #2295 | taiki-e/install-action 2.85.5 → 2.85.10 |
| #2294 | globset 0.4.19 → 0.4.20 (cargo) |
| #2293 | ignore 0.4.28 → 0.4.33 (cargo) |
| #2292 | tree-sitter 0.26.11 → 0.26.12 (cargo) |
| #2165 | napi-derive 3.6.1 → 3.6.2 (cargo) |
| #2231 | h2 4.3.0 → 4.4.1 in /evals (**closes Dependabot alert #34**) |
| #2168 | p-limit 7.3.0 → 7.3.1 (npm) |
| #2163 | @napi-rs/cli 3.8.1 → 3.8.2 (npm, packages/natives) |

### npm audit
- nanoid → 3.3.18 (GHSA-2v37-7h3g-55p8, high; dev-only transitive via vitest → vite → postcss). `npm audit` is now clean.

### Deliberately not taken — pi pin parity
Per policy, deps that upstream `earendil-works/pi` pins stay on pi's exact versions unless vulnerable. None of these are flagged by audit or Dependabot:
- #2228 semver / @types/semver (pi pins 7.8.0 / 7.7.1)
- #2167 diff 9.0.0 (pi pins 8.0.4)
- #2166 highlight.js 11.x (pi pins 10.7.3)
- #2162 typebox 1.3.11 (pi pins 1.3.7)

### @napi-rs/cli pin-regression re-measurement
`test/unit/semver-7.8.0-pin-regression.test.ts` pins the CLI version its semver baseline was measured against. 3.8.2 was diffed against 3.8.1: dependency table, semver imports, and the `restrictWasiNodeEngine` body are byte-identical, so the measurement carries over and the pin moves to 3.8.2. The runtime baseline assertions pass against the installed 3.8.2 build.

### Code scanning
No code changes needed; the three open alerts are dismissed with reasons:
- #56 (`js/resource-exhaustion`, live-server.mjs): false positive — the poll timeout is already clamped to `DEFAULT_POLL_TIMEOUT` via `Math.min`; CodeQL does not credit the bound.
- #165/#166 (`js/shell-command-injection-from-environment`, child-process.ts): by design — a local CLI spawning user-configured commands with array args; cross-spawn handles Windows escaping. Code is pi-parity.

### Validation
- `npm run check` clean (biome + tsc + shrinkwrap; shrinkwrap regenerated)
- `npm run test:unit`: 6041 passed
- `npm audit`: 0 vulnerabilities

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789060706&installation_model_id=10562&pr_number=2320&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2320&signature=86920a5567b72b87ac4e47d89ed98d14ea338cecc9f4f0563638d5866b6a668f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change refreshes release-workflow actions and locked Rust, npm, and Python evaluation dependencies.

The checked dependency failure paths were disproved: a clean npm installation, published shrinkwrap verification, CLI invocation, and all six targeted semver regression tests passed before and after the npm updates; the updated native Rust lockfile also passed locked debug and release builds plus all 46 library tests. The updated h2 wheel matched its locked hash and metadata, installed in an isolated environment, and successfully initialized an HTTP/2 connection.

## T-Rex validation blocked
A repository-wide offline `uv lock --check` could not run because the checking environment lacked Python 3.14 and offline mode could not download the managed interpreter. The exact h2 package path was validated independently, including its declared Python compatibility and installation behavior.

<h3>Confidence Score: 5/5</h3>

The dependency refresh is safe to merge based on successful clean-install, native build, regression-test, and isolated HTTP/2 package checks.

No defects remain after exercising the changed npm, Rust native-addon, and h2 dependency paths. The only unavailable check was the repository-wide offline Python lock verification, while the updated h2 artifact itself was directly verified and executed.

**Files Needing Attention:** No files require changes. If a full evaluation-environment verification is desired, rerun `uv lock --check` with Python 3.14 available.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the authored dependency validation script against the parent commit and this change; npm resolved nanoid@3.3.18 and p-limit@7.3.1, six semver regression tests passed, and the native builds succeeded.
- Ran the h2 lockfile validation harness against both the parent lockfile and this change; the updated h2 wheel hash matched the lockfile, Python \>= 3.10 is required, and the isolated environment initialized an H2Connection.
- Disproved semver, npm consistency, and Cargo/native hypotheses; authored validation script source and command captures were uploaded.
- Authored h2 lock validation harness and recorded before/after installation and blocked full-lock capture; installation succeeded and HTTP/2 preface initialized, while the full uv-lock check was blocked by missing Python 3.14.
- Artifacts from dependency validation and h2 lock validation proofs were collected and uploaded for review.

<a href="https://app.greptile.com/trex/runs/18341358/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["deps: apply dependabot bumps, fix npm au..."](https://github.com/bastani-inc/atomic/commit/37105449d7a3279460eefc6e74661f0bcf699514) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52278768)</sub>

<!-- /greptile_comment -->