### PR TITLE
feat(workflows): populate per-attempt model usage

### DIFF
--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -2741,6 +2741,8 @@ interface WorkflowModelAttempt extends WorkflowSerializableObject {
 }
 ```
 
+When a stage explicitly configures `model` or `fallbackModels`, each recorded attempt can include usage aggregated from meaningful assistant responses in that attempt. The four token buckets remain separate, `cost` sums the provider-reported total cost, and `turns` counts the assistant usage records included in the aggregate. Usage from earlier retained or reattached session history is excluded, while billed error responses removed during a same-model retry remain attributed to that attempt. The `usage` property is omitted when the provider reports no meaningful token or cost signal. Stages that use only the default model without explicit fallback configuration do not currently create model-attempt records.
+
 ### `WorkflowDetails`
 
 ```typescript

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Workflow command, worktree Git/setup-hook, and Playwright CLI subprocesses now receive `AI_AGENT=atomic` for generic child-process attribution without mutating caller-supplied environment objects.
 
+- Workflow model fallback attempt metadata now includes per-attempt input/output tokens, cache reads/writes, provider-reported total cost, and meaningful assistant-turn counts when usage is available.
+
 ### Fixed
 
 - Fixed graph overlay rendering to keep its live vertical position in pi-tui's `ScrollView` and preserve OSC-8 hyperlink terminators when normalizing layout rows.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Workflow command, worktree Git/setup-hook, and Playwright CLI subprocesses now receive `AI_AGENT=atomic` for generic child-process attribution without mutating caller-supplied environment objects.
 
-- Workflow model fallback attempt metadata now includes per-attempt input/output tokens, cache reads/writes, provider-reported total cost, and meaningful assistant-turn counts when usage is available.
+- Workflow model fallback attempt metadata now includes per-attempt input/output tokens, cache reads/writes, provider-reported total cost, and meaningful assistant-turn counts when usage is available ([#2197](https://github.com/bastani-inc/atomic/issues/2197)).
 
 ### Fixed
 

--- a/packages/workflows/src/durable/dbos-envelope.ts
+++ b/packages/workflows/src/durable/dbos-envelope.ts
@@ -477,7 +477,8 @@ function isModelUsage(value: WorkflowSerializableValue): boolean {
 	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
 	const usage = value as Record<string, WorkflowSerializableValue>;
 	return ["input", "output", "cacheRead", "cacheWrite", "cost", "turns"].every(
-		(key) => usage[key] === undefined || (typeof usage[key] === "number" && Number.isFinite(usage[key])),
+		(key) =>
+			usage[key] === undefined || (typeof usage[key] === "number" && Number.isFinite(usage[key]) && usage[key] >= 0),
 	);
 }
 

--- a/packages/workflows/src/runs/foreground/stage-runner-controller.ts
+++ b/packages/workflows/src/runs/foreground/stage-runner-controller.ts
@@ -220,7 +220,14 @@ export class StageSessionController {
 	/** Message index latched once per high-level candidate prompt; never re-read later. */
 	private attemptUsageStartIndex: number | undefined;
 	/** Usage accrued from error assistants removed by retry restoration. */
-	private discardedAttemptUsage: AttemptUsageTotals = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 };
+	private discardedAttemptUsage: AttemptUsageTotals = {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		cost: 0,
+		turns: 0,
+	};
 	private readonly terminatingToolCallIds = new Set<string>();
 	private latestStructuredOutputToolErrorValue: string | undefined;
 	private unsubscribeTerminateWatcher: (() => void) | undefined;

--- a/packages/workflows/src/runs/foreground/stage-runner-controller.ts
+++ b/packages/workflows/src/runs/foreground/stage-runner-controller.ts
@@ -14,6 +14,7 @@ import type {
 	StageUserMessageContent,
 	WorkflowModelAttempt,
 	WorkflowModelCatalogPort,
+	WorkflowModelUsage,
 } from "../../shared/types.js";
 import {
 	buildModelCandidatesFromCatalog,
@@ -66,6 +67,63 @@ import {
 } from "./stage-runner-unresolved-overflow.js";
 
 type RetryPauseResume = NonNullable<ReturnType<StageSessionPause["currentResume"]>>;
+
+type StageMessage = StageSessionRuntime["messages"][number];
+type StageAssistantMessage = Extract<StageMessage, { role: "assistant" }>;
+
+type AttemptUsageTotals = {
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+	cost: number;
+	turns: number;
+};
+
+/**
+ * A present usage object is meaningful when any token bucket, the total token
+ * count, or the provider-reported total cost is positive. Usage-less test
+ * doubles and providers that report no usage are not meaningful.
+ */
+function hasMeaningfulUsage(usage: StageAssistantMessage["usage"] | undefined): boolean {
+	return (
+		usage !== undefined &&
+		(usage.input > 0 ||
+			usage.output > 0 ||
+			usage.cacheRead > 0 ||
+			usage.cacheWrite > 0 ||
+			usage.totalTokens > 0 ||
+			usage.cost.total > 0)
+	);
+}
+
+/**
+ * Aggregate the assistant-message usage admitted since the latched attempt
+ * boundary, plus usage accrued from error assistants that a retry restoration
+ * removed from the live transcript. Returns undefined when nothing meaningful
+ * was seen, so no `usage: undefined` enters the serializable attempt record.
+ */
+function usageForAttempt(
+	messages: readonly StageMessage[],
+	start: number,
+	discarded: AttemptUsageTotals,
+): WorkflowModelUsage | undefined {
+	const totals = { ...discarded };
+	let meaningful = totals.turns > 0;
+
+	for (const message of messages.slice(start)) {
+		if (message.role !== "assistant" || !hasMeaningfulUsage(message.usage)) continue;
+		totals.input += message.usage.input;
+		totals.output += message.usage.output;
+		totals.cacheRead += message.usage.cacheRead;
+		totals.cacheWrite += message.usage.cacheWrite;
+		totals.cost += message.usage.cost.total;
+		totals.turns += 1;
+		meaningful = true;
+	}
+
+	return meaningful ? totals : undefined;
+}
 
 interface ThrownErrorRetryState {
 	readonly controller: AbortController;
@@ -159,6 +217,10 @@ export class StageSessionController {
 	private sessionPromise: Promise<StageSessionRuntime> | undefined;
 	private reattachSessionFile: string | undefined;
 	private lastPromptStartIndex: number | undefined;
+	/** Message index latched once per high-level candidate prompt; never re-read later. */
+	private attemptUsageStartIndex: number | undefined;
+	/** Usage accrued from error assistants removed by retry restoration. */
+	private discardedAttemptUsage: AttemptUsageTotals = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 };
 	private readonly terminatingToolCallIds = new Set<string>();
 	private latestStructuredOutputToolErrorValue: string | undefined;
 	private unsubscribeTerminateWatcher: (() => void) | undefined;
@@ -418,6 +480,7 @@ export class StageSessionController {
 				this.activeCandidateIndex = index;
 				this.selectedModel = candidate.id;
 				this.notifyModelFallbackMetaChange();
+				this.beginAttemptUsage(activeSession);
 				const { terminalScanStartIndex } = await this.promptWithThrownErrorRetry(
 					activeSession,
 					promptText,
@@ -564,6 +627,49 @@ export class StageSessionController {
 		return undefined;
 	}
 	/**
+	 * Latch a fresh high-level usage window against the active session. The
+	 * boundary is the message length before the candidate prompt, so retries,
+	 * pause/re-prompts, and recording never re-read a later index.
+	 */
+	private beginAttemptUsage(session: StageSessionRuntime): void {
+		this.attemptUsageStartIndex = session.messages.length;
+		this.discardedAttemptUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 };
+	}
+
+	/**
+	 * Consume the current window exactly once. A session-creation failure has no
+	 * window: clear the latch instead of reading a previous session's messages.
+	 */
+	private takeAttemptUsage(session: StageSessionRuntime | undefined): WorkflowModelUsage | undefined {
+		const start = this.attemptUsageStartIndex;
+		const usage =
+			session === undefined || start === undefined
+				? undefined
+				: usageForAttempt(session.messages, start, this.discardedAttemptUsage);
+		this.clearAttemptUsage();
+		return usage;
+	}
+
+	private clearAttemptUsage(): void {
+		this.attemptUsageStartIndex = undefined;
+		this.discardedAttemptUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 };
+	}
+
+	/**
+	 * Keep the usage of an error assistant that a retry restoration is about to
+	 * remove from the live transcript, so the final attempt total still counts it.
+	 */
+	private accrueDiscardedAttemptUsage(message: StageAssistantMessage): void {
+		if (!hasMeaningfulUsage(message.usage)) return;
+		this.discardedAttemptUsage.input += message.usage.input;
+		this.discardedAttemptUsage.output += message.usage.output;
+		this.discardedAttemptUsage.cacheRead += message.usage.cacheRead;
+		this.discardedAttemptUsage.cacheWrite += message.usage.cacheWrite;
+		this.discardedAttemptUsage.cost += message.usage.cost.total;
+		this.discardedAttemptUsage.turns += 1;
+	}
+
+	/**
 	 * Drop this attempt's failed input from live state before a same-candidate
 	 * retry, keeping unrelated concurrent messages. The durable transcript keeps
 	 * everything; this mirrors main-chat retry, which also only edits live state.
@@ -581,6 +687,12 @@ export class StageSessionController {
 	): StageSessionRuntime["messages"][number] | undefined {
 		const snapshotMessages = new Set(snapshot);
 		const admitted = session.messages.filter((message) => !snapshotMessages.has(message));
+		// Error assistants the filter below removes still carry real provider
+		// usage; accrue it before the splice so the retry total keeps it.
+		for (const message of admitted) {
+			if (message.role !== "assistant" || message.stopReason !== "error") continue;
+			this.accrueDiscardedAttemptUsage(message);
+		}
 		const failedAssistantIndex = admitted.findLastIndex(
 			(message) => message.role === "assistant" && message.stopReason === "error",
 		);
@@ -1175,11 +1287,17 @@ export class StageSessionController {
 		const resumedSession = this.session;
 		const resumedLabel = this.selectedModel ?? workflowModelId(resumedSession.model) ?? candidates[0]!.id;
 		this.notifyModelFallbackMetaChange();
+		this.beginAttemptUsage(resumedSession);
 		try {
 			const { terminalScanStartIndex } = await this.promptWithThrownErrorRetry(resumedSession, text, sdkOptions);
 			const terminalFailure = latestTerminalAssistantFailureSince(resumedSession.messages, terminalScanStartIndex);
 			if (terminalFailure === undefined || this.capturedStructuredOutputForAttempt()) {
-				this.modelAttempts.push({ model: resumedLabel, success: true });
+				const usage = this.takeAttemptUsage(resumedSession);
+				this.modelAttempts.push({
+					model: resumedLabel,
+					success: true,
+					...(usage === undefined ? {} : { usage }),
+				});
 				this.pendingFallbackWarnings.length = 0;
 				this.resumeCurrentSession = true;
 				return true;
@@ -1187,13 +1305,24 @@ export class StageSessionController {
 			throw new WorkflowPromptModelFailure(terminalFailure);
 		} catch (err) {
 			if (this.capturedStructuredOutputForAttempt() && isRetryableModelFailure(err)) {
-				this.modelAttempts.push({ model: resumedLabel, success: true });
+				const usage = this.takeAttemptUsage(resumedSession);
+				this.modelAttempts.push({
+					model: resumedLabel,
+					success: true,
+					...(usage === undefined ? {} : { usage }),
+				});
 				this.pendingFallbackWarnings.length = 0;
 				this.resumeCurrentSession = true;
 				return true;
 			}
 			const message = errorMessage(err);
-			this.modelAttempts.push({ model: resumedLabel, success: false, error: message });
+			const usage = this.takeAttemptUsage(resumedSession);
+			this.modelAttempts.push({
+				model: resumedLabel,
+				success: false,
+				...(usage === undefined ? {} : { usage }),
+				error: message,
+			});
 			if (this.opts.signal?.aborted || !isRetryableModelFailure(err)) {
 				this.modelWarnings.push(...this.pendingFallbackWarnings);
 				this.pendingFallbackWarnings.length = 0;
@@ -1233,10 +1362,12 @@ export class StageSessionController {
 			this.recordSuccessfulAttempt(candidate);
 			return "handled";
 		}
+		const usage = this.takeAttemptUsage(this.session);
 		this.modelAttempts.push({
 			model: candidate.id,
 			success: false,
 			...modelAttemptReasoning(candidate, this.effectiveStageOptions?.thinkingLevel),
+			...(usage === undefined ? {} : { usage }),
 			error: message,
 		});
 		if (this.opts.signal?.aborted || !isRetryableModelFailure(err) || index === candidates.length - 1) {
@@ -1258,10 +1389,12 @@ export class StageSessionController {
 	}
 
 	private recordSuccessfulAttempt(candidate: WorkflowResolvedModelCandidate): void {
+		const usage = this.takeAttemptUsage(this.session);
 		this.modelAttempts.push({
 			model: candidate.id,
 			success: true,
 			...modelAttemptReasoning(candidate, this.effectiveStageOptions?.thinkingLevel),
+			...(usage === undefined ? {} : { usage }),
 		});
 		this.pendingFallbackWarnings.length = 0;
 		this.resumeCurrentSession = true;

--- a/packages/workflows/src/runs/foreground/stage-runner-controller.ts
+++ b/packages/workflows/src/runs/foreground/stage-runner-controller.ts
@@ -82,19 +82,14 @@ type AttemptUsageTotals = {
 
 /**
  * A present usage object is meaningful when any token bucket, the total token
- * count, or the provider-reported total cost is positive. Usage-less test
- * doubles and providers that report no usage are not meaningful.
+ * count, or the provider-reported total cost is positive. Reject the entire
+ * provider record when any aggregated value is non-finite or negative so
+ * malformed telemetry cannot poison a durable stage checkpoint.
  */
 function hasMeaningfulUsage(usage: StageAssistantMessage["usage"] | undefined): boolean {
-	return (
-		usage !== undefined &&
-		(usage.input > 0 ||
-			usage.output > 0 ||
-			usage.cacheRead > 0 ||
-			usage.cacheWrite > 0 ||
-			usage.totalTokens > 0 ||
-			usage.cost.total > 0)
-	);
+	if (usage === undefined) return false;
+	const values = [usage.input, usage.output, usage.cacheRead, usage.cacheWrite, usage.totalTokens, usage.cost.total];
+	return values.every((value) => Number.isFinite(value) && value >= 0) && values.some((value) => value > 0);
 }
 
 /**

--- a/test/unit/durable-dbos-backend.test.ts
+++ b/test/unit/durable-dbos-backend.test.ts
@@ -107,6 +107,14 @@ describe("DbosDurableBackend (mock SDK)", () => {
 	});
 
 	test("stage checkpoint envelope round-trips hydration metadata", () => {
+		const usage = {
+			input: 101,
+			output: 23,
+			cacheRead: 47,
+			cacheWrite: 5,
+			cost: 0.0042,
+			turns: 2,
+		};
 		const cp: DurableStageCheckpoint = {
 			kind: "stage",
 			workflowId: "wf-stage-meta",
@@ -124,7 +132,7 @@ describe("DbosDurableBackend (mock SDK)", () => {
 			model: "gpt-test",
 			fastMode: true,
 			attemptedModels: ["gpt-test"],
-			modelAttempts: [{ model: "gpt-test", success: true }],
+			modelAttempts: [{ model: "gpt-test", success: true, usage }],
 			topology: { version: 1, stageId: "review", parentIds: [] },
 		};
 
@@ -133,6 +141,11 @@ describe("DbosDurableBackend (mock SDK)", () => {
 		assert.equal(env.durationMs, 2000);
 		assert.equal(env.result, "review passed");
 		assert.deepEqual(env.attemptedModels, ["gpt-test"]);
+		const encodedAttempts = env.modelAttempts;
+		assert.ok(Array.isArray(encodedAttempts));
+		const encodedAttempt = encodedAttempts[0];
+		assert.ok(encodedAttempt !== null && typeof encodedAttempt === "object" && !Array.isArray(encodedAttempt));
+		assert.deepEqual(encodedAttempt.usage, usage);
 
 		const decoded = decodeToCheckpoint("wf-stage-meta", "stage:review:1", env);
 		assert.ok(decoded?.kind === "stage");
@@ -144,6 +157,67 @@ describe("DbosDurableBackend (mock SDK)", () => {
 		assert.equal(decoded.fastMode, true);
 		assert.deepEqual(decoded.attemptedModels, ["gpt-test"]);
 		assert.equal(decoded.modelAttempts?.[0]?.success, true);
+		assert.deepEqual(decoded.modelAttempts?.[0]?.usage, usage);
+	});
+
+	test("stage checkpoint without model usage round-trips without a usage property", () => {
+		const cp: DurableStageCheckpoint = {
+			kind: "stage",
+			workflowId: "wf-stage-nousage",
+			checkpointId: "stage:review:2",
+			name: "review",
+			replayKey: "stage:review:2",
+			output: { verdict: "pass" },
+			completedAt: 3000,
+			topology: { version: 1, stageId: "review", parentIds: [] },
+			modelAttempts: [{ model: "gpt-test", success: true }],
+		};
+
+		const env = encodeCheckpoint(cp);
+		assert.ok(Array.isArray(env.modelAttempts));
+		const decoded = decodeToCheckpoint("wf-stage-nousage", "stage:review:2", env);
+		assert.ok(decoded?.kind === "stage");
+		assert.equal(decoded.modelAttempts?.[0]?.usage, undefined);
+	});
+
+	test("rejects non-numeric or non-finite nested model usage at the decode boundary", () => {
+		const cp: DurableStageCheckpoint = {
+			kind: "stage",
+			workflowId: "wf-stage-malformed",
+			checkpointId: "stage:review:3",
+			name: "review",
+			replayKey: "stage:review:3",
+			output: { verdict: "pass" },
+			completedAt: 3000,
+			topology: { version: 1, stageId: "review", parentIds: [] },
+			modelAttempts: [{ model: "gpt-test", success: true }],
+		};
+		const base = encodeCheckpoint(cp);
+		const malformedEnvelopes: DbosCheckpointEnvelope[] = [
+			{
+				...base,
+				modelAttempts: [
+					{
+						model: "gpt-test",
+						success: true,
+						usage: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4, cost: "0.0042", turns: 1 },
+					},
+				],
+			},
+			{
+				...base,
+				modelAttempts: [
+					{
+						model: "gpt-test",
+						success: true,
+						usage: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4, cost: Number.POSITIVE_INFINITY, turns: 1 },
+					},
+				],
+			},
+		];
+		for (const env of malformedEnvelopes) {
+			assert.equal(decodeToCheckpoint("wf-stage-malformed", "stage:review:3", env), undefined);
+		}
 	});
 
 	test("flush waits for queued async checkpoint writes", async () => {

--- a/test/unit/durable-dbos-backend.test.ts
+++ b/test/unit/durable-dbos-backend.test.ts
@@ -183,7 +183,7 @@ describe("DbosDurableBackend (mock SDK)", () => {
 		assert.equal(Object.hasOwn(decoded.modelAttempts?.[0] ?? {}, "usage"), false);
 	});
 
-	test("rejects non-numeric or non-finite nested model usage at the decode boundary", () => {
+	test("rejects non-numeric, non-finite, or negative nested model usage at the decode boundary", () => {
 		const cp: DurableStageCheckpoint = {
 			kind: "stage",
 			workflowId: "wf-stage-malformed",
@@ -214,6 +214,16 @@ describe("DbosDurableBackend (mock SDK)", () => {
 						model: "gpt-test",
 						success: true,
 						usage: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4, cost: Number.POSITIVE_INFINITY, turns: 1 },
+					},
+				],
+			},
+			{
+				...base,
+				modelAttempts: [
+					{
+						model: "gpt-test",
+						success: true,
+						usage: { input: 1, output: 2, cacheRead: -3, cacheWrite: 4, cost: 0.0042, turns: 1 },
 					},
 				],
 			},

--- a/test/unit/durable-dbos-backend.test.ts
+++ b/test/unit/durable-dbos-backend.test.ts
@@ -175,9 +175,12 @@ describe("DbosDurableBackend (mock SDK)", () => {
 
 		const env = encodeCheckpoint(cp);
 		assert.ok(Array.isArray(env.modelAttempts));
+		const encodedAttempt = env.modelAttempts[0];
+		assert.ok(encodedAttempt !== null && typeof encodedAttempt === "object" && !Array.isArray(encodedAttempt));
+		assert.equal(Object.hasOwn(encodedAttempt, "usage"), false);
 		const decoded = decodeToCheckpoint("wf-stage-nousage", "stage:review:2", env);
 		assert.ok(decoded?.kind === "stage");
-		assert.equal(decoded.modelAttempts?.[0]?.usage, undefined);
+		assert.equal(Object.hasOwn(decoded.modelAttempts?.[0] ?? {}, "usage"), false);
 	});
 
 	test("rejects non-numeric or non-finite nested model usage at the decode boundary", () => {

--- a/test/unit/durable-stage-frontier-fixes.test.ts
+++ b/test/unit/durable-stage-frontier-fixes.test.ts
@@ -237,6 +237,14 @@ test("cached replay hydrates persisted stage timing, result, session, and model 
 		startedAt: Date.now(),
 	});
 	const completedKeys = new Map<string, string>();
+	const usage = {
+		input: 101,
+		output: 23,
+		cacheRead: 47,
+		cacheWrite: 5,
+		cost: 0.0042,
+		turns: 2,
+	};
 	const cp: DurableCompletedStageCheckpoint = {
 		kind: "stage",
 		workflowId: WORKFLOW_ID,
@@ -254,7 +262,7 @@ test("cached replay hydrates persisted stage timing, result, session, and model 
 		model: "gpt-test",
 		fastMode: true,
 		attemptedModels: ["gpt-test"],
-		modelAttempts: [{ model: "gpt-test", success: true }],
+		modelAttempts: [{ model: "gpt-test", success: true, usage }],
 	};
 
 	recordCachedStageIntoStore(store, WORKFLOW_ID, "hydrate", cp.replayKey, cp.output, completedKeys, [], cp);
@@ -269,4 +277,5 @@ test("cached replay hydrates persisted stage timing, result, session, and model 
 	assert.equal(stage.fastMode, true);
 	assert.deepEqual(stage.attemptedModels, ["gpt-test"]);
 	assert.equal(stage.modelAttempts?.[0]?.success, true);
+	assert.deepEqual(stage.modelAttempts?.[0]?.usage, usage);
 });

--- a/test/unit/stage-runner-fallback-resume.test.ts
+++ b/test/unit/stage-runner-fallback-resume.test.ts
@@ -25,6 +25,7 @@ import type {
 } from "../../packages/workflows/src/runs/foreground/stage-runner.js";
 import { createStageContext } from "../../packages/workflows/src/runs/foreground/stage-runner.js";
 import { unresolvedContextOverflowFailure } from "../../packages/workflows/src/runs/foreground/stage-runner-unresolved-overflow.js";
+import { assistantMessageWithUsage, Type } from "./stage-runner-helpers.js";
 
 interface FakeSessionConfig {
 	/** Model object the session reports via `.model` (drives workflowModelId). */
@@ -33,12 +34,23 @@ interface FakeSessionConfig {
 	promptError?: Error;
 	/** Shared sink recording prompt/followUp/steer calls for assertions. */
 	calls?: Array<{ kind: "prompt" | "followUp" | "steer"; text: string }>;
+	/** Historical messages present in the session before the first prompt. */
+	history?: StageSessionRuntime["messages"];
+	/** When set, each prompt() appends a meaningful assistant message with this usage. */
+	assistantUsage?: { input: number; output: number; cacheRead: number; cacheWrite: number; cost: number };
+	/** Optional per-prompt hook (e.g. a scripted structured_output tool call). */
+	onPrompt?: (text: string) => Promise<void> | void;
 }
 
 function makeFakeStageSession(config: FakeSessionConfig): StageSessionRuntime {
+	const messages: StageSessionRuntime["messages"] = [...(config.history ?? [])];
 	const base: StageSessionRuntime = {
 		async prompt(text: string) {
 			config.calls?.push({ kind: "prompt", text });
+			if (config.assistantUsage !== undefined) {
+				messages.push(assistantMessageWithUsage(`stub:${text}`, config.assistantUsage));
+			}
+			await config.onPrompt?.(text);
 			if (config.promptError) throw config.promptError;
 			return `stub:${text}`;
 		},
@@ -64,7 +76,7 @@ function makeFakeStageSession(config: FakeSessionConfig): StageSessionRuntime {
 		agent: Object.create(null) as StageSessionRuntime["agent"],
 		model: config.model as StageSessionRuntime["model"],
 		thinkingLevel: "off",
-		messages: [] as StageSessionRuntime["messages"],
+		messages,
 		isStreaming: false as StageSessionRuntime["isStreaming"],
 		async navigateTree() {
 			return { cancelled: true };
@@ -140,7 +152,14 @@ describe("reattached follow-up resumes on the last working model (#1431 follow-u
 			// The reattach-resume create carries no model override (the SDK restores
 			// the saved model). Simulate a session that last worked on model-b.
 			if ((options?.model as unknown) === undefined) {
-				return makeFakeStageSession({ model: B });
+				return makeFakeStageSession({
+					model: B,
+					// Historical usage from the pre-completion transcript must never be
+					// charged to the follow-up attempt, even though it is large and
+					// distinct from the new response.
+					history: [assistantMessageWithUsage("historical answer", { input: 9999, output: 8888, cacheRead: 7777, cacheWrite: 6666, cost: 9.99 })],
+					assistantUsage: { input: 11, output: 22, cacheRead: 33, cacheWrite: 44, cost: 0.011 },
+				});
 			}
 			return makeFakeStageSession({ model: A });
 		}, createdWith);
@@ -166,6 +185,11 @@ describe("reattached follow-up resumes on the last working model (#1431 follow-u
 			[{ model: "anthropic/model-b", success: true }],
 			"only the resumed working model should be attempted",
 		);
+		assert.deepEqual(
+			attempts.map((a) => a.usage),
+			[{ input: 11, output: 22, cacheRead: 33, cacheWrite: 44, cost: 0.011, turns: 1 }],
+			"the reattached follow-up must charge only the new response, never the historical transcript",
+		);
 	});
 
 	test("restarts the full chain from the primary when the resumed model fails again", async () => {
@@ -173,13 +197,21 @@ describe("reattached follow-up resumes on the last working model (#1431 follow-u
 		const opts = makeOpts((options) => {
 			// Resume attempt (no model override): saved model-b, but it now fails.
 			if ((options?.model as unknown) === undefined) {
-				return makeFakeStageSession({ model: B, promptError: new Error("rate limit exceeded") });
+				return makeFakeStageSession({
+					model: B,
+					promptError: new Error("rate limit exceeded"),
+					// The failed resumed response still carries real provider usage.
+					assistantUsage: { input: 11, output: 22, cacheRead: 33, cacheWrite: 44, cost: 0.011 },
+				});
 			}
 			// Restarted chain: primary (model-a) fails, fallback (model-b) succeeds.
 			if ((options?.model as unknown) === "anthropic/model-a") {
 				return makeFakeStageSession({ model: A, promptError: new Error("rate limit exceeded") });
 			}
-			return makeFakeStageSession({ model: B });
+			return makeFakeStageSession({
+				model: B,
+				assistantUsage: { input: 111, output: 222, cacheRead: 333, cacheWrite: 444, cost: 0.111 },
+			});
 		}, createdWith);
 
 		const ctx = createStageContext(opts);
@@ -203,6 +235,57 @@ describe("reattached follow-up resumes on the last working model (#1431 follow-u
 				{ model: "anthropic/model-b", success: true },
 			],
 			"resume failure is recorded, then the full chain runs from the primary",
+		);
+		assert.deepEqual(
+			attempts.map((a) => a.usage),
+			[
+				{ input: 11, output: 22, cacheRead: 33, cacheWrite: 44, cost: 0.011, turns: 1 },
+				undefined,
+				{ input: 111, output: 222, cacheRead: 333, cacheWrite: 444, cost: 0.111, turns: 1 },
+			],
+			"the failed resumed attempt keeps its own usage and the restarted chain starts fresh windows",
+		);
+	});
+
+	test("a reattached structured-output success records usage before the caught branch returns", async () => {
+		const createdWith: CreateRecord[] = [];
+		let createOptions: StageSessionCreateOptions | undefined;
+		const base = makeOpts((options) => {
+			createOptions = options;
+			return makeFakeStageSession({
+				model: B,
+				promptError: new Error("429 rate limit exceeded after structured output"),
+				assistantUsage: { input: 11, output: 22, cacheRead: 33, cacheWrite: 44, cost: 0.011 },
+				onPrompt: async () => {
+					const structuredTool = createOptions?.customTools?.find((tool) => tool.name === "structured_output");
+					assert.ok(structuredTool);
+					await structuredTool.execute("structured-call", { ok: true }, undefined, undefined, undefined as never);
+				},
+			});
+		}, createdWith);
+		const opts: StageRunnerOpts = {
+			...base,
+			stageOptions: {
+				...base.stageOptions,
+				schema: Type.Object({ ok: Type.Boolean() }, { additionalProperties: false }),
+			},
+		};
+
+		const ctx = createStageContext(opts);
+		await ctx.__ensureSessionFromFile("/tmp/does-not-exist-structured-resume.jsonl");
+		await ctx.prompt("follow up");
+		await ctx.__dispose();
+
+		const attempts = ctx.__modelFallbackMeta().modelAttempts ?? [];
+		assert.deepEqual(
+			attempts.map((a) => ({ model: a.model, success: a.success })),
+			[{ model: "anthropic/model-b", success: true }],
+			"the caught structured-output branch records a resumed success",
+		);
+		assert.deepEqual(
+			attempts.map((a) => a.usage),
+			[{ input: 11, output: 22, cacheRead: 33, cacheWrite: 44, cost: 0.011, turns: 1 }],
+			"usage is attached before the caught structured-output branch returns",
 		);
 	});
 });
@@ -346,7 +429,13 @@ describe("live (retained-session) follow-up resumes on the settled model (#1431 
 			if ((options?.model as unknown) === "anthropic/model-a") {
 				return makeFakeStageSession({ model: A, promptError: new Error("rate limit exceeded") });
 			}
-			return makeFakeStageSession({ model: B, calls: settledCalls });
+			// The settled fallback appends the same scripted usage on every prompt;
+			// a cumulative implementation would double it on the second record.
+			return makeFakeStageSession({
+				model: B,
+				calls: settledCalls,
+				assistantUsage: { input: 11, output: 22, cacheRead: 33, cacheWrite: 44, cost: 0.011 },
+			});
 		}, createdWith);
 
 		const ctx = createStageContext(opts);
@@ -371,6 +460,15 @@ describe("live (retained-session) follow-up resumes on the settled model (#1431 
 				{ model: "anthropic/model-b", success: true },
 				{ model: "anthropic/model-b", success: true },
 			],
+		);
+		assert.deepEqual(
+			attempts.map((a) => a.usage),
+			[
+				undefined,
+				{ input: 11, output: 22, cacheRead: 33, cacheWrite: 44, cost: 0.011, turns: 1 },
+				{ input: 11, output: 22, cacheRead: 33, cacheWrite: 44, cost: 0.011, turns: 1 },
+			],
+			"each retained-session prompt gets its own window: the second record is not a cumulative total",
 		);
 	});
 });

--- a/test/unit/stage-runner-fallback-resume.test.ts
+++ b/test/unit/stage-runner-fallback-resume.test.ts
@@ -157,7 +157,15 @@ describe("reattached follow-up resumes on the last working model (#1431 follow-u
 					// Historical usage from the pre-completion transcript must never be
 					// charged to the follow-up attempt, even though it is large and
 					// distinct from the new response.
-					history: [assistantMessageWithUsage("historical answer", { input: 9999, output: 8888, cacheRead: 7777, cacheWrite: 6666, cost: 9.99 })],
+					history: [
+						assistantMessageWithUsage("historical answer", {
+							input: 9999,
+							output: 8888,
+							cacheRead: 7777,
+							cacheWrite: 6666,
+							cost: 9.99,
+						}),
+					],
 					assistantUsage: { input: 11, output: 22, cacheRead: 33, cacheWrite: 44, cost: 0.011 },
 				});
 			}

--- a/test/unit/stage-runner-helpers.ts
+++ b/test/unit/stage-runner-helpers.ts
@@ -46,6 +46,8 @@ export interface AssistantUsageValues {
 	readonly totalTokens?: number;
 }
 
+type TestAssistantMessage = Extract<AgentSession["messages"][number], { role: "assistant" }>;
+
 /**
  * Build a scripted assistant message carrying a concrete per-bucket usage
  * payload. Bucket values are kept distinct per fixture so accidental merging
@@ -56,9 +58,12 @@ export function assistantMessageWithUsage(
 	values: AssistantUsageValues,
 	stopReason: "stop" | "error" = "stop",
 ): AgentSession["messages"][number] {
-	return {
+	const message = {
 		role: "assistant",
 		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "test-model",
 		usage: {
 			input: values.input,
 			output: values.output,
@@ -68,7 +73,9 @@ export function assistantMessageWithUsage(
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: values.cost },
 		},
 		stopReason,
-	} as unknown as AgentSession["messages"][number];
+		timestamp: 0,
+	} satisfies TestAssistantMessage;
+	return message;
 }
 
 export function makeSignal(): AbortSignal {

--- a/test/unit/stage-runner-helpers.ts
+++ b/test/unit/stage-runner-helpers.ts
@@ -43,6 +43,7 @@ export interface AssistantUsageValues {
 	readonly cacheRead: number;
 	readonly cacheWrite: number;
 	readonly cost: number;
+	readonly totalTokens?: number;
 }
 
 /**
@@ -63,7 +64,7 @@ export function assistantMessageWithUsage(
 			output: values.output,
 			cacheRead: values.cacheRead,
 			cacheWrite: values.cacheWrite,
-			totalTokens: values.input + values.output + values.cacheRead + values.cacheWrite,
+			totalTokens: values.totalTokens ?? values.input + values.output + values.cacheRead + values.cacheWrite,
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: values.cost },
 		},
 		stopReason,

--- a/test/unit/stage-runner-helpers.ts
+++ b/test/unit/stage-runner-helpers.ts
@@ -37,6 +37,39 @@ export type {
 };
 export { assert, createStageContext, join, mkdtemp, readFile, rm, Type, tmpdir, writeFile };
 
+export interface AssistantUsageValues {
+	readonly input: number;
+	readonly output: number;
+	readonly cacheRead: number;
+	readonly cacheWrite: number;
+	readonly cost: number;
+}
+
+/**
+ * Build a scripted assistant message carrying a concrete per-bucket usage
+ * payload. Bucket values are kept distinct per fixture so accidental merging
+ * or cross-bucket attribution is visible in aggregate assertions.
+ */
+export function assistantMessageWithUsage(
+	text: string,
+	values: AssistantUsageValues,
+	stopReason: "stop" | "error" = "stop",
+): AgentSession["messages"][number] {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		usage: {
+			input: values.input,
+			output: values.output,
+			cacheRead: values.cacheRead,
+			cacheWrite: values.cacheWrite,
+			totalTokens: values.input + values.output + values.cacheRead + values.cacheWrite,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: values.cost },
+		},
+		stopReason,
+	} as unknown as AgentSession["messages"][number];
+}
+
 export function makeSignal(): AbortSignal {
 	return new AbortController().signal;
 }

--- a/test/unit/stage-runner-model-fallback-1.test.ts
+++ b/test/unit/stage-runner-model-fallback-1.test.ts
@@ -5,7 +5,14 @@ import type {
 	InternalStageContext,
 	StageSessionCreateOptions,
 } from "./stage-runner-helpers.js";
-import { assert, assistantMessageWithUsage, createStageContext, makeMockSession, makeOpts, Type } from "./stage-runner-helpers.js";
+import {
+	assert,
+	assistantMessageWithUsage,
+	createStageContext,
+	makeMockSession,
+	makeOpts,
+	Type,
+} from "./stage-runner-helpers.js";
 
 const USAGE_A = { input: 11, output: 22, cacheRead: 33, cacheWrite: 44, cost: 0.011 };
 const USAGE_B = { input: 111, output: 222, cacheRead: 333, cacheWrite: 444, cost: 0.111 };
@@ -209,13 +216,17 @@ describe("createStageContext — model fallback", () => {
 					async prompt() {
 						if (model === "anthropic/primary") {
 							messages.push(
-								assistantMessageWithUsage("empty provider response", {
-									input: 0,
-								output: 0,
-								cacheRead: 0,
-								cacheWrite: 0,
-								cost: 0,
-							}, "error"),
+								assistantMessageWithUsage(
+									"empty provider response",
+									{
+										input: 0,
+										output: 0,
+										cacheRead: 0,
+										cacheWrite: 0,
+										cost: 0,
+									},
+									"error",
+								),
 							);
 							return;
 						}

--- a/test/unit/stage-runner-model-fallback-1.test.ts
+++ b/test/unit/stage-runner-model-fallback-1.test.ts
@@ -67,8 +67,8 @@ describe("createStageContext — model fallback", () => {
 		assert.equal(meta.modelAttempts?.[0]?.error, "429 rate limit exceeded");
 		assert.equal(meta.warnings, undefined);
 		// Neither attempt admitted an assistant response, so neither may carry usage.
-		assert.equal(meta.modelAttempts?.[0]?.usage, undefined);
-		assert.equal(meta.modelAttempts?.[1]?.usage, undefined);
+		assert.equal(Object.hasOwn(meta.modelAttempts?.[0] ?? {}, "usage"), false);
+		assert.equal(Object.hasOwn(meta.modelAttempts?.[1] ?? {}, "usage"), false);
 	});
 
 	test("a successful candidate with one meaningful assistant reports the exact usage aggregate", async () => {
@@ -250,12 +250,103 @@ describe("createStageContext — model fallback", () => {
 		assert.equal(await ctx.prompt("go"), "fallback answer");
 		const meta = ctx.__modelFallbackMeta();
 		assert.deepEqual(meta.attemptedModels, ["anthropic/primary", "openai/fallback"]);
-		assert.equal(meta.modelAttempts?.[0]?.usage, undefined);
+		assert.equal(Object.hasOwn(meta.modelAttempts?.[0] ?? {}, "usage"), false);
 		assert.deepEqual(meta.modelAttempts?.[1], {
 			model: "openai/fallback",
 			success: true,
 			usage: { ...USAGE_A, turns: 1 },
 		});
+	});
+
+	test("cost-only and total-token-only signals each count as meaningful turns", async () => {
+		const messages: AgentSession["messages"] = [];
+		const agentSession: AgentSessionAdapter = {
+			async create() {
+				const { session } = makeMockSession({
+					messages,
+					async prompt() {
+						messages.push(
+							assistantMessageWithUsage("cost-only", {
+								input: 0,
+								output: 0,
+								cacheRead: 0,
+								cacheWrite: 0,
+								cost: 0.25,
+								totalTokens: 0,
+							}),
+							assistantMessageWithUsage("total-only", {
+								input: 0,
+								output: 0,
+								cacheRead: 0,
+								cacheWrite: 0,
+								cost: 0,
+								totalTokens: 7,
+							}),
+						);
+					},
+					getLastAssistantText: () => "total-only",
+				});
+				return session;
+			},
+		};
+		const ctx = createStageContext(
+			makeOpts({ adapters: { agentSession }, stageOptions: { model: "anthropic/primary" } }),
+		) as InternalStageContext;
+
+		assert.equal(await ctx.prompt("go"), "total-only");
+		assert.deepEqual(ctx.__modelFallbackMeta().modelAttempts?.[0]?.usage, {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: 0.25,
+			turns: 2,
+		});
+	});
+
+	test("malformed usage records are omitted instead of poisoning the aggregate", async () => {
+		const messages: AgentSession["messages"] = [];
+		const agentSession: AgentSessionAdapter = {
+			async create() {
+				const { session } = makeMockSession({
+					messages,
+					async prompt() {
+						messages.push(
+							assistantMessageWithUsage("nan", {
+								input: 1,
+								output: Number.NaN,
+								cacheRead: 0,
+								cacheWrite: 0,
+								cost: 0,
+							}),
+							assistantMessageWithUsage("infinite", {
+								input: Number.POSITIVE_INFINITY,
+								output: 0,
+								cacheRead: 0,
+								cacheWrite: 0,
+								cost: 0,
+							}),
+							assistantMessageWithUsage("negative", {
+								input: 1,
+								output: -1,
+								cacheRead: 0,
+								cacheWrite: 0,
+								cost: 0,
+								totalTokens: 0,
+							}),
+						);
+					},
+					getLastAssistantText: () => "negative",
+				});
+				return session;
+			},
+		};
+		const ctx = createStageContext(
+			makeOpts({ adapters: { agentSession }, stageOptions: { model: "anthropic/primary" } }),
+		) as InternalStageContext;
+
+		assert.equal(await ctx.prompt("go"), "negative");
+		assert.equal(Object.hasOwn(ctx.__modelFallbackMeta().modelAttempts?.[0] ?? {}, "usage"), false);
 	});
 
 	test("schema-backed structured_output capture prevents fallback retry after a later model error", async () => {

--- a/test/unit/stage-runner-model-fallback-1.test.ts
+++ b/test/unit/stage-runner-model-fallback-1.test.ts
@@ -5,7 +5,10 @@ import type {
 	InternalStageContext,
 	StageSessionCreateOptions,
 } from "./stage-runner-helpers.js";
-import { assert, createStageContext, makeMockSession, makeOpts, Type } from "./stage-runner-helpers.js";
+import { assert, assistantMessageWithUsage, createStageContext, makeMockSession, makeOpts, Type } from "./stage-runner-helpers.js";
+
+const USAGE_A = { input: 11, output: 22, cacheRead: 33, cacheWrite: 44, cost: 0.011 };
+const USAGE_B = { input: 111, output: 222, cacheRead: 333, cacheWrite: 444, cost: 0.111 };
 
 describe("createStageContext — model fallback", () => {
 	test("primary retryable failure tries fallback and records metadata", async () => {
@@ -56,19 +59,208 @@ describe("createStageContext — model fallback", () => {
 		);
 		assert.equal(meta.modelAttempts?.[0]?.error, "429 rate limit exceeded");
 		assert.equal(meta.warnings, undefined);
+		// Neither attempt admitted an assistant response, so neither may carry usage.
+		assert.equal(meta.modelAttempts?.[0]?.usage, undefined);
+		assert.equal(meta.modelAttempts?.[1]?.usage, undefined);
+	});
+
+	test("a successful candidate with one meaningful assistant reports the exact usage aggregate", async () => {
+		const messages: AgentSession["messages"] = [];
+		const agentSession: AgentSessionAdapter = {
+			async create() {
+				const { session } = makeMockSession({
+					messages,
+					async prompt() {
+						messages.push(assistantMessageWithUsage("primary answer", USAGE_A));
+					},
+					getLastAssistantText() {
+						return "primary answer";
+					},
+				});
+				return session;
+			},
+		};
+
+		const ctx = createStageContext(
+			makeOpts({
+				adapters: { agentSession },
+				stageOptions: { model: "anthropic/primary", fallbackModels: ["openai/fallback"] },
+			}),
+		) as InternalStageContext;
+
+		assert.equal(await ctx.prompt("go"), "primary answer");
+		const meta = ctx.__modelFallbackMeta();
+		assert.deepEqual(meta.attemptedModels, ["anthropic/primary"]);
+		assert.deepEqual(meta.modelAttempts?.[0], {
+			model: "anthropic/primary",
+			success: true,
+			usage: { ...USAGE_A, turns: 1 },
+		});
+	});
+
+	test("multiple meaningful assistants in one attempt sum every bucket and count each turn", async () => {
+		const messages: AgentSession["messages"] = [];
+		const agentSession: AgentSessionAdapter = {
+			async create() {
+				const { session } = makeMockSession({
+					messages,
+					async prompt() {
+						// One provider round that recovered after an error, then the final answer.
+						messages.push(assistantMessageWithUsage("recovered", USAGE_A, "error"));
+						messages.push(assistantMessageWithUsage("primary answer", USAGE_B));
+					},
+					getLastAssistantText() {
+						return "primary answer";
+					},
+				});
+				return session;
+			},
+		};
+
+		const ctx = createStageContext(
+			makeOpts({
+				adapters: { agentSession },
+				stageOptions: { model: "anthropic/primary", fallbackModels: ["openai/fallback"] },
+			}),
+		) as InternalStageContext;
+
+		assert.equal(await ctx.prompt("go"), "primary answer");
+		const meta = ctx.__modelFallbackMeta();
+		assert.deepEqual(meta.attemptedModels, ["anthropic/primary"]);
+		assert.deepEqual(meta.modelAttempts?.[0], {
+			model: "anthropic/primary",
+			success: true,
+			usage: {
+				input: USAGE_A.input + USAGE_B.input,
+				output: USAGE_A.output + USAGE_B.output,
+				cacheRead: USAGE_A.cacheRead + USAGE_B.cacheRead,
+				cacheWrite: USAGE_A.cacheWrite + USAGE_B.cacheWrite,
+				cost: USAGE_A.cost + USAGE_B.cost,
+				turns: 2,
+			},
+		});
+	});
+
+	test("a failed provider response keeps its usage while the fallback keeps its own window", async () => {
+		const calls: string[] = [];
+		const agentSession: AgentSessionAdapter = {
+			async create(options) {
+				const model =
+					typeof options.model === "string"
+						? options.model
+						: `${String(options.model?.provider)}/${options.model?.id}`;
+				calls.push(model);
+				const messages: AgentSession["messages"] = [];
+				const { session } = makeMockSession({
+					messages,
+					async prompt() {
+						if (model === "anthropic/primary") {
+							messages.push(assistantMessageWithUsage("partial primary response", USAGE_A, "error"));
+							throw new Error("429 rate limit exceeded");
+						}
+						messages.push(assistantMessageWithUsage("fallback answer", USAGE_B));
+					},
+					dispose() {
+						calls.push(`dispose:${model}`);
+					},
+					getLastAssistantText() {
+						return model === "openai/fallback" ? "fallback answer" : undefined;
+					},
+				});
+				return session;
+			},
+		};
+
+		const ctx = createStageContext(
+			makeOpts({
+				adapters: { agentSession },
+				stageOptions: {
+					model: "anthropic/primary",
+					fallbackModels: ["openai/fallback"],
+				},
+			}),
+		) as InternalStageContext;
+
+		assert.equal(await ctx.prompt("go"), "fallback answer");
+		assert.deepEqual(calls, ["anthropic/primary", "openai/fallback", "dispose:anthropic/primary"]);
+		const meta = ctx.__modelFallbackMeta();
+		assert.deepEqual(meta.attemptedModels, ["anthropic/primary", "openai/fallback"]);
+		assert.deepEqual(meta.modelAttempts?.[0], {
+			model: "anthropic/primary",
+			success: false,
+			error: "429 rate limit exceeded",
+			usage: { ...USAGE_A, turns: 1 },
+		});
+		assert.deepEqual(meta.modelAttempts?.[1], {
+			model: "openai/fallback",
+			success: true,
+			usage: { ...USAGE_B, turns: 1 },
+		});
+	});
+
+	test("a zeroed assistant usage object is omitted from the attempt", async () => {
+		const messages: AgentSession["messages"] = [];
+		const agentSession: AgentSessionAdapter = {
+			async create(options) {
+				const modelValue = options.model as unknown;
+				const model = typeof modelValue === "string" ? modelValue : "object-model";
+				const { session } = makeMockSession({
+					messages,
+					async prompt() {
+						if (model === "anthropic/primary") {
+							messages.push(
+								assistantMessageWithUsage("empty provider response", {
+									input: 0,
+								output: 0,
+								cacheRead: 0,
+								cacheWrite: 0,
+								cost: 0,
+							}, "error"),
+							);
+							return;
+						}
+						messages.push(assistantMessageWithUsage("fallback answer", USAGE_A));
+					},
+					getLastAssistantText() {
+						return model === "openai/fallback" ? "fallback answer" : undefined;
+					},
+				});
+				return session;
+			},
+		};
+
+		const ctx = createStageContext(
+			makeOpts({
+				adapters: { agentSession },
+				stageOptions: { model: "anthropic/primary", fallbackModels: ["openai/fallback"] },
+			}),
+		) as InternalStageContext;
+
+		assert.equal(await ctx.prompt("go"), "fallback answer");
+		const meta = ctx.__modelFallbackMeta();
+		assert.deepEqual(meta.attemptedModels, ["anthropic/primary", "openai/fallback"]);
+		assert.equal(meta.modelAttempts?.[0]?.usage, undefined);
+		assert.deepEqual(meta.modelAttempts?.[1], {
+			model: "openai/fallback",
+			success: true,
+			usage: { ...USAGE_A, turns: 1 },
+		});
 	});
 
 	test("schema-backed structured_output capture prevents fallback retry after a later model error", async () => {
 		const calls: string[] = [];
 		const disposed: string[] = [];
 		let createOptions: StageSessionCreateOptions | undefined;
+		const messages: AgentSession["messages"] = [];
 		const agentSession: AgentSessionAdapter = {
 			async create(options) {
 				createOptions = options;
 				const model = typeof options.model === "string" ? options.model : "object-model";
 				calls.push(model);
 				const { session } = makeMockSession({
+					messages,
 					async prompt() {
+						messages.push(assistantMessageWithUsage("structured tool call", USAGE_A));
 						const structuredTool = createOptions?.customTools?.find((tool) => tool.name === "structured_output");
 						assert.ok(structuredTool);
 						await structuredTool.execute(
@@ -108,6 +300,9 @@ describe("createStageContext — model fallback", () => {
 			meta.modelAttempts?.map((attempt) => ({ model: attempt.model, success: attempt.success })),
 			[{ model: "anthropic/primary", success: true }],
 		);
+		// The provider response that carried the structured tool call is part of
+		// this successful attempt, so its usage must be present.
+		assert.deepEqual(meta.modelAttempts?.[0]?.usage, { ...USAGE_A, turns: 1 });
 		assert.equal(meta.warnings, undefined);
 	});
 
@@ -173,6 +368,9 @@ describe("createStageContext — model fallback", () => {
 		);
 		assert.equal(meta.modelAttempts?.[0]?.error, "地域化されたプロバイダー エラー");
 		assert.equal(meta.warnings, undefined);
+		// The error assistant carries no usage object, so the failed attempt must omit usage.
+		assert.equal(meta.modelAttempts?.[0]?.usage, undefined);
+		assert.equal(meta.modelAttempts?.[1]?.usage, undefined);
 	});
 
 	test("recovered non-throwing assistant failure in the same prompt does not try fallback", async () => {

--- a/test/unit/stage-runner-model-fallback-1.test.ts
+++ b/test/unit/stage-runner-model-fallback-1.test.ts
@@ -209,8 +209,10 @@ describe("createStageContext — model fallback", () => {
 		const messages: AgentSession["messages"] = [];
 		const agentSession: AgentSessionAdapter = {
 			async create(options) {
-				const modelValue = options.model as unknown;
-				const model = typeof modelValue === "string" ? modelValue : "object-model";
+				const model =
+					typeof options.model === "string"
+						? options.model
+						: `${String(options.model?.provider)}/${options.model?.id}`;
 				const { session } = makeMockSession({
 					messages,
 					async prompt() {

--- a/test/unit/stage-runner-thrown-retry.test.ts
+++ b/test/unit/stage-runner-thrown-retry.test.ts
@@ -116,7 +116,13 @@ describe("createStageContext — thrown model failure retry", () => {
 	test("a same-model retry keeps the dropped error assistant's usage in the attempt aggregate", async () => {
 		const messages: StageSessionRuntime["messages"] = [
 			// Historical transcript usage must never be charged to this attempt.
-			assistantMessageWithUsage("historical answer", { input: 9999, output: 8888, cacheRead: 7777, cacheWrite: 6666, cost: 9.99 }),
+			assistantMessageWithUsage("historical answer", {
+				input: 9999,
+				output: 8888,
+				cacheRead: 7777,
+				cacheWrite: 6666,
+				cost: 9.99,
+			}),
 		];
 		let promptCalls = 0;
 		const settings = retrySettings();
@@ -129,12 +135,22 @@ describe("createStageContext — thrown model failure retry", () => {
 						messages.push({ role: "user", content: "go", timestamp: Date.now() } as never);
 						if (promptCalls === 1) {
 							messages.push(
-								assistantMessageWithUsage("failed attempt", { input: 11, output: 22, cacheRead: 33, cacheWrite: 44, cost: 0.011 }, "error"),
+								assistantMessageWithUsage(
+									"failed attempt",
+									{ input: 11, output: 22, cacheRead: 33, cacheWrite: 44, cost: 0.011 },
+									"error",
+								),
 							);
 							throw new Error("503 service unavailable");
 						}
 						messages.push(
-							assistantMessageWithUsage("final answer", { input: 111, output: 222, cacheRead: 333, cacheWrite: 444, cost: 0.111 }),
+							assistantMessageWithUsage("final answer", {
+								input: 111,
+								output: 222,
+								cacheRead: 333,
+								cacheWrite: 444,
+								cost: 0.111,
+							}),
 						);
 						return "ok";
 					},
@@ -804,7 +820,13 @@ describe("createStageContext — continuation eligibility across admitted orderi
 			admit: (messages, call) => {
 				if (call === 2) {
 					messages.push(
-						assistantMessageWithUsage("resumed answer", { input: 111, output: 222, cacheRead: 333, cacheWrite: 444, cost: 0.111 }),
+						assistantMessageWithUsage("resumed answer", {
+							input: 111,
+							output: 222,
+							cacheRead: 333,
+							cacheWrite: 444,
+							cost: 0.111,
+						}),
 					);
 				}
 			},

--- a/test/unit/stage-runner-thrown-retry.test.ts
+++ b/test/unit/stage-runner-thrown-retry.test.ts
@@ -10,6 +10,7 @@ import type { WorkflowFastModeSettingsManager } from "../../packages/workflows/s
 import { nextRetryDecision as workflowsNextRetryDecision } from "../../packages/workflows/src/runs/shared/retry.js";
 import {
 	assert,
+	assistantMessageWithUsage,
 	createStageContext,
 	flushMicrotasks,
 	makeMockSession,
@@ -110,6 +111,59 @@ describe("createStageContext — thrown model failure retry", () => {
 		assert.equal(await ctx.prompt("go"), "ok");
 		assert.equal(promptCalls, 3);
 		assert.equal(activeSession?.messages.length, 1);
+	});
+
+	test("a same-model retry keeps the dropped error assistant's usage in the attempt aggregate", async () => {
+		const messages: StageSessionRuntime["messages"] = [
+			// Historical transcript usage must never be charged to this attempt.
+			assistantMessageWithUsage("historical answer", { input: 9999, output: 8888, cacheRead: 7777, cacheWrite: 6666, cost: 9.99 }),
+		];
+		let promptCalls = 0;
+		const settings = retrySettings();
+		const agentSession: AgentSessionAdapter = {
+			async create() {
+				return sessionWithSettings(
+					settings,
+					async () => {
+						promptCalls += 1;
+						messages.push({ role: "user", content: "go", timestamp: Date.now() } as never);
+						if (promptCalls === 1) {
+							messages.push(
+								assistantMessageWithUsage("failed attempt", { input: 11, output: 22, cacheRead: 33, cacheWrite: 44, cost: 0.011 }, "error"),
+							);
+							throw new Error("503 service unavailable");
+						}
+						messages.push(
+							assistantMessageWithUsage("final answer", { input: 111, output: 222, cacheRead: 333, cacheWrite: 444, cost: 0.111 }),
+						);
+						return "ok";
+					},
+					{ messages, getLastAssistantText: () => "ok" },
+				);
+			},
+		};
+		const ctx = createStageContext(
+			makeOpts({ adapters: { agentSession }, stageOptions: { model: "anthropic/primary" } }),
+		) as InternalStageContext;
+
+		assert.equal(await ctx.prompt("go"), "ok");
+		assert.equal(promptCalls, 2, "the same session must retry once and succeed");
+		assert.equal(
+			messages.filter((message) => message.role === "assistant" && message.stopReason === "error").length,
+			0,
+			"restore semantics must still drop the failed error assistant from the live transcript",
+		);
+		assert.deepEqual(
+			ctx.__modelFallbackMeta().modelAttempts,
+			[
+				{
+					model: "anthropic/primary",
+					success: true,
+					usage: { input: 122, output: 244, cacheRead: 366, cacheWrite: 488, cost: 0.122, turns: 2 },
+				},
+			],
+			"one attempt record sums only the retry-window responses and counts both turns",
+		);
 	});
 
 	test("keeps the admitted stage prompt when the retry continues the real session turn", async () => {
@@ -659,6 +713,16 @@ function realSessionProbe(
 						stopReason: "error",
 						errorMessage: "503 service unavailable",
 						content: [],
+						// Meaningful usage so retry-discard accounting keeps this response
+						// in the final attempt aggregate even though restore drops it.
+						usage: {
+							input: 11,
+							output: 22,
+							cacheRead: 33,
+							cacheWrite: 44,
+							totalTokens: 110,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.011 },
+						},
 					} as never);
 					throw new Error("503 service unavailable");
 				},
@@ -733,7 +797,18 @@ describe("createStageContext — continuation eligibility across admitted orderi
 	});
 
 	test("a pause during backoff drops the retained prompt and uses the resumed text", async () => {
-		const probe = realSessionProbe(retrySettings({ baseDelayMs: 1000 }), { failCalls: 1 });
+		const probe = realSessionProbe(retrySettings({ baseDelayMs: 1000 }), {
+			failCalls: 1,
+			// The replacement prompt's own response also carries usage, so a
+			// lastPromptStartIndex-based aggregate would see only this value.
+			admit: (messages, call) => {
+				if (call === 2) {
+					messages.push(
+						assistantMessageWithUsage("resumed answer", { input: 111, output: 222, cacheRead: 333, cacheWrite: 444, cost: 0.111 }),
+					);
+				}
+			},
+		});
 		const ctx = createStageContext(
 			makeOpts({ adapters: { agentSession: probe.agentSession }, stageOptions: { model: "anthropic/primary" } }),
 		) as InternalStageContext;
@@ -749,6 +824,11 @@ describe("createStageContext — continuation eligibility across admitted orderi
 		assert.deepEqual(probe.continuedTranscripts, [], "a resumed prompt does not continue the old turn");
 		assert.deepEqual(probe.promptTexts, ["do it", "resumed"]);
 		assert.equal(userMessagesWithText(probe.messages, "do it"), 0, "the abandoned input must not survive the resume");
+		assert.deepEqual(
+			ctx.__modelFallbackMeta().modelAttempts?.[0]?.usage,
+			{ input: 122, output: 244, cacheRead: 366, cacheWrite: 488, cost: 0.122, turns: 2 },
+			"the aggregate spans the original boundary: the pre-pause dropped error and the replacement response both count",
+		);
 	});
 
 	test("ctx.abort during backoff stops before any continuation", async () => {

--- a/test/unit/stage-runner-thrown-retry.test.ts
+++ b/test/unit/stage-runner-thrown-retry.test.ts
@@ -294,19 +294,47 @@ describe("createStageContext — thrown model failure retry", () => {
 		const promptCalls: string[] = [];
 		const created: string[] = [];
 		const disposed: string[] = [];
+		let primaryPromptCalls = 0;
 		const settings = retrySettings();
 		const agentSession: AgentSessionAdapter = {
 			async create(options) {
 				const model = modelFor(options);
 				created.push(model);
+				const messages: StageSessionRuntime["messages"] = [];
 				return sessionWithSettings(
 					settings,
 					async () => {
 						promptCalls.push(model);
-						if (model === "anthropic/primary") throw new Error("503 service unavailable");
+						if (model === "anthropic/primary") {
+							primaryPromptCalls += 1;
+							messages.push(
+								assistantMessageWithUsage(
+									`failed response ${primaryPromptCalls}`,
+									{
+										input: primaryPromptCalls,
+										output: primaryPromptCalls * 2,
+										cacheRead: primaryPromptCalls * 3,
+										cacheWrite: primaryPromptCalls * 4,
+										cost: primaryPromptCalls / 1000,
+									},
+									"error",
+								),
+							);
+							throw new Error("503 service unavailable");
+						}
+						messages.push(
+							assistantMessageWithUsage("fallback answer", {
+								input: 10,
+								output: 20,
+								cacheRead: 30,
+								cacheWrite: 40,
+								cost: 0.01,
+							}),
+						);
 						return "fallback answer";
 					},
 					{
+						messages,
 						dispose: () => {
 							disposed.push(model);
 						},
@@ -330,13 +358,19 @@ describe("createStageContext — thrown model failure retry", () => {
 		assert.deepEqual(promptCalls, ["anthropic/primary", "anthropic/primary", "anthropic/primary", "openai/fallback"]);
 		assert.deepEqual(created, ["anthropic/primary", "openai/fallback"]);
 		assert.deepEqual(disposed, ["anthropic/primary"]);
-		assert.deepEqual(
-			ctx.__modelFallbackMeta().modelAttempts?.map(({ model, success }) => ({ model, success })),
-			[
-				{ model: "anthropic/primary", success: false },
-				{ model: "openai/fallback", success: true },
-			],
-		);
+		assert.deepEqual(ctx.__modelFallbackMeta().modelAttempts, [
+			{
+				model: "anthropic/primary",
+				success: false,
+				error: "503 service unavailable",
+				usage: { input: 6, output: 12, cacheRead: 18, cacheWrite: 24, cost: 0.006, turns: 3 },
+			},
+			{
+				model: "openai/fallback",
+				success: true,
+				usage: { input: 10, output: 20, cacheRead: 30, cacheWrite: 40, cost: 0.01, turns: 1 },
+			},
+		]);
 	});
 
 	test("retries session creation on the same candidate before advancing", async () => {
@@ -794,11 +828,25 @@ describe("createStageContext — continuation eligibility across admitted orderi
 			failCalls: 1,
 			admit: (messages, call) => {
 				if (call === 1) {
-					messages.push({
-						role: "assistant",
-						stopReason: "stop",
-						content: [{ type: "text", text: "partial" }],
-					} as never);
+					messages.push(
+						assistantMessageWithUsage("partial", {
+							input: 1,
+							output: 2,
+							cacheRead: 3,
+							cacheWrite: 4,
+							cost: 0.001,
+						}),
+					);
+				} else {
+					messages.push(
+						assistantMessageWithUsage("final", {
+							input: 111,
+							output: 222,
+							cacheRead: 333,
+							cacheWrite: 444,
+							cost: 0.111,
+						}),
+					);
 				}
 			},
 		});
@@ -810,6 +858,11 @@ describe("createStageContext — continuation eligibility across admitted orderi
 		assert.deepEqual(probe.continuedTranscripts, [], "an assistant tail is not a valid continuation");
 		assert.deepEqual(probe.promptTexts, ["do it", "do it"], "the retry must re-send the prompt instead");
 		assert.equal(userMessagesWithText(probe.messages, "do it"), 1, "the re-prompt must not duplicate the input");
+		assert.deepEqual(
+			ctx.__modelFallbackMeta().modelAttempts?.[0]?.usage,
+			{ input: 123, output: 246, cacheRead: 369, cacheWrite: 492, cost: 0.123, turns: 3 },
+			"the latched window includes the retained response, discarded error, and re-prompt response",
+		);
 	});
 
 	test("a pause during backoff drops the retained prompt and uses the resumed text", async () => {


### PR DESCRIPTION
## Summary

Workflow model attempts already exposed an optional `usage` field, but the runtime never populated it. This PR attributes provider usage to each existing fallback attempt so workflow authors can inspect token and cost data without reconstructing it from session JSONL files.

## What changed

- Aggregate input, output, cache-read, and cache-write tokens, provider-reported total cost, and meaningful assistant turns for each recorded model attempt.
- Keep one accounting window across same-model retries and resumed prompts, including billed error responses removed during transcript rollback without charging retained session history again.
- Omit `usage` when no meaningful signal exists, and reject malformed negative or non-finite provider records before they can enter a durable checkpoint.
- Cover success, failure, fallback, retry exhaustion, retained and reattached sessions, resumed attempts, property omission, and DBOS checkpoint round-trips.
- Document the public accounting semantics and add the change to the workflows changelog.

## Scope

This is the field-population slice recommended in the issue discussion. Stage and run rollups, completion-notice totals, and a live `BACKGROUND` total remain follow-up work, so this PR does not close the broader issue.

## Validation

- `npm run check`
- Focused workflow suite: 80 tests passed across model fallback, retry/resume, and durable checkpoint coverage
- A full `npm run test:unit` attempt was blocked by an unrelated `ELOCKED` collision on the existing `~/.atomic/agent` lock in `workflow-stage-bundled-resources.test.ts`; the affected workflow tests pass independently.

Related: #2197

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789066019&installation_model_id=10562&pr_number=2321&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2321&signature=3539dc0bbac3730d4bed46736d26234a30f6f006d4a6f0742fcd89f727cce30c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change records token usage, provider cost, and response counts for each configured workflow model attempt. It also preserves billable usage across retry recovery, excludes retained session history from new attempts, and rejects invalid durable usage values.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

Focused execution confirmed retry accounting retains removed billable responses without charging historical messages, resumed sessions charge only newly produced responses, and durable data rejects negative usage values.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran focused Vitest checks for same-model retry accounting, reattached-session accounting, and durable checkpoint decoding.
- Retry accounting metrics were captured for the removed error response and final response, showing input 122, output 244, cacheRead 366, cacheWrite 488, cost 0.122, turns 2, and excluding historical usage.
- Reattached-session accounting captured only the new assistant response, showing input 11, output 22, cacheRead 33, cacheWrite 44, cost 0.011, turns 1.
- Durable checkpoint decoding validation passed: malformed nested usage including cacheRead -3 is rejected.

<a href="https://app.greptile.com/trex/runs/18448137/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(workflows): validate model usage fix..."](https://github.com/bastani-inc/atomic/commit/916eebde1196ac989f26184484cba08de09c5611) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52313829)</sub>

<!-- /greptile_comment -->