### PR TITLE
fix(test): quote Windows shim executable paths

### DIFF
--- a/test/helpers/runtime.ts
+++ b/test/helpers/runtime.ts
@@ -275,7 +275,8 @@ export function spawnProcess(first: readonly string[] | BunSpawnOptions, second?
 	// since Node 20.12 (CVE-2024-27980) it refuses to exec a `.cmd` or `.bat`
 	// without a shell. Spawn the resolved path, through a shell only for shims.
 	const isShim = /\.(?:cmd|bat)$/iu.test(executable);
-	const child = nodeSpawn(executable, args, {
+	const commandLine = isShim ? `"${executable}"` : executable;
+	const child = nodeSpawn(commandLine, args, {
 		cwd: options.cwd,
 		env: environment(options.env),
 		timeout: options.timeout,

--- a/test/unit/runtime-space-shim.test.ts
+++ b/test/unit/runtime-space-shim.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "vitest";
+import { readStreamText, spawnProcess } from "../helpers/runtime.js";
+
+const shimScript = process.platform === "win32" ? "@echo off\r\necho %~1\r\n" : "#!/bin/sh\nprintf '%s\\n' \"$1\"\n";
+
+for (const extension of [".cmd", ".bat"]) {
+	test(`runs a ${extension} shim when its path contains a space`, async () => {
+		const directory = mkdtempSync(join(tmpdir(), "atomic spawn shim-"));
+		const executable = join(directory, `echo${extension}`);
+		writeFileSync(executable, shimScript);
+		if (process.platform !== "win32") chmodSync(executable, 0o755);
+
+		try {
+			const child = spawnProcess([executable, "quoted-shim-argument"], {
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			const [stdout, stderr, exitCode] = await Promise.all([
+				readStreamText(child.stdout),
+				readStreamText(child.stderr),
+				child.exited,
+			]);
+
+			assert.equal(exitCode, 0, stderr);
+			assert.equal(stdout.trim(), "quoted-shim-argument");
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+}


### PR DESCRIPTION
Assistant-model: GPT-5.6 Luna

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

Closes #2291

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789068961&installation_model_id=10562&pr_number=2322&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2322&signature=f3cf6460a4de1c9026327471ae2febf276d889fc2272d14165d2da675fb67ddf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change quotes resolved Windows `.cmd` and `.bat` shim paths before shell execution, allowing executable paths containing spaces to run as a single command. The focused runtime tests passed for both shim extensions, and a before/after reproduction confirmed that quoting preserves the executable path and delivers the argument unchanged. No defects were found; the change is safe to merge.

<h3>Confidence Score: 5/5</h3>

The updated command construction correctly treats a spaced shim path as one executable command and preserves its argument.

Focused tests covered both `.cmd` and `.bat` shim extensions, and an executed before/after reproduction showed the old unquoted form fail while the updated quoted form completed successfully.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the unit test for runtime-space-shim.test.ts and confirmed that both .cmd and .bat shim cases passed.
- I reproduced the unquoted shim-path workflow before the change and observed a failure with shell exit 127.
- I reproduced the updated quoted shim-path workflow after the change; both shim paths executed successfully and printed quoted-shim-argument.
- I validated the additional spawnProcess helper test and confirmed it passed after the PR change.

<a href="https://app.greptile.com/trex/runs/18368186/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(test): quote Windows shim executable..."](https://github.com/bastani-inc/atomic/commit/6aa7e4397612dd1d6160574e63a03b671c304a1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52332699)</sub>

<!-- /greptile_comment -->