### PR TITLE
fix(check): typecheck coding-agent package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ everywhere. Where the split differs from pi, the reason is written down.
 | Supply-chain gate | committed `.npmrc` | Byte-identical to pi's: `save-exact=true` and `min-release-age=2`. Binds every contributor's install, not just CI. `.github/dependabot.yml` carries the matching `cooldown` |
 | Build | `npm run build` | tsgo, not Bun; no behaviour change |
 | Lint / format | `biome check` (`npm run check`, `npm run format`) | pi's rule set exactly: recommended preset plus the same six overrides. Tab indent width 3, line width 120 |
-| Typecheck / check | `npm run check` (biome + `tsc --noEmit` + shrinkwrap check) | pi runs biome + tsgo here |
+| Typecheck / check | `npm run check` (biome + `tsc --noEmit` + the coding-agent package's `tsgo -p tsconfig.build.json --noEmit` + shrinkwrap check) | pi runs biome + tsgo here. The second typecheck pass covers `packages/coding-agent`, which the root tsconfig excludes, under its own stricter build config (including `erasableSyntaxOnly`) |
 | Root test suites | `vitest --run --project {unit,integration,ci}` | pi uses vitest for its workspace tests, with a shared `vitest.base.ts` setting only `resolve.alias` |
 | `packages/coding-agent` suite | `vitest --run` | already parity; it now runs under Node rather than `bun --bun`, SQLite selectors included |
 | Script tests | `node --test scripts/*.test.mjs` | pi parity. Scripts Node can run are tested with Node's own runner |
@@ -51,7 +51,7 @@ a *toolchain* goal, not a CI-topology goal.
 
 - `npm ci --ignore-scripts` — install dependencies from `package-lock.json`
 - `npm install <pkg>` — add a dependency; `.npmrc` applies the 3-day release-age gate and `save-exact`
-- `npm run check` — `tsc --noEmit` plus the published-shrinkwrap check. `npm run typecheck` is the typecheck alone
+- `npm run check` — `tsc --noEmit`, then the coding-agent package typecheck (`tsgo -p tsconfig.build.json --noEmit`), plus the published-shrinkwrap check. `npm run typecheck` runs both typecheck passes alone
 - `npm run test:unit`, `npm run test:integration`, `npm run test:ci-contracts`, `npm run test:all`
 - `npm run test --workspace=@bastani/atomic` — the coding-agent vitest suite, under Node
 - `npm run test:scripts` — `node --test scripts/*.test.mjs`

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -228,7 +228,10 @@ Run these from the workspace root:
 | `npm run hooks:install`     | Install `prek.toml` Git hooks using `default_install_hook_types` |
 | `npm run hooks:run`         | Run all `prek.toml` hooks across the repository                  |
 
-`check` runs `biome check --error-on-warnings`, then `tsc --noEmit`, then verifies
+`check` runs `biome check --error-on-warnings`, then `tsc --noEmit`, then the coding-agent
+package's own typecheck (`tsgo -p tsconfig.build.json --noEmit` — a second pass under a
+different compiler and a stricter config, including `erasableSyntaxOnly`, because the root
+tsconfig excludes `packages/coding-agent`), then verifies
 `packages/coding-agent/npm-shrinkwrap.json` is still derivable from `package-lock.json`; `lint`
 is an alias for `check`, and `npm run format` applies Biome's formatter. Biome is configured in
 [`biome.json`](./biome.json) with upstream pi's rule set.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:ci-contracts": "vitest --run --project ci",
     "test:all": "npm run test:unit && npm run test:integration",
     "test:scripts": "node --test \"scripts/*.test.mjs\"",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && npm run typecheck --workspace=@bastani/atomic",
     "format": "biome format --write .",
     "check": "biome check --error-on-warnings . && npm run typecheck && npm run check:shrinkwrap",
     "lint": "npm run check",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -66,6 +66,7 @@
   "scripts": {
     "clean": "shx rm -rf dist",
     "dev": "tsgo -p tsconfig.build.json --watch --preserveWatchOutput",
+    "typecheck": "tsgo -p tsconfig.build.json --noEmit",
     "build": "tsgo -p tsconfig.build.json && shx chmod +x dist/cli.js dist/rpc-entry.js && bun run copy-assets",
     "bundle:dev": "bun build src/cli.ts --target=bun --minify --external mupdf --define process.env.ATOMIC_BUNDLED_BUILD=\"'1'\" --outfile dist-dev/cli.js",
     "start:fast": "bun run bundle:dev && bun dist-dev/cli.js",


### PR DESCRIPTION
Assistant-model: GPT-5.6 Luna

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789069747&installation_model_id=10562&pr_number=2323&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2323&signature=610ed6c74d54de91f920f8e5818d4d44f6f1ee3e6dd342338b73afbc0c77efcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

Closes #2319

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The root typecheck command now covers both the repository TypeScript configuration and the coding-agent package’s stricter build configuration. The documented command flow matches the implemented behavior, and the full root typecheck completed successfully.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The root typecheck completed successfully, including the nested coding-agent workspace typecheck under its dedicated build configuration.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The root repository typecheck was run and completed, and the nested workspace typecheck was triggered as part of the npm typecheck flow.
- The verbose typecheck run showed the nested @bastani/atomic workspace typecheck was invoked and the tsgo tool ran with --noEmit, with both root and nested invocations exiting successfully.
- The root and workspace scripts were identified: the root command chains tsc --noEmit and npm run typecheck for the workspace, and the coding-agent workspace runs tsgo -p tsconfig.build.json --noEmit.
- Verbose execution traces were captured in logs, documenting the commands and exit codes for both root and nested runs.

<a href="https://app.greptile.com/trex/runs/18410253/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["docs: describe the two-pass typecheck in..."](https://github.com/bastani-inc/atomic/commit/ed5ba5b544c1e395807bd3946796d9bdbaf61060) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52350494)</sub>

<!-- /greptile_comment -->