### PR TITLE
fix(model-runtime): sequence registration refreshes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -63,6 +63,7 @@
 ### Fixed
 
 - Fixed fullscreen mouse routing for focused workflow graphs and stage chats. SGR/X10 wheel and click sequences now reach the focused overlay through the existing bounded custom-input reply path before the alternate-screen viewport, so graph scrolling and click-to-attach work without changing keyboard viewport fallback behavior ([#2303](https://github.com/bastani-inc/atomic/issues/2303)).
+- Fixed registration-triggered offline model catalog refreshes racing newer credential-resolved refreshes, so configured `$ENV` and `!command` credentials remain authoritative ([#2318](https://github.com/bastani-inc/atomic/issues/2318)).
 - Fixed fullscreen overlay text selection when one input read contains multiple SGR mouse reports. Reports are replayed one at a time, while Shift/Option/Ctrl-modified presses and motion stay out of application selection; modifier-bearing SGR releases still close an active selection, and legacy X10 release remains excluded because pi-tui cannot identify it for selection.
 - Fixed `atomic auth check --no-refresh` resolving command-backed API keys as configured values rather than treating `!command` as a literal credential.
 

--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -138,6 +138,7 @@ export class ModelRuntime implements Models {
 	private readonly providerAvailabilitySeq = new Map<string, number>();
 	private readonly credentialOperations = new Map<string, Promise<unknown>>();
 	private availabilityError: string | undefined;
+	private refreshSequence = 0;
 	private constructor(
 		credentials: RuntimeCredentials,
 		config: ModelConfig,
@@ -653,7 +654,28 @@ export class ModelRuntime implements Models {
 	}
 
 	async refresh(options: ModelsRefreshOptions = {}): Promise<ModelsRefreshResult> {
-		this.config = await ModelConfig.load(this.modelsPath);
+		return this.runRefresh(options, ++this.refreshSequence);
+	}
+
+	/**
+	 * A registration's offline catalog pass must not publish after a newer refresh
+	 * that resolves configured credentials.
+	 */
+	private scheduleRegistrationRefresh(): void {
+		const sequence = ++this.refreshSequence;
+		void this.runRefresh({ allowNetwork: false }, sequence, true);
+	}
+
+	private async runRefresh(
+		options: ModelsRefreshOptions,
+		sequence: number,
+		discardIfSuperseded = false,
+	): Promise<ModelsRefreshResult> {
+		const config = await ModelConfig.load(this.modelsPath);
+		if (discardIfSuperseded && sequence !== this.refreshSequence) {
+			return { aborted: true, errors: new Map<string, Error>() };
+		}
+		this.config = config;
 		this.configureRadiusProviders();
 		if (options.providers) {
 			for (const providerId of new Set(options.providers)) this.recomposeProvider(providerId);
@@ -690,7 +712,7 @@ export class ModelRuntime implements Models {
 		this.nativeExtensionProviders.set(provider.id, provider);
 		this.recomposeProvider(provider.id);
 		this.updateModelSnapshot();
-		void this.refresh({ allowNetwork: false });
+		this.scheduleRegistrationRefresh();
 	}
 
 	registerProvider(providerId: string, config: ProviderConfigInput): void {
@@ -735,7 +757,7 @@ export class ModelRuntime implements Models {
 			}
 			this.snapshot = { ...this.snapshot, auth, configuredProviders, available };
 		}
-		void this.refresh({ allowNetwork: false });
+		this.scheduleRegistrationRefresh();
 	}
 
 	unregisterProvider(providerId: string): void {
@@ -743,6 +765,6 @@ export class ModelRuntime implements Models {
 		this.nativeExtensionProviders.delete(providerId);
 		this.recomposeProvider(providerId);
 		this.updateModelSnapshot();
-		void this.refresh({ allowNetwork: false });
+		this.scheduleRegistrationRefresh();
 	}
 }

--- a/packages/coding-agent/test/model-registry-dynamic-providers.suite.ts
+++ b/packages/coding-agent/test/model-registry-dynamic-providers.suite.ts
@@ -388,6 +388,7 @@ describeModelRegistry((context) => {
 					},
 				});
 				const staleRefresh = getModelRuntime(registry).refresh();
+				const supersededStaleRefresh = getModelRuntime(registry).refresh();
 				await allStaleStarted;
 
 				const freshModels = providerConfig("https://manual.test/v1", [{ id: "manual" }]).models!;
@@ -399,7 +400,7 @@ describeModelRegistry((context) => {
 				});
 				await getModelRuntime(registry).refresh();
 				releaseStale();
-				await Promise.all([staleRefresh, allStaleFinished]);
+				await Promise.all([staleRefresh, supersededStaleRefresh, allStaleFinished]);
 
 				expect(getModelsForProvider(registry, "dynamic").map((model) => model.id)).toEqual(["manual"]);
 				// Re-registration supersedes both stale refresh generations, so their

--- a/packages/coding-agent/test/model-registry-refresh-credential-resolution.test.ts
+++ b/packages/coding-agent/test/model-registry-refresh-credential-resolution.test.ts
@@ -1,9 +1,9 @@
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, test, vi } from "vitest";
-import { ModelConfig } from "../src/core/model-config.ts";
-import { describeModelRegistry } from "./model-registry-fixtures.ts";
-import { createInMemoryModelRegistry, createModelRegistry, getModelRuntime } from "./model-runtime-test-utils.ts";
+import { ModelConfig } from "../src/core/model-config.js";
+import { describeModelRegistry } from "./model-registry-fixtures.js";
+import { createInMemoryModelRegistry, createModelRegistry, getModelRuntime } from "./model-runtime-test-utils.js";
 
 describeModelRegistry((context) => {
 	describe("extension catalog credential resolution", () => {

--- a/packages/coding-agent/test/model-registry-refresh-credential-resolution.test.ts
+++ b/packages/coding-agent/test/model-registry-refresh-credential-resolution.test.ts
@@ -1,8 +1,9 @@
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
+import { ModelConfig } from "../src/core/model-config.ts";
 import { describeModelRegistry } from "./model-registry-fixtures.ts";
-import { createModelRegistry, getModelRuntime } from "./model-runtime-test-utils.ts";
+import { createInMemoryModelRegistry, createModelRegistry, getModelRuntime } from "./model-runtime-test-utils.ts";
 
 describeModelRegistry((context) => {
 	describe("extension catalog credential resolution", () => {
@@ -54,6 +55,45 @@ describeModelRegistry((context) => {
 			if (observedKey === undefined) result = await registry.refresh();
 			expect(result.errors.size).toBe(0);
 			expect(observedKey).toBe("command-catalog-key");
+		});
+
+		test("does not let a delayed registration refresh erase a newer resolved key", async () => {
+			const registry = await createInMemoryModelRegistry(context.authStorage);
+			const registrationConfig = await ModelConfig.load(undefined);
+			let releaseRegistrationLoad: () => void = () => {};
+			const registrationLoad = new Promise<typeof registrationConfig>((resolve) => {
+				releaseRegistrationLoad = () => resolve(registrationConfig);
+			});
+			const originalLoad = ModelConfig.load;
+			let loadCount = 0;
+			const load = vi.spyOn(ModelConfig, "load").mockImplementation((modelsJsonPath) => {
+				loadCount += 1;
+				return loadCount === 1 ? registrationLoad : originalLoad(modelsJsonPath);
+			});
+			let refreshCalls = 0;
+			let observedKey: string | undefined;
+			try {
+				registry.registerProvider("delayed-catalog", {
+					apiKey: "configured-catalog-key",
+					refreshModels: async ({ credential }) => {
+						refreshCalls += 1;
+						observedKey = credential?.type === "api_key" ? credential.key : undefined;
+						return [];
+					},
+				});
+
+				await registry.refresh();
+				const callsAfterForegroundRefresh = refreshCalls;
+				expect(observedKey).toBe("configured-catalog-key");
+
+				releaseRegistrationLoad();
+				await new Promise<void>((resolve) => setImmediate(resolve));
+				expect(refreshCalls).toBe(callsAfterForegroundRefresh);
+				expect(observedKey).toBe("configured-catalog-key");
+			} finally {
+				releaseRegistrationLoad();
+				load.mockRestore();
+			}
 		});
 
 		test("resolves stored API-key expressions", async () => {


### PR DESCRIPTION
Assistant-model: GPT-5.6 Luna

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789071882&installation_model_id=10562&pr_number=2325&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2325&signature=43de16784e1dfe51aab3480e7881b6d21926e05a9155c0d07cfc5bcf969f8f11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

Closes #2318

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The refresh sequencing change correctly prevents an older registration-triggered refresh from replacing a newer credential-resolved refresh. However, the new delayed-refresh regression test can time out because it does not ensure the background refresh has reached its delayed configuration load before starting the foreground refresh.

<h3>Confidence Score: 4/5</h3>

Not ready to merge until the delayed-refresh regression test is made deterministic.

The runtime guard behaved correctly in a deterministic reproduction, but the committed regression test can deadlock under a valid scheduling order and fail the test suite.

**Files Needing Attention:** packages/coding-agent/test/model-registry-refresh-credential-resolution.test.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and linked it to the corresponding review comment.
- The deterministic reproduction path was captured, including the delayed registration refresh source and the exact reproduction command, and the deterministic concurrency reproduction passed.
- The contract validation gathered before, source, and after execution logs to confirm the reproduction workflow, showing the pre-state timeout, the TypeScript reproduction source, and a passing Vitest run.

<a href="https://app.greptile.com/trex/runs/18410264/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/test/model-registry-refresh-credential-resolution.test.ts:85
**Delayed-refresh regression test can deadlock**

The test assumes that the background registration refresh has reached its mocked `ModelConfig.load` call before the foreground `registry.refresh()` starts. That ordering is not guaranteed: if the foreground refresh wins, it consumes the first mocked load and waits indefinitely on `registrationLoad`, causing Vitest to time out. Wait until the registration refresh is known to be pending before starting the foreground refresh so this test deterministically exercises the intended supersession path.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(test): use JavaScript ESM specifiers"](https://github.com/bastani-inc/atomic/commit/7d2b035171fe5f450be8deefd6507bfcf0b4f923) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52350505)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->