### PR TITLE
feat(tui): rename ADHD status to 'ADHD Mode' and separate footer statuses with •

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -57,6 +57,7 @@
 
 ### Changed
 
+- Footer and workflow stage-chat extension statuses are now joined with a dim `•` separator instead of a bare space, so adjacent statuses read as distinct items.
 - Live tool-call argument previews no longer update while a tool call's arguments are still streaming. On the default interactive path the assistant message is now rebuilt from `message_update` deltas, and `toolcall_start`/`toolcall_delta` carry an unparsable fragment of JSON rather than a usable value, so the accumulator deliberately ignores them and installs the complete parsed call at `toolcall_end`. The tool card itself still appears as soon as the call starts — it is created by `tool_execution_start`, not by the argument stream — and the arguments it finally shows are correct and complete; what is gone is the partially-filled argument text that used to fill in progressively before the call was ready. This is a deliberate trade for correctness: the previous incremental preview was only possible because every streaming frame re-sent the entire message, which is exactly the quadratic amplification removed above.
 
 - Adopted the pi 0.84.1 coding-agent, agent, AI, client, protocol, telemetry, and TUI runtime surfaces. The TUI adoption supplies the renderer behavior described above; Atomic keeps its isolated interactive engine, provider, path, and legacy `PI_*`/`.pi` compatibility surfaces.

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -249,7 +249,7 @@ export class FooterComponent implements Component {
 		if (statuses.length > 0) {
 			lines.push(
 				truncateToWidth(
-					statuses.map(([, text]) => sanitizeStatusText(text)).join(" "),
+					statuses.map(([, text]) => sanitizeStatusText(text)).join(` ${this.renderStyle.dim("•")} `),
 					width,
 					this.renderStyle.dim("..."),
 				),

--- a/packages/i-have-adhd/CHANGELOG.md
+++ b/packages/i-have-adhd/CHANGELOG.md
@@ -12,3 +12,4 @@ All notable changes to the `@bastani/i-have-adhd` extension will be documented i
 ### Changed
 
 - Enabled ADHD-friendly output by default for new sessions while preserving saved per-session state across restarts, branches, and compaction.
+- Renamed the footer status label from `ADHD ON` to `ADHD Mode`; the status is only shown while the mode is on, so the `ON` suffix was redundant.

--- a/packages/i-have-adhd/index.ts
+++ b/packages/i-have-adhd/index.ts
@@ -124,7 +124,7 @@ export default function iHaveAdhdExtension(pi: IHaveAdhdExtensionAPI) {
 		}
 
 		const dot = ctx.ui.theme.fg("success", "●");
-		const label = ctx.ui.theme.fg("accent", "ADHD ON");
+		const label = ctx.ui.theme.fg("accent", "ADHD Mode");
 		ctx.ui.setStatus(STATUS_KEY, `${dot} ${label}`);
 	};
 

--- a/test/unit/i-have-adhd.test.ts
+++ b/test/unit/i-have-adhd.test.ts
@@ -71,7 +71,7 @@ test("activates i-have-adhd and injects one hidden rules message into context", 
 		assert.ok(firstRulesEntry);
 		if (firstRulesEntry.type !== "custom_message") assert.fail("expected a custom message entry");
 		assert.equal(firstRulesEntry.display, false);
-		assert.equal(statuses.at(-1)?.value, "● ADHD ON");
+		assert.equal(statuses.at(-1)?.value, "● ADHD Mode");
 
 		await sessionStart({ type: "session_start", reason: "startup" }, ctx);
 		contextEntries = buildContextEntries(sessionManager.getEntries(), sessionManager.getLeafId());

--- a/test/unit/pi-parity-group-5.test.ts
+++ b/test/unit/pi-parity-group-5.test.ts
@@ -212,7 +212,7 @@ describe("Group 5 parity", () => {
 	test("idle status fills two rows", () => {
 		assert.deepEqual(new IdleStatus().render(4), ["    ", "    "]);
 	});
-	test("footer renders branch, session name, and sorted sanitized extension statuses", () => {
+	test("footer renders branch, session name, and sorted sanitized extension statuses with • separators", () => {
 		initTheme("dark");
 		const session = {
 			state: { model: undefined, thinkingLevel: "off" },
@@ -234,7 +234,7 @@ describe("Group 5 parity", () => {
 			.render(120)
 			.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
 		assert.match(lines[0] ?? "", /project \(feature\).*demo/);
-		assert.equal(lines[1], "alpha status zeta status");
+		assert.equal(lines[1], "alpha status • zeta status");
 	});
 
 	test("footer keeps ANSI-colored extension statuses intact instead of leaking stripped sequences", () => {


### PR DESCRIPTION
## Summary

Renames the footer status label `ADHD ON` → `ADHD Mode` (the status only renders while the mode is on, so the `ON` suffix carried no information) and joins adjacent extension statuses with a dim `•` separator instead of a bare space.

## Changes

- `packages/i-have-adhd/index.ts`: status label `ADHD ON` → `ADHD Mode`
- `packages/coding-agent/src/modes/interactive/components/footer.ts`: extension statuses join with ` • ` (dim); this `FooterComponent` is shared by the main chat footer and workflow stage-chat footers, so both surfaces pick it up
- Updated `test/unit/i-have-adhd.test.ts` and `test/unit/pi-parity-group-5.test.ts` expectations
- Changelog entries under `[Unreleased]` for `@bastani/i-have-adhd` and `@bastani/atomic`

## Notes

The fullscreen workflow graph overlay statusline already separates statuses with `·` and is unchanged. Verified with the unit suites above plus `npm run typecheck`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789092043&installation_model_id=10562&pr_number=2339&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2339&signature=67a67c8d57241cbe80c53b88e170a56901ccb65df7b98f6b52602dacda0f08b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change renames the enabled ADHD status to “ADHD Mode” and separates multiple interactive footer statuses with a dim bullet. Focused tests passed before and after the change, and a targeted footer rendering check exercised sorted ANSI-colored statuses, control-character sanitization, dim separator rendering, and narrow-width truncation. Those checks disproved presentation regressions in the updated status and footer paths.

<h3>Confidence Score: 5/5</h3>

The updated terminal presentation behavior is covered by focused tests and direct rendering checks, with no defects found.

All executed checks passed, including the exact status-label update and the footer composition paths most likely to regress when adding styled separators.

**Files Needing Attention:** No files require follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran focused unit tests on the parent commit and the PR commit; all 13 tests passed in each environment.
- Executed the targeted FooterComponent harness against the updated implementation with unsorted ANSI-colored statuses, control characters, dim rendering, and a narrow width; its single test passed.
- Verified the harness output confirms the ADHD label, sorted sanitized statuses, retained ANSI styling, dim bullet separator, and narrow-width truncation behave as intended.
- Compared baseline and PR-run presentation artifacts to confirm consistent rendering across commits.

<a href="https://app.greptile.com/trex/runs/18428293/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(tui): rename ADHD status to &#39;ADHD M..."](https://github.com/bastani-inc/atomic/commit/14ad3f6d34484308cb56d2346760293e779f5d1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52441421)</sub>

<!-- /greptile_comment -->