### PR TITLE
fix(workflows): hide ADHD status from graph overlay

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 - Fixed completed `ctx.exit()` runs losing the reserved returned-status convention, legacy child replay records losing their exit discriminator, and failed author-exit resume surfaces falling back to snapshot inspection instead of durable retry.
 
+- Fixed the workflow graph overlay statusline echoing the `i-have-adhd` extension's `ADHD Mode` badge. The badge remains in the main-chat footer while other extension statuses continue to render in the overlay ([#2341](https://github.com/bastani-inc/atomic/issues/2341)).
+
 - Fixed fullscreen workflow graph and stage-chat mouse routing. Focused workflow overlays now receive SGR/X10 wheel and click press/release sequences through the host's bounded custom-input reply channel before pi-tui's alternate-screen viewport, restoring graph scrolling and click-to-attach without a workflow-owned TTY-tracking seam; the fullscreen route also mirrors consumed left-button events into pi-tui's application-owned selection path ([#2303](https://github.com/bastani-inc/atomic/issues/2303)).
 - Fixed graph overlay rendering to keep its live vertical position in pi-tui's `ScrollView` and preserve OSC-8 hyperlink terminators when normalizing layout rows.
 

--- a/packages/workflows/src/tui/workflow-status.ts
+++ b/packages/workflows/src/tui/workflow-status.ts
@@ -3,7 +3,7 @@ export const WORKFLOW_STATUS_KEY = "pi-workflows";
 
 /**
  * Host status keys hidden from the workflow orchestrator statusline. The MCP
- * server count is main-chat chrome and carries no workflow signal, so the
- * overlay keeps its statusline for run-scoped hints instead.
+ * server count and ADHD Mode badge are main-chat chrome and carry no workflow
+ * signal, so the overlay keeps its statusline for run-scoped hints instead.
  */
-export const OVERLAY_HIDDEN_STATUS_KEYS: ReadonlySet<string> = new Set(["mcp"]);
+export const OVERLAY_HIDDEN_STATUS_KEYS: ReadonlySet<string> = new Set(["mcp", "i-have-adhd"]);

--- a/test/unit/overlay-graph-statusline-statuses.test.ts
+++ b/test/unit/overlay-graph-statusline-statuses.test.ts
@@ -54,6 +54,18 @@ describe("workflow orchestrator statusline extension statuses", () => {
 		assert.match(rendered, /Other extension status/);
 	});
 
+	test("hides the i-have-adhd ADHD Mode badge while preserving other extension statuses", () => {
+		const rendered = renderOverlay(
+			new Map([
+				["i-have-adhd", "● ADHD Mode"],
+				["other-extension", "Other extension status"],
+			]),
+		);
+
+		assert.doesNotMatch(rendered, /ADHD Mode/);
+		assert.match(rendered, /Other extension status/);
+	});
+
 	test("hides workflow-owned status keys", () => {
 		const rendered = renderOverlay(
 			new Map([


### PR DESCRIPTION
Assistant-model: GPT-5.6 Luna

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789101862&installation_model_id=10562&pr_number=2342&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2342&signature=8b9bc3c7912b64c0c26969c15d9954679f3c24767b5ae24fa282f8c9bd62d3b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change removes the `i-have-adhd` extension’s `ADHD Mode` badge from the workflow graph overlay while preserving unrelated extension statuses and main-chat footer behavior.

The graph overlay previously rendered `● ADHD Mode` alongside another extension status. The updated focused overlay test passes all 3 checks, confirming that the badge is now omitted without suppressing other extension statuses. The extension status producer and interactive main-chat footer tests also pass.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the overlay-only status filter behaves as intended and does not suppress main-chat status handling.

No defects were found. The changed render path was checked against the prior behavior and the updated behavior, and related status-producer and main-chat footer coverage passed.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran overlay-graph-statusline-statuses.test.ts against HEAD^ and observed a failure with ADHD Mode · Other extension status in the overlay footer.
- Ran the overlay-graph-statusline-statuses.test.ts on this PR revision; it passed with 1 file and 3 tests, confirming ADHD Mode is omitted while another extension status remains visible.
- Ran i-have-adhd.test.ts and pi-parity-group-5.test.ts; it passed with 2 files and 13 tests, confirming the extension continues to produce its status and the interactive main-chat footer behavior remains available.

<a href="https://app.greptile.com/trex/runs/18443295/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(workflows): hide ADHD status from gr..."](https://github.com/bastani-inc/atomic/commit/e14d0c6a4111effeaa635ffcbd7011aeb63a4ae6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52468925)</sub>

<!-- /greptile_comment -->