### PR TITLE
fix(docs): make published workflow examples runnable under Node

### DIFF
--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -5,7 +5,7 @@ This page gets you from install to a useful first Atomic session. Atomic is the 
 ## Prerequisites
 
 - **Node.js 24 LTS or newer** — Atomic requires the latest Node LTS runtime. Check with `node --version`.
-- **A package manager** — use npm (included with Node), pnpm, Yarn, or Bun. Use Bun 1.3.14+ for Bun installs or workflow-authoring examples.
+- **A package manager** — use npm (included with Node), pnpm, Yarn, or Bun. Bun installs need Bun 1.3.14+.
 - **Model-provider access** — Use `/login` after startup. Supports provider subscriptions and APIs.
 
 ## Install
@@ -31,6 +31,10 @@ bun add -g @bastani/atomic
 ```
 
 Atomic does not require package install scripts. If you want to disable dependency lifecycle scripts during the Atomic install, you can add `--ignore-scripts` to the install command.
+
+### Which runtime runs your workflows
+
+How you install Atomic decides which runtime hosts it: a package-manager install runs under Node, while the standalone binaries are Bun-compiled and run under Bun. Authored workflows execute inside whichever host is active, so a workflow that reaches for a `Bun.*` global runs only under the standalone binary and fails with `Bun is not defined` under an npm install. Installing Bun separately does not change that — the npm install still runs on Node. Write workflow code against APIs both hosts provide, such as `node:child_process` and `node:fs`; see [Workflows](/workflows) for the rule and worked examples.
 
 ### Alpine and musl Linux archives
 

--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -385,6 +385,7 @@ A natural-language request for a worktree does not configure runner isolation. I
 
 ```ts
 // .atomic/workflows/issue-to-pr.ts
+import { spawnSync } from "node:child_process";
 import { workflow } from "@bastani/workflows";
 import { Type, type Static } from "typebox";
 
@@ -396,12 +397,22 @@ const reviewDecision = Type.Object(
   { additionalProperties: false },
 );
 
+function spawnCommand(argv: readonly string[], cwd: string) {
+  const [command, ...args] = argv;
+  if (command === undefined) throw new Error("spawnCommand requires a command");
+  const result = spawnSync(command, args, { cwd, encoding: "utf8" });
+  // A command that could not be spawned at all arrives on `error` with a null
+  // status, so it has to be raised here or it reads as an ordinary failure.
+  if (result.error) throw result.error;
+  return result;
+}
+
 function runCommand(argv: readonly string[], cwd: string): string {
-  const result = Bun.spawnSync([...argv], { cwd, stdout: "pipe", stderr: "pipe" });
-  const stdout = result.stdout.toString().trim();
-  const stderr = result.stderr.toString().trim();
-  if (result.exitCode !== 0) {
-    throw new Error(`${argv.join(" ")} failed (${result.exitCode})\n${stderr || stdout}`);
+  const result = spawnCommand(argv, cwd);
+  const stdout = (result.stdout ?? "").trim();
+  const stderr = (result.stderr ?? "").trim();
+  if (result.status !== 0) {
+    throw new Error(`${argv.join(" ")} failed (${result.status})\n${stderr || stdout}`);
   }
   return stdout;
 }
@@ -430,12 +441,12 @@ export default workflow({
     const baseRef = ctx.inputs.base_ref;
 
     await ctx.tool("select-feature-branch", { branch, base_ref: baseRef }, async () => {
-      const probe = Bun.spawnSync(
+      const probe = spawnCommand(
         ["git", "show-ref", "--verify", "--quiet", `refs/heads/${branch}`],
-        { cwd, stdout: "pipe", stderr: "pipe" },
+        cwd,
       );
-      if (probe.exitCode === 0) return runCommand(["git", "switch", branch], cwd);
-      if (probe.exitCode !== 1) throw new Error(probe.stderr.toString().trim());
+      if (probe.status === 0) return runCommand(["git", "switch", branch], cwd);
+      if (probe.status !== 1) throw new Error((probe.stderr ?? "").trim());
       return runCommand(["git", "switch", "-c", branch, baseRef], cwd);
     });
 
@@ -848,6 +859,8 @@ Run open-claude-design to refresh the settings page hierarchy.
 If required inputs are missing or ambiguous, Atomic asks for them or opens the inline picker. Named runs execute in the background and return a full run id.
 
 ## Writing a Workflow
+
+**A workflow executes inside whichever host is running Atomic, so its code has to work on both.** Standalone binaries are Bun-compiled while npm installs run under Node, and the active host is what loads your workflow file — so a `Bun.*` global reaches a workflow only when Atomic itself is running under Bun, and fails with `Bun is not defined` otherwise. Installing Bun separately does not change this. Write workflow code against APIs both hosts provide: `node:child_process` instead of `Bun.spawn`/`Bun.spawnSync`, `node:fs` instead of `Bun.file`, `node:path` instead of Bun's path helpers. Every example on this page follows that rule; a snippet that deliberately requires one host is marked with a `host-specific:` comment naming it.
 
 Workflow files are TypeScript modules that export a workflow definition:
 
@@ -4678,17 +4691,28 @@ The parent should verify each child before creating the next boundary. If a gate
 The calls below are deliberately unrolled. Repeat the downstream shape for the planned slices, giving every call a fresh child boundary and distinct tracked nodes; do not reopen an ancestor or add a back-edge.
 
 ```ts
+import { spawnSync } from "node:child_process";
 import { resolve } from "node:path";
 import { Type } from "typebox";
 import { workflow } from "@bastani/workflows";
 import { goal } from "@bastani/workflows/builtin";
 
+function spawnCommand(argv: readonly string[], cwd: string) {
+  const [command, ...args] = argv;
+  if (command === undefined) throw new Error("spawnCommand requires a command");
+  const result = spawnSync(command, args, { cwd, encoding: "utf8" });
+  // A command that could not be spawned at all arrives on `error` with a null
+  // status, so it has to be raised here or it reads as an ordinary failure.
+  if (result.error) throw result.error;
+  return result;
+}
+
 function runCommand(argv: readonly string[], cwd: string): string {
-  const result = Bun.spawnSync([...argv], { cwd, stdout: "pipe", stderr: "pipe" });
-  const stdout = result.stdout.toString().trim();
-  const stderr = result.stderr.toString().trim();
-  if (result.exitCode !== 0) {
-    throw new Error(`${argv.join(" ")} failed (${result.exitCode})\n${stderr || stdout}`);
+  const result = spawnCommand(argv, cwd);
+  const stdout = (result.stdout ?? "").trim();
+  const stderr = (result.stderr ?? "").trim();
+  if (result.status !== 0) {
+    throw new Error(`${argv.join(" ")} failed (${result.status})\n${stderr || stdout}`);
   }
   return stdout;
 }
@@ -4719,28 +4743,28 @@ export default workflow({
         toolName,
         { branch, base_branch: baseBranch, git_worktree_dir: gitWorktreeDir },
         async () => {
-          const current = Bun.spawnSync(
+          const current = spawnCommand(
             ["git", "-C", worktreePath, "branch", "--show-current"],
-            { cwd: repoRoot, stdout: "pipe", stderr: "pipe" },
+            repoRoot,
           );
-          if (current.exitCode === 0) {
-            const checkedOutBranch = current.stdout.toString().trim();
+          if (current.status === 0) {
+            const checkedOutBranch = (current.stdout ?? "").trim();
             if (checkedOutBranch !== branch) {
               throw new Error(`${worktreePath} is checked out on ${checkedOutBranch || "detached HEAD"}, expected ${branch}`);
             }
             return { branch, worktree: worktreePath };
           }
 
-          const branchProbe = Bun.spawnSync(
+          const branchProbe = spawnCommand(
             ["git", "show-ref", "--verify", "--quiet", `refs/heads/${branch}`],
-            { cwd: repoRoot, stdout: "pipe", stderr: "pipe" },
+            repoRoot,
           );
-          if (branchProbe.exitCode === 0) {
+          if (branchProbe.status === 0) {
             runCommand(["git", "worktree", "add", worktreePath, branch], repoRoot);
-          } else if (branchProbe.exitCode === 1) {
+          } else if (branchProbe.status === 1) {
             runCommand(["git", "worktree", "add", "-b", branch, worktreePath, baseBranch], repoRoot);
           } else {
-            throw new Error(branchProbe.stderr.toString().trim() || `could not inspect branch ${branch}`);
+            throw new Error((branchProbe.stderr ?? "").trim() || `could not inspect branch ${branch}`);
           }
           return { branch, worktree: worktreePath };
         },

--- a/test/unit/workflow-docs-host-portability.test.ts
+++ b/test/unit/workflow-docs-host-portability.test.ts
@@ -1,0 +1,118 @@
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+import { moduleDir, readText } from "../helpers/runtime.js";
+
+const repositoryRoot = resolve(moduleDir(import.meta.url), "../..");
+
+/**
+ * The pages a reader copies workflow code out of. Prose that names a Bun API is
+ * fine anywhere; this contract governs only the fenced examples, because those
+ * are what lands in a `.atomic/workflows/*.ts` file and runs in the active host.
+ */
+const publishedWorkflowDocs = [
+	"packages/coding-agent/docs/workflows.md",
+	"packages/coding-agent/docs/quickstart.md",
+	"packages/workflows/README.md",
+	"docs/workflow-playbook.md",
+] as const;
+
+/** The escape hatch for an example that deliberately demonstrates one host. */
+const hostSpecificMarker = /host-specific:[^\n]*\b(?:bun|node)\b/iu;
+
+const codeFence = /^```(\w[\w+-]*)\n([\s\S]*?)^```/gmu;
+const bunGlobal = /(?<![\w.$])Bun\.\w+/gu;
+const executableLanguages = new Set(["ts", "typescript", "tsx", "js", "javascript", "jsx", "mjs"]);
+
+/**
+ * A floor rather than an exact count, so ordinary doc edits do not touch this
+ * file. It exists because a broken fence pattern or a renamed page would
+ * otherwise scan nothing and pass — the one failure mode a lint-shaped test
+ * cannot afford.
+ */
+const MINIMUM_SCANNED_EXAMPLES = 100;
+
+interface CodeExample {
+	readonly doc: string;
+	readonly line: number;
+	readonly code: string;
+}
+
+async function readRepositoryFile(path: string): Promise<string> {
+	return (await readText(resolve(repositoryRoot, path))).replaceAll("\r\n", "\n");
+}
+
+function codeExamples(doc: string, content: string): CodeExample[] {
+	const examples: CodeExample[] = [];
+	for (const match of content.matchAll(codeFence)) {
+		const language = (match[1] ?? "").toLowerCase();
+		if (!executableLanguages.has(language)) continue;
+		examples.push({ doc, line: content.slice(0, match.index).split("\n").length, code: match[2] ?? "" });
+	}
+	return examples;
+}
+
+function unguardedBunUse(example: CodeExample): string[] {
+	if (hostSpecificMarker.test(example.code)) return [];
+	return [...new Set(example.code.match(bunGlobal) ?? [])];
+}
+
+function soleExample(markdown: string): CodeExample {
+	const [example] = codeExamples("sample.md", markdown);
+	if (!example) throw new Error("sample markdown produced no code example");
+	return example;
+}
+
+async function publishedExamples(): Promise<CodeExample[]> {
+	const collected: CodeExample[] = [];
+	for (const doc of publishedWorkflowDocs) collected.push(...codeExamples(doc, await readRepositoryFile(doc)));
+	return collected;
+}
+
+describe("published workflow examples stay host-portable", () => {
+	test("no example reaches for a Bun global without naming the host", async () => {
+		const violations = (await publishedExamples()).flatMap((example) => {
+			const globals = unguardedBunUse(example);
+			return globals.length === 0 ? [] : [`${example.doc}:${example.line} uses ${globals.join(", ")}`];
+		});
+
+		expect(
+			violations,
+			"npm-installed Atomic runs under Node, where these fail with `Bun is not defined`. Use the node: " +
+				"builtins, or mark the example with a `host-specific:` comment naming the host it requires.",
+		).toEqual([]);
+	});
+
+	test("scans the examples it claims to scan", async () => {
+		const examples = await publishedExamples();
+
+		expect(examples.length).toBeGreaterThan(MINIMUM_SCANNED_EXAMPLES);
+		expect(examples.some((example) => example.code.includes("node:child_process"))).toBe(true);
+	});
+
+	test("still fails on an unmarked Bun global, and the marker is the only way out", () => {
+		const unmarked = '```ts\nconst probe = Bun.spawnSync(["git", "status"]);\n```\n';
+		const marked = '```ts\n// host-specific: bun\nconst probe = Bun.spawnSync(["git", "status"]);\n```\n';
+		const prose = "Under the hood the binary calls `Bun.spawnSync`, which is why it needs Bun.\n";
+
+		expect(unguardedBunUse(soleExample(unmarked))).toEqual(["Bun.spawnSync"]);
+		expect(unguardedBunUse(soleExample(marked))).toEqual([]);
+		expect(codeExamples("sample.md", prose)).toEqual([]);
+	});
+
+	test("states the both-hosts rule where workflows are authored", async () => {
+		const workflows = await readRepositoryFile("packages/coding-agent/docs/workflows.md");
+		const quickstart = await readRepositoryFile("packages/coding-agent/docs/quickstart.md");
+
+		for (const phrase of [
+			"executes inside whichever host is running Atomic",
+			"Bun is not defined",
+			"node:child_process",
+		]) {
+			expect(workflows, "workflows.md").toContain(phrase);
+		}
+
+		for (const phrase of ["a package-manager install runs under Node", "Bun is not defined"]) {
+			expect(quickstart, "quickstart.md").toContain(phrase);
+		}
+	});
+});


### PR DESCRIPTION
Related: #2346

I posted the approach on the issue and am happy to hold, rescope, or split this — pushing the branch so there is something concrete to look at rather than to jump the assignment queue.

## Problem

The published workflow examples call `Bun.spawnSync`. A standalone Atomic binary is Bun-compiled, but an npm-installed Atomic runs under Node, and an authored workflow executes inside whichever host is active — so a workflow copied out of the docs fails with `Bun is not defined`. Installing Bun separately does not help, which is what `quickstart.md` implied.

## What changed

**Five call sites ported to `node:child_process`**, all in `packages/coding-agent/docs/workflows.md` — two in the `issue-to-pr` example, three in `stacked-slices`.

This is not a rename, and the three differences are why the examples grew a `spawnCommand` helper rather than a one-line swap:

| | `Bun.spawnSync` | `node:child_process` |
|---|---|---|
| exit code | `exitCode` | `status` |
| spawn failure | throws | returned on `error`, `status: null` |
| output | `Buffer`, `.toString()` at each site | `string` with `encoding: "utf8"`, `null` when the spawn failed |

The `error` row is the one that bites: both probes branch on the exit code (`=== 0`, `!== 1`), so a straight swap would turn a missing `git` into an ordinary non-zero-exit path instead of an error. `spawnCommand` raises it, and `runCommand` keeps its original contract on top.

Nothing else in the examples changed — same commands, same control flow, same error text.

**Guidance.** `workflows.md` now states the rule at the top of *Writing a Workflow*: examples use APIs both hosts provide, and a deliberately host-specific snippet is marked with a `host-specific:` comment naming the host. `quickstart.md` drops "Use Bun 1.3.14+ for Bun installs or workflow-authoring examples" and gains a short *Which runtime runs your workflows* section describing the actual npm/Node and standalone/Bun split.

**Contract test** at `test/unit/workflow-docs-host-portability.test.ts`, shaped after `workflow-authoring-folder-disclosure.test.ts`. It parses the fenced `ts`/`typescript`/`js` blocks out of `workflows.md`, `quickstart.md`, `packages/workflows/README.md` and `docs/workflow-playbook.md` and fails on an unmarked `Bun.` global, naming the file, line, and API. Prose that mentions a Bun API is untouched — only fenced examples are governed, so `security.md:64` and `extensions.md:103` stay as they are.

Two of its four cases exist to keep the check honest rather than to assert the fix:

- it asserts a floor on the number of examples scanned and that a `node:child_process` example is among them, so a broken fence pattern or a renamed page cannot pass by scanning nothing;
- it round-trips a synthetic violation and a marked one through the same scanner, so the check cannot rot into something that no longer fails.

## Verification

```
$ npx tsc --noEmit
(clean)

$ npx biome check --error-on-warnings .
Checked 2437 files in 1850ms. No fixes applied.

$ npx vitest run <the new file>
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

And the same suite with a `Bun.spawnSync` example temporarily appended to `workflows.md`, to confirm the contract is live:

```
 Test Files  1 failed (1)
      Tests  1 failed | 3 passed (4)

AssertionError: npm-installed Atomic runs under Node, where these fail with `Bun is not defined`.
Use the node: builtins, or mark the example with a `host-specific:` comment naming the host it requires.
+   "packages/coding-agent/docs/workflows.md:5181 uses Bun.spawnSync"
```

`npm run check` also runs `check:shrinkwrap`, which I did not run — this branch touches no dependency.

## Not done here

The issue's last bullet — an installed-package test that runs a representative workflow subprocess step under Node — is the open question on #2346. I left it out rather than guess at where it belongs, since that suite builds and installs a package. Happy to add it here or file it as a follow-up, whichever you prefer.

## Unrelated, found while verifying

`npm run test:unit` cannot start on Windows, before any test runs. `test/global-setup-natives.ts:163` builds the missing binding with `spawnSyncCollect(["npm", ...])`, and `spawnSyncCollect` passes the bare name to `node:child_process` — npm on Windows is `npm.cmd`, so it exits `spawnSync npm ENOENT` instead of building. `spawnProcess` in the same helper already handles `.cmd`/`.bat` shims (`runtime.ts:283-294`); the sync path did not get the same treatment. I verified this branch with a scratch vitest config that skips the natives global setup, which this suite does not need. Say the word and I will open a separate issue with the details.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789126237&installation_model_id=10562&pr_number=2348&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2348&signature=730e4a8c5ca88610dd4224218eeabae04baa13ea7efb3d37d7d4278cfb8447d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes published workflow examples work under both Node-hosted package-manager installs and Bun standalone binaries. The Node command helpers in `packages/coding-agent/docs/workflows.md` were exercised with successful output, a nonzero command that writes to stderr, and a missing executable; all behaviors matched the documented error handling. The focused workflow-portability test also passed all four checks.

The investigated concern that the replacement helpers could lose output, misreport failed commands, or hide spawn errors is disproved by the executed Node contract script and focused test suite.

<h3>Confidence Score: 5/5</h3>

The updated published workflow helpers preserve command output and failure behavior when executed by Node, making the documentation change safe to merge.

Direct Node execution covered successful commands, nonzero exits with stderr, and missing executables. The focused documentation portability test passed all four checks, and no defects remain in the final review.

**Files Needing Attention:** No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the Node contract script trex-artifacts/pr-2348-workflow-node-contract.mjs to extract and run the published spawnCommand and runCommand helpers under Node, validating three contract outcomes: a successful run with trimmed stdout, a failing run with exit status 23 and stderr, and an ENOENT error for a missing executable.
- Ran the focused Vitest unit test suite test/unit/workflow-docs-host-portability.test.ts; the focused suite passed 4 of 4 tests.
- Confirmed that trex-artifacts/pr-2348-workflow-node-contract.mjs is the authored executable Node contract script, and checked that the contract output log shows all three contract cases passing.
- Verified that the portability test output log shows the portability suite passing 4/4 tests with exit code 0.

<a href="https://app.greptile.com/trex/runs/18483987/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(docs): make published workflow examp..."](https://github.com/bastani-inc/atomic/commit/aac28fcce9e00007bbeafce17b61752f0daa7436) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52548002)</sub>

<!-- /greptile_comment -->