### PR TITLE
fix(workflows): answer the sole pending prompt without a stageId

### DIFF
--- a/packages/workflows/src/extension/workflow-tool-send.ts
+++ b/packages/workflows/src/extension/workflow-tool-send.ts
@@ -5,15 +5,20 @@ import {
 import type { DetachedStageHandleLease, StageControlHandle } from "../runs/foreground/stage-control-registry.js";
 import { stageControlRegistry } from "../runs/foreground/stage-control-registry.js";
 import type { StageUserMessageDeliveryAction } from "../runs/foreground/stage-runner-types.js";
+import {
+	type ExpandedWorkflowStage,
+	expandedStageLabel,
+	expandWorkflowGraph,
+} from "../shared/expanded-workflow-graph.js";
 import { coerceStageInputAnswer, hasStageInputAnswerContent, type StageInputAnswer } from "../shared/stage-prompt.js";
 import { stageUiBroker } from "../shared/stage-ui-broker.js";
 import { store } from "../shared/store.js";
 import { isTerminalRunStatus } from "../shared/store-internal.js";
-import { subscribeStoreInvalidation } from "../shared/store-observation.js";
+import { readGraphStoreSnapshot, subscribeStoreInvalidation } from "../shared/store-observation.js";
 import { reciprocalWorkflowRootRunId } from "../shared/workflow-run-ownership.js";
 import type { WorkflowToolArgs } from "./public-types.js";
 import type { WorkflowToolResult } from "./render-result.js";
-import { resolveToolRunTarget, resolveToolStageTarget } from "./workflow-targets.js";
+import { resolveToolRunTarget, resolveToolStageTarget, type ToolStageTarget } from "./workflow-targets.js";
 
 /**
  * Optional dependencies enabling `workflow send` to revive an eligible
@@ -47,6 +52,53 @@ function brokerAnswerFromArgs(args: WorkflowToolArgs): StageInputAnswer {
 	}
 	const text = textPayloadFromArgs(args);
 	return text !== undefined ? { text } : {};
+}
+
+/**
+ * Whether this delivery is one whose destination a pending prompt determines.
+ *
+ * `answer` and `auto` are both documented as answering pending prompts first,
+ * and an explicit `promptId` names a prompt without naming its stage. Steering
+ * deliveries are excluded: a live stage is a destination in its own right, so
+ * there is nothing for a prompt to disambiguate.
+ */
+function answersPendingPrompt(delivery: string, promptId: string | undefined): boolean {
+	return delivery === "answer" || delivery === "auto" || promptId !== undefined;
+}
+
+/**
+ * Whether an `answer` delivery has something to resolve on this stage.
+ *
+ * Covers the same three prompt kinds the delivery path dispatches on —
+ * brokered, custom-footprint, and plain pending prompts — so a stage counted
+ * here is one the send would actually act on rather than merely mention.
+ */
+function hasAnswerablePrompt(stage: ExpandedWorkflowStage): boolean {
+	const target = stage.workflowGraphTarget;
+	if (stageUiBroker.peekStagePrompt(target.runId, target.stageId) !== undefined) return true;
+	if (stage.pendingPrompt !== undefined) return true;
+	return stage.status === "awaiting_input" && stage.promptFootprint?.kind === "custom";
+}
+
+/**
+ * Resolve the stage an answer is for when the caller named a prompt but no stage.
+ *
+ * Returns the target unchanged when nothing is pending, so a run with no prompt
+ * still reports that a stage is required rather than inventing a destination.
+ */
+function inferPromptStageTarget(runId: string, delivery: string, promptId: string | undefined): ToolStageTarget {
+	if (!answersPendingPrompt(delivery, promptId)) return { ok: true, runId };
+	const pending = expandWorkflowGraph(readGraphStoreSnapshot(store), runId).stages.filter(hasAnswerablePrompt);
+	const only = pending[0];
+	if (pending.length !== 1 || only === undefined) {
+		return pending.length === 0
+			? { ok: true, runId }
+			: {
+					ok: false,
+					message: `${pending.length} prompts pending; pass stageId: ${pending.map(expandedStageLabel).join(", ")}`,
+				};
+	}
+	return { ok: true, runId: only.workflowGraphTarget.runId, stageId: only.workflowGraphTarget.stageId };
 }
 
 type WorkflowSendToolResult = Extract<WorkflowToolResult, { action: "send" }>;
@@ -131,7 +183,11 @@ export async function workflowSendAction(
 	if (rootRun !== undefined && isTerminalRunStatus(rootRun.status)) {
 		return terminalWorkflowSendResult(rootRun.id, args.stageId?.trim() ?? "", rootRun.status);
 	}
-	const stage = resolveToolStageTarget(target.runId, args.stageId);
+	const requested = resolveToolStageTarget(target.runId, args.stageId);
+	const stage =
+		requested.ok && requested.stageId === undefined
+			? inferPromptStageTarget(target.runId, requestedDelivery, args.promptId)
+			: requested;
 	if (!stage.ok || stage.stageId === undefined) {
 		return workflowSendResult(
 			target.runId,

--- a/packages/workflows/src/extension/workflow-tool-send.ts
+++ b/packages/workflows/src/extension/workflow-tool-send.ts
@@ -67,38 +67,54 @@ function answersPendingPrompt(delivery: string, promptId: string | undefined): b
 }
 
 /**
- * Whether an `answer` delivery has something to resolve on this stage.
+ * Ids of the prompts an `answer` delivery could resolve on this stage.
  *
  * Covers the same three prompt kinds the delivery path dispatches on —
  * brokered, custom-footprint, and plain pending prompts — so a stage counted
  * here is one the send would actually act on rather than merely mention.
  */
-function hasAnswerablePrompt(stage: ExpandedWorkflowStage): boolean {
+function answerablePromptIds(stage: ExpandedWorkflowStage): string[] {
 	const target = stage.workflowGraphTarget;
-	if (stageUiBroker.peekStagePrompt(target.runId, target.stageId) !== undefined) return true;
-	if (stage.pendingPrompt !== undefined) return true;
-	return stage.status === "awaiting_input" && stage.promptFootprint?.kind === "custom";
+	const ids: string[] = [];
+	const brokered = stageUiBroker.peekStagePrompt(target.runId, target.stageId);
+	if (brokered !== undefined) ids.push(brokered.id);
+	if (stage.pendingPrompt !== undefined) ids.push(stage.pendingPrompt.id);
+	if (stage.status === "awaiting_input" && stage.promptFootprint?.kind === "custom") {
+		ids.push(stage.promptFootprint.id);
+	}
+	return ids;
 }
 
 /**
  * Resolve the stage an answer is for when the caller named a prompt but no stage.
+ *
+ * A named `promptId` already identifies its stage, so it narrows the candidates
+ * before uniqueness is decided — otherwise naming one of two pending prompts
+ * would be rejected as ambiguous, and naming an unknown one would target the
+ * unrelated stage that happened to be the only one waiting.
  *
  * Returns the target unchanged when nothing is pending, so a run with no prompt
  * still reports that a stage is required rather than inventing a destination.
  */
 function inferPromptStageTarget(runId: string, delivery: string, promptId: string | undefined): ToolStageTarget {
 	if (!answersPendingPrompt(delivery, promptId)) return { ok: true, runId };
-	const pending = expandWorkflowGraph(readGraphStoreSnapshot(store), runId).stages.filter(hasAnswerablePrompt);
+	const pending = expandWorkflowGraph(readGraphStoreSnapshot(store), runId).stages.filter((stage) => {
+		const ids = answerablePromptIds(stage);
+		return promptId === undefined ? ids.length > 0 : ids.includes(promptId);
+	});
 	const only = pending[0];
-	if (pending.length !== 1 || only === undefined) {
-		return pending.length === 0
-			? { ok: true, runId }
-			: {
-					ok: false,
-					message: `${pending.length} prompts pending; pass stageId: ${pending.map(expandedStageLabel).join(", ")}`,
-				};
+	if (pending.length === 1 && only !== undefined) {
+		return { ok: true, runId: only.workflowGraphTarget.runId, stageId: only.workflowGraphTarget.stageId };
 	}
-	return { ok: true, runId: only.workflowGraphTarget.runId, stageId: only.workflowGraphTarget.stageId };
+	if (pending.length === 0) {
+		return promptId === undefined
+			? { ok: true, runId }
+			: { ok: false, message: `No pending prompt ${promptId} in run ${runId}.` };
+	}
+	return {
+		ok: false,
+		message: `${pending.length} prompts pending; pass stageId: ${pending.map(expandedStageLabel).join(", ")}`,
+	};
 }
 
 type WorkflowSendToolResult = Extract<WorkflowToolResult, { action: "send" }>;

--- a/test/unit/workflow-tool-send-prompt-auto-target.test.ts
+++ b/test/unit/workflow-tool-send-prompt-auto-target.test.ts
@@ -92,6 +92,31 @@ describe("workflow send — answering without naming a stage", () => {
 		assert.equal(result.message, "Stage id or name is required.");
 	});
 
+	test("a named promptId selects among several pending prompts", async () => {
+		const runId = runWithStages("prompt-id-selects", ["select", "approve-release"]);
+		assert.equal(store.recordStagePendingPrompt(runId, "stage-select", prompt("prompt-1")), true);
+		assert.equal(store.recordStagePendingPrompt(runId, "stage-approve-release", prompt("prompt-2")), true);
+
+		// The id already identifies its stage, so this is not ambiguous even
+		// though two prompts are waiting.
+		const result = await workflowSendAction({ runId, promptId: "prompt-2", text: "ship it" });
+
+		assert.equal(result.status, "ok");
+		assert.equal(result.stageId, "stage-approve-release");
+		assert.equal(result.message, "Answered prompt prompt-2.");
+	});
+
+	test("an unknown promptId does not fall through to an unrelated stage", async () => {
+		const runId = runWithStages("prompt-id-unknown", ["review"]);
+		assert.equal(store.recordStagePendingPrompt(runId, "stage-review", prompt("prompt-1")), true);
+
+		const result = await workflowSendAction({ runId, promptId: "prompt-missing", text: "yes" });
+
+		assert.equal(result.status, "noop");
+		assert.equal(result.stageId, "");
+		assert.equal(result.message, `No pending prompt prompt-missing in run ${runId}.`);
+	});
+
 	test("an explicit stageId still selects among several pending prompts", async () => {
 		const runId = runWithStages("explicit-wins", ["select", "approve-release"]);
 		assert.equal(store.recordStagePendingPrompt(runId, "stage-select", prompt("prompt-1")), true);

--- a/test/unit/workflow-tool-send-prompt-auto-target.test.ts
+++ b/test/unit/workflow-tool-send-prompt-auto-target.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, test } from "vitest";
+import { workflowSendAction } from "../../packages/workflows/src/extension/workflow-tool-send.js";
+import { store } from "../../packages/workflows/src/shared/store.js";
+import { testRunId } from "../helpers/run-id.js";
+
+const runIds = new Set<string>();
+
+afterEach(() => {
+	for (const runId of runIds) store.removeRun(runId);
+	runIds.clear();
+});
+
+function prompt(id: string) {
+	return { id, kind: "input" as const, message: `answer ${id}?`, createdAt: 1 };
+}
+
+/** A running run whose stages are named, so labels in errors stay readable. */
+function runWithStages(seed: string, stageNames: readonly string[]): string {
+	const runId = testRunId(seed);
+	runIds.add(runId);
+	store.recordRunStart({
+		id: runId,
+		name: "prompt-auto-target",
+		inputs: {},
+		status: "running",
+		startedAt: 1,
+		stages: stageNames.map((name) => ({
+			id: `stage-${name}`,
+			name,
+			status: "running" as const,
+			parentIds: [],
+			toolEvents: [],
+			attachable: true,
+		})),
+	});
+	return runId;
+}
+
+describe("workflow send — answering without naming a stage", () => {
+	for (const delivery of ["answer", undefined] as const) {
+		test(`${delivery ?? "default auto"} delivery targets the only pending prompt`, async () => {
+			const runId = runWithStages(`sole-prompt-${delivery ?? "auto"}`, ["review"]);
+			assert.equal(store.recordStagePendingPrompt(runId, "stage-review", prompt("prompt-1")), true);
+
+			const result = await workflowSendAction({
+				runId,
+				text: "fix-p0-and-p1",
+				...(delivery === undefined ? {} : { delivery }),
+			});
+
+			assert.equal(result.status, "ok");
+			assert.equal(result.delivery, "answer");
+			assert.equal(result.stageId, "stage-review");
+			assert.equal(result.message, "Answered prompt prompt-1.");
+		});
+	}
+
+	test("names the candidates when more than one prompt is pending", async () => {
+		const runId = runWithStages("two-prompts", ["select", "approve-release"]);
+		assert.equal(store.recordStagePendingPrompt(runId, "stage-select", prompt("prompt-1")), true);
+		assert.equal(store.recordStagePendingPrompt(runId, "stage-approve-release", prompt("prompt-2")), true);
+
+		const result = await workflowSendAction({ runId, text: "yes", delivery: "answer" });
+
+		assert.equal(result.status, "noop");
+		// Recovery has to be possible from this message alone; the previous one
+		// forced a second `stages` call to discover the same two ids.
+		assert.match(result.message, /^2 prompts pending; pass stageId: /);
+		assert.match(result.message, /select \(.+stage-select\)/);
+		assert.match(result.message, /approve-release \(.+stage-approve-release\)/);
+	});
+
+	test("still requires a stage when nothing is pending", async () => {
+		const runId = runWithStages("no-prompt", ["review"]);
+
+		const result = await workflowSendAction({ runId, text: "hello", delivery: "answer" });
+
+		assert.equal(result.status, "noop");
+		assert.equal(result.message, "Stage id or name is required.");
+	});
+
+	test("does not redirect a steer at a pending prompt", async () => {
+		const runId = runWithStages("steer-untouched", ["review"]);
+		assert.equal(store.recordStagePendingPrompt(runId, "stage-review", prompt("prompt-1")), true);
+
+		const result = await workflowSendAction({ runId, text: "change direction", delivery: "steer" });
+
+		// A steer names a live stage as its destination, so a pending prompt is
+		// not evidence of where it was meant to go.
+		assert.equal(result.status, "noop");
+		assert.equal(result.message, "Stage id or name is required.");
+	});
+
+	test("an explicit stageId still selects among several pending prompts", async () => {
+		const runId = runWithStages("explicit-wins", ["select", "approve-release"]);
+		assert.equal(store.recordStagePendingPrompt(runId, "stage-select", prompt("prompt-1")), true);
+		assert.equal(store.recordStagePendingPrompt(runId, "stage-approve-release", prompt("prompt-2")), true);
+
+		const result = await workflowSendAction({
+			runId,
+			stageId: "stage-approve-release",
+			text: "ship it",
+			delivery: "answer",
+		});
+
+		assert.equal(result.status, "ok");
+		assert.equal(result.stageId, "stage-approve-release");
+		assert.equal(result.message, "Answered prompt prompt-2.");
+	});
+});


### PR DESCRIPTION
Closes #2196

Implements the fix @flora131 described in triage — auto-target the sole pending prompt, keep explicit `stageId` selection, and list the candidates when several are waiting. Happy to hold this until the issue is assigned.

## Problem

`workflowSendAction` resolved the stage target and bailed before ever looking at what the run was waiting on:

```ts
const stage = resolveToolStageTarget(target.runId, args.stageId);
if (!stage.ok || stage.stageId === undefined) {
	return workflowSendResult(target.runId, "", requestedDelivery, "noop", "Stage id or name is required.");
}
```

With one stage in `awaiting_input` and one pending prompt, that is a noop asking for an id the tool could already compute. Recovery cost a `stages` call, a scan for the `awaiting_input` stage, and a resend.

## Fix

When no `stageId` was given and the delivery is one whose destination a prompt determines, resolve the target from the pending prompts in the run's expanded graph:

- **exactly one pending** — target it;
- **several pending** — `2 prompts pending; pass stageId: select (<run>/stage-select), approve-release (<run>/stage-approve-release)`, reusing `expandedStageLabel` so nested stages are named the same way ambiguity errors already name them;
- **none pending** — unchanged, still `Stage id or name is required.`

Three details worth calling out, since each is a place the change could have overreached:

**Which deliveries.** Only `answer`, `auto`, and any call carrying an explicit `promptId`. `auto` is included because it shares the documented "answers pending prompts first" semantics, and the existing `targetsPrompt` branch already answers a pending prompt under `auto` once a stage is named — so this keeps the two consistent rather than introducing a new behaviour. **Steering is excluded**: a live stage is a destination in its own right, so a pending prompt elsewhere is not evidence of where a `steer` was meant to go.

**Which prompts count.** `hasAnswerablePrompt` mirrors the same three kinds the delivery path below it dispatches on — brokered (`stageUiBroker.peekStagePrompt`), plain `pendingPrompt`, and an `awaiting_input` stage with a `custom` `promptFootprint`. A stage counted as a candidate is therefore one the send would actually act on. The custom-footprint case still returns its existing "requires the interactive workflow graph" noop, which is a more useful answer than asking for a stage id.

**Scope of the search.** `expandWorkflowGraph` rather than `run.stages`, so a prompt pending in a nested child run is found and answered through its own `workflowGraphTarget`, matching how `resolveToolStageTarget` already routes an explicit id.

## Verification

```
$ npx tsc --noEmit
(clean)

$ npx biome check --error-on-warnings .
Checked 2438 files in 1352ms. No fixes applied.
```

The new suite plus the neighbouring send/routing suites, to check nothing regressed:

```
 Test Files  7 passed (7)
      Tests  61 passed (61)
```

(`workflow-tool-send-prompt-auto-target`, `-idle-routing`, `-postmortem`, `-terminal-race`, `workflow-tool-interactions`, `nested-workflow-target-routing`, and the docs suite from #2348.)

And the new file against unpatched source, to confirm it tests the change rather than the fixture:

```
 Tests  3 failed | 3 passed (6)

AssertionError: The input did not match the regular expression /^2 prompts pending; pass stageId: /.
Input: 'Stage id or name is required.'
```

The three that still pass there are the guards — nothing pending, a steer, and an explicit `stageId` — so they are asserting behaviour this branch deliberately leaves alone.

## Note on running the suites

`npm run test:unit` cannot start on Windows: `test/global-setup-natives.ts:163` builds the missing binding with `spawnSyncCollect(["npm", ...])`, and npm on Windows is `npm.cmd`, so it exits `spawnSync npm ENOENT` before any test runs. `spawnProcess` in the same helper already handles `.cmd`/`.bat` shims (`runtime.ts:283-294`); the sync path did not get the same treatment. I ran the suites above through a scratch vitest config that skips that global setup. Mentioned on #2348 too — glad to open a separate issue for it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2349"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789126607&installation_model_id=10562&pr_number=2349&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2349&signature=aa6fde83038611c82d189d0b0abadce69922a7754ee3db6be931ee77ebc15631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Workflow send now filters pending prompts by an explicitly requested prompt ID before choosing a destination. Focused automated checks verified that a named prompt routes to its matching workflow location and that an unknown prompt ID leaves unrelated pending work unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge.

No blocking failure remains.

<sub>Reviews (2): Last reviewed commit: ["fix(workflows): narrow prompt inference ..."](https://github.com/bastani-inc/atomic/commit/aac208ff1be5f5a41607a68dfe1bd17b995d7184) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52549310)</sub>

<!-- /greptile_comment -->
