### PR TITLE
build(natives): resolve workspace-local napi bin in build-native.ts

### DIFF
--- a/packages/natives/scripts/build-native.ts
+++ b/packages/natives/scripts/build-native.ts
@@ -1,5 +1,5 @@
 import { copyFileSync, mkdirSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { delimiter, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 
 const repoRoot = resolve(import.meta.dir, "../../..");
@@ -13,6 +13,14 @@ const nativeTarget = Bun.env.NATIVE_TARGET;
 const glibcTarget = crossTarget?.match(/^((?:x86_64|aarch64)-unknown-linux-gnu)\.([0-9]+\.[0-9]+)$/u);
 
 mkdirSync(nativeDir, { recursive: true });
+
+// npm does not hoist the `napi` bin to the repo root; it lands in this workspace's
+// own node_modules/.bin. `npm run build` works because npm prepends every relevant
+// .bin dir to PATH, but a direct `bun scripts/build-native.ts` does not get that,
+// and `bunx --no-install` from the repo root then fails to find `napi`. Prepend the
+// same .bin dirs here so both invocations work.
+const binPaths = [join(packageRoot, "node_modules", ".bin"), join(repoRoot, "node_modules", ".bin")];
+const buildEnv = { ...process.env, PATH: [...binPaths, process.env.PATH ?? ""].join(delimiter) };
 
 const args = [
 	"--bun",
@@ -55,7 +63,7 @@ if (glibcTarget) {
 	if (nativeTarget) args.push("--target", nativeTarget);
 	if (crossTarget) args.push("--target", crossTarget, "--cross-compile");
 
-	const result = spawnSync("bunx", args, { cwd: repoRoot, stdio: "inherit" });
+	const result = spawnSync("bunx", args, { cwd: repoRoot, stdio: "inherit", env: buildEnv });
 	if (result.status !== 0) {
 		throw new Error(`Failed to build Atomic native bindings (napi exited ${result.status ?? "null"})`);
 	}


### PR DESCRIPTION
## Summary

Direct invocation of the natives build script (`bun scripts/build-native.ts` from `packages/natives`) failed with `Could not find an existing 'napi' binary`, because npm places the `napi` bin from `@napi-rs/cli` in `packages/natives/node_modules/.bin` rather than hoisting it to the repo root, and the script spawns `bunx --no-install napi` with `cwd` at the repo root. `npm run build --workspace=@bastani/atomic-natives` only worked because npm prepends every workspace `.bin` dir to `PATH`.

## Changes

- `packages/natives/scripts/build-native.ts`: prepend the package-local and repo-root `node_modules/.bin` dirs to `PATH` (platform-aware via `node:path` `delimiter`) for the `bunx --no-install napi` spawn, with a comment explaining why.

## Notes

- The `cargo zigbuild` cross-compile path is untouched.
- Verified both `bun scripts/build-native.ts` (previously failing) and `npm run build --workspace=@bastani/atomic-natives` build `native/atomic_natives.darwin-arm64.node` successfully.
- No changelog entry: maintainer build script, not shipped package behavior.
- Context: a missing local natives binding made `bun packages/coding-agent/src/cli.ts` abort at startup (subagents extension eagerly imports `SubagentControl` from `@bastani/atomic-natives`); this script bug made the obvious direct rebuild command fail too.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789146296&installation_model_id=10562&pr_number=2353&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2353&signature=83caa58900369a21157767092d0a0040b6f36cb9cdcfeb7f90c27969f0719d4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change lets direct native-addon builds resolve the workspace-local `napi` executable when the build subprocess runs from the repository root. An isolated execution confirmed that the old lookup path fails without a root-level executable, while the updated path resolves `packages/natives/node_modules/.bin/napi` and succeeds. The focused portability tests for Linux glibc, musl, and Darwin build arguments passed.

<h3>Confidence Score: 5/5</h3>

The native build script is safe to merge based on the exercised direct-build behavior and focused portability coverage.

No actionable defects remain. The key failure path was tested with root-level `napi` intentionally unavailable: the prior lookup failed, and the updated environment resolved the workspace-local executable and completed successfully.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification.
- During that verification, T-Rex's local artifact references were not uploaded.
- A second verification was run as part of the request.
- During the second verification, T-Rex's local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["build(natives): resolve workspace-local ..."](https://github.com/bastani-inc/atomic/commit/bf21c65eb2019d5aedd6b37f9ca7bf7d3eea491f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52654511)</sub>

<!-- /greptile_comment -->