### PR TITLE
docs(changelog): move #2197 entry out of released 0.9.13-alpha.2 section

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Workflow model fallback attempt metadata now includes per-attempt input/output tokens, cache reads/writes, provider-reported total cost, and meaningful assistant-turn counts when usage is available ([#2197](https://github.com/bastani-inc/atomic/issues/2197)).
+
 ## [0.9.13-alpha.2] - 2026-08-12
 
 ### Breaking Changes
@@ -24,8 +28,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Retired the legacy terminal-row callback thread from graph and stage-chat views. The two fullscreen-frame consumers still read `terminal.rows` directly: GraphView uses it for the overlay frame, and StageChatView uses it for the chat line count, falling back to the unhosted `VIEW_LINE_COUNT = 32` frame when no host is present. `PiCustomComponent.render` supplies only a width, so the #2223 viewport-row criterion remains partial at those call paths ([#2223](https://github.com/bastani-inc/atomic/issues/2223)).
 
 - Workflow command, worktree Git/setup-hook, and Playwright CLI subprocesses now receive `AI_AGENT=atomic` for generic child-process attribution without mutating caller-supplied environment objects.
-
-- Workflow model fallback attempt metadata now includes per-attempt input/output tokens, cache reads/writes, provider-reported total cost, and meaningful assistant-turn counts when usage is available ([#2197](https://github.com/bastani-inc/atomic/issues/2197)).
 
 ### Fixed
 - Fixed completed `ctx.exit()` runs losing the reserved returned-status convention, legacy child replay records losing their exit discriminator, and failed author-exit resume surfaces falling back to snapshot inspection instead of durable retry.


### PR DESCRIPTION
## Summary

PR #2321 appended its changelog entry to the already-released `[0.9.13-alpha.2]` section of `packages/workflows/CHANGELOG.md`. Released sections are immutable once tagged, so `test/unit/changelog.test.ts > released changelog sections` now fails on main and blocks every PR that merges with it (e.g. #2297's pre-push hook).

This moves the #2197 entry under `## [Unreleased]` / `### Changed`.

## Validation

- `npx vitest --run --project unit test/unit/changelog.test.ts` — 12/12 passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789173533&installation_model_id=10562&pr_number=2356&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2356&signature=1aaa393d4a7844ff9924d21fb0223ea9121a086a97b91eec404c3981713d3e92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moves the #2197 workflow metadata release note into Unreleased. The released `0.9.13-alpha.2` section must retain its original entry so published release notes remain historically accurate.

<h3>Confidence Score: 4/5</h3>

Not ready to merge until the released changelog entry is restored.

There is one non-security P2 repository-rule finding. Under the scoring rules, P2-only findings result in a score of 4.

**Files Needing Attention:** `packages/workflows/CHANGELOG.md`: restore the #2197 entry under `0.9.13-alpha.2` while retaining the intended Unreleased note as appropriate.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/workflows/CHANGELOG.md:29
**Released history is modified**

Removing the #2197 entry from `0.9.13-alpha.2` changes an immutable released section, so the published release history no longer matches its original contents.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): move #2197 entry out of..."](https://github.com/bastani-inc/atomic/commit/a2408f6cbe64e28158efae17c9df10c238e7c655) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52804236)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->