### PR TITLE
fix(subagents): apply the configured model to forked child sessions and show the full model id

### DIFF
--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a fork-context subagent ignoring its agent's configured model. The selected model candidate was only ever a `provider/model[:thinking]` string, so nothing was handed to the child session's `model` argument and the session fell back to the model persisted in the session file — which, for a fork, is the parent's. A child declaring `openai-codex/gpt-5.6-luna:max` therefore ran every turn on the parent's model, and an explicit `model:` override lost its first attempt the same way. The selected candidate is now resolved against the model registry and applied to the child session, together with the thinking level carried in the candidate's suffix, for both fresh and fork contexts and across the single, parallel, async/background, and resume paths. A candidate that names no usable model still starts the run instead of failing it.
+- Fixed subagent progress and status lines stripping the provider prefix from the model name, so a child rendered as `claude-fable-5` where the main chat shows `anthropic/claude-fable-5`. The full model id is now displayed, including every segment of a routed id such as `openrouter/anthropic/claude-fable-5`; known thinking suffixes are still split off into the `thinking <level>` label.
+
 ## [0.9.13-alpha.2] - 2026-08-12
 
 ### Breaking Changes

--- a/packages/subagents/src/runs/foreground/inprocess-run-sync.ts
+++ b/packages/subagents/src/runs/foreground/inprocess-run-sync.ts
@@ -199,6 +199,11 @@ export async function runSingleInProcess(
 		return noSpawnableCandidatesResult(agent, task, filteredCandidates.skippedAttempts);
 	const candidate = filteredCandidates.candidates[0];
 	const fallbackCandidates = filteredCandidates.candidates.slice(1);
+	// The candidate is only a string. `createAgentSession` selects a model from a
+	// `Model<Api>` object and otherwise restores the model persisted in the
+	// session file — which, for a fork-context child, is the parent's model.
+	// Resolving the candidate here is what makes the agent's configured model win.
+	const resolvedCandidate = candidate ? options.resolveCandidateModel?.(candidate) : undefined;
 	const fastModeSettings = getSubagentCodexFastModeSettings(cwd);
 	const orchestrationContext = workflowOrchestrationContext(options);
 	const fastModeScope = resolveSubagentCodexFastModeScope(
@@ -248,8 +253,8 @@ export async function runSingleInProcess(
 		tools: agent.tools,
 		mcpDirectTools: agent.mcpDirectTools,
 		skills: options.skills ?? agent.skills,
-		model: undefined,
-		thinkingLevel: agent.thinking as ChildSpec["thinkingLevel"],
+		model: resolvedCandidate?.model,
+		thinkingLevel: (resolvedCandidate?.thinkingLevel ?? agent.thinking) as ChildSpec["thinkingLevel"],
 		parent,
 		intercom: options.orchestratorIntercomTarget
 			? {
@@ -305,7 +310,7 @@ export async function runSingleInProcess(
 	const neverAbort = new AbortController().signal;
 	const running = control.startAttempt(
 		admission.admitted,
-		{ modelId: candidate, thinkingLevel: spec.thinkingLevel },
+		{ model: resolvedCandidate?.model, modelId: candidate, thinkingLevel: spec.thinkingLevel },
 		{
 			abort: options.signal ?? neverAbort,
 			interrupt: options.interruptSignal ?? neverAbort,
@@ -330,7 +335,11 @@ export async function runSingleInProcess(
 			lastActivityAt: Date.now(),
 		});
 	}
-	control.registerNestedAttempt(options.runId, running, { modelId: candidate, thinkingLevel: spec.thinkingLevel });
+	control.registerNestedAttempt(options.runId, running, {
+		model: resolvedCandidate?.model,
+		modelId: candidate,
+		thinkingLevel: spec.thinkingLevel,
+	});
 	if (options.backgroundContinuation) {
 		control.continueInBackground(running, "async-requested");
 		void running.promise.then(

--- a/packages/subagents/src/runs/foreground/subagent-executor-async.ts
+++ b/packages/subagents/src/runs/foreground/subagent-executor-async.ts
@@ -2,6 +2,7 @@ import { APP_NAME } from "@bastani/atomic";
 import { normalizeSkillInput } from "../../agents/skills.ts";
 import { resolveSubagentIntercomTarget } from "../../intercom/intercom-bridge.ts";
 import { collectKnownModelProviders, toModelInfo } from "../../shared/model-info.ts";
+import { createCandidateModelResolver } from "../../shared/model-resolution.ts";
 import type { SingleResult, SubagentToolResult } from "../../shared/types.ts";
 import {
 	resolveChildMaxSubagentDepth,
@@ -135,6 +136,7 @@ export async function runAsyncPath(
 			modelOverride,
 			availableModels,
 			knownModelProviders,
+			resolveCandidateModel: createCandidateModelResolver(data.ctx.modelRegistry, data.ctx.model?.provider),
 			maxSubagentDepth: resolveChildMaxSubagentDepth(depthPolicy.maxSubagentDepth, agent.maxSubagentDepth),
 			parentDepth: data.parentDepth,
 			workflowStageSubagentGuard: depthPolicy.workflowStageSubagentGuard,

--- a/packages/subagents/src/runs/foreground/subagent-executor-parallel-task.ts
+++ b/packages/subagents/src/runs/foreground/subagent-executor-parallel-task.ts
@@ -2,6 +2,7 @@ import type { ExtensionContext } from "@bastani/atomic";
 import type { AgentConfig } from "../../agents/agents.ts";
 import { INTERCOM_BRIDGE_MARKER } from "../../intercom/intercom-bridge.ts";
 import type { ModelInfo } from "../../shared/model-info.ts";
+import type { CandidateModelResolver } from "../../shared/model-resolution.ts";
 import { buildTaskInstructions, type ResolvedStepBehavior } from "../../shared/settings.ts";
 import type {
 	AgentProgress,
@@ -42,6 +43,7 @@ interface ForegroundParallelRunInput {
 	workflowStageSubagentGuard?: boolean;
 	availableModels: ModelInfo[];
 	knownModelProviders: string[];
+	resolveCandidateModel: CandidateModelResolver;
 	modelOverrides: (string | undefined)[];
 	behaviors: ResolvedStepBehavior[];
 	firstProgressIndex: number;
@@ -144,6 +146,7 @@ export async function runForegroundParallelTasks(input: ForegroundParallelRunInp
 				modelOverride: input.modelOverrides[index],
 				availableModels: input.availableModels,
 				knownModelProviders: input.knownModelProviders,
+				resolveCandidateModel: input.resolveCandidateModel,
 				preferredModelProvider: input.ctx.model?.provider,
 				currentModel: currentModelFullId(input.ctx.model),
 				skills: effectiveSkills === false ? [] : effectiveSkills,

--- a/packages/subagents/src/runs/foreground/subagent-executor-parallel.ts
+++ b/packages/subagents/src/runs/foreground/subagent-executor-parallel.ts
@@ -2,6 +2,7 @@ import type { AgentConfig } from "../../agents/agents.ts";
 import { normalizeSkillInput } from "../../agents/skills.ts";
 import { resolveSubagentIntercomTarget } from "../../intercom/intercom-bridge.ts";
 import { collectKnownModelProviders, type ModelInfo, toModelInfo } from "../../shared/model-info.ts";
+import { createCandidateModelResolver } from "../../shared/model-resolution.ts";
 import {
 	resolveStepBehavior,
 	type StepOverrides,
@@ -212,6 +213,7 @@ export async function runParallelPath(
 			workflowStageSubagentGuard,
 			availableModels,
 			knownModelProviders,
+			resolveCandidateModel: createCandidateModelResolver(ctx.modelRegistry, currentProvider),
 			modelOverrides,
 			behaviors,
 			firstProgressIndex: parallelProgressPrecreated ? -1 : firstProgressIndex,

--- a/packages/subagents/src/runs/foreground/subagent-executor-single.ts
+++ b/packages/subagents/src/runs/foreground/subagent-executor-single.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { normalizeSkillInput } from "../../agents/skills.ts";
 import { INTERCOM_BRIDGE_MARKER, resolveSubagentIntercomTarget } from "../../intercom/intercom-bridge.ts";
 import { collectKnownModelProviders, type ModelInfo, toModelInfo } from "../../shared/model-info.ts";
+import { createCandidateModelResolver } from "../../shared/model-resolution.ts";
 import {
 	injectSingleProgressInstruction,
 	resolveSingleProgress,
@@ -217,6 +218,7 @@ export async function runSinglePath(
 			modelOverride,
 			availableModels,
 			knownModelProviders,
+			resolveCandidateModel: createCandidateModelResolver(ctx.modelRegistry, currentProvider),
 			preferredModelProvider: currentProvider,
 			currentModel: currentModelFullId(ctx.model),
 			skills: effectiveSkills,

--- a/packages/subagents/src/runs/foreground/subagent-executor.ts
+++ b/packages/subagents/src/runs/foreground/subagent-executor.ts
@@ -11,6 +11,7 @@ import {
 import { requestSupervisorAuthorization } from "../../intercom/supervisor-authorization.ts";
 import { getArtifactsDir } from "../../shared/artifacts.ts";
 import { toModelInfo } from "../../shared/model-info.ts";
+import { createCandidateModelResolver } from "../../shared/model-resolution.ts";
 import { resolveSingleProgress } from "../../shared/settings.ts";
 import {
 	DEFAULT_ARTIFACT_CONFIG,
@@ -105,6 +106,7 @@ async function resumeRetainedForegroundChild(
 		progress: resolveSingleProgress(agentConfig, params.progress, message),
 		modelOverride: params.model,
 		availableModels: ctx.modelRegistry.getAvailable().map(toModelInfo),
+		resolveCandidateModel: createCandidateModelResolver(ctx.modelRegistry, ctx.model?.provider),
 		// The child's own effective limit, recorded when the run was retained. An
 		// older record without one falls back to narrowing the current limit by the
 		// agent definition, so a resume never widens a child's delegation budget.

--- a/packages/subagents/src/runs/inprocess/background-single.ts
+++ b/packages/subagents/src/runs/inprocess/background-single.ts
@@ -136,6 +136,7 @@ export async function executeAsyncSingle(id: string, params: AsyncSingleParams):
 		modelOverride: filteredCandidates.candidates[0] ?? params.modelOverride ?? agentConfig.model,
 		availableModels,
 		knownModelProviders,
+		resolveCandidateModel: params.resolveCandidateModel,
 		preferredModelProvider: ctx.currentModelProvider,
 		currentModel: ctx.currentModel,
 		skills: resolvedSkills.map((skill) => skill.name),

--- a/packages/subagents/src/runs/inprocess/background.ts
+++ b/packages/subagents/src/runs/inprocess/background.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI, SessionWorkflowMetadata } from "@bastani/atomic";
 import type { AgentConfig } from "../../agents/agents.ts";
 import type { SupervisorAuthorization } from "../../intercom/supervisor-authorization.ts";
 import type { ModelInfo } from "../../shared/model-info.ts";
+import type { CandidateModelResolver } from "../../shared/model-resolution.ts";
 import type { RunSyncOptions } from "../../shared/types.ts";
 
 export interface AsyncExecutionContext {
@@ -41,6 +42,7 @@ export interface AsyncSingleParams {
 	modelOverride?: string;
 	availableModels?: ModelInfo[];
 	knownModelProviders?: string[];
+	resolveCandidateModel?: CandidateModelResolver;
 	maxSubagentDepth: number;
 	parentDepth?: number;
 	workflowStageSubagentGuard?: boolean;

--- a/packages/subagents/src/shared/formatters.ts
+++ b/packages/subagents/src/shared/formatters.ts
@@ -14,13 +14,11 @@ export function formatTokens(n: number): string {
 
 export function formatModelThinking(model?: string, thinking?: string, fastMode?: boolean): string {
 	const parsed = model ? splitKnownThinkingSuffix(model) : undefined;
-	let displayModel = parsed?.baseModel ?? model;
+	// Keep the full `provider/model` id so subagent lines read exactly like the
+	// main chat's model display; only a known thinking suffix is split off.
+	const displayModel = parsed?.baseModel ?? model;
 	const explicitThinking = THINKING_LEVELS.find((level) => level === thinking?.trim());
 	const displayThinking = parsed?.thinkingSuffix ? parsed.thinkingSuffix.slice(1) : explicitThinking;
-	if (displayModel) {
-		const slashIdx = displayModel.lastIndexOf("/");
-		if (slashIdx !== -1) displayModel = displayModel.slice(slashIdx + 1);
-	}
 	const parts = [displayModel, displayThinking ? `thinking ${displayThinking}` : undefined].filter(Boolean);
 	if (fastMode && parts.length > 0) parts.push("fast");
 	return parts.join(" · ");

--- a/packages/subagents/src/shared/model-resolution.ts
+++ b/packages/subagents/src/shared/model-resolution.ts
@@ -1,0 +1,78 @@
+/**
+ * Resolution of a selected model candidate id to a concrete registry model.
+ *
+ * `buildModelCandidates` yields `provider/model[:thinking]` strings. Those
+ * strings alone never reach the child session: `createAgentSession` takes a
+ * `Model<Api>` object, and when no model is supplied it restores the model
+ * persisted in the session file. For a fork-context child that file is a copy
+ * of the parent's, so the parent's model silently won. Resolving the selected
+ * candidate to a real model here is what lets the configured model be handed
+ * to the child session instead.
+ *
+ * The lookup semantics deliberately mirror the SDK's own fallback-entry
+ * resolution (`resolveFallbackModel`), so the primary candidate and the
+ * fallback candidates handed to the same session agree on what a candidate
+ * string means.
+ */
+
+import type { Api, Model } from "@earendil-works/pi-ai/compat";
+import { splitKnownThinkingSuffix, THINKING_LEVELS, type ThinkingLevel } from "./model-info.ts";
+
+/** Registry surface needed to resolve a candidate; satisfied by `ctx.modelRegistry`. */
+export interface CandidateModelLookup {
+	getAvailable(): Model<Api>[];
+	find(provider: string, modelId: string): Model<Api> | undefined;
+	hasConfiguredAuth(model: Model<Api>): boolean;
+}
+
+/** A candidate string resolved to a concrete model and its requested thinking level. */
+export interface ResolvedCandidateModel {
+	model: Model<Api>;
+	thinkingLevel?: ThinkingLevel;
+}
+
+/**
+ * Resolve one `provider/model[:thinking]` candidate id against the registry.
+ * Returns `undefined` when the candidate names no usable model, which leaves
+ * the caller on its previous behavior rather than failing the run.
+ */
+export type CandidateModelResolver = (candidateId: string) => ResolvedCandidateModel | undefined;
+
+function thinkingLevelFromSuffix(suffix: string): ThinkingLevel | undefined {
+	if (!suffix) return undefined;
+	const level = suffix.slice(1);
+	return THINKING_LEVELS.find((known) => known === level);
+}
+
+export function resolveCandidateModel(
+	candidateId: string,
+	lookup: CandidateModelLookup,
+	preferredProvider?: string,
+): ResolvedCandidateModel | undefined {
+	const trimmed = candidateId.trim();
+	if (!trimmed) return undefined;
+	const { baseModel, thinkingSuffix } = splitKnownThinkingSuffix(trimmed);
+	const thinkingLevel = thinkingLevelFromSuffix(thinkingSuffix);
+	const slash = baseModel.indexOf("/");
+	if (slash < 0) {
+		const available = lookup.getAvailable().filter((entry) => entry.id === baseModel);
+		const model =
+			available.find((entry) => entry.provider === preferredProvider) ??
+			(available.length === 1 ? available[0] : undefined);
+		if (!model) return undefined;
+		return thinkingLevel === undefined ? { model } : { model, thinkingLevel };
+	}
+	const provider = baseModel.slice(0, slash);
+	const modelId = baseModel.slice(slash + 1);
+	const model = lookup.find(provider, modelId);
+	if (!model || !lookup.hasConfiguredAuth(model)) return undefined;
+	return thinkingLevel === undefined ? { model } : { model, thinkingLevel };
+}
+
+/** Bind a registry and the parent's provider into a reusable candidate resolver. */
+export function createCandidateModelResolver(
+	lookup: CandidateModelLookup,
+	preferredProvider?: string,
+): CandidateModelResolver {
+	return (candidateId: string) => resolveCandidateModel(candidateId, lookup, preferredProvider);
+}

--- a/packages/subagents/src/shared/types-config.ts
+++ b/packages/subagents/src/shared/types-config.ts
@@ -4,6 +4,7 @@
 
 import type { SessionWorkflowMetadata } from "@bastani/atomic";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import type { CandidateModelResolver } from "./model-resolution.ts";
 import type { NestedRouteInfo } from "./types-async.ts";
 import type {
 	ArtifactConfig,
@@ -104,6 +105,13 @@ export interface RunSyncOptions {
 	availableModels?: Array<{ provider: string; id: string; fullId: string }>;
 	/** Providers known to the registry before auth filtering */
 	knownModelProviders?: string[];
+	/**
+	 * Resolve the selected `provider/model[:thinking]` candidate to a concrete
+	 * registry model. Without it the child session receives no model and a
+	 * fork-context child silently runs on the model restored from the parent's
+	 * session file.
+	 */
+	resolveCandidateModel?: CandidateModelResolver;
 	/** Current parent-session provider to prefer for ambiguous bare model ids */
 	preferredModelProvider?: string;
 	/** Current parent-session model to try after configured fallback models */

--- a/test/unit/subagents-fork-context-model.test.ts
+++ b/test/unit/subagents-fork-context-model.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Regression coverage: a fork-context subagent must start on the agent's
+ * configured model.
+ *
+ * `buildModelCandidates` only ever produced `provider/model[:thinking]` strings,
+ * and the string was handed to the attempt as `ModelCandidate.modelId` while
+ * `ModelCandidate.model` and `ChildSpec.model` stayed `undefined`. The runner
+ * then called `createAgentSession({ model: candidate.model ?? policy.model })`
+ * with nothing, and `createAgentSession` falls back to the model persisted in
+ * the session file. For a fork that file carries the PARENT's `model_change`
+ * entries, so the parent's model silently won and the agent's declared model was
+ * never used — observed as a child declaring `openai-codex/gpt-5.6-luna:max`
+ * running every turn on the parent's `anthropic/claude-fable-5`.
+ *
+ * These tests pin the handoff at the seam that carried the defect: the
+ * `ChildSpec` and `ModelCandidate` handed to `startAttempt`, which are the only
+ * two values that reach `createAgentSession`'s `model` argument.
+ */
+
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Api, Model } from "@earendil-works/pi-ai/compat";
+import { afterAll, describe, test, vi } from "vitest";
+import type { AgentConfig } from "../../packages/subagents/src/agents/agent-types.ts";
+import type { AttemptOutcome, ChildSpec, ModelCandidate } from "../../packages/subagents/src/runs/inprocess/runner.ts";
+import { createCandidateModelResolver } from "../../packages/subagents/src/shared/model-resolution.ts";
+
+interface CapturedAttempt {
+	spec: ChildSpec;
+	candidate: ModelCandidate;
+}
+
+const harness = vi.hoisted(() => ({
+	attempts: [] as { spec: unknown; candidate: unknown }[],
+	nested: [] as unknown[],
+}));
+
+/**
+ * The control plane is the natives-backed admission door; this run needs only
+ * the four calls `runSingleInProcess` makes around one attempt, so the double
+ * records the attempt inputs and returns a settled outcome.
+ */
+vi.mock("../../packages/subagents/src/runs/inprocess/control-registry.ts", () => {
+	const outcome = {
+		status: "ok" as const,
+		output: "done",
+		envelope: "done",
+		path: "child/0",
+		stats: {
+			sessionFile: undefined,
+			sessionId: "test-session",
+			userMessages: 1,
+			assistantMessages: 1,
+			toolCalls: 0,
+			toolResults: 0,
+			totalMessages: 2,
+			tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			cost: 0,
+		},
+	};
+	const control = {
+		registerAgents: () => undefined,
+		admitChildSession: (spec: unknown) => ({
+			admitted: {
+				identity: { path: "child/0", depth: 1 },
+				spec,
+				policy: { cwd: "" },
+				sessionDir: "",
+			},
+		}),
+		startAttempt: (admitted: { spec: unknown }, candidate: unknown) => {
+			harness.attempts.push({ spec: admitted.spec, candidate });
+			return {
+				status: "running",
+				promise: Promise.resolve(outcome as AttemptOutcome),
+			};
+		},
+		registerNestedAttempt: (_runId: string, _running: unknown, candidate: unknown) => {
+			harness.nested.push(candidate);
+		},
+		continueInBackground: () => undefined,
+		deliverChildResult: async () => undefined,
+		getDeliveredResult: () => undefined,
+	};
+	return { getOrCreateSubagentControl: () => control };
+});
+
+const { runSingleInProcess } = await import("../../packages/subagents/src/runs/foreground/inprocess-run-sync.ts");
+
+const PARENT_MODEL_ID = "anthropic/claude-fable-5";
+const CONFIGURED_MODEL_ID = "openai-codex/gpt-5.6-luna";
+
+function model(provider: string, id: string): Model<Api> {
+	return {
+		id,
+		name: id,
+		api: "openai-completions",
+		provider,
+		baseUrl: `https://example.invalid/${provider}`,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 64_000,
+	};
+}
+
+const configuredModel = model("openai-codex", "gpt-5.6-luna");
+const parentModel = model("anthropic", "claude-fable-5");
+
+/** Stands in for `ctx.modelRegistry`, with both providers authenticated. */
+const registry = {
+	getAvailable: () => [configuredModel, parentModel],
+	find: (provider: string, id: string) =>
+		[configuredModel, parentModel].find((entry) => entry.provider === provider && entry.id === id),
+	hasConfiguredAuth: () => true,
+};
+
+const roots: string[] = [];
+
+function makeCwd(): string {
+	const cwd = mkdtempSync(join(tmpdir(), "subagent-fork-model-"));
+	roots.push(cwd);
+	return cwd;
+}
+
+function agentConfig(overrides: Partial<AgentConfig>): AgentConfig {
+	return {
+		name: "worker",
+		description: "worker",
+		systemPromptMode: "append",
+		inheritProjectContext: true,
+		inheritSkills: true,
+		systemPrompt: "worker",
+		source: "user",
+		filePath: "/tmp/worker.md",
+		...overrides,
+	} as AgentConfig;
+}
+
+async function runAndCapture(options: {
+	agent: AgentConfig;
+	modelOverride?: string;
+	resolve?: boolean;
+}): Promise<CapturedAttempt> {
+	harness.attempts.length = 0;
+	harness.nested.length = 0;
+	const cwd = makeCwd();
+	await runSingleInProcess(cwd, options.agent, "do the thing", {
+		cwd,
+		runId: "run-1",
+		testSession: { output: "done" },
+		// A fork run reuses the parent's session file, which is exactly where the
+		// parent's model was being restored from.
+		sessionFile: join(cwd, "parent-session.jsonl"),
+		availableModels: [
+			{ provider: "openai-codex", id: "gpt-5.6-luna", fullId: CONFIGURED_MODEL_ID },
+			{ provider: "anthropic", id: "claude-fable-5", fullId: PARENT_MODEL_ID },
+		],
+		knownModelProviders: ["openai-codex", "anthropic"],
+		preferredModelProvider: "anthropic",
+		currentModel: PARENT_MODEL_ID,
+		...(options.modelOverride === undefined ? {} : { modelOverride: options.modelOverride }),
+		...(options.resolve === false
+			? {}
+			: { resolveCandidateModel: createCandidateModelResolver(registry, "anthropic") }),
+	});
+	assert.equal(harness.attempts.length, 1, "exactly one attempt should start");
+	const captured = harness.attempts[0]!;
+	return { spec: captured.spec as ChildSpec, candidate: captured.candidate as ModelCandidate };
+}
+
+afterAll(() => {
+	for (const root of roots) rmSync(root, { recursive: true, force: true });
+});
+
+describe("fork-context subagent model selection", () => {
+	test("the agent's configured model reaches the child session instead of the parent's", async () => {
+		const { spec, candidate } = await runAndCapture({
+			agent: agentConfig({ model: `${CONFIGURED_MODEL_ID}:max` }),
+		});
+
+		// `createAgentSession({ model: candidate.model ?? policy.model })` is the
+		// only input that beats the model restored from the forked session file.
+		assert.deepEqual(candidate.model, configuredModel);
+		assert.deepEqual(spec.model, configuredModel);
+		assert.notDeepEqual(candidate.model, parentModel);
+		assert.equal(candidate.modelId, `${CONFIGURED_MODEL_ID}:max`);
+	});
+
+	test("the thinking level in the candidate suffix is applied to the child session", async () => {
+		const { spec, candidate } = await runAndCapture({
+			agent: agentConfig({ model: `${CONFIGURED_MODEL_ID}:max`, thinking: "low" }),
+		});
+
+		assert.equal(spec.thinkingLevel, "max");
+		assert.equal(candidate.thinkingLevel, "max");
+	});
+
+	test("an explicit model override wins on the first attempt", async () => {
+		const { spec, candidate } = await runAndCapture({
+			agent: agentConfig({ model: PARENT_MODEL_ID }),
+			modelOverride: `${CONFIGURED_MODEL_ID}:max`,
+		});
+
+		assert.deepEqual(candidate.model, configuredModel);
+		assert.deepEqual(spec.model, configuredModel);
+	});
+
+	test("the nested-resume candidate carries the same resolved model", async () => {
+		await runAndCapture({ agent: agentConfig({ model: CONFIGURED_MODEL_ID }) });
+
+		assert.equal(harness.nested.length, 1);
+		assert.deepEqual((harness.nested[0] as ModelCandidate).model, configuredModel);
+	});
+
+	test("an unresolvable candidate leaves the model unset rather than failing the run", async () => {
+		const { spec, candidate } = await runAndCapture({
+			agent: agentConfig({ model: "unknown-provider/absent-model" }),
+		});
+
+		assert.equal(candidate.model, undefined);
+		assert.equal(spec.model, undefined);
+		assert.equal(candidate.modelId, "unknown-provider/absent-model");
+	});
+
+	test("a host that supplies no resolver keeps the previous behavior", async () => {
+		const { spec, candidate } = await runAndCapture({
+			agent: agentConfig({ model: CONFIGURED_MODEL_ID }),
+			resolve: false,
+		});
+
+		assert.equal(candidate.model, undefined);
+		assert.equal(spec.model, undefined);
+	});
+});

--- a/test/unit/subagents-fork-context-session-model.test.ts
+++ b/test/unit/subagents-fork-context-session-model.test.ts
@@ -1,0 +1,289 @@
+/**
+ * End-to-end coverage for the fork-context model defect, executed rather than
+ * inferred.
+ *
+ * `test/unit/subagents-fork-context-model.test.ts` pins the seam that carried
+ * the bug — the `ChildSpec`/`ModelCandidate` handed to `startAttempt` — but it
+ * stops there, so the final link rested on reading `createAgentSession`:
+ * `let model = options.model;` followed by a session-file restore guarded by
+ * `if (!model && hasExistingSession …)` (`packages/coding-agent/src/core/sdk.ts`).
+ *
+ * This suite executes that whole chain against real collaborators: a real
+ * `ModelRuntime`/`ModelRegistry` built from a temporary `models.json`, the real
+ * candidate resolution inside `runSingleInProcess`, a real session file written
+ * by a real `SessionManager` and reopened with `SessionManager.open` the way the
+ * fork path does, and the real `createAgentSession`. The assertion is on the
+ * created session's active model.
+ *
+ * No provider is contacted: `createAgentSession` refreshes the model runtime
+ * with `allowNetwork: false`, the runtime is created with `allowModelNetwork`
+ * unset, both models are declared locally in `models.json`, and no turn is run.
+ */
+
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Api, Model } from "@earendil-works/pi-ai/compat";
+import { afterAll, describe, test, vi } from "vitest";
+import { AuthStorage } from "../../packages/coding-agent/src/core/auth-storage.ts";
+import { createExtensionRuntime } from "../../packages/coding-agent/src/core/extensions/loader.ts";
+import { ModelRegistry } from "../../packages/coding-agent/src/core/model-registry.ts";
+import { ModelRuntime } from "../../packages/coding-agent/src/core/model-runtime.ts";
+import type { ResourceLoader } from "../../packages/coding-agent/src/core/resource-loader.ts";
+import { createAgentSession } from "../../packages/coding-agent/src/core/sdk.ts";
+import { SessionManager } from "../../packages/coding-agent/src/core/session-manager.ts";
+import { SettingsManager } from "../../packages/coding-agent/src/core/settings-manager.ts";
+import type { AgentConfig } from "../../packages/subagents/src/agents/agent-types.ts";
+import type { AttemptOutcome, ModelCandidate } from "../../packages/subagents/src/runs/inprocess/runner.ts";
+import { createCandidateModelResolver } from "../../packages/subagents/src/shared/model-resolution.ts";
+
+const harness = vi.hoisted(() => ({ attempts: [] as { spec: unknown; candidate: unknown }[] }));
+
+/**
+ * The control plane is the natives-backed admission door and is no part of
+ * model selection; this double records the attempt inputs and settles. Every
+ * other collaborator in this file is real.
+ */
+vi.mock("../../packages/subagents/src/runs/inprocess/control-registry.ts", () => {
+	const outcome = {
+		status: "ok" as const,
+		output: "done",
+		envelope: "done",
+		path: "child/0",
+		stats: {
+			sessionFile: undefined,
+			sessionId: "test-session",
+			userMessages: 1,
+			assistantMessages: 1,
+			toolCalls: 0,
+			toolResults: 0,
+			totalMessages: 2,
+			tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			cost: 0,
+		},
+	};
+	const control = {
+		registerAgents: () => undefined,
+		admitChildSession: (spec: unknown) => ({
+			admitted: {
+				identity: { path: "child/0", depth: 1 },
+				spec,
+				policy: { cwd: "" },
+				sessionDir: "",
+			},
+		}),
+		startAttempt: (admitted: { spec: unknown }, candidate: unknown) => {
+			harness.attempts.push({ spec: admitted.spec, candidate });
+			return { status: "running", promise: Promise.resolve(outcome as AttemptOutcome) };
+		},
+		registerNestedAttempt: () => undefined,
+		continueInBackground: () => undefined,
+		deliverChildResult: async () => undefined,
+		getDeliveredResult: () => undefined,
+	};
+	return { getOrCreateSubagentControl: () => control };
+});
+
+const { runSingleInProcess } = await import("../../packages/subagents/src/runs/foreground/inprocess-run-sync.ts");
+
+const PARENT_PROVIDER = "fork-parent-provider";
+const PARENT_MODEL_ID = "parent-model";
+const CHILD_PROVIDER = "fork-child-provider";
+const CHILD_MODEL_ID = "child-model";
+const PARENT_FULL_ID = `${PARENT_PROVIDER}/${PARENT_MODEL_ID}`;
+const CHILD_FULL_ID = `${CHILD_PROVIDER}/${CHILD_MODEL_ID}`;
+
+const roots: string[] = [];
+
+afterAll(() => {
+	for (const root of roots) rmSync(root, { recursive: true, force: true });
+});
+
+/** A locally declared provider: no catalog fetch and no off-box credential. */
+function providerEntry(baseUrl: string, modelId: string): Record<string, unknown> {
+	return {
+		baseUrl,
+		apiKey: "test-key",
+		api: "openai-completions",
+		models: [
+			{
+				id: modelId,
+				name: modelId,
+				reasoning: true,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 200_000,
+				maxTokens: 32_000,
+			},
+		],
+	};
+}
+
+function resourceLoader(): ResourceLoader {
+	return {
+		getExtensions: () => ({ extensions: [], errors: [], runtime: createExtensionRuntime() }),
+		getSkills: () => ({ skills: [], diagnostics: [] }),
+		getPrompts: () => ({ prompts: [], diagnostics: [] }),
+		getThemes: () => ({ themes: [], diagnostics: [] }),
+		getAgentsFiles: () => ({ agentsFiles: [] }),
+		getSystemPrompt: () => "CHILD_PROMPT",
+		getSystemPromptSource: () => undefined,
+		getAppendSystemPrompt: () => [],
+		getAppendSystemPromptSources: () => [],
+		extendResources: async () => {},
+		reload: async () => {},
+	};
+}
+
+interface ForkFixture {
+	readonly cwd: string;
+	readonly agentDir: string;
+	readonly sessionDir: string;
+	/** A real session file carrying the parent's message and `model_change`. */
+	readonly parentSessionFile: string;
+	readonly modelRuntime: ModelRuntime;
+	readonly registry: ModelRegistry;
+	readonly childModel: Model<Api>;
+	readonly parentModel: Model<Api>;
+}
+
+/**
+ * Build what a fork-context child starts from: a real session file whose
+ * persisted model is the parent's, and a runtime that knows both models.
+ */
+async function createForkFixture(): Promise<ForkFixture> {
+	const root = mkdtempSync(join(tmpdir(), "subagent-fork-session-"));
+	roots.push(root);
+	const cwd = join(root, "project");
+	const agentDir = join(root, "agent");
+	const sessionDir = join(root, "sessions");
+	for (const dir of [cwd, agentDir, sessionDir]) mkdirSync(dir, { recursive: true });
+
+	writeFileSync(
+		join(agentDir, "models.json"),
+		JSON.stringify({
+			providers: {
+				[PARENT_PROVIDER]: providerEntry("https://parent.invalid/v1", PARENT_MODEL_ID),
+				[CHILD_PROVIDER]: providerEntry("https://child.invalid/v1", CHILD_MODEL_ID),
+			},
+		}),
+	);
+
+	const authStorage = AuthStorage.create(join(agentDir, "auth.json"));
+	await authStorage.modify(PARENT_PROVIDER, async () => ({ type: "api_key", key: "test-key" }));
+	await authStorage.modify(CHILD_PROVIDER, async () => ({ type: "api_key", key: "test-key" }));
+
+	const modelRuntime = await ModelRuntime.create({
+		credentials: authStorage,
+		modelsPath: join(agentDir, "models.json"),
+	});
+	const registry = new ModelRegistry(modelRuntime);
+	const childModel = registry.find(CHILD_PROVIDER, CHILD_MODEL_ID);
+	const parentModel = registry.find(PARENT_PROVIDER, PARENT_MODEL_ID);
+	assert.ok(childModel, "the child model must be declared in the temporary models.json");
+	assert.ok(parentModel, "the parent model must be declared in the temporary models.json");
+
+	// Write the parent's session with the real writer, so the file carries the
+	// exact entries a fork inherits.
+	const parent = SessionManager.create(cwd, sessionDir);
+	parent.appendMessage({ role: "user", content: "parent turn", timestamp: Date.now() });
+	parent.appendModelChange(PARENT_PROVIDER, PARENT_MODEL_ID);
+	parent.flush();
+	const parentSessionFile = parent.getSessionFile();
+	assert.ok(parentSessionFile, "the parent session must be file-backed");
+
+	return { cwd, agentDir, sessionDir, parentSessionFile, modelRuntime, registry, childModel, parentModel };
+}
+
+function agentConfig(model: string): AgentConfig {
+	return {
+		name: "worker",
+		description: "worker",
+		systemPromptMode: "append",
+		inheritProjectContext: true,
+		inheritSkills: true,
+		systemPrompt: "worker",
+		source: "user",
+		filePath: "/tmp/worker.md",
+		model,
+	} as AgentConfig;
+}
+
+/** Run the real selection path and return the candidate handed to the attempt. */
+async function selectCandidate(fixture: ForkFixture, options: { resolve: boolean }): Promise<ModelCandidate> {
+	harness.attempts.length = 0;
+	const resolver = options.resolve
+		? { resolveCandidateModel: createCandidateModelResolver(fixture.registry, PARENT_PROVIDER) }
+		: {};
+	await runSingleInProcess(fixture.cwd, agentConfig(CHILD_FULL_ID), "do the thing", {
+		cwd: fixture.cwd,
+		runId: "run-1",
+		testSession: { output: "done" },
+		sessionFile: fixture.parentSessionFile,
+		availableModels: [
+			{ provider: CHILD_PROVIDER, id: CHILD_MODEL_ID, fullId: CHILD_FULL_ID },
+			{ provider: PARENT_PROVIDER, id: PARENT_MODEL_ID, fullId: PARENT_FULL_ID },
+		],
+		knownModelProviders: [CHILD_PROVIDER, PARENT_PROVIDER],
+		preferredModelProvider: PARENT_PROVIDER,
+		currentModel: PARENT_FULL_ID,
+		...resolver,
+	});
+	assert.equal(harness.attempts.length, 1, "exactly one attempt should start");
+	return harness.attempts[0]!.candidate as ModelCandidate;
+}
+
+/**
+ * Create the child session exactly as `runChildAttempt` does for a fork:
+ * `SessionManager.open` on the inherited file, and
+ * `model: candidate.model ?? policy.model` — this run carries no policy model.
+ */
+async function openChildSession(fixture: ForkFixture, candidate: ModelCandidate): Promise<Model<Api> | undefined> {
+	const sessionManager = SessionManager.open(fixture.parentSessionFile, fixture.sessionDir, fixture.cwd);
+	const { session } = await createAgentSession({
+		cwd: fixture.cwd,
+		agentDir: fixture.agentDir,
+		model: candidate.model,
+		thinkingLevel: candidate.thinkingLevel,
+		modelRuntime: fixture.modelRuntime,
+		settingsManager: SettingsManager.create(fixture.cwd, fixture.agentDir),
+		sessionManager,
+		resourceLoader: resourceLoader(),
+	});
+	return session.model;
+}
+
+describe("fork-context child session model (executed end to end)", () => {
+	test("the resolved candidate model beats the model persisted in the forked session file", async () => {
+		const fixture = await createForkFixture();
+		const candidate = await selectCandidate(fixture, { resolve: true });
+		const sessionModel = await openChildSession(fixture, candidate);
+
+		// The session-level assertion comes first on purpose: it is the claim
+		// that matters, and it is what fails on pre-fix source.
+		assert.equal(sessionModel?.provider, CHILD_PROVIDER);
+		assert.equal(sessionModel?.id, CHILD_MODEL_ID);
+		assert.deepEqual(candidate.model, fixture.childModel);
+	});
+	test("the forked session file really does carry the parent's model", async () => {
+		const fixture = await createForkFixture();
+		const sessionModel = await openChildSession(fixture, {});
+
+		assert.equal(sessionModel?.provider, PARENT_PROVIDER);
+		assert.equal(sessionModel?.id, PARENT_MODEL_ID);
+	});
+
+	test("an unresolved candidate lets the parent's model win — the reported bug", async () => {
+		const fixture = await createForkFixture();
+		const candidate = await selectCandidate(fixture, { resolve: false });
+
+		// The pre-fix state: a candidate string, and no model object to hand on.
+		assert.equal(candidate.model, undefined);
+		assert.equal(candidate.modelId, CHILD_FULL_ID);
+
+		const sessionModel = await openChildSession(fixture, candidate);
+		assert.equal(sessionModel?.provider, PARENT_PROVIDER);
+		assert.equal(sessionModel?.id, PARENT_MODEL_ID);
+	});
+});

--- a/test/unit/subagents-formatters.test.ts
+++ b/test/unit/subagents-formatters.test.ts
@@ -6,20 +6,39 @@ describe("subagent formatModelThinking", () => {
 	test("appends fast after model and inferred thinking suffix", () => {
 		assert.equal(
 			formatModelThinking("openai/gpt-5.1-codex:medium", undefined, true),
-			"gpt-5.1-codex · thinking medium · fast",
+			"openai/gpt-5.1-codex · thinking medium · fast",
 		);
 	});
 
 	test("omits fast when fast mode metadata is missing or disabled", () => {
-		assert.equal(formatModelThinking("openai/gpt-5.1-codex:medium"), "gpt-5.1-codex · thinking medium");
+		assert.equal(formatModelThinking("openai/gpt-5.1-codex:medium"), "openai/gpt-5.1-codex · thinking medium");
 		assert.equal(
 			formatModelThinking("openai/gpt-5.1-codex:medium", undefined, false),
-			"gpt-5.1-codex · thinking medium",
+			"openai/gpt-5.1-codex · thinking medium",
 		);
 	});
 
 	test("appends fast after explicit thinking metadata", () => {
-		assert.equal(formatModelThinking("openai/gpt-5.1-codex", "high", true), "gpt-5.1-codex · thinking high · fast");
+		assert.equal(
+			formatModelThinking("openai/gpt-5.1-codex", "high", true),
+			"openai/gpt-5.1-codex · thinking high · fast",
+		);
+	});
+
+	test("keeps the provider prefix so the line matches the main chat model display", () => {
+		assert.equal(formatModelThinking("anthropic/claude-fable-5", "high"), "anthropic/claude-fable-5 · thinking high");
+		assert.equal(formatModelThinking("anthropic/claude-fable-5"), "anthropic/claude-fable-5");
+	});
+
+	test("keeps every segment of a multi-segment routed model id", () => {
+		assert.equal(
+			formatModelThinking("openrouter/anthropic/claude-fable-5:max"),
+			"openrouter/anthropic/claude-fable-5 · thinking max",
+		);
+	});
+
+	test("splits only a known thinking suffix", () => {
+		assert.equal(formatModelThinking("openai/gpt-5.1-codex:preview"), "openai/gpt-5.1-codex:preview");
 	});
 });
 

--- a/test/unit/subagents-model-candidate-filtering.test.ts
+++ b/test/unit/subagents-model-candidate-filtering.test.ts
@@ -106,6 +106,7 @@ describe("subagent pre-spawn model candidate filtering", () => {
 				maxSubagentDepths: [0],
 				availableModels: [{ provider: "provider-b", id: "working", fullId: "provider-b/working" }],
 				knownModelProviders,
+				resolveCandidateModel: () => undefined,
 				modelOverrides: ["provider-a/stalled"],
 				behaviors: [{ output: false, outputMode: "inline", reads: false, progress: false, skills: false }],
 				firstProgressIndex: -1,
@@ -172,6 +173,7 @@ describe("subagent pre-spawn model candidate filtering", () => {
 				maxSubagentDepths: [0, 0],
 				availableModels: [],
 				knownModelProviders: [],
+				resolveCandidateModel: () => undefined,
 				modelOverrides,
 				behaviors: [
 					{ output: false, outputMode: "inline", reads: false, progress: false, skills: false },

--- a/test/unit/subagents-parallel-intercom-detach.test.ts
+++ b/test/unit/subagents-parallel-intercom-detach.test.ts
@@ -63,6 +63,7 @@ test("one parallel child's supervisor detach releases every active foreground si
 		maxSubagentDepths: [0, 0, 0],
 		availableModels: [],
 		knownModelProviders: [],
+		resolveCandidateModel: () => undefined,
 		modelOverrides: [undefined, undefined, undefined],
 		behaviors: [
 			{ output: false, outputMode: "inline", reads: false, progress: false, skills: false },


### PR DESCRIPTION
## Summary

Two defects made a subagent report and run on the wrong model.

**Fork-context subagents ignored the agent's configured model.** `buildModelCandidates` produces `provider/model[:thinking]` *strings*, but `createAgentSession` selects from a `Model<Api>` object and, when handed none, restores the model persisted in the session file. A fork-context child's session file is a copy of the parent's, so the parent's `model_change` silently won: a `worker` declaring `openai-codex/gpt-5.6-luna:max` ran every turn on the parent's model, and an explicit `model:` override lost its first attempt the same way.

The selected candidate is now resolved against the model registry into a real `Model<Api>` — carrying the thinking level from the candidate's `:max`-style suffix — and handed to the child session. A new `packages/subagents/src/shared/model-resolution.ts` mirrors the SDK's own `resolveFallbackModel` semantics so the primary candidate and the fallback candidates given to the same session agree on what a candidate string means. The resolver is plumbed through the single, parallel, async/background, and resume construction sites; the async path was affected too, since it funnels through the same `runSingleInProcess`. A candidate naming no usable model resolves to `undefined` and leaves the run on its previous behavior rather than failing it.

**Subagent display stripped the provider prefix.** `formatModelThinking` sliced at the last `/`, so a child rendered as `claude-fable-5` where the main chat shows `anthropic/claude-fable-5`. The slice is gone; the full id renders, including every segment of a routed id like `openrouter/anthropic/claude-fable-5`. Thinking-suffix splitting and the `fast` marker are unchanged.

`packages/coding-agent` is untouched. Resolution semantics were duplicated inside `packages/subagents` rather than adding an SDK export, per the no-SDK-changes constraint.

## Changes

- `packages/subagents/src/shared/model-resolution.ts` (new) — candidate id → `Model<Api>` + thinking level.
- `packages/subagents/src/runs/foreground/inprocess-run-sync.ts` — the actual defect: `model: undefined` becomes the resolved candidate model, and the resolved model reaches attempt registration.
- `packages/subagents/src/shared/formatters.ts` — drop the `lastIndexOf("/")` slice.
- `packages/subagents/src/shared/types-config.ts` plus the executor/background modules — plumb `resolveCandidateModel` through single, parallel, async, and resume paths.
- `packages/subagents/CHANGELOG.md` — `### Fixed` under `## [Unreleased]` covering both fixes.
- Tests: `test/unit/subagents-fork-context-model.test.ts` and `test/unit/subagents-fork-context-session-model.test.ts` (new), `test/unit/subagents-formatters.test.ts` extended, two fixture updates.

## Testing

| Command | Result |
| --- | --- |
| `npm run check` | Green — biome, `tsc --noEmit`, coding-agent `tsgo`, shrinkwrap |
| `npm run test:unit` | Green — 640 files, 6159 passed, 2 skipped, 0 failed |
| Pre-fix reproduction (`packages/subagents/src` reverted, new tests kept) | 11 tests fail, including both criterion tests |

Pre-fix failures:

```
× the resolved candidate model beats the model persisted in the forked session file
    Expected: "fork-child-provider"   Received: "fork-parent-provider"
× keeps the provider prefix so the line matches the main chat model display
    Expected: "openai/gpt-5.1-codex · thinking medium"   Received: "gpt-5.1-codex · thinking medium"
```

`subagents-fork-context-session-model.test.ts` proves the SDK link by execution rather than code reading: it writes a real parent session file through a real `SessionManager`, reopens it the way the fork path does, runs the real candidate resolution and the real `createAgentSession`, and asserts on `session.model`. No network — the runtime is created without `allowModelNetwork`, refresh uses `allowNetwork: false`, both models are declared in a temp `models.json`, and no turn runs. Two negative controls (no model supplied, and an unresolved candidate) keep the passing state from being vacuous.

Live A/B, same agent and task, published pre-fix binary vs. locally built CLI:

```
PRE-FIX   ✓ worker (claude-fable-5 · thinking high) [fork] · ⟳ 3 · 1 tool use · 48k token · 4s
POST-FIX  ✓ worker (openai-codex/gpt-5.6-luna · thinking max · fast) [fork] · ⟳ 3 · 1 tool use · 43k token · 4s
```

## Review notes

- **Commit `7e958f887` duplicates open PR [#2356](https://github.com/bastani-inc/atomic/pull/2356)**, byte for byte (both produce blob `17ca6dbab`). `npm run test:unit` was already red at the base commit — `00e1d40c7` added a `[0.9.13-alpha.2]` entry to an already-released section — and acceptance required a green suite, so the entry was moved to `## [Unreleased] → ### Changed`. It is a separate 4-line commit; drop it if #2356 lands first. This is the only change outside `packages/subagents`.
- **E2E scope.** Only the foreground single path was exercised live. Parallel, async/background, and resume share `runSingleInProcess` and are covered by unit tests, but were not run against a real provider. The pre-fix half of the A/B came from the published binary, which differs from this checkout by more than this fix.
- **Unrelated flake seen once.** A first full `npm run test:unit` reported failures in `workflow-active-blocked-lifecycle` and `subagents-completion-notification`; two later full runs were green and both files passed 3/3 in isolation. Neither touches the changed source.
- **Pre-existing, not addressed.** Forking a subagent from a session that has not yet taken a turn fails with `Session manager returned a forked session file that does not exist`. It reproduces on the pre-fix binary too.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789174414&installation_model_id=10562&pr_number=2357&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2357&signature=d923203d78b4cece8b5b70f668434e24ccc43a9ed6290c736a3ac8e642f6b53b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change resolves configured subagent model names to registry models and carries the resolved model through child-session execution paths. A verified reliability issue remains: if a child has fallen back to a working model and is later cold-resumed, it restarts with the originally failed primary model instead of preserving the active fallback.

<h3>Confidence Score: 4/5</h3>

Not merge-safe until cold-resumed child sessions retain their effective fallback model.

There is one independent, verified P1 finding and it is not security-related, which maps to a score of 4.

**Files Needing Attention:** packages/subagents/src/runs/foreground/inprocess-run-sync.ts and the nested cold-resume logic in packages/subagents/src/runs/inprocess/runner.ts need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and linked it to the finding-comment-proof.
- T-Rex ran a focused cold-resume runtime test to exercise the relevant code path and generate supporting evidence.
- T-Rex inspected the cold-resume runtime output to verify the observed behavior and captured results for review.
- T-Rex gathered the relevant implementation capture to show the exact code area involved in the test and its relation to the finding.

<a href="https://app.greptile.com/trex/runs/18620615/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/subagents/src/runs/foreground/inprocess-run-sync.ts:338-341
**Cold resume resets the fallback model**

`registerNestedAttempt` persists the initially resolved candidate as an explicit `model`. When a child has moved from that failed primary to a fallback and its session must be cold-resumed, the runner reuses this registered explicit model ahead of the model restored from the session. The resumed attempt therefore retries the failed primary instead of continuing with the working fallback. Preserve the session's active model for cold resumes rather than forcing the initially resolved primary.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(subagents): execute the fork-contex..."](https://github.com/bastani-inc/atomic/commit/3b4bed637a2c3bacd34dac0c0cc9ec71c828e217) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52807338)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->