### PR TITLE
feat(intercom)!: display and accept only full session IDs

### DIFF
--- a/packages/coding-agent/docs/intercom.md
+++ b/packages/coding-agent/docs/intercom.md
@@ -12,7 +12,7 @@ Atomic bundles `@bastani/intercom`, a first-party extension for direct 1:1 messa
 **Key capabilities:**
 - **Session messaging** - `send`, `ask` (blocking, 10-minute timeout), `reply`, `pending`, `list`, and `status` via the `intercom` tool
 - **Runtime groups** - `join` or `leave` named groups without restarting; joined sessions keep their broker IDs and subagents inherit the joined group
-- **Session discovery** - List connected sessions with name, short ID, working directory, model, and live status
+- **Session discovery** - List connected sessions with name, full session ID, working directory, model, and live status
 - **Keyboard overlay** - ALT+M or `/intercom` opens a session picker and compose overlay
 - **Attachments** - Share `file`, `snippet`, and `context` payloads between sessions
 - **Subagent escalation** - Delegated children get a `contact_supervisor` tool for decisions, structured interviews, and progress updates
@@ -74,20 +74,20 @@ The agent can list sessions and send messages using the `intercom` tool. Tool ca
 // List active sessions
 intercom({ action: "list" })
 // → **Current session:**
-// → • executor (20d43841) — ~/projects/api (claude-sonnet-4) [self, idle]
+// → • executor (20d43841-1111-4222-8333-123456789abc) — ~/projects/api (claude-sonnet-4) [self, idle]
 // → **Other sessions:**
-// → • research (6332faab) — ~/projects/api (claude-sonnet-4) [same cwd, thinking]
+// → • research (6332faab-1111-4222-8333-123456789abc) — ~/projects/api (claude-sonnet-4) [same cwd, thinking]
 
 // Send a message
 intercom({ action: "send", to: "research", message: "Check if UserService.validate() handles null" })
 // → Message sent to research
 
-// The short ID printed by list is also a valid target
-intercom({ action: "ask", to: "6332faab", message: "Which validation path should I use?" })
+// The full session ID printed by list is also a valid target
+intercom({ action: "ask", to: "6332faab-1111-4222-8333-123456789abc", message: "Which validation path should I use?" })
 
 // Check connection status
 intercom({ action: "status" })
-// → Connected: Yes, Session ID: abc123, Active sessions: 3
+// → Connected: Yes, Session ID: abc12345-1111-4222-8333-123456789abc, Active sessions: 3
 
 // Send with attachments (code snippets, files, or context)
 intercom({
@@ -131,14 +131,14 @@ A session becomes intercom-connected when all of these are true:
 
 The session list only shows intercom-connected sessions, not every open Atomic process on the machine.
 
-Name sessions with `/name` so they can target each other (for example `/name planner` and `/name worker`). If a session is unnamed, Intercom exposes a runtime-only fallback alias like `subagent-chat-1a2b3c4d` so other sessions can still target it. That alias is not persisted as the session title, so resume pickers keep showing the transcript snippet instead of a generic name.
+Name sessions with `/name` so they can target each other (for example `/name planner` and `/name worker`). If a session is unnamed, Intercom exposes a runtime-only fallback alias like `subagent-chat-1a2b3c4d-1111-4222-8333-123456789abc` so other sessions can still target it. That alias is not persisted as the session title, so resume pickers keep showing the transcript snippet instead of a generic name.
 
 ## The intercom Tool
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `action` | string | `"list"`, `"join"`, `"leave"`, `"send"`, `"ask"`, `"reply"`, `"pending"`, or `"status"` |
-| `to` | string | Exact session name, exact full ID, or unique ID prefix (for send/ask, or to disambiguate reply) |
+| `to` | string | Exact session name or exact full session ID (for send/ask, or targeted reply) |
 | `message` | string | Message text (for send/ask/reply) |
 | `attachments` | array | Optional `file`, `snippet`, or `context` attachments |
 | `replyTo` | string | Optional message ID for threading or replying to an `ask` |
@@ -150,7 +150,7 @@ Name sessions with `/name` so they can target each other (for example `/name pla
 |--------|----------|
 | `join` | Moves the session into a trimmed named group and creates it if needed. The action waits for broker acknowledgement before changing local inheritance state. `default` is the shared group; `true` and `auto` are reserved for subagent auto-groups. |
 | `leave` | Returns the session to its resolved home group from startup. It takes no `group` parameter. |
-| `list` | Returns the current session plus other active intercom-connected sessions with name, short ID, working directory, model, and live status (`idle`, `thinking`, or `tool:<name>`, derived from lifecycle events). Every displayed short ID is a valid target. |
+| `list` | Returns the current session plus other active intercom-connected sessions with name, full session ID, working directory, model, and live status (`idle`, `thinking`, or `tool:<name>`, derived from lifecycle events). Every displayed full session ID is a valid target. |
 | `send` | Fire-and-forget delivery. Requires `to` and `message`; returns delivery confirmation or the delivery-failure reason. Cannot message the current session. |
 | `ask` | Sends a message and blocks until the recipient replies (10-minute timeout). The reply is returned as the tool result, so the agent continues in the same turn. |
 | `reply` | Replies to the intercom-triggered message of the current turn; otherwise falls back to the single unresolved inbound ask. With multiple pending asks, pass `to` or inspect with `pending` first. |
@@ -169,7 +169,7 @@ Sent and received messages are recorded in session history as `intercom_sent` / 
 
 ### Targeting Sessions
 
-Target lookup resolves an exact full ID first, then an exact case-insensitive name, then a unique session-ID prefix. If a prefix matches multiple sessions, Intercom reports every match and asks for a longer ID or exact name instead of guessing. Resolving a prefix to the current session triggers the normal self-target rejection ("Cannot message the current session"). Targeting is also **group-scoped** — see [Groups](#groups) below.
+Target lookup accepts only an exact full session ID or an exact case-insensitive session name. Targeting is also **group-scoped** — see [Groups](#groups) below.
 
 ### Groups
 

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- Removed unique-ID-prefix targeting. `send`, `ask`, and `reply` now accept only an exact full session ID or an exact case-insensitive session name.
+
+### Changed
+
+- Intercom now displays full session and message IDs everywhere: list rows, the session-list overlay, inbound message headers, reply-to lines, message-id result badges, and unnamed-session `subagent-chat-<id>` aliases.
+
 ## [0.9.13-alpha.2] - 2026-08-12
 
 ### Changed

--- a/packages/intercom/README.md
+++ b/packages/intercom/README.md
@@ -58,7 +58,7 @@ A session becomes intercom-connected when all of these are true:
 
 The session list only shows intercom-connected sessions, not every open Pi process on the machine.
 
-If a session is unnamed, intercom exposes a runtime-only fallback alias like `subagent-chat-1a2b3c4d` so other sessions can still target it. That alias is not persisted as the session title, so resume pickers can keep showing the transcript snippet instead of a generic `session-...` name.
+If a session is unnamed, intercom exposes a runtime-only fallback alias like `subagent-chat-1a2b3c4d-1111-4222-8333-123456789abc` so other sessions can still target it. That alias is not persisted as the session title, so resume pickers can keep showing the transcript snippet instead of a generic `session-...` name.
 
 ## Quick Start
 
@@ -78,9 +78,9 @@ The agent can list sessions and send messages using the `intercom` tool. Tool ca
 // List active sessions
 intercom({ action: "list" })
 // → **Current session:**
-// → • executor (20d43841) — ~/projects/api (claude-sonnet-4) [self, idle]
+// → • executor (20d43841-1111-4222-8333-123456789abc) — ~/projects/api (claude-sonnet-4) [self, idle]
 // → **Other sessions:**
-// → • research (6332faab) — ~/projects/api (claude-sonnet-4) [same cwd, thinking]
+// → • research (6332faab-1111-4222-8333-123456789abc) — ~/projects/api (claude-sonnet-4) [same cwd, thinking]
 
 // Join a named group (it is created if no session is there yet)
 intercom({ action: "join", group: "api-review" })
@@ -94,12 +94,12 @@ intercom({ action: "leave" })
 intercom({ action: "send", to: "research", message: "Check if UserService.validate() handles null" })
 // → Message sent to research
 
-// The short ID printed by list is also a valid target
-intercom({ action: "ask", to: "6332faab", message: "Which validation path should I use?" })
+// The full session ID printed by list is also a valid target
+intercom({ action: "ask", to: "6332faab-1111-4222-8333-123456789abc", message: "Which validation path should I use?" })
 
 // Check connection status
 intercom({ action: "status" })
-// → Connected: Yes, Session ID: abc123, Active sessions: 3
+// → Connected: Yes, Session ID: abc12345-1111-4222-8333-123456789abc, Active sessions: 3
 
 // Send with attachments (code snippets, files, or context)
 intercom({
@@ -334,7 +334,7 @@ The supervisor can reply with plain JSON or a fenced `json` block. If the reply 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `action` | string | `"list"`, `"join"`, `"leave"`, `"send"`, `"ask"`, `"reply"`, `"pending"`, or `"status"` |
-| `to` | string | Exact session name, exact full ID, or unique ID prefix (for send/ask, or to disambiguate reply) |
+| `to` | string | Exact session name or exact full session ID (for send/ask, or targeted reply) |
 | `message` | string | Message text (for send/ask/reply) |
 | `attachments` | array | Optional `file`, `snippet`, or `context` attachments |
 | `replyTo` | string | Optional message ID for threading or replying to an `ask` |
@@ -362,15 +362,15 @@ Only registered in sessions where `pi-subagents` supplied the required child bri
 
 **`leave`** — Moves this session back to the resolved home group from session startup. It takes no `group` parameter.
 
-**`list`** — Returns the current session plus other active intercom-connected sessions with name, short ID, working directory, model, and live status. Every displayed short ID can be passed directly to `send`, `ask`, or targeted `reply`.
+**`list`** — Returns the current session plus other active intercom-connected sessions with name, full session ID, working directory, model, and live status. Every displayed full session ID can be passed directly to `send`, `ask`, or targeted `reply`.
 
-Target lookup preserves exact full IDs and exact case-insensitive names, then accepts a unique session-ID prefix. If a prefix matches multiple sessions, Intercom reports every match and asks for a longer ID or exact name instead of guessing. Resolving a prefix to the current session still triggers the normal self-target rejection.
+Target lookup accepts only an exact full session ID or an exact case-insensitive session name. Targeting is also **group-scoped** — see [Groups](#groups) below.
 
 **`send`** — Sends a message to the specified session. By default it sends immediately, including in interactive sessions. Set `confirmSend: true` in config if you want a confirmation dialog for non-reply sends. Replies that include `replyTo` skip confirmation. Returns delivery confirmation.
 
 **`ask`** — Sends a message and waits for the recipient to reply (10-minute timeout). The reply is returned as the tool result. No confirmation dialog. Only one pending `ask` is allowed per session at a time; if several blocking requests race (parallel `ask` calls, or `ask` alongside `contact_supervisor`), one wins the reservation and each other call returns a normal "Already waiting for a reply" tool error without disturbing the pending ask. Use this when the agent needs the answer to continue working.
 
-**`reply`** — Replies to the current intercom-triggered message if there is one. Otherwise it falls back to the single unresolved inbound ask. If multiple asks are pending, pass an exact name, exact full ID, or unique ID prefix in `to`, or inspect them with `pending` first. Under the hood this is still a normal `send` with the exact `replyTo` value.
+**`reply`** — Replies to the current intercom-triggered message if there is one. Otherwise it falls back to the single unresolved inbound ask. If multiple asks are pending, pass an exact name or exact full session ID in `to`, or inspect them with `pending` first. Under the hood this is still a normal `send` with the exact `replyTo` value.
 
 **`pending`** — Lists unresolved inbound asks with sender, message ID, elapsed time, and a short preview. Useful when replying after the original triggered turn.
 

--- a/packages/intercom/incoming-message-delivery.ts
+++ b/packages/intercom/incoming-message-delivery.ts
@@ -38,7 +38,7 @@ export function createIncomingMessageSender(input: {
 }
 
 export function buildIncomingCustomMessage(entry: InboundMessageEntry) {
-  const senderDisplay = entry.from.name || entry.from.id.slice(0, 8);
+  const senderDisplay = entry.from.name || entry.from.id;
   const replyInstruction = entry.replyCommand ? `\n\nTo reply, use the intercom tool: ${entry.replyCommand}` : "";
   return {
     customType: "intercom_message" as const,

--- a/packages/intercom/index.ts
+++ b/packages/intercom/index.ts
@@ -424,7 +424,7 @@ Usage:
 		promptSnippet: "Use to coordinate with other local agent sessions in your intercom group: list peers, send updates, ask for help, or check intercom connectivity. Groups are isolated; you can only message sessions in your own group.",
 		parameters: Type.Object({
 			action: Type.String({ description: "Action: 'list', 'join', 'leave', 'send', 'ask', 'reply', 'pending', or 'status'" }),
-			to: Type.Optional(Type.String({ description: "Target session name or ID (for 'send', 'ask', or disambiguating 'reply')" })),
+			to: Type.Optional(Type.String({ description: "Exact session name or exact full session ID (for 'send', 'ask', or targeted 'reply')" })),
 			message: Type.Optional(Type.String({ description: "Message to send (for 'send', 'ask', or 'reply' action)" })),
 			attachments: Type.Optional(Type.Array(Type.Object({
 				type: Type.Union([Type.Literal("file"), Type.Literal("snippet"), Type.Literal("context")]),

--- a/packages/intercom/intercom-tool.ts
+++ b/packages/intercom/intercom-tool.ts
@@ -71,7 +71,7 @@ does not grant cross-group access: contact_supervisor is the only cross-group pa
         description: "Action: 'list', 'join', 'leave', 'send', 'ask', 'reply', 'pending', or 'status'",
       }),
       to: Type.Optional(Type.String({
-        description: "Target session name or ID (for 'send', 'ask', or disambiguating 'reply')",
+        description: "Exact session name or exact full session ID (for 'send', 'ask', or targeted 'reply')",
       })),
       message: Type.Optional(Type.String({
         description: "Message to send (for 'send', 'ask', or 'reply' action)",

--- a/packages/intercom/intercom-utils.ts
+++ b/packages/intercom/intercom-utils.ts
@@ -345,9 +345,6 @@ export function duplicateSessionNames(sessions: SessionInfo[]): Set<string> {
       .filter((name, index, names) => names.indexOf(name) !== index)
   );
 }
-function shortSessionId(sessionId: string): string {
-  return sessionId.slice(0, 8);
-}
 export function parseSubagentIntercomPayload(payload: unknown): { to: string; message: string; requestId?: string } | null {
   if (typeof payload !== "object" || payload === null) {
     return null;
@@ -394,7 +391,7 @@ export function resolveIntercomPresenceName(sessionName: string | undefined, ses
     return trimmedName;
   }
   const normalizedSessionId = sessionId.startsWith("session-") ? sessionId.slice("session-".length) : sessionId;
-  return `${DEFAULT_UNNAMED_SESSION_ALIAS_PREFIX}-${normalizedSessionId.slice(0, 8)}`;
+  return `${DEFAULT_UNNAMED_SESSION_ALIAS_PREFIX}-${normalizedSessionId}`;
 }
 export function buildPresenceIdentity(pi: ExtensionAPI, sessionId: string): { name: string } {
   return {
@@ -406,7 +403,7 @@ export function formatSessionLabel(session: SessionInfo, duplicates: Set<string>
     return session.id;
   }
   return duplicates.has(session.name.toLowerCase())
-    ? `${session.name} (${shortSessionId(session.id)})`
+    ? `${session.name} (${session.id})`
     : session.name;
 }
 export function formatSessionListRow(session: SessionInfo, currentCwd: string, isSelf: boolean): string {
@@ -416,7 +413,7 @@ export function formatSessionListRow(session: SessionInfo, currentCwd: string, i
   const tags = [isSelf ? "self" : session.cwd === currentCwd ? "same cwd" : undefined, session.status, groupTag]
     .filter((tag): tag is string => Boolean(tag));
   const suffix = tags.length ? ` [${tags.join(", ")}]` : "";
-  return `• ${name} (${shortSessionId(session.id)}) — ${session.cwd} (${session.model})${suffix}`;
+  return `• ${name} (${session.id}) — ${session.cwd} (${session.model})${suffix}`;
 }
 export function previewText(value: unknown, maxLength = 72): string | undefined {
   if (typeof value !== "string") {

--- a/packages/intercom/result-renderers.ts
+++ b/packages/intercom/result-renderers.ts
@@ -55,7 +55,7 @@ export const renderIntercomResult: ToolResultRenderer = (result, { isPartial }, 
 	let text = failed ? theme.fg("error", "✗ ") : theme.fg("success", "✓ ");
 	text += theme.fg(failed ? "error" : "text", firstTextContent(result));
 	if (details?.messageId && !context.expanded) {
-		text += theme.fg("dim", ` (${details.messageId.slice(0, 8)})`);
+		text += theme.fg("dim", ` (${details.messageId})`);
 	}
 	if (details?.reason && context.expanded) {
 		text += "\n" + theme.fg("dim", `Reason: ${details.reason}`);

--- a/packages/intercom/session-target.ts
+++ b/packages/intercom/session-target.ts
@@ -3,10 +3,9 @@ import type { SessionInfo } from "./types.js";
 export type SessionTargetResolution =
   | { kind: "resolved"; session: SessionInfo }
   | { kind: "ambiguous_name"; matches: readonly SessionInfo[] }
-  | { kind: "ambiguous_prefix"; matches: readonly SessionInfo[] }
   | { kind: "not_found" };
 
-/** Resolve an Intercom session by exact ID, exact case-insensitive name, or unique ID prefix. */
+/** Resolve an Intercom session by exact ID or exact case-insensitive name. */
 export function resolveSessionTarget(
   sessions: readonly SessionInfo[],
   nameOrId: string,
@@ -26,13 +25,6 @@ export function resolveSessionTarget(
     return { kind: "ambiguous_name", matches: exactNames };
   }
 
-  const prefixedIds = sessions.filter((session) => session.id.startsWith(target));
-  if (prefixedIds.length === 1) {
-    return { kind: "resolved", session: prefixedIds[0]! };
-  }
-  if (prefixedIds.length > 1) {
-    return { kind: "ambiguous_prefix", matches: prefixedIds };
-  }
   return { kind: "not_found" };
 }
 
@@ -42,12 +34,6 @@ export function sessionTargetFailureReason(
 ): string {
   if (resolution.kind === "ambiguous_name") {
     return `Multiple sessions named "${target}" are connected. Use the session ID instead.`;
-  }
-  if (resolution.kind === "ambiguous_prefix") {
-    const labels = resolution.matches
-      .map((session) => `${session.name ?? "Unnamed session"} (${session.id})`)
-      .join(", ");
-    return `Ambiguous session ID prefix "${target}" matches: ${labels}. Use a longer ID or an exact session name.`;
   }
   return "Session not found";
 }

--- a/packages/intercom/skills/intercom/SKILL.md
+++ b/packages/intercom/skills/intercom/SKILL.md
@@ -67,15 +67,15 @@ intercom({
 
 ### Pattern 2: Quick Status Check
 
-Before sending, verify who's connected. The short ID printed by `list` is directly usable by `send`, `ask`, and targeted `reply`:
+Before sending, verify who's connected. The full session ID printed by `list` is directly usable by `send`, `ask`, and targeted `reply`:
 
 ```typescript
 intercom({ action: "list" })
-// → • planner (6332faab) — /workspace (model) [idle]
-intercom({ action: "ask", to: "6332faab", message: "Which option should I use?" })
+// → • planner (6332faab-1111-4222-8333-123456789abc) — /workspace (model) [idle]
+intercom({ action: "ask", to: "6332faab-1111-4222-8333-123456789abc", message: "Which option should I use?" })
 ```
 
-Intercom resolves exact full IDs first, exact case-insensitive names second, and unique ID prefixes last. A colliding prefix returns an ambiguity error; use a longer displayed ID or an exact name rather than guessing.
+Intercom accepts only an exact full session ID or an exact case-insensitive session name. Use the full ID printed by `list` or the session's exact name.
 
 ### Runtime named groups
 
@@ -230,9 +230,9 @@ In Atomic workflows, each invocation has its own Intercom group, and parallel st
 | `leave` | Returns to the resolved home group | Restore the session's startup group |
 | `send` | Fire-and-forget | You don't need a response |
 | `ask` | Blocks until reply (10 min timeout) | You need an answer to continue |
-| `reply` | Responds to the active or pending inbound ask; `to` accepts a displayed short ID | You were asked something and need to answer naturally |
+| `reply` | Responds to the active or pending inbound ask; `to` accepts an exact full session ID or exact session name | You were asked something and need to answer naturally |
 | `pending` | Lists unresolved inbound asks | You need to see who is waiting before replying |
-| `list` | Returns all sessions in the current group with actionable short IDs and live status | You need to discover targets or choose an idle peer |
+| `list` | Returns all sessions in the current group with full session IDs and live status | You need to discover targets or choose an idle peer |
 | `status` | Returns your connection state and current group | Troubleshooting |
 
 Inside workflows, `ask` may target a sibling stage that has already completed. If that stage retains a valid conversation, Atomic automatically schedules a post-mortem turn there and preserves the exact child-to-child reply thread; do not send a separate workflow follow-up. Missing, deleted, non-resumable, or failed-to-reopen completed targets return an actionable error. A parent or unrelated session cannot satisfy the pending ask.

--- a/packages/intercom/ui/inline-message.ts
+++ b/packages/intercom/ui/inline-message.ts
@@ -24,11 +24,11 @@ export class InlineMessageComponent implements Component {
     const lines: string[] = [];
     const borderChar = "─";
     if (width < 3) {
-      return [truncateToWidth(`From ${this.from.name || this.from.id.slice(0, 8)}`, width)];
+      return [truncateToWidth(`From ${this.from.name || this.from.id}`, width)];
     }
     const bodyWidth = Math.max(1, width - 2);
 
-    const senderName = this.from.name || this.from.id.slice(0, 8);
+    const senderName = this.from.name || this.from.id;
     const header = ` 📨 From: ${senderName} (${this.from.cwd}) `;
     const headerText = truncateToWidth(header, bodyWidth, "");
     const headerPadding = Math.max(0, bodyWidth - visibleWidth(headerText));
@@ -63,7 +63,7 @@ export class InlineMessageComponent implements Component {
 
     if (this.message.replyTo && !this.message.expectsReply) {
       lines.push(this.theme.fg("accent", `│${" ".repeat(bodyWidth)}│`));
-      const reply = this.theme.fg("dim", ` ↳ Reply to ${this.message.replyTo.slice(0, 8)}`);
+      const reply = this.theme.fg("dim", ` ↳ Reply to ${this.message.replyTo}`);
       const text = truncateToWidth(reply, bodyWidth, "");
       const padding = Math.max(0, bodyWidth - visibleWidth(text));
       lines.push(this.theme.fg("accent", `│${text}${" ".repeat(padding)}│`));

--- a/packages/intercom/ui/session-list.ts
+++ b/packages/intercom/ui/session-list.ts
@@ -46,17 +46,12 @@ function middleTruncate(text: string, maxWidth: number): string {
 
   return truncateToWidth(`${left}…${right}`, maxWidth, "");
 }
-
-function shortSessionId(sessionId: string): string {
-  return sessionId.slice(0, 8);
-}
-
 function sessionTitle(session: SessionInfo, options?: { self?: boolean; sameCwd?: boolean }): string {
   const name = session.name || "Unnamed session";
   const tags = [options?.self ? "self" : undefined, options?.sameCwd ? "same cwd" : undefined]
     .filter((tag): tag is string => Boolean(tag));
   const suffix = tags.length ? ` [${tags.join(", ")}]` : "";
-  return `${name} (${shortSessionId(session.id)})${suffix}`;
+  return `${name} (${session.id})${suffix}`;
 }
 
 export class SessionListOverlay implements Component {

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Unnamed subagent sessions now expose runtime-only `subagent-chat-<full-id>` Intercom aliases so supervisor targeting uses the full session ID.
+
 ### Fixed
 
 - Fixed a fork-context subagent ignoring its agent's configured model. The selected model candidate was only ever a `provider/model[:thinking]` string, so nothing was handed to the child session's `model` argument and the session fell back to the model persisted in the session file — which, for a fork, is the parent's. A child declaring `openai-codex/gpt-5.6-luna:max` therefore ran every turn on the parent's model, and an explicit `model:` override lost its first attempt the same way. The selected candidate is now resolved against the model registry and applied to the child session, together with the thinking level carried in the candidate's suffix, for both fresh and fork contexts and across single, parallel, and resume paths. A candidate that names no usable model still starts the run instead of failing it.

--- a/packages/subagents/src/intercom/intercom-bridge.ts
+++ b/packages/subagents/src/intercom/intercom-bridge.ts
@@ -83,7 +83,7 @@ export function resolveIntercomSessionTarget(sessionName: string | undefined, se
 	const trimmedName = sessionName?.trim();
 	if (trimmedName) return trimmedName;
 	const normalizedSessionId = sessionId.startsWith("session-") ? sessionId.slice("session-".length) : sessionId;
-	return `${DEFAULT_INTERCOM_TARGET_PREFIX}-${normalizedSessionId.slice(0, 8)}`;
+	return `${DEFAULT_INTERCOM_TARGET_PREFIX}-${normalizedSessionId}`;
 }
 
 function sanitizeIntercomTargetPart(value: string): string {

--- a/test/evidence/intercom-full-ids/README.md
+++ b/test/evidence/intercom-full-ids/README.md
@@ -1,0 +1,63 @@
+# Intercom full-ID live evidence
+
+This evidence was captured on 2026-08-13 from the clean checkout at commit
+`ddab8bf05541044e3dc3b0659e6cff3a2115f1bd` after building the local package.
+The captures are from a throwaway broker, not the developer's live broker.
+
+## Isolation and startup
+
+The throwaway agent directory was `/tmp/atomic-intercom-full-ids-e2e.TDaYLw/agent`.
+Both Atomic panes used the same `ATOMIC_CODING_AGENT_DIR` value; the probe pane did
+as well. The exact startup command was:
+
+```sh
+npm run build --workspace=@bastani/atomic
+tmux new-session -d -s atomic-intercom-full-id-e2e -n planner \
+  -c /Users/tonystark/Documents/projects/atomic-intercom-full-ids \
+  "ATOMIC_CODING_AGENT_DIR='/tmp/atomic-intercom-full-ids-e2e.TDaYLw/agent' ATOMIC_OFFLINE=1 node packages/coding-agent/dist/cli.js --no-context-files --no-themes --name planner"
+tmux split-window -h -t atomic-intercom-full-id-e2e:0 \
+  -c /Users/tonystark/Documents/projects/atomic-intercom-full-ids \
+  "ATOMIC_CODING_AGENT_DIR='/tmp/atomic-intercom-full-ids-e2e.TDaYLw/agent' ATOMIC_OFFLINE=1 node packages/coding-agent/dist/cli.js --no-context-files --no-themes --name worker"
+```
+
+Each pane was trusted for this session and renamed with `/name planner` and
+`/name worker`. The worker pane ran `/intercom`; its real session-picker overlay
+is in `tmux-list-overlay.txt`. It prints complete UUIDs:
+
+- worker: `737986a2-62da-4c43-92d3-8f343da5fddf`
+- planner: `f996d39d-5efd-41f7-8b01-22769b77873f`
+
+The worker selected planner in that overlay, entered `Full ID tmux delivery`,
+and pressed Enter. `tmux-worker-send.txt` records `Message sent to planner`; the
+recipient's `tmux-planner-receive.txt` records the inbound `From: worker` header
+and message.
+
+## Real intercom-tool list/send/rejection
+
+Because this isolated run had no configured model, a deterministic probe was run
+in a third tmux window against the same live broker. It imported the built
+`broker/client.ts` and `intercom-tool.ts`, registered the real `intercom` tool,
+and executed its real `list` and `send` actions:
+
+```sh
+ATOMIC_CODING_AGENT_DIR='/tmp/atomic-intercom-full-ids-e2e.TDaYLw/agent' \
+  ATOMIC_OFFLINE=1 bun /tmp/atomic-intercom-full-id-tool-probe.mjs
+```
+
+`tmux-tool-list-send-prefix.txt` contains the captured pane output. The key lines
+are:
+
+```text
+TOOL_FULL_ID=f996d39d-5efd-41f7-8b01-22769b77873f
+TOOL_FULL_SEND=Message sent to f996d39d-5efd-41f7-8b01-22769b77873f
+TOOL_PREFIX=f996d39d
+TOOL_PREFIX_SEND=Message to "f996d39d" was not delivered: Session not found
+```
+
+The same capture's `TOOL_LIST_START`/`TOOL_LIST_END` block shows full UUIDs in
+both current and other-session rows. The probe's full-ID send produced another
+`From: tool-probe` message in the planner pane, demonstrating real delivery; the
+prefix send produced no inbound message and returned `Session not found`.
+
+Cleanup completed with `tmux kill-session -t atomic-intercom-full-id-e2e` and
+`rm -rf /tmp/atomic-intercom-full-ids-e2e.TDaYLw` after all captures were written.

--- a/test/evidence/intercom-full-ids/tmux-list-overlay.txt
+++ b/test/evidence/intercom-full-ids/tmux-list-overlay.txt
@@ -1,0 +1,60 @@
+
+   ██████▙                  ▟██████    Atomic v0.0.0
+    ██████▙                ▟██████░░   (unknown) unknown
+     ██████▙              ▟██████░░    ~/Documents/projects/atomic-intercom-full-ids
+      ██████▙            ▟██████░░
+       ████████████████████████░░      We question,
+        ██████▛░░░░░░░░▜██████░░       we break away from what is accepted.
+         ██████▛      ▜██████░░        Engineering matters.
+          ██████▛    ▜██████░░
+           ██████▛  ▜██████░░
+            ░████████████░░░
+              ░░░░░░░░░░░░
+
+RESOURCES context ready · 19 skills · 14 prompts
+
+
+ Warning: No models available. Use /login to log into a provider via OAuth or API key. See:
+   /Users/tonystark/Documents/projects/atomic-intercom-full-ids/packages/coding-agent/docs/providers.md
+   /Users/tonystark/Documents/projects/atomic-intercom-full-ids/packages/coding-agent/docs/models.md
+
+ Session name set: worker
+
+ Message sent to pl╭────────────────────────────────────────────────────────────────────────────╮
+                   │ Current Session                                                            │
+                   ├────────────────────────────────────────────────────────────────────────────┤
+                   │                                                                            │
+                   │  worker (737986a2-62da-4c43-92d3-8f343da5fddf) [self]                      │
+                   │  /Users/tonystark/Documents/projects/atomic-intercom-full-ids • unknown    │
+                   │                                                                            │
+                   ├────────────────────────────────────────────────────────────────────────────┤
+                   │ Other Sessions                                                             │
+                   │                                                                            │
+                   │→ planner (f996d39d-5efd-41f7-8b01-22769b77873f) [same cwd]                 │
+                   │  /Users/tonystark/Documents/projects/atomic-intercom-full-ids • unknown    │
+                   │                                                                            │
+                   ├────────────────────────────────────────────────────────────────────────────┤
+                   │ Enter: Message • Escape/CTRL+C: Close                                      │
+                   ╰────────────────────────────────────────────────────────────────────────────╯
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ ∀ Working...
+
+                                                                                                          0.0%/0 (auto)
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+❯
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+unknown • ~/Documents/projects/atomic-intercom-full-ids (detached)
+● ADHD Mode • MCP: 0/1 servers

--- a/test/evidence/intercom-full-ids/tmux-planner-receive.txt
+++ b/test/evidence/intercom-full-ids/tmux-planner-receive.txt
@@ -1,0 +1,60 @@
+╭ 📨 From: probe (/Users/tonystark/Documents/projects/atomic-intercom-full-ids) ───────────────────────────────────────╮
+│Full ID probe delivery                                                                                                │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+ Error: Unknown provider: unknown
+
+╭ 📨 From: probe (/Users/tonystark/Documents/projects/atomic-intercom-full-ids) ───────────────────────────────────────╮
+│Full ID probe delivery                                                                                                │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+ Error: Unknown provider: unknown
+
+╭ 📨 From: probe (/Users/tonystark/Documents/projects/atomic-intercom-full-ids) ───────────────────────────────────────╮
+│Full ID probe delivery                                                                                                │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+ Error: Unknown provider: unknown
+
+╭ 📨 From: probe (/Users/tonystark/Documents/projects/atomic-intercom-full-ids) ───────────────────────────────────────╮
+│Full ID probe delivery                                                                                                │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+ Error: Unknown provider: unknown
+
+╭ 📨 From: tool-probe (/Users/tonystark/Documents/projects/atomic-intercom-full-ids) ──────────────────────────────────╮
+│Full ID tool delivery                                                                                                 │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+ Error: Unknown provider: unknown
+
+╭ 📨 From: tool-probe (/Users/tonystark/Documents/projects/atomic-intercom-full-ids) ──────────────────────────────────╮
+│Full ID tool delivery                                                                                                 │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+ Error: Unknown provider: unknown
+
+╭ 📨 From: tool-probe (/Users/tonystark/Documents/projects/atomic-intercom-full-ids) ──────────────────────────────────╮
+│Full ID tool delivery                                                                                                 │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+ Error: Unknown provider: unknown
+
+╭ 📨 From: tool-probe (/Users/tonystark/Documents/projects/atomic-intercom-full-ids) ──────────────────────────────────╮
+│Full ID tool delivery                                                                                                 │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+ Error: Unknown provider: unknown
+
+╭ 📨 From: worker (/Users/tonystark/Documents/projects/atomic-intercom-full-ids) ──────────────────────────────────────╮
+│Full ID tmux delivery                                                                                                 │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+ Error: Unknown provider: unknown
+
+                                                                                                           0.0%/0 (auto)
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+unknown • ~/Documents/projects/atomic-intercom-full-ids (detached) • planner
+● ADHD Mode • MCP: 0/1 servers

--- a/test/evidence/intercom-full-ids/tmux-tool-list-send-prefix.txt
+++ b/test/evidence/intercom-full-ids/tmux-tool-list-send-prefix.txt
@@ -1,0 +1,25 @@
+
+atomic-intercom-full-ids on  HEAD (ddab8bf) [?] is 📦 v0.0.0 via 🦀 v1.97.0
+❯ ATOMIC_CODING_AGENT_DIR='/tmp/atomic-intercom-full-ids-e2e.TDaYLw/agent' ATOMI
+C_OFFLINE=1 bun /tmp/atomic-intercom-full-id-tool-probe.mjs
+TOOL_LIST_START
+**Current session** (group: default):
+• tool-probe (8796ba81-f05e-4f9c-b70c-090b68771334) — /Users/tonystark/Documents
+/projects/atomic-intercom-full-ids (probe) [self, idle]
+
+**Other sessions** (group: default):
+• planner (f996d39d-5efd-41f7-8b01-22769b77873f) — /Users/tonystark/Documents/pr
+ojects/atomic-intercom-full-ids (unknown) [same cwd, idle]
+• worker (737986a2-62da-4c43-92d3-8f343da5fddf) — /Users/tonystark/Documents/pro
+jects/atomic-intercom-full-ids (unknown) [same cwd, idle]
+TOOL_LIST_END
+TOOL_FULL_ID=f996d39d-5efd-41f7-8b01-22769b77873f
+TOOL_FULL_SEND=Message sent to f996d39d-5efd-41f7-8b01-22769b77873f
+TOOL_PREFIX=f996d39d
+TOOL_PREFIX_SEND=Message to "f996d39d" was not delivered: Session not found
+atomic-intercom-full-ids on  HEAD (ddab8bf) [?] is 📦 v0.0.0 via 🦀 v1.97.0
+❯
+
+
+
+

--- a/test/evidence/intercom-full-ids/tmux-worker-send.txt
+++ b/test/evidence/intercom-full-ids/tmux-worker-send.txt
@@ -1,0 +1,60 @@
+
+   ██████▙                  ▟██████    Atomic v0.0.0
+    ██████▙                ▟██████░░   (unknown) unknown
+     ██████▙              ▟██████░░    ~/Documents/projects/atomic-intercom-full-ids
+      ██████▙            ▟██████░░
+       ████████████████████████░░      We question,
+        ██████▛░░░░░░░░▜██████░░       we break away from what is accepted.
+         ██████▛      ▜██████░░        Engineering matters.
+          ██████▛    ▜██████░░
+           ██████▛  ▜██████░░
+            ░████████████░░░
+              ░░░░░░░░░░░░
+
+RESOURCES context ready · 19 skills · 14 prompts
+
+
+ Warning: No models available. Use /login to log into a provider via OAuth or API key. See:
+   /Users/tonystark/Documents/projects/atomic-intercom-full-ids/packages/coding-agent/docs/providers.md
+   /Users/tonystark/Documents/projects/atomic-intercom-full-ids/packages/coding-agent/docs/models.md
+
+ Session name set: worker
+
+ Message sent to planner
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                                                          0.0%/0 (auto)
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+❯
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+unknown • ~/Documents/projects/atomic-intercom-full-ids (detached)
+● ADHD Mode • MCP: 0/1 servers

--- a/test/unit/intercom-broker-send-handler.test.ts
+++ b/test/unit/intercom-broker-send-handler.test.ts
@@ -166,8 +166,7 @@ test("broker wire send keeps absent attemptId compatibility but rejects malforme
 		"malformed attemptId must not downgrade and forward",
 	);
 });
-
-test("broker routes the session ID exactly as displayed by intercom list", () => {
+test("broker routes the exact full session ID", () => {
 	const sender = {} as net.Socket;
 	const recipient = {} as net.Socket;
 	const recipientId = "aa56071e-1111-4222-8333-123456789abc";
@@ -179,7 +178,7 @@ test("broker routes the session ID exactly as displayed by intercom list", () =>
 
 	handleBrokerSend(
 		sender,
-		{ type: "send", to: recipientId.slice(0, 8), message: message("displayed-id") },
+		{ type: "send", to: recipientId, message: message("full-id") },
 		"sender",
 		sessions,
 		new DeliveredMessageCache(),
@@ -196,7 +195,35 @@ test("broker routes the session ID exactly as displayed by intercom list", () =>
 	);
 });
 
-test("broker never routes a short session ID back to its sender", () => {
+test("broker rejects an 8-character session ID prefix", () => {
+	const sender = {} as net.Socket;
+	const recipient = {} as net.Socket;
+	const recipientId = "aa56071e-1111-4222-8333-123456789abc";
+	const sessions = new Map<string, BrokerConnectedSession>([
+		["sender", session("sender", "sender", sender)],
+		[recipientId, session(recipientId, "recipient", recipient)],
+	]);
+	const writes: Array<{ socket: net.Socket; message: BrokerMessage }> = [];
+
+	handleBrokerSend(
+		sender,
+		{ type: "send", to: recipientId.slice(0, 8), message: message("prefix") },
+		"sender",
+		sessions,
+		new DeliveredMessageCache(),
+		(socket, value) => writes.push({ socket, message: value }),
+	);
+
+	assert.equal(
+		writes.some((entry) => entry.message.type === "message"),
+		false,
+	);
+	const failure = writes.find((entry) => entry.message.type === "delivery_failed")?.message;
+	assert.equal(failure?.type, "delivery_failed");
+	assert.match(failure?.reason ?? "", /Session not found/);
+});
+
+test("broker rejects an exact self session ID", () => {
 	const sender = {} as net.Socket;
 	const senderId = "aa56071e-1111-4222-8333-123456789abc";
 	const sessions = new Map<string, BrokerConnectedSession>([[senderId, session(senderId, "sender", sender)]]);
@@ -204,7 +231,7 @@ test("broker never routes a short session ID back to its sender", () => {
 
 	handleBrokerSend(
 		sender,
-		{ type: "send", to: senderId.slice(0, 8), message: message("self-target") },
+		{ type: "send", to: senderId, message: message("self-target") },
 		senderId,
 		sessions,
 		new DeliveredMessageCache(),
@@ -218,4 +245,28 @@ test("broker never routes a short session ID back to its sender", () => {
 	const failure = writes.find((entry) => entry.message.type === "delivery_failed")?.message;
 	assert.equal(failure?.type, "delivery_failed");
 	assert.match(failure?.reason ?? "", /current session/i);
+});
+
+test("broker rejects an 8-character self ID prefix as not found", () => {
+	const sender = {} as net.Socket;
+	const senderId = "aa56071e-1111-4222-8333-123456789abc";
+	const sessions = new Map<string, BrokerConnectedSession>([[senderId, session(senderId, "sender", sender)]]);
+	const writes: Array<{ socket: net.Socket; message: BrokerMessage }> = [];
+
+	handleBrokerSend(
+		sender,
+		{ type: "send", to: senderId.slice(0, 8), message: message("self-prefix") },
+		senderId,
+		sessions,
+		new DeliveredMessageCache(),
+		(socket, value) => writes.push({ socket, message: value }),
+	);
+
+	assert.equal(
+		writes.some((entry) => entry.message.type === "message"),
+		false,
+	);
+	const failure = writes.find((entry) => entry.message.type === "delivery_failed")?.message;
+	assert.equal(failure?.type, "delivery_failed");
+	assert.match(failure?.reason ?? "", /Session not found/);
 });

--- a/test/unit/intercom-id-targeting.test.ts
+++ b/test/unit/intercom-id-targeting.test.ts
@@ -65,6 +65,9 @@ function toolFixture(replyTracker: ReplyTracker, sessions: SessionInfo[] = []) {
 				expectsReply?: boolean;
 			},
 		) {
+			if (sessions.length > 0 && !sessions.some((entry) => entry.id === to)) {
+				return { id: message.messageId ?? "failed-message", delivered: false, reason: "Session not found" };
+			}
 			sent.push({
 				to,
 				...(message.messageId !== undefined ? { messageId: message.messageId } : {}),
@@ -101,38 +104,42 @@ const context = {
 	hasUI: false,
 };
 
-describe("Intercom displayed session ID targeting", () => {
-	test("targeted reply accepts the unique short session ID shown by list", async () => {
-		const first = session("aa56071e-1111-4222-8333-123456789abc", "first");
-		const second = session("bb67082f-1111-4222-8333-123456789abc", "second");
-		const replies = new ReplyTracker();
-		replies.recordIncomingMessage(first, ask("question-first"));
-		replies.recordIncomingMessage(second, ask("question-second"));
-		const current = toolFixture(replies);
+describe("Intercom full session ID targeting", () => {
+	test("list displays the full session ID", async () => {
+		const self = session("self-session-id", "self");
+		const recipient = session("aa56071e-1111-4222-8333-123456789abc", "recipient");
+		const current = toolFixture(new ReplyTracker(), [self, recipient]);
+
+		const listed = await current.tool.execute("list-call", { action: "list" }, undefined, undefined, context);
+		const text = listed.content[0]?.text ?? "";
+		assert.match(text, new RegExp(`recipient \\(${recipient.id}\\)`));
+	});
+
+	test("send accepts an exact full session ID", async () => {
+		const self = session("self-session-id", "self");
+		const recipient = session("cc78193a-1111-4222-8333-123456789abc", "recipient");
+		const current = toolFixture(new ReplyTracker(), [self, recipient]);
 
 		const result = await current.tool.execute(
-			"reply-call",
-			{ action: "reply", to: first.id.slice(0, 8), message: "answer" },
+			"send",
+			{ action: "send", to: recipient.id, message: "hello" },
 			undefined,
 			undefined,
 			context,
 		);
 
 		assert.equal(result.isError, false, result.content[0]?.text);
-		assert.deepEqual(current.sent, [{ to: first.id, replyTo: "question-first" }]);
+		assert.deepEqual(current.sent, [{ to: recipient.id }]);
 	});
 
-	test("blocking ask accepts the ID exactly as displayed by list and correlates the reply", async () => {
+	test("blocking ask accepts an exact full session ID and correlates the reply", async () => {
 		const self = session("self-session-id", "self");
 		const recipient = session("aa56071e-1111-4222-8333-123456789abc", "recipient");
 		const current = toolFixture(new ReplyTracker(), [self, recipient]);
-		const listed = await current.tool.execute("list-call", { action: "list" }, undefined, undefined, context);
-		const displayedId = recipient.id.slice(0, 8);
-		assert.match(listed.content[0]?.text ?? "", new RegExp(`recipient \\(${displayedId}\\)`));
 
 		const execution = current.tool.execute(
 			"ask-call",
-			{ action: "ask", to: displayedId, message: "question" },
+			{ action: "ask", to: recipient.id, message: "question" },
 			undefined,
 			undefined,
 			context,
@@ -156,123 +163,121 @@ describe("Intercom displayed session ID targeting", () => {
 		assert.match(result.content[0]?.text ?? "", /answer/);
 	});
 
-	test("send accepts the unique short session ID shown by list", async () => {
-		const self = session("self-session-id", "self");
-		const recipient = session("cc78193a-1111-4222-8333-123456789abc", "recipient");
-		const current = toolFixture(new ReplyTracker(), [self, recipient]);
-		const listed = await current.tool.execute("list", { action: "list" }, undefined, undefined, context);
-		const displayedId = recipient.id.slice(0, 8);
-		assert.match(listed.content[0]?.text ?? "", new RegExp(`recipient \\(${displayedId}\\)`));
+	test("targeted reply accepts an exact full session ID", async () => {
+		const sender = session("bb67082f-1111-4222-8333-123456789abc", "sender");
+		const replies = new ReplyTracker();
+		replies.recordIncomingMessage(sender, ask("question-sender"));
+		const current = toolFixture(replies);
 
 		const result = await current.tool.execute(
-			"send",
-			{ action: "send", to: displayedId, message: "hello" },
+			"reply-call",
+			{ action: "reply", to: sender.id, message: "answer" },
 			undefined,
 			undefined,
 			context,
 		);
 
 		assert.equal(result.isError, false, result.content[0]?.text);
-		assert.equal(current.sent[0]?.to, recipient.id);
+		assert.deepEqual(current.sent, [{ to: sender.id, replyTo: "question-sender" }]);
 	});
 
-	test("colliding displayed prefixes fail clearly instead of selecting a session", async () => {
+	test("exact case-insensitive session names resolve to the full ID", async () => {
 		const self = session("self-session-id", "self");
-		const first = session("dd892a4b-1111-4222-8333-123456789abc", "first");
-		const second = session("dd892a4b-9999-4222-8333-123456789abc", "second");
-		const current = toolFixture(new ReplyTracker(), [self, first, second]);
+		const recipient = session("dd892a4b-1111-4222-8333-123456789abc", "Recipient");
+		const current = toolFixture(new ReplyTracker(), [self, recipient]);
 
 		const result = await current.tool.execute(
-			"send",
-			{ action: "send", to: "dd892a4b", message: "hello" },
+			"send-name",
+			{ action: "send", to: "recipient", message: "by name" },
+			undefined,
+			undefined,
+			context,
+		);
+
+		assert.equal(result.isError, false, result.content[0]?.text);
+		assert.deepEqual(current.sent, [{ to: recipient.id }]);
+	});
+
+	test("an 8-character ID prefix is rejected for send", async () => {
+		const self = session("self-session-id", "self");
+		const recipient = session("de903b5c-1111-4222-8333-123456789abc", "recipient");
+		const current = toolFixture(new ReplyTracker(), [self, recipient]);
+
+		const result = await current.tool.execute(
+			"send-prefix",
+			{ action: "send", to: recipient.id.slice(0, 8), message: "hello" },
 			undefined,
 			undefined,
 			context,
 		);
 
 		assert.equal(result.isError, true);
-		assert.match(result.content[0]?.text ?? "", /Ambiguous session ID prefix "dd892a4b"/);
-		assert.match(result.content[0]?.text ?? "", new RegExp(first.id));
-		assert.match(result.content[0]?.text ?? "", new RegExp(second.id));
+		assert.match(result.content[0]?.text ?? "", /Session not found/);
 		assert.deepEqual(current.sent, []);
 	});
 
-	test("blocking ask rejects a colliding displayed prefix before sending", async () => {
+	test("an 8-character ID prefix is rejected for blocking ask", async () => {
 		const self = session("self-session-id", "self");
-		const first = session("de903b5c-1111-4222-8333-123456789abc", "first");
-		const second = session("de903b5c-9999-4222-8333-123456789abc", "second");
-		const current = toolFixture(new ReplyTracker(), [self, first, second]);
+		const recipient = session("df014c6d-1111-4222-8333-123456789abc", "recipient");
+		const current = toolFixture(new ReplyTracker(), [self, recipient]);
 
 		const result = await current.tool.execute(
-			"ask",
-			{ action: "ask", to: "de903b5c", message: "question" },
+			"ask-prefix",
+			{ action: "ask", to: recipient.id.slice(0, 8), message: "question" },
 			undefined,
 			undefined,
 			context,
 		);
 
 		assert.equal(result.isError, true);
-		assert.match(result.content[0]?.text ?? "", /Ambiguous session ID prefix "de903b5c"/);
+		assert.match(result.content[0]?.text ?? "", /Session not found/);
 		assert.deepEqual(current.sent, []);
 	});
 
-	test("targeted reply rejects a colliding displayed prefix before sending", async () => {
-		const first = session("df014c6d-1111-4222-8333-123456789abc", "first");
-		const second = session("df014c6d-9999-4222-8333-123456789abc", "second");
+	test("an 8-character ID prefix is rejected for targeted reply", async () => {
+		const sender = session("ee903b5c-1111-4222-8333-123456789abc", "sender");
 		const replies = new ReplyTracker();
-		replies.recordIncomingMessage(first, ask("question-first"));
-		replies.recordIncomingMessage(second, ask("question-second"));
+		replies.recordIncomingMessage(sender, ask("question-sender"));
 		const current = toolFixture(replies);
 
 		const result = await current.tool.execute(
-			"reply",
-			{ action: "reply", to: "df014c6d", message: "answer" },
+			"reply-prefix",
+			{ action: "reply", to: sender.id.slice(0, 8), message: "answer" },
 			undefined,
 			undefined,
 			context,
 		);
 
 		assert.equal(result.isError, true);
-		assert.match(result.content[0]?.text ?? "", /Ambiguous session ID prefix "df014c6d"/);
+		assert.match(result.content[0]?.text ?? "", /No pending ask/);
 		assert.deepEqual(current.sent, []);
 	});
 
-	test("exact names and exact full IDs take precedence over prefix matching", async () => {
+	test("an unknown target is not found", async () => {
 		const self = session("self-session-id", "self");
-		const byName = session("ee903b5c-1111-4222-8333-123456789abc", "target-alias");
-		const byId = session("target-alias-full-id", "other");
-		const current = toolFixture(new ReplyTracker(), [self, byName, byId]);
+		const recipient = session("ff014c6d-1111-4222-8333-123456789abc", "recipient");
+		const current = toolFixture(new ReplyTracker(), [self, recipient]);
 
-		const nameResult = await current.tool.execute(
-			"send-name",
-			{ action: "send", to: "target-alias", message: "by name" },
-			undefined,
-			undefined,
-			context,
-		);
-		const idResult = await current.tool.execute(
-			"send-id",
-			{ action: "send", to: byId.id, message: "by id" },
+		const result = await current.tool.execute(
+			"send-missing",
+			{ action: "send", to: "missing-session-id", message: "hello" },
 			undefined,
 			undefined,
 			context,
 		);
 
-		assert.equal(nameResult.isError, false, nameResult.content[0]?.text);
-		assert.equal(idResult.isError, false, idResult.content[0]?.text);
-		assert.deepEqual(
-			current.sent.map((entry) => entry.to),
-			[byName.id, byId.id],
-		);
+		assert.equal(result.isError, true);
+		assert.match(result.content[0]?.text ?? "", /Session not found/);
+		assert.deepEqual(current.sent, []);
 	});
 
-	test("a short self ID is rejected before delivery", async () => {
+	test("an exact full self ID is rejected before delivery", async () => {
 		const self = session("self-session-id", "self");
-		const selfClient = toolFixture(new ReplyTracker(), [self]);
+		const current = toolFixture(new ReplyTracker(), [self]);
 
-		const result = await selfClient.tool.execute(
+		const result = await current.tool.execute(
 			"send-self",
-			{ action: "send", to: "self-ses", message: "loop" },
+			{ action: "send", to: self.id, message: "loop" },
 			undefined,
 			undefined,
 			context,
@@ -280,6 +285,24 @@ describe("Intercom displayed session ID targeting", () => {
 
 		assert.equal(result.isError, true);
 		assert.match(result.content[0]?.text ?? "", /Cannot message the current session/);
-		assert.deepEqual(selfClient.sent, []);
+		assert.deepEqual(current.sent, []);
+	});
+
+	test("an 8-character self ID prefix is not resolvable", async () => {
+		const self = session("self-session-id", "self");
+		const current = toolFixture(new ReplyTracker(), [self]);
+
+		const result = await current.tool.execute(
+			"send-self-prefix",
+			{ action: "send", to: self.id.slice(0, 8), message: "loop" },
+			undefined,
+			undefined,
+			context,
+		);
+
+		assert.equal(result.isError, true);
+		assert.match(result.content[0]?.text ?? "", /Session not found/);
+		assert.doesNotMatch(result.content[0]?.text ?? "", /Cannot message the current session/);
+		assert.deepEqual(current.sent, []);
 	});
 });

--- a/test/unit/intercom-lazy-relay-context.test.ts
+++ b/test/unit/intercom-lazy-relay-context.test.ts
@@ -31,7 +31,7 @@ import { sleep } from "../helpers/runtime.js";
 type Handler = (event: Record<string, unknown>, ctx: Record<string, unknown>) => void | Promise<void>;
 
 const SESSION_ID = "019f0000-aaaa-7bbb-8ccc-dddddddddddd";
-const SELF_ALIAS = "subagent-chat-019f0000";
+const SELF_ALIAS = "subagent-chat-019f0000-aaaa-7bbb-8ccc-dddddddddddd";
 
 function fixture(options: { rejectLateRoutes?: number } = {}) {
 	const handlers = new Map<string, Handler[]>();

--- a/test/unit/intercom-presence-alias.test.ts
+++ b/test/unit/intercom-presence-alias.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { resolveIntercomPresenceName } from "../../packages/intercom/intercom-utils.js";
+import { resolveIntercomSessionTarget } from "../../packages/subagents/src/intercom/intercom-bridge.js";
+
+const SESSION_ID_ENV = "ATOMIC_INTERCOM_SESSION_ID";
+
+test("uses the full session ID for an unnamed presence alias", () => {
+	assert.equal(
+		resolveIntercomPresenceName(undefined, "session-019f0000-aaaa-7bbb-8ccc-dddddddddddd"),
+		"subagent-chat-019f0000-aaaa-7bbb-8ccc-dddddddddddd",
+	);
+});
+
+test("prefers a trimmed explicit session name for the presence alias", () => {
+	assert.equal(resolveIntercomPresenceName("  planner  ", "session-019f0000-aaaa-7bbb-8ccc-dddddddddddd"), "planner");
+});
+
+test("keeps unnamed presence and subagent target aliases identical", () => {
+	const previous = process.env[SESSION_ID_ENV];
+	delete process.env[SESSION_ID_ENV];
+	try {
+		const sessionId = "session-019f0000-aaaa-7bbb-8ccc-dddddddddddd";
+		assert.equal(
+			resolveIntercomPresenceName(undefined, sessionId),
+			resolveIntercomSessionTarget(undefined, sessionId),
+		);
+	} finally {
+		if (previous === undefined) delete process.env[SESSION_ID_ENV];
+		else process.env[SESSION_ID_ENV] = previous;
+	}
+});

--- a/test/unit/subagents-intercom-session-target.test.ts
+++ b/test/unit/subagents-intercom-session-target.test.ts
@@ -17,6 +17,20 @@ test("prefers the connected Intercom session id over a duplicate-prone display n
 		else process.env[SESSION_ID_ENV] = previous;
 	}
 });
+test("uses the full session ID for an unnamed Intercom alias", () => {
+	const previous = process.env[SESSION_ID_ENV];
+	delete process.env[SESSION_ID_ENV];
+	try {
+		const sessionId = "session-019f0000-aaaa-7bbb-8ccc-dddddddddddd";
+		assert.equal(
+			resolveIntercomSessionTarget(undefined, sessionId),
+			"subagent-chat-019f0000-aaaa-7bbb-8ccc-dddddddddddd",
+		);
+	} finally {
+		if (previous === undefined) delete process.env[SESSION_ID_ENV];
+		else process.env[SESSION_ID_ENV] = previous;
+	}
+});
 
 test("detects Atomic's bundled Intercom extension in a source checkout", () => {
 	const diagnostic = diagnoseIntercomBridge({


### PR DESCRIPTION
## Summary

Intercom printed and accepted 8-character short-form session/message IDs, while workflows print full run IDs. This removes the short form entirely: Intercom now shows full IDs everywhere and resolves targets only by an exact full session ID or an exact case-insensitive session name.

## Breaking change

`send`, `ask`, and `reply` no longer resolve a unique ID prefix. An 8-character prefix that used to work now returns `Session not found`. Use the full ID that `intercom list` prints, or the exact session name.

The `ambiguous_prefix` resolution kind, its resolution branch, and its error message are deleted from `packages/intercom/session-target.ts`. The union is now `resolved | ambiguous_name | not_found`.

## Display changes

All seven truncation sites print the full ID:

| Site | File |
| --- | --- |
| `list` rows and duplicate-name labels | `packages/intercom/intercom-utils.ts` |
| Session-list overlay titles | `packages/intercom/ui/session-list.ts` |
| Inbound sender line and `↳ Reply to` | `packages/intercom/ui/inline-message.ts` |
| Inbound message header | `packages/intercom/incoming-message-delivery.ts` |
| Message-id result badge | `packages/intercom/result-renderers.ts` |

`grep -rn "slice(0, *8)" packages/intercom/` returns nothing.

## Cross-package alias

`packages/subagents/src/intercom/intercom-bridge.ts` and `packages/intercom/intercom-utils.ts` independently build the `subagent-chat-<id>` presence alias for unnamed sessions. Subagents computes the target name that Intercom registers as presence identity, and `contact_supervisor` resolves that target by exact name — with prefix fallback gone, any drift between the two builders would break supervisor targeting silently. Both builders move to the full ID in the same commit, and `test/unit/intercom-presence-alias.test.ts` fails if either side drifts.

## Docs

`packages/intercom/README.md`, `packages/intercom/skills/intercom/SKILL.md`, `packages/coding-agent/docs/intercom.md`, and both `to` parameter descriptions (`index.ts`, `intercom-tool.ts`) no longer mention prefix resolution or short IDs.

## Changelog

Entries added under the existing `## [Unreleased]` heading in `packages/intercom/CHANGELOG.md` (Breaking Changes + Changed) and `packages/subagents/CHANGELOG.md` (Changed). No released section is touched.

## Tests

- `test/unit/intercom-id-targeting.test.ts` rewritten: full ID and exact name resolve on `send`/`ask`/`reply`; an 8-character prefix is rejected on all three paths; exact self-ID is still rejected.
- New `test/unit/intercom-presence-alias.test.ts` pins alias parity across the two packages.
- Updated: `intercom-broker-send-handler`, `intercom-lazy-relay-context`, `subagents-intercom-session-target`.

## Validation

| Command | Result |
| --- | --- |
| `npm run check` | Passed (biome, `tsc --noEmit`, tsgo build typecheck, shrinkwrap) |
| `vitest --run --project unit` over intercom/subagents-intercom suites | 44 files, 338 tests passed |
| Full `vitest --run --project unit` (reviewer re-run) | 637 files, 6140 tests passed |

A live two-session tmux run against the real broker with an isolated `ATOMIC_CODING_AGENT_DIR` is captured under `test/evidence/intercom-full-ids/`:

```
• planner (f996d39d-5efd-41f7-8b01-22769b77873f) — … [same cwd, idle]
TOOL_FULL_SEND=Message sent to f996d39d-5efd-41f7-8b01-22769b77873f
TOOL_PREFIX_SEND=Message to "f996d39d" was not delivered: Session not found
```

## Known non-blocking issue

Two reviewers independently flagged the same P3: `sessionTitle` in `packages/intercom/ui/session-list.ts:54` is not width-aware, and `render` hard-clips each row at `contentWidth`. A 36-character UUID lengthens every title by ~28 columns, so below roughly 62 columns the overlay cuts the ID mid-UUID. A runtime probe showed width 40 rendering `→ peer (cc78193a-1111-4222-8333-1234` while widths 62 and 80 render the full UUID; borders stay intact at every width tested, so this is legibility only. Both reviewers classified it as consistent with the objective and non-blocking. The repository precedent for workflow run IDs was to wrap rather than cut, which is the natural follow-up.

## Review status

Three reviewers (completion, evidence, risk) each returned `patch is correct` with `stop_review_loop=true`; confidence 0.93 / 0.90 / 0.93. No blocking findings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789201146&installation_model_id=10562&pr_number=2360&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2360&signature=5689f31088917a52b0052ca18678f3e088b3f9e48899527ae82916574daf3f7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Intercom now uses complete session IDs in session displays, targeting, incoming-message presentation, and unnamed-session aliases, while exact case-insensitive names remain supported. An isolated broker/client check confirmed that complete IDs deliver, exact names resolve to the intended session, and eight-character prefixes are rejected. Focused Intercom and subagent tests passed 23 checks across four files. No defects were found.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the new complete-ID contract worked through a live broker/client interaction and the targeted automated coverage passed.

The changed delivery and resolution paths were exercised with complete IDs, exact names, rejected prefixes, and unnamed alias parity. The observed behavior matched the intended contract, with no actionable defects found.

**Files Needing Attention:** No files need follow-up. The most behavior-sensitive files checked were packages/intercom/session-target.ts, packages/intercom/intercom-tool.ts, packages/intercom/intercom-utils.ts, and packages/subagents/src/intercom/intercom-bridge.ts.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran an isolated live broker/client probe against the merge-base to exercise the new full-session-ID behavior.
- Compared the baseline behavior with the post-change behavior: the baseline accepted a shortened ID prefix and produced short unnamed aliases, while the change uses a complete ID, resolves exact names, rejects shortened prefixes, and yields matching complete unnamed aliases.
- Ran the focused Vitest coverage for ID targeting, broker routing, presence aliases, and subagent target behavior; all 23 tests in four files passed.
- Reviewed before/after logs and focused test results to verify the migration outcomes, confirming the after state delivers full IDs and parity in aliases.

<a href="https://app.greptile.com/trex/runs/18662953/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["test(intercom): cover full-ID presence a..."](https://github.com/bastani-inc/atomic/commit/7a5983df9c775e21366c5c5d96d71298edaf49df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52891776)</sub>

<!-- /greptile_comment -->