### PR TITLE
fix(intercom): make full session IDs width-aware in the session-list overlay

### DIFF
--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 - Intercom now displays full session and message IDs everywhere: list rows, the session-list overlay, inbound message headers, reply-to lines, message-id result badges, and unnamed-session `subagent-chat-<id>` aliases.
 
+### Fixed
+
+- Fixed the session-list overlay clipping full session IDs at narrow terminal widths by wrapping IDs onto dim rows and marking unavoidable truncation with a visible ellipsis; inline sender and reply-to IDs now also signal overflow.
+
 ## [0.9.13-alpha.2] - 2026-08-12
 
 ### Changed

--- a/packages/intercom/ui/inline-message.ts
+++ b/packages/intercom/ui/inline-message.ts
@@ -30,7 +30,8 @@ export class InlineMessageComponent implements Component {
 
     const senderName = this.from.name || this.from.id;
     const header = ` 📨 From: ${senderName} (${this.from.cwd}) `;
-    const headerText = truncateToWidth(header, bodyWidth, "");
+    // An empty ellipsis silently clips full sender IDs; keep header overflow visible.
+    const headerText = truncateToWidth(header, bodyWidth, "…");
     const headerPadding = Math.max(0, bodyWidth - visibleWidth(headerText));
     lines.push(this.theme.fg("accent", `╭${headerText}${borderChar.repeat(headerPadding)}╮`));
 
@@ -63,8 +64,9 @@ export class InlineMessageComponent implements Component {
 
     if (this.message.replyTo && !this.message.expectsReply) {
       lines.push(this.theme.fg("accent", `│${" ".repeat(bodyWidth)}│`));
+      // An empty ellipsis silently clips full reply-to IDs; keep overflow visible.
       const reply = this.theme.fg("dim", ` ↳ Reply to ${this.message.replyTo}`);
-      const text = truncateToWidth(reply, bodyWidth, "");
+      const text = truncateToWidth(reply, bodyWidth, "…");
       const padding = Math.max(0, bodyWidth - visibleWidth(text));
       lines.push(this.theme.fg("accent", `│${text}${" ".repeat(padding)}│`));
     }

--- a/packages/intercom/ui/session-list.ts
+++ b/packages/intercom/ui/session-list.ts
@@ -46,12 +46,23 @@ function middleTruncate(text: string, maxWidth: number): string {
 
   return truncateToWidth(`${left}…${right}`, maxWidth, "");
 }
-function sessionTitle(session: SessionInfo, options?: { self?: boolean; sameCwd?: boolean }): string {
+function sessionTitleLines(
+  session: SessionInfo,
+  availableWidth: number,
+  options?: { self?: boolean; sameCwd?: boolean },
+): string[] {
   const name = session.name || "Unnamed session";
   const tags = [options?.self ? "self" : undefined, options?.sameCwd ? "same cwd" : undefined]
     .filter((tag): tag is string => Boolean(tag));
   const suffix = tags.length ? ` [${tags.join(", ")}]` : "";
-  return `${name} (${session.id})${suffix}`;
+  const title = `${name} (${session.id})${suffix}`;
+  if (visibleWidth(title) <= availableWidth) {
+    return [title];
+  }
+
+  const label = middleTruncate(`${name}${suffix}`, availableWidth);
+  const id = truncateToWidth(session.id, availableWidth, "…");
+  return [label, id];
 }
 
 export class SessionListOverlay implements Component {
@@ -130,7 +141,11 @@ export class SessionListOverlay implements Component {
     lines.push(row(this.theme.bold(" Current Session")));
     lines.push(border(`├${"─".repeat(contentWidth)}┤`));
     lines.push(row());
-    lines.push(row(`  ${this.theme.fg("dim", sessionTitle(this.currentSession, { self: true }))}`));
+    const currentTitleLines = sessionTitleLines(this.currentSession, Math.max(1, contentWidth - 2), { self: true });
+    lines.push(row(`  ${this.theme.fg("dim", currentTitleLines[0])}`));
+    for (const idLine of currentTitleLines.slice(1)) {
+      lines.push(row(`  ${this.theme.fg("dim", idLine)}`));
+    }
     lines.push(row(`  ${this.theme.fg("dim", `${middleTruncate(this.currentSession.cwd, Math.max(8, contentWidth - 4))} • ${this.currentSession.model}`)}`));
     lines.push(row());
     lines.push(border(`├${"─".repeat(contentWidth)}┤`));
@@ -151,10 +166,13 @@ export class SessionListOverlay implements Component {
         const isSelected = index === this.selectedIndex;
         const sameCwd = session.cwd === this.currentSession.cwd;
         const prefix = isSelected ? this.theme.fg("accent", "→ ") : "  ";
-        const title = sessionTitle(session, { sameCwd });
+        const titleLines = sessionTitleLines(session, Math.max(1, contentWidth - 2), { sameCwd });
         const pathText = `${middleTruncate(session.cwd, Math.max(8, contentWidth - 4))} • ${session.model}`;
 
-        lines.push(row(`${prefix}${isSelected ? this.theme.fg("accent", title) : title}`));
+        lines.push(row(`${prefix}${isSelected ? this.theme.fg("accent", titleLines[0]) : titleLines[0]}`));
+        for (const idLine of titleLines.slice(1)) {
+          lines.push(row(`  ${this.theme.fg("dim", idLine)}`));
+        }
         lines.push(row(`  ${this.theme.fg("dim", pathText)}`));
         if (index < endIndex - 1) {
           lines.push(row());

--- a/test/evidence/intercom-session-list-width/README.md
+++ b/test/evidence/intercom-session-list-width/README.md
@@ -1,0 +1,138 @@
+# Intercom session-list width-aware live evidence
+
+This evidence was captured on 2026-08-13 from the clean checkout at commit
+`5f239dd5c8e67cf745659354d06b7b1b9e041c26` (`fix(intercom): make full session IDs width-aware`)
+after building the local package. The captures came from a throwaway broker and
+throwaway Atomic sessions, not the developer's live broker.
+
+## Isolation and startup
+
+The throwaway agent directory was
+`/tmp/atomic-intercom-width-e2e.wxQAZM/agent`. Both real Atomic sessions used the
+same `ATOMIC_CODING_AGENT_DIR`; the planner and worker ran in separate full-width
+windows of the same tmux session. The exact startup commands were:
+
+```sh
+npm run build --workspace=@bastani/atomic
+DIR=/tmp/atomic-intercom-width-e2e.wxQAZM
+SESSION=atomic-intercom-width-e2e
+
+tmux new-session -d -s "$SESSION" -n planner -x 80 -y 40 \
+  -c /Users/tonystark/Documents/projects/atomic-intercom-width-aware \
+  "ATOMIC_CODING_AGENT_DIR='$DIR/agent' ATOMIC_OFFLINE=1 node packages/coding-agent/dist/cli.js --no-context-files --no-themes --name planner"
+tmux new-window -d -t "$SESSION" -n worker \
+  -c /Users/tonystark/Documents/projects/atomic-intercom-width-aware \
+  "ATOMIC_CODING_AGENT_DIR='$DIR/agent' ATOMIC_OFFLINE=1 node packages/coding-agent/dist/cli.js --no-context-files --no-themes --name worker"
+```
+
+Each window was trusted by sending Enter to its trust prompt, then the sessions
+were named explicitly:
+
+```sh
+for window in planner worker; do
+  tmux send-keys -t "$SESSION:$window" Enter
+done
+sleep 8
+for window in planner worker; do
+  tmux send-keys -t "$SESSION:$window" "/name $window" Enter
+done
+sleep 2
+tmux send-keys -t "$SESSION:worker" "/intercom" Enter
+```
+
+After the planner registered, the worker overlay was closed and reopened so its
+presence snapshot included the planner:
+
+```sh
+tmux send-keys -t "$SESSION:worker" C-c
+sleep 1
+tmux send-keys -t "$SESSION:planner" "/intercom" Enter
+sleep 3
+tmux send-keys -t "$SESSION:planner" C-c
+sleep 1
+tmux send-keys -t "$SESSION:worker" "/intercom" Enter
+sleep 3
+```
+
+The two real session UUIDs observed in the overlay were:
+
+- worker: `c910cfd2-7798-4b3e-bed2-b3d1082bdd18`
+- planner: `ab3514fa-360b-42b2-a1a1-827740c259fa`
+
+The worker window was resized and captured at every required width with these
+exact commands:
+
+```sh
+EVIDENCE=test/evidence/intercom-session-list-width
+mkdir -p "$EVIDENCE"
+for width in 40 42 62 63 80; do
+  tmux resize-window -t "$SESSION:worker" -x "$width" -y 40
+  sleep 1
+  tmux capture-pane -p -t "$SESSION:worker" -S -80 > "$EVIDENCE/tmux-overlay-w${width}.txt"
+done
+```
+
+## Observed thresholds
+
+The files `tmux-overlay-w40.txt`, `tmux-overlay-w42.txt`,
+`tmux-overlay-w62.txt`, `tmux-overlay-w63.txt`, and `tmux-overlay-w80.txt`
+contain the complete pane captures. Relevant overlay rows are quoted below.
+
+- **40 columns** (`availableWidth = 34`): names and cwd rows remain readable;
+  each UUID is on its own dim row and is visibly ellipsized:
+
+  ```text
+  │  worker [self]                     │
+  │  c910cfd2-7798-4b3e-bed2-b3d1082bd…│
+  │  /Users/tonystar…com-width-aware • │
+  │→ planner [same cwd]                │
+  │  ab3514fa-360b-42b2-a1a1-827740c25…│
+  │  /Users/tonystar…com-width-aware • │
+  ```
+
+- **42 columns** (`availableWidth = 36`): both complete 36-character UUIDs
+  appear on their own rows without an ellipsis; names, tags, and cwd remain
+  readable:
+
+  ```text
+  │  worker [self]                       │
+  │  c910cfd2-7798-4b3e-bed2-b3d1082bdd18│
+  │→ planner [same cwd]                  │
+  │  ab3514fa-360b-42b2-a1a1-827740c259fa│
+  ```
+
+- **62 columns** (`availableWidth = 56`): the selected planner title still
+  wraps, while its complete UUID remains on a separate row:
+
+  ```text
+  │→ planner [same cwd]                                      │
+  │  ab3514fa-360b-42b2-a1a1-827740c259fa                    │
+  ```
+
+- **63 columns** (`availableWidth = 57`): the planner name, complete UUID, and
+  `[same cwd]` tag fit on one title row:
+
+  ```text
+  │→ planner (ab3514fa-360b-42b2-a1a1-827740c259fa) [same cwd]│
+  ```
+
+- **80 columns**: the full worker and planner title rows fit without wrapping:
+
+  ```text
+  │  worker (c910cfd2-7798-4b3e-bed2-b3d1082bdd18) [self]                      │
+  │→ planner (ab3514fa-360b-42b2-a1a1-827740c259fa) [same cwd]                 │
+  ```
+
+All five derived thresholds held exactly. There was no observed divergence.
+At the 40-column minimum the full IDs are intentionally not fully visible, but
+the overflow is explicit (`…`) and the complete IDs are available at 42 columns
+and wider; no fixed 8-character ID is rendered.
+
+## Cleanup
+
+Cleanup was completed after all captures were written:
+
+```sh
+tmux kill-session -t atomic-intercom-width-e2e
+rm -rf /tmp/atomic-intercom-width-e2e.wxQAZM
+```

--- a/test/evidence/intercom-session-list-width/tmux-overlay-w40.txt
+++ b/test/evidence/intercom-session-list-width/tmux-overlay-w40.txt
@@ -1,0 +1,40 @@
+ in.
+ Use it to implement tickets, research
+ a codebase, design a UI,
+ or build and run your own loops.
+ Run dynamic workflows and save the
+ ones you like for future use.
+ Start building a verifiable software
+ factory.
+
+ Type a message or slash command below
+ to continue normally.
+╭────────────────────────────────────╮
+│ Current Session                    │
+├────────────────────────────────────┤
+│                                    │
+│  worker [self]                     │
+│  c910cfd2-7798-4b3e-bed2-b3d1082bd…│
+│  /Users/tonystar…com-width-aware • │
+│                                    │
+├────────────────────────────────────┤
+│ Other Sessions                     │
+│                                    │
+│→ planner [same cwd]                │
+│  ab3514fa-360b-42b2-a1a1-827740c25…│
+│  /Users/tonystar…com-width-aware • │
+│                                    │
+├────────────────────────────────────┤
+│ Enter: Message • Escape/CTRL+C: Clo│
+╰────────────────────────────────────╯
+
+ Session name set: worker
+
+ ∀ Working...
+
+                           0.0%/0 (auto)
+────────────────────────────────────────
+❯
+────────────────────────────────────────
+unknown • ~/Documents/projects/atomic...
+● ADHD Mode • MCP: 0/1 servers

--- a/test/evidence/intercom-session-list-width/tmux-overlay-w42.txt
+++ b/test/evidence/intercom-session-list-width/tmux-overlay-w42.txt
@@ -1,0 +1,40 @@
+ in.
+ Use it to implement tickets, research a
+ codebase, design a UI,
+ or build and run your own loops.
+ Run dynamic workflows and save the ones
+ you like for future use.
+ Start building a verifiable software
+ factory.
+
+ Type a message or slash command below to
+ continue normally.
+╭──────────────────────────────────────╮
+│ Current Session                      │
+├──────────────────────────────────────┤
+│                                      │
+│  worker [self]                       │
+│  c910cfd2-7798-4b3e-bed2-b3d1082bdd18│
+│  /Users/tonystark…rcom-width-aware • │
+│                                      │
+├──────────────────────────────────────┤
+│ Other Sessions                       │
+│                                      │
+│→ planner [same cwd]                  │
+│  ab3514fa-360b-42b2-a1a1-827740c259fa│
+│  /Users/tonystark…rcom-width-aware • │
+│                                      │
+├──────────────────────────────────────┤
+│ Enter: Message • Escape/CTRL+C: Close│
+╰──────────────────────────────────────╯
+
+ Session name set: worker
+
+ ∀ Working...
+
+                             0.0%/0 (auto)
+──────────────────────────────────────────
+❯
+──────────────────────────────────────────
+unknown • ~/Documents/projects/atomic-i...
+● ADHD Mode • MCP: 0/1 servers

--- a/test/evidence/intercom-session-list-width/tmux-overlay-w62.txt
+++ b/test/evidence/intercom-session-list-width/tmux-overlay-w62.txt
@@ -1,0 +1,40 @@
+RESOURCES context ready · 19 skills · 14 prompts
+
+──────────────────────────────────────────────────────────────
+ Atomic is a verifiable coding agent runtime for building and
+ running
+ agent workflows you can feel confident in.
+ Use it to implement tickets, research a codebase, design a
+ UI,
+ or build and run your own loops.
+ Run dynamic workflows and save the ones you like for future
+ use.
+╭──────────────────────────────────────────────────────────╮
+│ Current Session                                          │
+├──────────────────────────────────────────────────────────┤
+│                                                          │
+│  worker (c910cfd2-7798-4b3e-bed2-b3d1082bdd18) [self]    │
+│  /Users/tonystark/Documents…tomic-intercom-width-aware • │
+│                                                          │
+├──────────────────────────────────────────────────────────┤
+│ Other Sessions                                           │
+│                                                          │
+│→ planner [same cwd]                                      │
+│  ab3514fa-360b-42b2-a1a1-827740c259fa                    │
+│  /Users/tonystark/Documents…tomic-intercom-width-aware • │
+│                                                          │
+├──────────────────────────────────────────────────────────┤
+│ Enter: Message • Escape/CTRL+C: Close                    │
+╰──────────────────────────────────────────────────────────╯
+ are/packages/coding-agent/docs/models.md
+
+ Session name set: worker
+
+ ∀ Working...
+
+                                                 0.0%/0 (auto)
+──────────────────────────────────────────────────────────────
+❯
+──────────────────────────────────────────────────────────────
+unknown • ~/Documents/projects/atomic-intercom-width-aware ...
+● ADHD Mode • MCP: 0/1 servers

--- a/test/evidence/intercom-session-list-width/tmux-overlay-w63.txt
+++ b/test/evidence/intercom-session-list-width/tmux-overlay-w63.txt
@@ -1,0 +1,40 @@
+
+RESOURCES context ready · 19 skills · 14 prompts
+
+───────────────────────────────────────────────────────────────
+ Atomic is a verifiable coding agent runtime for building and
+ running
+ agent workflows you can feel confident in.
+ Use it to implement tickets, research a codebase, design a
+ UI,
+ or build and run your own loops.
+ Run dynamic workflows and save the ones you like for future
+ use.
+╭───────────────────────────────────────────────────────────╮
+│ Current Session                                           │
+├───────────────────────────────────────────────────────────┤
+│                                                           │
+│  worker (c910cfd2-7798-4b3e-bed2-b3d1082bdd18) [self]     │
+│  /Users/tonystark/Documents/…atomic-intercom-width-aware •│
+│                                                           │
+├───────────────────────────────────────────────────────────┤
+│ Other Sessions                                            │
+│                                                           │
+│→ planner (ab3514fa-360b-42b2-a1a1-827740c259fa) [same cwd]│
+│  /Users/tonystark/Documents/…atomic-intercom-width-aware •│
+│                                                           │
+├───────────────────────────────────────────────────────────┤
+│ Enter: Message • Escape/CTRL+C: Close                     │
+╰───────────────────────────────────────────────────────────╯
+ re/packages/coding-agent/docs/models.md
+
+ Session name set: worker
+
+ ∀ Working...
+
+                                                  0.0%/0 (auto)
+───────────────────────────────────────────────────────────────
+❯
+───────────────────────────────────────────────────────────────
+unknown • ~/Documents/projects/atomic-intercom-width-aware (...
+● ADHD Mode • MCP: 0/1 servers

--- a/test/evidence/intercom-session-list-width/tmux-overlay-w80.txt
+++ b/test/evidence/intercom-session-list-width/tmux-overlay-w80.txt
@@ -1,0 +1,40 @@
+
+ We question,
+ we break away from what is accepted.
+ Engineering matters.
+
+RESOURCES context ready · 19 skills · 14 prompts
+
+────────────────────────────────────────────────────────────────────────────────
+ Atomic is a verifiable coding agent runtime for building and running
+ agent workflows you can feel confident in.
+ Use it to implement tickets, research a codebase, design a UI,
+ or build and run your own loops.
+╭────────────────────────────────────────────────────────────────────────────╮
+│ Current Session                                                            │
+├────────────────────────────────────────────────────────────────────────────┤
+│                                                                            │
+│  worker (c910cfd2-7798-4b3e-bed2-b3d1082bdd18) [self]                      │
+│  /Users/tonystark/Documents/projects/atomic-intercom-width-aware • unknown │
+│                                                                            │
+├────────────────────────────────────────────────────────────────────────────┤
+│ Other Sessions                                                             │
+│                                                                            │
+│→ planner (ab3514fa-360b-42b2-a1a1-827740c259fa) [same cwd]                 │
+│  /Users/tonystark/Documents/projects/atomic-intercom-width-aware • unknown │
+│                                                                            │
+├────────────────────────────────────────────────────────────────────────────┤
+│ Enter: Message • Escape/CTRL+C: Close                                      │
+╰────────────────────────────────────────────────────────────────────────────╯
+ g-agent/docs/models.md
+
+ Session name set: worker
+
+ ∀ Working...
+
+                                                                   0.0%/0 (auto)
+────────────────────────────────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────────────────────────────────
+unknown • ~/Documents/projects/atomic-intercom-width-aware (fix/intercom-sess...
+● ADHD Mode • MCP: 0/1 servers

--- a/test/unit/intercom-session-list-overlay.test.ts
+++ b/test/unit/intercom-session-list-overlay.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
+import { beforeAll, test } from "vitest";
+import { KeybindingsManager } from "../../packages/coding-agent/src/core/keybindings.ts";
+import { initTheme, theme } from "../../packages/coding-agent/src/modes/interactive/theme/theme.ts";
+import type { Message, SessionInfo } from "../../packages/intercom/types.ts";
+import { InlineMessageComponent } from "../../packages/intercom/ui/inline-message.ts";
+import { SessionListOverlay } from "../../packages/intercom/ui/session-list.ts";
+
+const CURRENT_ID = "f996d39d-5efd-41f7-8b01-22769b77873f";
+const OTHER_ID = "1a2b3c4d-1111-4222-8333-123456789abc";
+const REPLY_ID = "abcdef12-3456-4789-8abc-def012345678";
+
+beforeAll(() => {
+	initTheme("dark");
+});
+
+function session(id: string, name: string, cwd = "/workspace/project"): SessionInfo {
+	return {
+		id,
+		name,
+		cwd,
+		model: "test-model",
+		pid: 1234,
+		startedAt: 1,
+		lastActivity: 2,
+	};
+}
+
+function plain(lines: string[]): string[] {
+	return lines.map(stripTerminalSequences);
+}
+
+function makeOverlay(): SessionListOverlay {
+	const current = session(CURRENT_ID, "planner");
+	const other = session(OTHER_ID, "worker");
+	return new SessionListOverlay(theme, new KeybindingsManager(), current, [other], () => {});
+}
+
+test("session-list overlay keeps full IDs accessible while fitting every rendered row", () => {
+	for (const width of [34, 50, 80]) {
+		const rendered = plain(makeOverlay().render(width));
+		const expectedWidth = Math.max(36, Math.min(width - 2, 88));
+		for (const line of rendered) {
+			assert.ok(
+				visibleWidth(line) <= expectedWidth,
+				`rendered line exceeds the ${expectedWidth}-column overlay at width ${width}: ${line}`,
+			);
+		}
+
+		const output = rendered.join("\n");
+		assert.match(output, /planner/);
+		assert.match(output, /worker/);
+		assert.match(output, /\/workspace\/project/);
+		assert.doesNotMatch(output, new RegExp(`${CURRENT_ID.slice(0, 8)}\\)`));
+		assert.doesNotMatch(output, new RegExp(`${OTHER_ID.slice(0, 8)}\\)`));
+
+		if (width === 34) {
+			for (const id of [CURRENT_ID, OTHER_ID]) {
+				const idLine = rendered.find((line) => line.includes(id.slice(0, 8)));
+				assert.ok(idLine?.includes("…"), `narrow row for ${id} should show a visible ellipsis`);
+			}
+			assert.doesNotMatch(output, new RegExp(CURRENT_ID));
+			assert.doesNotMatch(output, new RegExp(OTHER_ID));
+		} else {
+			assert.match(output, new RegExp(CURRENT_ID));
+			assert.match(output, new RegExp(OTHER_ID));
+		}
+	}
+});
+
+test("inline-message marks clipped full sender and reply IDs with visible ellipses", () => {
+	const from = session(CURRENT_ID, "");
+	const message: Message = {
+		id: "01234567-89ab-4cde-8fab-0123456789ab",
+		timestamp: 1,
+		replyTo: REPLY_ID,
+		expectsReply: false,
+		content: { text: "message body" },
+	};
+	const rendered = plain(new InlineMessageComponent(from, message, theme).render(34));
+	const output = rendered.join("\n");
+
+	assert.match(output, /From: .*…/);
+	assert.match(output, /Reply to .*…/);
+	for (const line of rendered) {
+		assert.ok(visibleWidth(line) <= 34, `inline-message row exceeds 34 columns: ${line}`);
+	}
+});


### PR DESCRIPTION
## Summary

Follow-up to #2360, which removed every 8-character short-form session ID. The session-list overlay then embedded the full 36-character UUID in a title string that was not width-aware, and the enclosing `row()` helper hard-clipped at `contentWidth` (floor 34). Below roughly 63 terminal columns the ID was silently cut off with no marker.

`sessionTitle(): string` becomes `sessionTitleLines(session, availableWidth, options): string[]`:

- When `name (uuid) [tags]` fits, the row is byte-for-byte what it was.
- When it does not fit, the row splits into a `name [tags]` line plus a separate dim line carrying the full UUID.
- Only when a whole line cannot hold 36 columns is the UUID ellipsized, with a visible `…`.
- Widths are measured on plain text before theming, so ANSI escapes never inflate the measurement. `row()`'s clip stays as a backstop but no longer receives information-bearing overflow.

No fixed 8-character short ID is reintroduced anywhere: `grep -rn "slice(0, *8)" packages/intercom` returns nothing.

## `inline-message.ts` audit — fixed

The objective asked for an audit with the decision recorded. `truncateToWidth(text, maxWidth, ellipsis?, pad?)` was called with `""` at both ID-bearing call sites, which is a silent hard clip: a 36-character sender ID or `replyTo` ID at narrow width vanished with no marker. Both now pass `"…"`, each with a comment stating why. No structural change — the header still truncates rather than wraps, keeping the box chrome intact.

## Geometry and verified thresholds

`render()` computes `innerWidth = max(36, min(width - 2, 88))`, `contentWidth = innerWidth - 2` (floor 34), `availableWidth = contentWidth - 2`. Derived thresholds were then confirmed empirically against live sessions:

- Full UUID rendered unclipped from terminal width **42**.
- Complete one-line `planner (uuid) [same cwd]` title from terminal width **63** — matching the "~63 columns" in the original finding.

## Testing

| Command | Outcome |
| --- | --- |
| `npm run check` | biome (2439 files), `tsc --noEmit`, `tsgo -p tsconfig.build.json --noEmit`, shrinkwrap — all pass |
| `npx vitest --run --project unit test/unit/intercom-session-list-overlay.test.ts` | 2/2 pass |
| Same test with sources reverted to the pre-fix state | **2/2 fail** — "narrow row … should show a visible ellipsis" and "did not match /From: .*…/" |
| `npx vitest --run --project unit test/unit/intercom` | 35 files, 284 tests pass |
| `npm run test:unit` | 638 files, 6142 pass, 1 skipped |

The new `test/unit/intercom-session-list-overlay.test.ts` covers widths 34, 50, and 80 for the session list, plus inline-message overflow. It was confirmed to fail before the fix, so it is a real regression guard rather than a description of current behavior.

## Live evidence

`test/evidence/intercom-session-list-width/` holds tmux captures of two real Atomic sessions against a throwaway broker, at five widths:

- **w40** — `│  worker [self]` / `│  c910cfd2-7798-4b3e-bed2-b3d1082bd…│`; name and cwd readable, truncation marked.
- **w42** — `│  c910cfd2-7798-4b3e-bed2-b3d1082bdd18│`, full UUID, no ellipsis.
- **w62** — `planner [same cwd]` wraps; `ab3514fa-360b-42b2-a1a1-827740c259fa` complete on its own row.
- **w63** — `│→ planner (ab3514fa-360b-42b2-a1a1-827740c259fa) [same cwd]│` on one line.
- **w80** — single-line titles for both sessions.

Pre-fix, the w40 row would have read `worker (c910cfd2-…bdd18) [self]` hard-clipped at column 34, with the ID silently gone.

## Files changed

- `packages/intercom/ui/session-list.ts` — width-aware title/ID line splitting.
- `packages/intercom/ui/inline-message.ts` — visible ellipsis for sender and reply-to IDs.
- `test/unit/intercom-session-list-overlay.test.ts` — new.
- `packages/intercom/CHANGELOG.md` — new `### Fixed` entry under `## [Unreleased]`; no released section touched (`git diff … -- CHANGELOG.md | grep '^-'` shows no deletions).
- `test/evidence/intercom-session-list-width/` — README plus five captures.

Docs were deliberately left alone. `packages/intercom/README.md`, `skills/intercom/SKILL.md`, and `packages/coding-agent/docs/intercom.md` describe the `intercom list` **tool markdown**, not overlay row layout. Verified by grep.

## Review notes

Three independent reviewers approved with `stop_review_loop = true` (confidence 0.91 / 0.93 / 0.88) and every requirement marked `proven`. Their non-blocking P3 findings, recorded here rather than acted on because they fall outside this objective:

1. Splitting the ID onto its own row grows the overlay by up to one line per session at narrow widths while `maxVisible` stays at 8. No clipping was observed in the captures.
2. The reply-to line still truncates the full message ID at narrow widths, while the reply-command line directly above it preserves the ID.
3. Pre-existing and unrelated to IDs: at w40 the footer (`Enter: Message • Escape/CTRL+C: Clo`) and the `cwd • model` row still hard-clip with no ellipsis, losing the model name.

## Base

Rebased onto `main` at `518a95207` (the squash-merge of #2360). The pre-rebase base tree was identical to `origin/main`, so the replay was content-neutral.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789204365&installation_model_id=10562&pr_number=2363&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2363&signature=d34376ce2497d18d87eae185bd13af0e6ca66e3e2c96f54d94f87710cad715ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes Intercom session-list titles adapt to narrow terminal widths by placing overflowed UUIDs on a separate dim row and marking unavoidable truncation. One repository convention issue remains: the new unit test imports local TypeScript files with `.ts` extensions rather than the required emitted ESM `.js` specifiers.

<h3>Confidence Score: 4/5</h3>

The rendering behavior is covered by focused width regression tests, but the new test file should conform to the repository’s ESM import-specifier rule before merging.

There is one non-security P2 finding and no P0 or P1 findings, which maps to a score of 4.

**Files Needing Attention:** test/unit/intercom-session-list-overlay.test.ts lines 4-8 should replace repository-local `.ts` import specifiers with `.js` specifiers.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
test/unit/intercom-session-list-overlay.test.ts:4-8
**TypeScript import extensions violate convention**

These new repository-local imports use `.ts` extensions instead of the required `.js` ESM specifiers. This diverges from the repository convention and is incompatible with emitted-module workflows that do not permit TypeScript-extension imports.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(intercom): capture width-aware sess..."](https://github.com/bastani-inc/atomic/commit/19209bc8ead43b3815c5204b90686c610c755e17) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52902311)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->