### PR TITLE
docs(changelog): prepare 0.9.13-alpha.3 release notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ## [Unreleased]
 
-### Added
-
-- Added generated session summaries to the resume picker, so `/resume` and `atomic -r` show what a conversation was about in a dedicated summary column beside the session name or first message. Atomic writes a one-line summary once the agent goes idle, reusing the session's existing model, credentials, stream function, and retry policy with a dedicated one-line prompt and no reasoning request; the stored line has its whitespace collapsed and length clamped so a long response cannot break picker layout. Each summary is persisted as a `session_summary` session entry anchored to the last user/assistant message it describes, and the picker shows it only while that message is still the newest one — a later message, or a later branch summary, retires it and the summary column shows "No summary available." instead, exactly as it does when a summary has not been generated, has failed, or is still in flight; the session name and first message are never displaced. Summaries are matched by picker search, and their token usage is counted toward session usage totals and the footer. Generation is best-effort and invisible: it is skipped for very short sessions, workflow stage sessions, and `--print`/JSON modes, it never blocks or delays a turn, it is cancelled when the next prompt starts or the session shuts down, and a slow request that outlives the conversation discards its own result rather than persisting a stale summary. Set `sessionSummary.enabled` to `false` to disable it ([#1033](https://github.com/bastani-inc/atomic/issues/1033)).
+## [0.9.13-alpha.3] - 2026-08-13
 
 ### Breaking Changes
 
 - The `bash` tool no longer accepts its `async` parameter, and the `__atomic_bash_job` and `__atomic_bash_job_cancel` polling and cancellation commands have been removed. Drop `async` from bash calls; run long-lived commands in a separate shell or process manager instead.
+
+### Added
+
+- Added generated session summaries to the resume picker, so `/resume` and `atomic -r` show what a conversation was about in a dedicated summary column beside the session name or first message. Atomic writes a one-line summary once the agent goes idle, reusing the session's existing model, credentials, stream function, and retry policy with a dedicated one-line prompt and no reasoning request; the stored line has its whitespace collapsed and length clamped so a long response cannot break picker layout. Each summary is persisted as a `session_summary` session entry anchored to the last user/assistant message it describes, and the picker shows it only while that message is still the newest one — a later message, or a later branch summary, retires it and the summary column shows "No summary available." instead, exactly as it does when a summary has not been generated, has failed, or is still in flight; the session name and first message are never displaced. Summaries are matched by picker search, and their token usage is counted toward session usage totals and the footer. Generation is best-effort and invisible: it is skipped for very short sessions, workflow stage sessions, and `--print`/JSON modes, it never blocks or delays a turn, it is cancelled when the next prompt starts or the session shuts down, and a slow request that outlives the conversation discards its own result rather than persisting a stale summary. Set `sessionSummary.enabled` to `false` to disable it ([#1033](https://github.com/bastani-inc/atomic/issues/1033)).
 
 ### Removed
 

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.13-alpha.3] - 2026-08-13
+
 ### Breaking Changes
 
 - Removed unique-ID-prefix targeting. `send`, `ask`, and `reply` now accept only an exact full session ID or an exact case-insensitive session name.

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.13-alpha.3] - 2026-08-13
+
+### Breaking Changes
+
+- The `subagent` tool no longer accepts `async: true`, `/run --bg` and related background slash flags are gone, and the `asyncByDefault` and `forceTopLevelAsync` settings have been removed. Remove those settings keys from user configuration; subagent calls now run in the foreground.
+
 ### Changed
 
 - Unnamed subagent sessions now expose runtime-only `subagent-chat-<full-id>` Intercom aliases so supervisor targeting uses the full session ID.
@@ -10,10 +16,6 @@
 
 - Fixed a fork-context subagent ignoring its agent's configured model. The selected model candidate was only ever a `provider/model[:thinking]` string, so nothing was handed to the child session's `model` argument and the session fell back to the model persisted in the session file — which, for a fork, is the parent's. A child declaring `openai-codex/gpt-5.6-luna:max` therefore ran every turn on the parent's model, and an explicit `model:` override lost its first attempt the same way. The selected candidate is now resolved against the model registry and applied to the child session, together with the thinking level carried in the candidate's suffix, for both fresh and fork contexts and across single, parallel, and resume paths. A candidate that names no usable model still starts the run instead of failing it.
 - Fixed subagent progress and status lines stripping the provider prefix from the model name, so a child rendered as `claude-fable-5` where the main chat shows `anthropic/claude-fable-5`. The full model id is now displayed, including every segment of a routed id such as `openrouter/anthropic/claude-fable-5`; known thinking suffixes are still split off into the `thinking <level>` label.
-
-### Breaking Changes
-
-- The `subagent` tool no longer accepts `async: true`, `/run --bg` and related background slash flags are gone, and the `asyncByDefault` and `forceTopLevelAsync` settings have been removed. Remove those settings keys from user configuration; subagent calls now run in the foreground.
 
 ### Removed
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.13-alpha.3] - 2026-08-13
+
 ### Changed
 
 - Workflow model fallback attempt metadata now includes per-attempt input/output tokens, cache reads/writes, provider-reported total cost, and meaningful assistant-turn counts when usage is available ([#2197](https://github.com/bastani-inc/atomic/issues/2197)).


### PR DESCRIPTION
## Summary

Prepares the release notes for prerelease **0.9.13-alpha.3**. Changelog-only: the accumulated `[Unreleased]` entries in four packages are promoted into a dated `## [0.9.13-alpha.3] - 2026-08-13` section, leaving `[Unreleased]` empty for the next cycle.

| Package | Sections moved |
| --- | --- |
| `packages/coding-agent` | Breaking Changes, Added, Removed |
| `packages/intercom` | Breaking Changes, Changed, Fixed |
| `packages/subagents` | Breaking Changes, Changed, Fixed, Removed |
| `packages/workflows` | Changed, Fixed |

Subsection order is also normalized so Breaking Changes leads each version section, matching the released `0.9.13-alpha.2` sections above it.

## Release-base invariants

This branch is **versionless**. No manifest is bumped here:

- every `packages/*/package.json` remains `0.0.0`
- `package-lock.json`, the `@bastani/atomic-natives` pin, `packages/natives/native/index.js`, and `Cargo.toml`/`Cargo.lock` are untouched
- `scripts/cut-release.ts` alone stamps the real version, on the detached `Release 0.9.13-alpha.3` commit created after this PR merges

No already-released version section was modified.

## Validation

Run locally against the exact commit:

- `npm run check` — biome (2439 files), `tsc --noEmit`, coding-agent `tsgo -p tsconfig.build.json --noEmit`, shrinkwrap check — pass
- `npm run test:unit` — 638 files, 6141 passed / 2 skipped
- `npm run test:integration`, `npm run test:ci-contracts` — pass via pre-push hooks
- targeted: `test/unit/changelog.test.ts` + `test/unit/package-metadata.test.ts` — 24 passed

All prek pre-commit and pre-push hooks ran; none were skipped.

## Next steps

Merge, then cut the tag with `bun run scripts/cut-release.ts 0.9.13-alpha.3 --base main --push`. The tag push starts `publish.yml`; no manual dispatch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789206423&installation_model_id=10562&pr_number=2364&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2364&signature=5fdb25f1f5634bef443386e5c8a8a0be0efed25285752367ac2444363ec11d33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change cuts the 0.9.13-alpha.3 release notes and updates Intercom to show full session IDs while requiring exact full IDs or exact session names for targeting. Direct checks confirmed that an eight-character prefix that resolved before the change now returns `not_found`, while the complete UUID and a case-insensitive exact name resolve successfully. Focused Intercom targeting and terminal-overlay tests passed, including send, ask, reply, list output, and constrained-width rendering.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on direct verification of the changed Intercom targeting contract and passing focused rendering coverage.

No defects remain in the final comments. The executed comparison confirmed that short prefixes are rejected after the change and that exact full IDs and exact names remain usable.

**Files Needing Attention:** No files need follow-up.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused session-target resolver harness against base be547944 and current b3a53a86 with the same session fixture.
- Observed that the short session ID prefix de903b5c resolves to not\_found/null after the change, while the full UUID and RECIPIENT resolve to de903b5c-1111-4222-8333-123456789abc.
- Ran direct Intercom targeting and session-overlay tests; all 13 tests passed, followed by TypeScript validation.
- Reviewed the focused Intercom session-target validation harness source and its role in the test suite.
- Focused test run verifies send, ask, targeted reply, list full-ID output, and width-constrained overlay rendering.

<a href="https://app.greptile.com/trex/runs/18672279/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.13-alpha.3 ..."](https://github.com/bastani-inc/atomic/commit/b3a53a86ae77be585b6b28ba38cc53ec12aec3f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52909372)</sub>

<!-- /greptile_comment -->