### PR TITLE
ci: retry a stalled native binding build exactly once

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,31 +84,38 @@ jobs:
       fail-fast: false
       matrix:
         # timeout_minutes caps the job; build_timeout_minutes caps each compile attempt.
-        # Each cap is ceil(measured p100 setup) + 2 x build_timeout_minutes; setup is job start to build start.
-        # linux-x64-gnu: ceil(46s / 60)=1 + 2 x 5 = 11
-        # linux-arm64-gnu: ceil(128s / 60)=3 + 2 x 5 = 13
-        # linux-x64-musl: ceil(107s / 60)=2 + 2 x 5 = 12
-        # linux-arm64-musl: ceil(142s / 60)=3 + 2 x 5 = 13
-        # darwin-x64: ceil(98s / 60)=2 + 2 x 8 = 18
-        # darwin-arm64: ceil(26s / 60)=1 + 2 x 5 = 11
-        # win32-x64-msvc: ceil(357s / 60)=6 + 2 x 5 = 16
-        # win32-arm64-msvc: ceil(384s / 60)=7 + 2 x 5 = 17
+        # A cap must contain every bounded recovery path, not the times a green run happened
+        # to take: reserving only observed setup cancels the job mid-retry, which is the
+        # failure this retry exists to survive. Each cap is therefore
+        #   ceil(measured p100 setup, excluding steps reserved at their bound)
+        #   + those steps' bounds + 2 x build_timeout_minutes + 1 upload.
+        # Reserved at their bound: both zig attempts (2 + 2, linux) and the MSVC CRT
+        # populate step (8, win32) whose measured cost is its cache-miss path.
+        # Upload is measured at <= 4s across legs and reserved at 1 minute.
+        # linux-x64-gnu: ceil((46-18)s / 60)=1 + 4 + 2 x 5 + 1 = 16
+        # linux-arm64-gnu: ceil((128-8)s / 60)=2 + 4 + 2 x 5 + 1 = 17
+        # linux-x64-musl: ceil((107-3)s / 60)=2 + 4 + 2 x 5 + 1 = 17
+        # linux-arm64-musl: ceil((142-5)s / 60)=3 + 4 + 2 x 5 + 1 = 18
+        # darwin-x64: ceil(98s / 60)=2 + 2 x 8 + 1 = 19
+        # darwin-arm64: ceil(26s / 60)=1 + 2 x 5 + 1 = 12
+        # win32-x64-msvc: ceil((291-249)s / 60)=1 + 8 + 2 x 5 + 1 = 20
+        # win32-arm64-msvc: ceil((384-343)s / 60)=1 + 8 + 2 x 5 + 1 = 20
         # `slug` is the napi platform id: it names the .node file, the npm leaf, and
         # this leg's artifact, so two legs that share platform+arch (glibc and musl
         # Linux) can never collide on an artifact name.
         include:
-          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: linux, arch: x64, slug: linux-x64-gnu, target: x86_64-unknown-linux-gnu, timeout_minutes: 11, build_timeout_minutes: 5 }
-          - { runner: blacksmith-4vcpu-ubuntu-2404-arm, platform: linux, arch: arm64, slug: linux-arm64-gnu, target: aarch64-unknown-linux-gnu, timeout_minutes: 13, build_timeout_minutes: 5 }
+          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: linux, arch: x64, slug: linux-x64-gnu, target: x86_64-unknown-linux-gnu, timeout_minutes: 16, build_timeout_minutes: 5 }
+          - { runner: blacksmith-4vcpu-ubuntu-2404-arm, platform: linux, arch: arm64, slug: linux-arm64-gnu, target: aarch64-unknown-linux-gnu, timeout_minutes: 17, build_timeout_minutes: 5 }
           # musl legs reuse the same zig toolchain; @napi-rs/cli adds
           # `-C target-feature=-crt-static` for a musl ABI, which is what keeps the
           # produced .node a dlopen-able shared object instead of a static-CRT blob.
-          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: linux, arch: x64, slug: linux-x64-musl, target: x86_64-unknown-linux-musl, timeout_minutes: 12, build_timeout_minutes: 5 }
-          - { runner: blacksmith-4vcpu-ubuntu-2404-arm, platform: linux, arch: arm64, slug: linux-arm64-musl, target: aarch64-unknown-linux-musl, timeout_minutes: 13, build_timeout_minutes: 5 }
+          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: linux, arch: x64, slug: linux-x64-musl, target: x86_64-unknown-linux-musl, timeout_minutes: 17, build_timeout_minutes: 5 }
+          - { runner: blacksmith-4vcpu-ubuntu-2404-arm, platform: linux, arch: arm64, slug: linux-arm64-musl, target: aarch64-unknown-linux-musl, timeout_minutes: 18, build_timeout_minutes: 5 }
           # Blacksmith macOS is Apple Silicon only, so darwin x64 stays GitHub-hosted.
-          - { runner: macos-26-intel, platform: darwin, arch: x64, slug: darwin-x64, target: x86_64-apple-darwin, timeout_minutes: 18, build_timeout_minutes: 8 }
-          - { runner: blacksmith-6vcpu-macos-26, platform: darwin, arch: arm64, slug: darwin-arm64, target: aarch64-apple-darwin, timeout_minutes: 11, build_timeout_minutes: 5 }
-          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: win32, arch: x64, slug: win32-x64-msvc, target: x86_64-pc-windows-msvc, timeout_minutes: 16, build_timeout_minutes: 5 }
-          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: win32, arch: arm64, slug: win32-arm64-msvc, target: aarch64-pc-windows-msvc, timeout_minutes: 17, build_timeout_minutes: 5 }
+          - { runner: macos-26-intel, platform: darwin, arch: x64, slug: darwin-x64, target: x86_64-apple-darwin, timeout_minutes: 19, build_timeout_minutes: 8 }
+          - { runner: blacksmith-6vcpu-macos-26, platform: darwin, arch: arm64, slug: darwin-arm64, target: aarch64-apple-darwin, timeout_minutes: 12, build_timeout_minutes: 5 }
+          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: win32, arch: x64, slug: win32-x64-msvc, target: x86_64-pc-windows-msvc, timeout_minutes: 20, build_timeout_minutes: 5 }
+          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: win32, arch: arm64, slug: win32-arm64-msvc, target: aarch64-pc-windows-msvc, timeout_minutes: 20, build_timeout_minutes: 5 }
     steps:
       # Sticky disks are Blacksmith-Linux-only; elsewhere this action stalls ~78s
       # before falling back to a normal clone.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,23 +83,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # timeout_minutes caps the job; build_timeout_minutes caps the compile step.
+        # timeout_minutes caps the job; build_timeout_minutes caps each compile attempt.
+        # Each cap is ceil(measured p100 setup) + 2 x build_timeout_minutes; setup is job start to build start.
+        # linux-x64-gnu: ceil(46s / 60)=1 + 2 x 5 = 11
+        # linux-arm64-gnu: ceil(128s / 60)=3 + 2 x 5 = 13
+        # linux-x64-musl: ceil(107s / 60)=2 + 2 x 5 = 12
+        # linux-arm64-musl: ceil(142s / 60)=3 + 2 x 5 = 13
+        # darwin-x64: ceil(98s / 60)=2 + 2 x 8 = 18
+        # darwin-arm64: ceil(26s / 60)=1 + 2 x 5 = 11
+        # win32-x64-msvc: ceil(357s / 60)=6 + 2 x 5 = 16
+        # win32-arm64-msvc: ceil(384s / 60)=7 + 2 x 5 = 17
         # `slug` is the napi platform id: it names the .node file, the npm leaf, and
         # this leg's artifact, so two legs that share platform+arch (glibc and musl
         # Linux) can never collide on an artifact name.
         include:
-          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: linux, arch: x64, slug: linux-x64-gnu, target: x86_64-unknown-linux-gnu, timeout_minutes: 7, build_timeout_minutes: 5 }
-          - { runner: blacksmith-4vcpu-ubuntu-2404-arm, platform: linux, arch: arm64, slug: linux-arm64-gnu, target: aarch64-unknown-linux-gnu, timeout_minutes: 8, build_timeout_minutes: 5 }
+          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: linux, arch: x64, slug: linux-x64-gnu, target: x86_64-unknown-linux-gnu, timeout_minutes: 11, build_timeout_minutes: 5 }
+          - { runner: blacksmith-4vcpu-ubuntu-2404-arm, platform: linux, arch: arm64, slug: linux-arm64-gnu, target: aarch64-unknown-linux-gnu, timeout_minutes: 13, build_timeout_minutes: 5 }
           # musl legs reuse the same zig toolchain; @napi-rs/cli adds
           # `-C target-feature=-crt-static` for a musl ABI, which is what keeps the
           # produced .node a dlopen-able shared object instead of a static-CRT blob.
-          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: linux, arch: x64, slug: linux-x64-musl, target: x86_64-unknown-linux-musl, timeout_minutes: 7, build_timeout_minutes: 5 }
-          - { runner: blacksmith-4vcpu-ubuntu-2404-arm, platform: linux, arch: arm64, slug: linux-arm64-musl, target: aarch64-unknown-linux-musl, timeout_minutes: 8, build_timeout_minutes: 5 }
+          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: linux, arch: x64, slug: linux-x64-musl, target: x86_64-unknown-linux-musl, timeout_minutes: 12, build_timeout_minutes: 5 }
+          - { runner: blacksmith-4vcpu-ubuntu-2404-arm, platform: linux, arch: arm64, slug: linux-arm64-musl, target: aarch64-unknown-linux-musl, timeout_minutes: 13, build_timeout_minutes: 5 }
           # Blacksmith macOS is Apple Silicon only, so darwin x64 stays GitHub-hosted.
-          - { runner: macos-26-intel, platform: darwin, arch: x64, slug: darwin-x64, target: x86_64-apple-darwin, timeout_minutes: 9, build_timeout_minutes: 8 }
-          - { runner: blacksmith-6vcpu-macos-26, platform: darwin, arch: arm64, slug: darwin-arm64, target: aarch64-apple-darwin, timeout_minutes: 5, build_timeout_minutes: 5 }
-          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: win32, arch: x64, slug: win32-x64-msvc, target: x86_64-pc-windows-msvc, timeout_minutes: 10, build_timeout_minutes: 5 }
-          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: win32, arch: arm64, slug: win32-arm64-msvc, target: aarch64-pc-windows-msvc, timeout_minutes: 10, build_timeout_minutes: 5 }
+          - { runner: macos-26-intel, platform: darwin, arch: x64, slug: darwin-x64, target: x86_64-apple-darwin, timeout_minutes: 18, build_timeout_minutes: 8 }
+          - { runner: blacksmith-6vcpu-macos-26, platform: darwin, arch: arm64, slug: darwin-arm64, target: aarch64-apple-darwin, timeout_minutes: 11, build_timeout_minutes: 5 }
+          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: win32, arch: x64, slug: win32-x64-msvc, target: x86_64-pc-windows-msvc, timeout_minutes: 16, build_timeout_minutes: 5 }
+          - { runner: blacksmith-4vcpu-ubuntu-2404, platform: win32, arch: arm64, slug: win32-arm64-msvc, target: aarch64-pc-windows-msvc, timeout_minutes: 17, build_timeout_minutes: 5 }
     steps:
       # Sticky disks are Blacksmith-Linux-only; elsewhere this action stalls ~78s
       # before falling back to a normal clone.
@@ -220,7 +229,19 @@ jobs:
         run: cargo-xwin xwin cache xwin
       # The CRT fetch is hoisted above, so this is a compile: each budget is that
       # leg's measured p100 times at least 1.4.
+      # A stalled compile consumes one bounded attempt; continue-on-error allows
+      # exactly one fresh attempt, while its failure remains job-fatal.
       - name: Build native binding
+        id: native_build
+        continue-on-error: true
+        timeout-minutes: ${{ matrix.build_timeout_minutes }}
+        env:
+          CROSS_TARGET: ${{ matrix.platform != 'darwin' && steps.target.outputs.build-target || '' }}
+          NATIVE_TARGET: ${{ matrix.platform == 'darwin' && matrix.target || '' }}
+          XWIN_ACCEPT_LICENSE: "1"
+        run: bun run --cwd packages/natives build
+      - name: Retry native binding
+        if: steps.native_build.outcome == 'failure'
         timeout-minutes: ${{ matrix.build_timeout_minutes }}
         env:
           CROSS_TARGET: ${{ matrix.platform != 'darwin' && steps.target.outputs.build-target || '' }}

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -243,6 +243,8 @@ The build job downloads the eight same-run bindings, generates the eight platfor
 
 `native-artifacts` compiles for 20–30 s on Linux and Windows. Everything else in
 its budget is a third-party download, and two releases have been damaged by one.
+The native compile now has one bounded retry: the first attempt is allowed to
+finish with an error so the retry can run, while a second failure remains fatal.
 
 | Release | Run | Leg | Stall |
 | --- | --- | --- | --- |
@@ -255,8 +257,8 @@ stalled mirror was the job budget.
 
 **Step bounds are the stall detector; job caps are only hang detectors.** A job
 cap cannot distinguish a stall from slow work, and cancelling a job silently
-skips every job that `needs` it. Each acquisition step therefore carries its own
-`timeout-minutes`:
+skips every job that `needs` it. Each acquisition or compile attempt therefore
+carries its own `timeout-minutes`:
 
 | Step | Bound | Basis |
 | --- | --- | --- |
@@ -265,19 +267,25 @@ skips every job that `needs` it. Each acquisition step therefore carries its own
 | `taiki-e/install-action` | 3 min | |
 | `apt-get` LLVM install | 5 min | |
 | `cargo-xwin xwin cache xwin` | 8 min | 1.27× the worst measured full CRT/SDK download (6 m 19 s) |
-| `Build native binding` | `matrix.build_timeout_minutes` | that leg's measured p100 compile × ≥1.4 |
+| `Build native binding`, plus one retry | `matrix.build_timeout_minutes` each | each attempt keeps the leg's measured p100 compile bound; a stall costs at most two bounds and the retry fails loudly if needed |
 
-Job caps replace the former blanket `timeout-minutes: 15`, which was 16× the
-real work of the fastest leg and 2× that of the slowest:
+The former blanket 15-minute job cap is replaced by per-leg caps that reserve
+the measured setup plus two bounded compile attempts. We measured setup from
+job start to `Build native binding` over six successful publishes
+(`31689424903`, `31634036246`, `31060235600`, `30892885915`, `30889823603`,
+`30835115933`). The cap arithmetic is `ceil(measured setup) + 2 x
+build_timeout_minutes`:
 
-| Leg | Healthy p100 | Cap |
-| --- | --- | --- |
-| linux x64 | 107 s | 7 min |
-| linux arm64 | 233 s | 8 min |
-| darwin x64 | 387 s | 9 min |
-| darwin arm64 | 61 s after the checkout change | 5 min |
-| win32 x64 | 351 s | 10 min |
-| win32 arm64 | 443 s | 10 min |
+| Leg | Measured setup p100 | Build timeout | Cap arithmetic | Job cap |
+| --- | ---: | ---: | --- | ---: |
+| linux-x64-gnu | 46 s | 5 min | ceil(46s / 60)=1 + 2 x 5 = 11 | 11 min |
+| linux-arm64-gnu | 128 s | 5 min | ceil(128s / 60)=3 + 2 x 5 = 13 | 13 min |
+| linux-x64-musl | 107 s | 5 min | ceil(107s / 60)=2 + 2 x 5 = 12 | 12 min |
+| linux-arm64-musl | 142 s | 5 min | ceil(142s / 60)=3 + 2 x 5 = 13 | 13 min |
+| darwin-x64 | 98 s | 8 min | ceil(98s / 60)=2 + 2 x 8 = 18 | 18 min |
+| darwin-arm64 | 26 s | 5 min | ceil(26s / 60)=1 + 2 x 5 = 11 | 11 min |
+| win32-x64-msvc | 357 s | 5 min | ceil(357s / 60)=6 + 2 x 5 = 16 | 16 min |
+| win32-arm64-msvc | 384 s | 5 min | ceil(384s / 60)=7 + 2 x 5 = 17 | 17 min |
 
 `native-artifacts` sets an explicit `name:`, so these matrix columns do not
 rename its jobs. Re-measure before tightening any of them further, and never

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -269,23 +269,31 @@ carries its own `timeout-minutes`:
 | `cargo-xwin xwin cache xwin` | 8 min | 1.27× the worst measured full CRT/SDK download (6 m 19 s) |
 | `Build native binding`, plus one retry | `matrix.build_timeout_minutes` each | each attempt keeps the leg's measured p100 compile bound; a stall costs at most two bounds and the retry fails loudly if needed |
 
-The former blanket 15-minute job cap is replaced by per-leg caps that reserve
-the measured setup plus two bounded compile attempts. We measured setup from
-job start to `Build native binding` over six successful publishes
-(`31689424903`, `31634036246`, `31060235600`, `30892885915`, `30889823603`,
-`30835115933`). The cap arithmetic is `ceil(measured setup) + 2 x
-build_timeout_minutes`:
+The former blanket 15-minute job cap is replaced by per-leg caps. A cap has to
+contain every bounded recovery path the leg owns, not the time a green run
+happened to take: a cap sized on observed setup cancels the job part-way through
+the retry, which is the exact failure the retry exists to survive. Two steps are
+therefore reserved at their bound rather than at their measurement — both
+`setup-zig` attempts (2 + 2 min, Linux) and `cargo-xwin xwin cache xwin` (8 min,
+Windows, whose measured cost is its cache-miss path) — and every leg reserves one
+minute for `upload-artifact`, measured at 4 s or less.
 
-| Leg | Measured setup p100 | Build timeout | Cap arithmetic | Job cap |
-| --- | ---: | ---: | --- | ---: |
-| linux-x64-gnu | 46 s | 5 min | ceil(46s / 60)=1 + 2 x 5 = 11 | 11 min |
-| linux-arm64-gnu | 128 s | 5 min | ceil(128s / 60)=3 + 2 x 5 = 13 | 13 min |
-| linux-x64-musl | 107 s | 5 min | ceil(107s / 60)=2 + 2 x 5 = 12 | 12 min |
-| linux-arm64-musl | 142 s | 5 min | ceil(142s / 60)=3 + 2 x 5 = 13 | 13 min |
-| darwin-x64 | 98 s | 8 min | ceil(98s / 60)=2 + 2 x 8 = 18 | 18 min |
-| darwin-arm64 | 26 s | 5 min | ceil(26s / 60)=1 + 2 x 5 = 11 | 11 min |
-| win32-x64-msvc | 357 s | 5 min | ceil(357s / 60)=6 + 2 x 5 = 16 | 16 min |
-| win32-arm64-msvc | 384 s | 5 min | ceil(384s / 60)=7 + 2 x 5 = 17 | 17 min |
+We measured setup from job start to `Build native binding` over six successful
+publishes (`31689424903`, `31634036246`, `31060235600`, `30892885915`,
+`30889823603`, `30835115933`). The cap arithmetic is `ceil(measured setup minus
+the steps reserved at their bound) + those bounds + 2 x build_timeout_minutes +
+1 upload`:
+
+| Leg | Setup p100 (excl. reserved) | Reserved at bound | Build timeout | Cap arithmetic | Job cap |
+| --- | ---: | ---: | ---: | --- | ---: |
+| linux-x64-gnu | 46 − 18 = 28 s | zig 4 min | 5 min | 1 + 4 + 2 x 5 + 1 = 16 | 16 min |
+| linux-arm64-gnu | 128 − 8 = 120 s | zig 4 min | 5 min | 2 + 4 + 2 x 5 + 1 = 17 | 17 min |
+| linux-x64-musl | 107 − 3 = 104 s | zig 4 min | 5 min | 2 + 4 + 2 x 5 + 1 = 17 | 17 min |
+| linux-arm64-musl | 142 − 5 = 137 s | zig 4 min | 5 min | 3 + 4 + 2 x 5 + 1 = 18 | 18 min |
+| darwin-x64 | 98 s | — | 8 min | 2 + 2 x 8 + 1 = 19 | 19 min |
+| darwin-arm64 | 26 s | — | 5 min | 1 + 2 x 5 + 1 = 12 | 12 min |
+| win32-x64-msvc | 291 − 249 = 42 s | xwin 8 min | 5 min | 1 + 8 + 2 x 5 + 1 = 20 | 20 min |
+| win32-arm64-msvc | 384 − 343 = 41 s | xwin 8 min | 5 min | 1 + 8 + 2 x 5 + 1 = 20 | 20 min |
 
 `native-artifacts` sets an explicit `name:`, so these matrix columns do not
 rename its jobs. Re-measure before tightening any of them further, and never

--- a/test/ci/ci-workflow-contracts.test.ts
+++ b/test/ci/ci-workflow-contracts.test.ts
@@ -464,22 +464,40 @@ test("the shipped build toolchain and Bun do not float", async () => {
 test("each native leg declares its own measured job and compile budget", async () => {
 	const native = jobBlock(await readText(publishPath), "native-artifacts", "linux-binary-smoke");
 	assert.match(native, /^ {4}timeout-minutes: \$\{\{ matrix\.timeout_minutes \}\}$/mu);
-	assert.match(native, /- name: Build native binding\n\s+timeout-minutes: \$\{\{ matrix\.build_timeout_minutes \}\}/u);
+	assert.match(
+		native,
+		/- name: Build native binding\n\s+id: native_build\n\s+continue-on-error: true\n\s+timeout-minutes: \$\{\{ matrix\.build_timeout_minutes \}\}/u,
+	);
+	assert.match(
+		native,
+		/- name: Retry native binding\n\s+if: steps\.native_build\.outcome == 'failure'\n\s+timeout-minutes: \$\{\{ matrix\.build_timeout_minutes \}\}/u,
+	);
+	const buildSteps = jobSteps(native).filter((step) => /(?:Build|Retry) native binding/u.test(step));
+	assert.deepEqual(
+		buildSteps.map((step) => /^name: .+$/mu.exec(step)?.[0]),
+		["name: Build native binding", "name: Retry native binding"],
+	);
+	assert.equal(
+		[...native.matchAll(/timeout-minutes: \$\{\{ matrix\.build_timeout_minutes \}\}/gu)].length,
+		2,
+		"both native compile attempts need their own bounded timeout",
+	);
+	assert.match(buildSteps[0] as string, /continue-on-error: true/u);
+	assert.doesNotMatch(buildSteps[1] as string, /continue-on-error/u);
 	const legs = [
 		...native.matchAll(/platform: (\w+), arch: (\w+),[^}]*timeout_minutes: (\d+), build_timeout_minutes: (\d+)/gu),
 	].map(([, platform, arch, job, build]) => `${platform} ${arch} ${job}/${build}`);
 	assert.deepEqual(legs, [
-		"linux x64 7/5",
-		"linux arm64 8/5",
-		"linux x64 7/5",
-		"linux arm64 8/5",
-		"darwin x64 9/8",
-		"darwin arm64 5/5",
-		"win32 x64 10/5",
-		"win32 arm64 10/5",
+		"linux x64 11/5",
+		"linux arm64 13/5",
+		"linux x64 12/5",
+		"linux arm64 13/5",
+		"darwin x64 18/8",
+		"darwin arm64 11/5",
+		"win32 x64 16/5",
+		"win32 arm64 17/5",
 	]);
-	// The single blanket cap that covered six legs spanning 55s to 443s of real
-	// work must not come back.
+	// No leg may fall back to the former blanket cap.
 	assert.doesNotMatch(native, /timeout-minutes: 15/u);
 });
 

--- a/test/ci/ci-workflow-contracts.test.ts
+++ b/test/ci/ci-workflow-contracts.test.ts
@@ -484,19 +484,33 @@ test("each native leg declares its own measured job and compile budget", async (
 	);
 	assert.match(buildSteps[0] as string, /continue-on-error: true/u);
 	assert.doesNotMatch(buildSteps[1] as string, /continue-on-error/u);
-	const legs = [
+	const legMatches = [
 		...native.matchAll(/platform: (\w+), arch: (\w+),[^}]*timeout_minutes: (\d+), build_timeout_minutes: (\d+)/gu),
-	].map(([, platform, arch, job, build]) => `${platform} ${arch} ${job}/${build}`);
+	];
+	const legs = legMatches.map(([, platform, arch, job, build]) => `${platform} ${arch} ${job}/${build}`);
 	assert.deepEqual(legs, [
-		"linux x64 11/5",
-		"linux arm64 13/5",
-		"linux x64 12/5",
-		"linux arm64 13/5",
-		"darwin x64 18/8",
-		"darwin arm64 11/5",
-		"win32 x64 16/5",
-		"win32 arm64 17/5",
+		"linux x64 16/5",
+		"linux arm64 17/5",
+		"linux x64 17/5",
+		"linux arm64 18/5",
+		"darwin x64 19/8",
+		"darwin arm64 12/5",
+		"win32 x64 20/5",
+		"win32 arm64 20/5",
 	]);
+	// A cap sized on a green run's setup cancels the job mid-retry, which is the
+	// failure the retry exists to survive. Every leg must still contain the bounded
+	// recovery paths it owns: both zig attempts (linux), the CRT populate bound
+	// (win32), two compile attempts, and the artifact upload.
+	const RESERVED_BOUND_MINUTES: Record<string, number> = { linux: 2 + 2, win32: 8, darwin: 0 };
+	const UPLOAD_RESERVE_MINUTES = 1;
+	for (const [, platform, arch, job, build] of legMatches) {
+		const floor = (RESERVED_BOUND_MINUTES[platform as string] ?? 0) + 2 * Number(build) + UPLOAD_RESERVE_MINUTES;
+		assert.ok(
+			Number(job) >= floor,
+			`${platform} ${arch} job cap ${job} cannot contain its bounded recovery path (needs >= ${floor})`,
+		);
+	}
 	// No leg may fall back to the former blanket cap.
 	assert.doesNotMatch(native, /timeout-minutes: 15/u);
 });


### PR DESCRIPTION
## Why

Publish run [31689424903](https://github.com/bastani-inc/atomic/actions/runs/31689424903) (Publish `0.9.13-alpha.3`) lost the entire release to one hung compile. The `Native linux-arm64-gnu` leg finished setup in 58 s, started `Build native binding` at 10:05:23, and the job was cancelled at 10:17:25 — roughly 12 minutes against a step budget of 5 and a job budget of 8. Every other native leg passed; all downstream jobs skipped, so the tag shipped nothing and recovery required a manual `gh run rerun --failed`.

The budgets are not too small. Measured `Native linux-arm64-gnu` durations across the last five publishes were 1.8, 3.5, 2.0, 2.1 and 2.2 minutes. The build hung.

## What changed

**One bounded retry, mirroring the file's own zig precedent.** `Build native binding` gains `id: native_build` and `continue-on-error: true`, keeping `timeout-minutes: ${{ matrix.build_timeout_minutes }}`. A new `Retry native binding` step is gated on `if: steps.native_build.outcome == 'failure'`, carries the same bounded timeout, and has **no** `continue-on-error`, so a second failure kills the job. This is the same shape as the existing `Setup zig for portable Linux builds` / `Retry zig acquisition on a re-shuffled mirror list` pair. Exactly two attempts exist; there is no loop, and per-step stall detection is preserved rather than replaced by a bigger budget.

**Job caps re-derived so a leg can hold setup plus two attempts.** `build_timeout_minutes` is untouched. Setup was measured job-start → build-start across six successful publishes (`31689424903`, `31634036246`, `31060235600`, `30892885915`, `30889823603`, `30835115933`), taking the p100 per leg. The arithmetic is `ceil(measured p100 setup / 60) + 2 × build_timeout_minutes`:

| Leg | Setup p100 | Build budget | Arithmetic | New cap | Was |
| --- | ---: | ---: | --- | ---: | ---: |
| linux-x64-gnu | 46 s | 5 | `ceil(46/60)=1 + 2×5` | 11 | 7 |
| linux-arm64-gnu | 128 s | 5 | `ceil(128/60)=3 + 2×5` | 13 | 8 |
| linux-x64-musl | 107 s | 5 | `ceil(107/60)=2 + 2×5` | 12 | 7 |
| linux-arm64-musl | 142 s | 5 | `ceil(142/60)=3 + 2×5` | 13 | 8 |
| darwin-x64 | 98 s | 8 | `ceil(98/60)=2 + 2×8` | 18 | 9 |
| darwin-arm64 | 26 s | 5 | `ceil(26/60)=1 + 2×5` | 11 | 5 |
| win32-x64-msvc | 357 s | 5 | `ceil(357/60)=6 + 2×5` | 16 | 10 |
| win32-arm64-msvc | 384 s | 5 | `ceil(384/60)=7 + 2×5` | 17 | 10 |

**Contract test updated deliberately, keeping its intent.** `test/ci/ci-workflow-contracts.test.ts` ("each native leg declares its own measured job and compile budget") now asserts the first attempt's `name → id → continue-on-error → timeout-minutes` adjacency, the retry's `name → if → timeout-minutes` adjacency, that exactly two steps match `(Build|Retry) native binding` in that order, that `matrix.build_timeout_minutes` appears exactly twice, that only the first attempt carries `continue-on-error`, and the eight new leg budget strings. The blanket-cap guard `assert.doesNotMatch(native, /timeout-minutes: 15/u)` is retained and passes.

**Docs.** `docs/ci.md` records the retry, the six run ids the setup measurement came from, and the per-leg arithmetic.

**No package changelog entry.** This is infrastructure/CI-only; per `AGENTS.md`, release-pipeline changes do not warrant a `packages/*/CHANGELOG.md` entry.

Three files, 82 insertions / 35 deletions. No other workflow file touched.

## Validation

| Command | Outcome |
| --- | --- |
| `npm run test:ci-contracts` | **6 files, 41 tests passed** — covers `ci-workflow-contracts`, `release-publisher-contracts`, `release-recovery-contracts`, `actions-cache-bump-contract`, plus topology and subagents-clean-break |
| `npm run check` | passed (biome, `tsc --noEmit`, `tsgo -p tsconfig.build.json --noEmit`, shrinkwrap) |
| `npm run test:unit`, `npm run test:integration` | passed via the pre-push hooks |

`actionlint` is not installed locally, so the edited workflow was parsed with the repo's `yaml` dependency and the shipped shape asserted structurally rather than by text match:

```
build: { name: "Build native binding", id: "native_build", coe: true,
         to: "${{ matrix.build_timeout_minutes }}", run: "bun run --cwd packages/natives build" }
retry: { name: "Retry native binding", if: "steps.native_build.outcome == 'failure'",
         coe: null,  to: "${{ matrix.build_timeout_minutes }}", run: "bun run --cwd packages/natives build" }
attempts named /native binding/: 2   identical env: true   identical run: true
every leg: job cap >= 2 x build budget  -> fits2=true for all eight
```

**Regression proof.** Restoring the pre-change `publish.yml` under the updated test fails it:

```
x each native leg declares its own measured job and compile budget
AssertionError: The input did not match /- name: Build native binding\n\s+id: native_build\n
  \s+continue-on-error: true\n\s+timeout-minutes: \$\{\{ matrix\.build_timeout_minutes \}\}/u
Tests  1 failed | 22 passed (23)
```

The test therefore discriminates old structure from new rather than merely tracking it.

## Known limits, stated not hidden

Three non-blocking reviewer observations, all consequences of the prescribed design rather than defects in it:

- **A job-cap cancellation still bypasses the retry.** The gate fires on step *outcome* `failure`. When a step timeout kills attempt one the runner sets `Result = Failed` before applying `continue-on-error`, so the retry works as designed. But when the job cap fires first, the step outcome is `cancelled` and the retry is skipped. The motivating incident is exactly that shape — neither budget fired on schedule — and with the new 13-minute arm64 cap a non-firing stall now burns longer before cancelling. Worth watching on the next stalled leg.
- **Post-build headroom is thin.** The cap formula reserves setup plus two attempts and nothing for `actions/upload-artifact`; in the worst retry case the only slack is the `ceil()` rounding (14 s on linux-x64-gnu). Adding one minute per leg would close this without touching `build_timeout_minutes`.
- **Windows caps reserve measured setup, not bounded worst-case setup.** `win32-x64-msvc` setup is dominated by the MSVC CRT cache populate step, whose own bound is 8 minutes; a legal but slow download plus a full retry could exceed the 16-minute cap. Setup headroom on those legs still rose from 5 to 6 minutes. Worth folding into the next re-measurement.

The retry path has not executed on a real runner; only its structure and contracts are proven locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789231839&installation_model_id=10562&pr_number=2366&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2366&signature=5d8d86302448b6d13464744db6c755c582c36ad0e46885d70416570dd9af6789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change expands native publishing job budgets to cover bounded toolchain recovery, two native-build attempts, and artifact upload time across all platform legs.

The prior finding, **Native job cap omits the Zig retry path**, is fixed. A deterministic calculation exercised the bounded recovery path against both revisions: the parent workflow undersized every native-artifact leg, while the current workflow meets the required recovery budget for all eight legs.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the native artifact job caps now accommodate their configured bounded recovery paths.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Authored the native recovery-cap validator, a deterministic YAML-based validator that parses the workflow and computes per-row recovery budgets.
- Observed that the prior workflow failure calculation showed all eight matrix rows undersized against their budgets on the parent workflow.
- Observed the current workflow passing calculation, with all matrix legs meeting their exact minimum caps and Darwin two-build-plus-upload paths passing.
- Ran the release recovery CI contract and confirmed three tests passed.

<a href="https://app.greptile.com/trex/runs/18737009/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["ci: reserve the bounded recovery paths i..."](https://github.com/bastani-inc/atomic/commit/2b6dc6adff4f8d8fb0dfca6b8196f3ba1bfa5546) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53037326)</sub>

<!-- /greptile_comment -->