### PR TITLE
feat(workflows): show the jump-to-bottom follow indicator in stage chat

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fixed a stall where a message queued during a turn was shown in the transcript but never answered, leaving the session idle until you typed another message. Escape and Ctrl+C hold queued work by pausing the agent's own steering and follow-up queues, but a message the agent loop has already polled is no longer in either queue: it is written straight into the transcript, so the interrupt cancelled its reply and nothing scheduled a new one. This was most visible after answering an `ask_user_question` questionnaire, which admits the queued message and immediately opens the request the interrupt then cancels. An admitted message whose reply was cancelled before it produced any output now receives that reply, and a message you send while that reply is still streaming is delivered as soon as it finishes. Queued messages that are still held are unchanged: Escape still restores them to the editor and leaves the session paused, and a reply that had already streamed some output is never restarted ([#2362](https://github.com/bastani-inc/atomic/issues/2362)).
+- Fixed isolated overlay components such as workflow stage chat failing to re-render after a terminal height change, which could clip the composer and footer after a vertical resize.
 
 ## [0.9.13-alpha.3] - 2026-08-13
 

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -404,6 +404,7 @@ export {
 	ThinkingSelectorComponent,
 	ToolExecutionComponent,
 	type ToolExecutionOptions,
+	TranscriptFollowIndicator,
 	TreeSelectorComponent,
 	truncateToVisualLines,
 	UsageMeterComponent,

--- a/packages/coding-agent/src/modes/interactive-engine/remote-component.ts
+++ b/packages/coding-agent/src/modes/interactive-engine/remote-component.ts
@@ -30,6 +30,7 @@ class RemoteComponent implements Component {
 	wantsKeyRelease = true;
 	private lines = ["Loading remote component…"];
 	private width = 0;
+	private rows = 0;
 	private requestId = 0;
 	private inputRequestId = 0;
 	private appliedRequestId = 0;
@@ -56,15 +57,17 @@ class RemoteComponent implements Component {
 	}
 
 	render(width: number): string[] {
-		if (!this.disposed && (this.dirty || width !== this.width)) {
+		const rows = this.getRows();
+		if (!this.disposed && (this.dirty || width !== this.width || rows !== this.rows)) {
 			this.width = width;
+			this.rows = rows;
 			this.dirty = false;
 			this.runtime.sendEngineCommand({
 				type: "engine_custom_render",
 				componentId: this.componentId,
 				requestId: ++this.requestId,
 				width,
-				rows: this.getRows(),
+				rows,
 			});
 		}
 		// The engine child re-renders asynchronously; until the fresh frame

--- a/packages/coding-agent/src/modes/interactive/components/index.ts
+++ b/packages/coding-agent/src/modes/interactive/components/index.ts
@@ -62,6 +62,7 @@ export { SkillInvocationMessageComponent } from "./skill-invocation-message.ts";
 export { ThemeSelectorComponent } from "./theme-selector.ts";
 export { ThinkingSelectorComponent } from "./thinking-selector.ts";
 export { ToolExecutionComponent, type ToolExecutionOptions } from "./tool-execution.ts";
+export { TranscriptFollowIndicator } from "./transcript-follow-indicator.ts";
 export { TreeSelectorComponent } from "./tree-selector.ts";
 export { TrustSelectorComponent } from "./trust-selector.ts";
 export { UserMessageComponent } from "./user-message.ts";

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- Added the shared clickable "Jump to bottom" follow indicator to workflow stage chat when its transcript is scrolled away from the live end, while preserving composer and footer rows in tight overlays.
+- Added the shared "Jump to bottom" follow indicator to workflow stage chat when its transcript is scrolled away from the live end, while preserving composer and footer rows in tight overlays.
 
 ## [0.9.13-alpha.3] - 2026-08-13
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added the shared clickable "Jump to bottom" follow indicator to workflow stage chat when its transcript is scrolled away from the live end, while preserving composer and footer rows in tight overlays.
+
 ## [0.9.13-alpha.3] - 2026-08-13
 
 ### Changed

--- a/packages/workflows/src/tui/keybindings-adapter.ts
+++ b/packages/workflows/src/tui/keybindings-adapter.ts
@@ -44,6 +44,7 @@ export const APP_ACTION = {
 } as const;
 
 export const TUI_ACTION = {
+	altScreenBottom: "tui.altScreen.bottom",
 	editorCursorUp: "tui.editor.cursorUp",
 	editorCursorDown: "tui.editor.cursorDown",
 	editorCursorLeft: "tui.editor.cursorLeft",

--- a/packages/workflows/src/tui/stage-chat-view-input.ts
+++ b/packages/workflows/src/tui/stage-chat-view-input.ts
@@ -1,4 +1,4 @@
-import { APP_ACTION, isKeybindingsLike, matchesAction } from "./keybindings-adapter.js";
+import { APP_ACTION, isKeybindingsLike, matchesAction, TUI_ACTION } from "./keybindings-adapter.js";
 import { parseTerminalMouseInput, terminalMouseWheelDirection } from "./mouse-input.js";
 import { defaultResponseFor, handlePromptCardInput, isPromptEscapeInput } from "./prompt-card.js";
 import { releaseMountedCustomUi } from "./stage-chat-view-custom-ui.js";
@@ -51,6 +51,10 @@ export function handleStageChatInput(ctx: StageChatViewContext, data: string): b
 	if (readOnlyPromptArchive && handlePromptScrollInput(ctx, data, true)) {
 		return true;
 	}
+	if (matchesAction(keybindings, data, TUI_ACTION.altScreenBottom)) {
+		ctx.chatHost.scrollToBottom();
+		return true;
+	}
 	if (ctx.chatHost.handleScrollInput(data)) return true;
 	if (matchesKey(data, Key.escape)) {
 		if (ctx.chatHost.isCompacting() || ctx.chatHost.isBashRunning() || ctx.chatHost.isEditingBashCommand()) {
@@ -79,7 +83,6 @@ export function handleStageChatInput(ctx: StageChatViewContext, data: string): b
 	if (blocked) return true;
 	return ctx.chatHost.handleInput(data);
 }
-
 function handleToolsExpandInput(ctx: StageChatViewContext, data: string): boolean {
 	const keybindings = isKeybindingsLike(ctx.piKeybindings) ? ctx.piKeybindings : undefined;
 	if (!matchesAction(keybindings, data, APP_ACTION.toolsExpand)) return false;

--- a/packages/workflows/src/tui/stage-chat-view-input.ts
+++ b/packages/workflows/src/tui/stage-chat-view-input.ts
@@ -51,10 +51,7 @@ export function handleStageChatInput(ctx: StageChatViewContext, data: string): b
 	if (readOnlyPromptArchive && handlePromptScrollInput(ctx, data, true)) {
 		return true;
 	}
-	if (matchesAction(keybindings, data, TUI_ACTION.altScreenBottom)) {
-		ctx.chatHost.scrollToBottom();
-		return true;
-	}
+	if (handleStageChatJumpToBottom(ctx, data)) return true;
 	if (ctx.chatHost.handleScrollInput(data)) return true;
 	if (matchesKey(data, Key.escape)) {
 		if (ctx.chatHost.isCompacting() || ctx.chatHost.isBashRunning() || ctx.chatHost.isEditingBashCommand()) {
@@ -83,6 +80,13 @@ export function handleStageChatInput(ctx: StageChatViewContext, data: string): b
 	if (blocked) return true;
 	return ctx.chatHost.handleInput(data);
 }
+
+function handleStageChatJumpToBottom(ctx: StageChatViewContext, data: string): boolean {
+	const keybindings = isKeybindingsLike(ctx.piKeybindings) ? ctx.piKeybindings : undefined;
+	if (!matchesAction(keybindings, data, TUI_ACTION.altScreenBottom)) return false;
+	ctx.chatHost.scrollToBottom();
+	return true;
+}
 function handleToolsExpandInput(ctx: StageChatViewContext, data: string): boolean {
 	const keybindings = isKeybindingsLike(ctx.piKeybindings) ? ctx.piKeybindings : undefined;
 	if (!matchesAction(keybindings, data, APP_ACTION.toolsExpand)) return false;
@@ -110,6 +114,10 @@ function handleMountedCustomUiInput(ctx: StageChatViewContext, data: string): bo
 	}
 	// Let scroll input reach the transcript so history stays scrollable while the
 	// question is shown, matching the standalone ask_user_question tool.
+	if (handleStageChatJumpToBottom(ctx, data)) {
+		ctx.requestRender?.();
+		return true;
+	}
 	if (ctx.chatHost.handleScrollInput(data)) {
 		ctx.requestRender?.();
 		return true;

--- a/packages/workflows/src/tui/stage-chat-view-input.ts
+++ b/packages/workflows/src/tui/stage-chat-view-input.ts
@@ -51,7 +51,7 @@ export function handleStageChatInput(ctx: StageChatViewContext, data: string): b
 	if (readOnlyPromptArchive && handlePromptScrollInput(ctx, data, true)) {
 		return true;
 	}
-	if (handleStageChatScrollInput(ctx, data)) return true;
+	if (ctx.chatHost.handleScrollInput(data)) return true;
 	if (matchesKey(data, Key.escape)) {
 		if (ctx.chatHost.isCompacting() || ctx.chatHost.isBashRunning() || ctx.chatHost.isEditingBashCommand()) {
 			return ctx.chatHost.handleInput(data);
@@ -80,14 +80,6 @@ export function handleStageChatInput(ctx: StageChatViewContext, data: string): b
 	return ctx.chatHost.handleInput(data);
 }
 
-function handleStageChatScrollInput(ctx: StageChatViewContext, data: string): boolean {
-	const wasScrolled = ctx.chatHost.bodyScrollFromBottom() > 0;
-	const handled = ctx.chatHost.handleScrollInput(data);
-	if (handled && wasScrolled && matchesKey(data, "pageDown") && ctx.chatHost.bodyScrollFromBottom() <= 1) {
-		ctx.chatHost.scrollToBottom();
-	}
-	return handled;
-}
 function handleToolsExpandInput(ctx: StageChatViewContext, data: string): boolean {
 	const keybindings = isKeybindingsLike(ctx.piKeybindings) ? ctx.piKeybindings : undefined;
 	if (!matchesAction(keybindings, data, APP_ACTION.toolsExpand)) return false;

--- a/packages/workflows/src/tui/stage-chat-view-input.ts
+++ b/packages/workflows/src/tui/stage-chat-view-input.ts
@@ -51,7 +51,7 @@ export function handleStageChatInput(ctx: StageChatViewContext, data: string): b
 	if (readOnlyPromptArchive && handlePromptScrollInput(ctx, data, true)) {
 		return true;
 	}
-	if (ctx.chatHost.handleScrollInput(data)) return true;
+	if (handleStageChatScrollInput(ctx, data)) return true;
 	if (matchesKey(data, Key.escape)) {
 		if (ctx.chatHost.isCompacting() || ctx.chatHost.isBashRunning() || ctx.chatHost.isEditingBashCommand()) {
 			return ctx.chatHost.handleInput(data);
@@ -78,6 +78,15 @@ export function handleStageChatInput(ctx: StageChatViewContext, data: string): b
 	}
 	if (blocked) return true;
 	return ctx.chatHost.handleInput(data);
+}
+
+function handleStageChatScrollInput(ctx: StageChatViewContext, data: string): boolean {
+	const wasScrolled = ctx.chatHost.bodyScrollFromBottom() > 0;
+	const handled = ctx.chatHost.handleScrollInput(data);
+	if (handled && wasScrolled && matchesKey(data, "pageDown") && ctx.chatHost.bodyScrollFromBottom() <= 1) {
+		ctx.chatHost.scrollToBottom();
+	}
+	return handled;
 }
 function handleToolsExpandInput(ctx: StageChatViewContext, data: string): boolean {
 	const keybindings = isKeybindingsLike(ctx.piKeybindings) ? ctx.piKeybindings : undefined;

--- a/packages/workflows/src/tui/stage-chat-view.ts
+++ b/packages/workflows/src/tui/stage-chat-view.ts
@@ -23,6 +23,7 @@
  *  - https://pi.dev/docs/latest/tui (canonical Pi-tui component contract)
  */
 
+import { keyText, TranscriptFollowIndicator } from "@bastani/atomic";
 import type { Component, Focusable } from "@earendil-works/pi-tui";
 import { fitStageChatFrame, planStageChatFrame } from "./stage-chat-layout.js";
 import {
@@ -155,26 +156,33 @@ export class StageChatView implements Component, Focusable {
 		const visibleFooterLines = takeRows(footerLines, plan.footerRows);
 		const bodyBudget = plan.bodyRows;
 		if (blocked) this.chatHost.scrollToBottom();
+		const indicator = new TranscriptFollowIndicator({
+			isFollowing: () => this.chatHost.bodyScrollFromBottom() === 0,
+			keyLabel: () => keyText("tui.altScreen.bottom"),
+		});
+		const indicatorLines = bodyBudget > 1 && this.chatHost.bodyScrollFromBottom() > 0 ? indicator.render(w) : [];
+		const bodyRenderBudget = bodyBudget - (indicatorLines.length > 0 ? 1 : 0);
 
 		let bodyLines: string[];
-		if (bodyBudget <= 0) {
+		if (bodyRenderBudget <= 0) {
 			bodyLines = [];
 		} else if (promptActive) {
-			bodyLines = renderPromptBody(ctx, w, bodyBudget);
+			bodyLines = renderPromptBody(ctx, w, bodyRenderBudget);
 		} else if (blocked) {
-			bodyLines = renderBlockedBody(ctx, w, bodyBudget, stage);
+			bodyLines = renderBlockedBody(ctx, w, bodyRenderBudget, stage);
 		} else if (!readOnlyArchive && isPaused(ctx, stage)) {
-			bodyLines = renderPausedBody(ctx, w, bodyBudget);
+			bodyLines = renderPausedBody(ctx, w, bodyRenderBudget);
 		} else if (readOnlyArchive) {
-			bodyLines = renderReadOnlyArchiveBody(ctx, w, bodyBudget, stage);
+			bodyLines = renderReadOnlyArchiveBody(ctx, w, bodyRenderBudget, stage);
 		} else {
-			bodyLines = this.chatHost.renderBody(w, bodyBudget);
+			bodyLines = this.chatHost.renderBody(w, bodyRenderBudget);
 		}
 
 		const lines = [
 			...headerLines,
 			...sepLines,
 			...bodyLines,
+			...indicatorLines,
 			...visiblePendingLines,
 			...visibleWorkingLines,
 			...visibleUsageLines,

--- a/packages/workflows/src/tui/stage-chat-view.ts
+++ b/packages/workflows/src/tui/stage-chat-view.ts
@@ -156,13 +156,9 @@ export class StageChatView implements Component, Focusable {
 		const visibleFooterLines = takeRows(footerLines, plan.footerRows);
 		const bodyBudget = plan.bodyRows;
 		if (blocked) this.chatHost.scrollToBottom();
-		const indicator = new TranscriptFollowIndicator({
-			isFollowing: () => this.chatHost.bodyScrollFromBottom() === 0,
-			keyLabel: () => keyText("tui.altScreen.bottom"),
-		});
-		const indicatorLines = bodyBudget > 1 ? indicator.render(w) : [];
 
 		let bodyLines: string[];
+		let transcriptBodyActive = false;
 		if (bodyBudget <= 0) {
 			bodyLines = [];
 		} else if (promptActive) {
@@ -174,10 +170,16 @@ export class StageChatView implements Component, Focusable {
 		} else if (readOnlyArchive) {
 			bodyLines = renderReadOnlyArchiveBody(ctx, w, bodyBudget, stage);
 		} else {
+			transcriptBodyActive = true;
 			bodyLines = this.chatHost.renderBody(w, bodyBudget);
 		}
+		const indicator = new TranscriptFollowIndicator({
+			isFollowing: () => this.chatHost.bodyScrollFromBottom() === 0,
+			keyLabel: () => keyText("tui.altScreen.bottom"),
+		});
+		const indicatorLines = transcriptBodyActive && bodyBudget > 1 ? indicator.render(w) : [];
 		const indicatorVisible = indicatorLines.length > 0;
-		const dropBodyRow = indicatorVisible && bodyLines.length >= bodyBudget;
+		const dropBodyRow = transcriptBodyActive && indicatorVisible && bodyLines.length >= bodyBudget;
 		const visibleBodyLines = bodyLines.slice(dropBodyRow ? 1 : 0, bodyBudget);
 
 		const lines = [

--- a/packages/workflows/src/tui/stage-chat-view.ts
+++ b/packages/workflows/src/tui/stage-chat-view.ts
@@ -160,28 +160,30 @@ export class StageChatView implements Component, Focusable {
 			isFollowing: () => this.chatHost.bodyScrollFromBottom() === 0,
 			keyLabel: () => keyText("tui.altScreen.bottom"),
 		});
-		const indicatorLines = bodyBudget > 1 && this.chatHost.bodyScrollFromBottom() > 0 ? indicator.render(w) : [];
-		const bodyRenderBudget = bodyBudget - (indicatorLines.length > 0 ? 1 : 0);
+		const indicatorLines = bodyBudget > 1 ? indicator.render(w) : [];
 
 		let bodyLines: string[];
-		if (bodyRenderBudget <= 0) {
+		if (bodyBudget <= 0) {
 			bodyLines = [];
 		} else if (promptActive) {
-			bodyLines = renderPromptBody(ctx, w, bodyRenderBudget);
+			bodyLines = renderPromptBody(ctx, w, bodyBudget);
 		} else if (blocked) {
-			bodyLines = renderBlockedBody(ctx, w, bodyRenderBudget, stage);
+			bodyLines = renderBlockedBody(ctx, w, bodyBudget, stage);
 		} else if (!readOnlyArchive && isPaused(ctx, stage)) {
-			bodyLines = renderPausedBody(ctx, w, bodyRenderBudget);
+			bodyLines = renderPausedBody(ctx, w, bodyBudget);
 		} else if (readOnlyArchive) {
-			bodyLines = renderReadOnlyArchiveBody(ctx, w, bodyRenderBudget, stage);
+			bodyLines = renderReadOnlyArchiveBody(ctx, w, bodyBudget, stage);
 		} else {
-			bodyLines = this.chatHost.renderBody(w, bodyRenderBudget);
+			bodyLines = this.chatHost.renderBody(w, bodyBudget);
 		}
+		const indicatorVisible = indicatorLines.length > 0;
+		const dropBodyRow = indicatorVisible && bodyLines.length >= bodyBudget;
+		const visibleBodyLines = bodyLines.slice(dropBodyRow ? 1 : 0, bodyBudget);
 
 		const lines = [
 			...headerLines,
 			...sepLines,
-			...bodyLines,
+			...visibleBodyLines,
 			...indicatorLines,
 			...visiblePendingLines,
 			...visibleWorkingLines,

--- a/test/unit/interactive-engine-resize-clamp.test.ts
+++ b/test/unit/interactive-engine-resize-clamp.test.ts
@@ -208,6 +208,69 @@ test("remote custom-UI widget frames are clamped after a shrink", () => {
 	assertMaxWidth(widget.render(NARROW), NARROW, "widget stale frame after shrink");
 });
 
+test("remote custom-UI frames re-render when only the host height changes", () => {
+	const fake = makeFakeRuntime();
+	let rows = 20;
+	let hostComponent: { render(width: number): string[] } | undefined;
+	const ui = {
+		requestRender: () => {},
+		setWidget: () => {},
+		custom: (
+			factory: (
+				tui: unknown,
+				theme: unknown,
+				keybindings: unknown,
+				done: (result: unknown) => void,
+			) => { render(width: number): string[] },
+		) => {
+			hostComponent = factory(
+				{
+					terminal: {
+						columns: 100,
+						get rows() {
+							return rows;
+						},
+					},
+				},
+				{},
+				{},
+				() => {},
+			);
+			return new Promise(() => {});
+		},
+	} as unknown as ExtensionUIContext;
+	const controller = new RemoteComponentController(fake.runtime, ui, regularTuiRendererLifecycle);
+
+	fake.emit({
+		type: "engine_custom_open",
+		componentId: "custom_1",
+		overlay: true,
+	} as InteractiveEngineMessage);
+	assert.ok(hostComponent, "custom component was not mounted on the host");
+
+	hostComponent.render(80);
+	const initial = fake.commands.at(-1);
+	assert.equal(initial?.type, "engine_custom_render");
+	assert.equal(initial?.width, 80);
+	assert.equal(initial?.rows, 20);
+	const commandCount = fake.commands.length;
+
+	hostComponent.render(80);
+	assert.equal(fake.commands.length, commandCount, "unchanged dimensions sent a redundant render request");
+
+	rows = 12;
+	hostComponent.render(80);
+	const resized = fake.commands.at(-1);
+	assert.equal(resized?.type, "engine_custom_render");
+	assert.equal(resized?.width, 80);
+	assert.equal(resized?.rows, 12);
+	assert.equal(fake.commands.length, commandCount + 1, "height-only resize did not request a fresh frame");
+
+	hostComponent.render(80);
+	assert.equal(fake.commands.length, commandCount + 1, "unchanged resized dimensions sent a redundant request");
+	controller.dispose();
+});
+
 test("RemoteFrameWidthClamp memoizes and passes through fitting frames untouched", () => {
 	const clamp = new RemoteFrameWidthClamp();
 	const fitting = ["short", "also short"];

--- a/test/unit/overlay-adapter-autowrap.test.ts
+++ b/test/unit/overlay-adapter-autowrap.test.ts
@@ -43,6 +43,7 @@ async function registerIsolatedTests(): Promise<void> {
 
 	mock.module("@bastani/atomic", () => ({
 		ChatSessionHost: TestComponent,
+		TranscriptFollowIndicator: TestComponent,
 		keyHint: (key: string) => key,
 		keyText: (key: string) => key,
 		rawKeyHint: (key: string) => key,

--- a/test/unit/overlay-adapter-hidden-render.test.ts
+++ b/test/unit/overlay-adapter-hidden-render.test.ts
@@ -59,6 +59,7 @@ async function registerIsolatedTests(): Promise<void> {
 
 	mock.module("@bastani/atomic", () => ({
 		ChatSessionHost: TestComponent,
+		TranscriptFollowIndicator: TestComponent,
 		keyHint: (key: string) => key,
 		keyText: (key: string) => key,
 		rawKeyHint: (key: string) => key,

--- a/test/unit/stage-chat-view-03.test.ts
+++ b/test/unit/stage-chat-view-03.test.ts
@@ -1,4 +1,6 @@
+import { getKeybindings, setKeybindings, stripTerminalSequences } from "@earendil-works/pi-tui";
 import { describe, test } from "vitest";
+import { KeybindingsManager } from "../../packages/coding-agent/src/core/keybindings.ts";
 import type { PiCustomComponent } from "../../packages/workflows/src/extension/ui-surface.js";
 import {
 	type AgentSession,
@@ -10,6 +12,7 @@ import {
 	makeFakeKeybindings,
 	makeHandle,
 	makePendingPrompt,
+	makeTestTui,
 	RETURN_HINT_TEXT,
 	StageChatView,
 	StageUiBroker,
@@ -19,6 +22,69 @@ import {
 } from "./stage-chat-view-helpers.js";
 
 describe("StageChatView", () => {
+	test("honors a remapped jump-to-bottom binding while custom UI is mounted", async () => {
+		const previousKeybindings = getKeybindings();
+		const keybindings = new KeybindingsManager({ "tui.altScreen.bottom": "ctrl+e" });
+		setKeybindings(keybindings);
+		const store = createStore();
+		setupRun(store, "run-1", "stage-a", "pending");
+		const broker = new StageUiBroker(store);
+		const { handle } = makeHandle();
+		const view = new StageChatView({
+			store,
+			graphTheme: deriveGraphTheme({}),
+			runId: "run-1",
+			stageId: "stage-a",
+			workflowName: "test-wf",
+			handle,
+			onDetach: () => {},
+			onClose: () => {},
+			piTui: makeTestTui(12),
+			piTheme: {},
+			piKeybindings: keybindings,
+			stageUiBroker: broker,
+		});
+		const abortController = new AbortController();
+		try {
+			for (let i = 0; i < 18; i++) {
+				for (const ch of `custom-follow-msg-${i}`) view.handleInput(ch);
+				view.handleInput(String.fromCharCode(13));
+				await flush();
+				await flush();
+			}
+			view.render(96);
+			assert.equal(view.handleInput(`${String.fromCharCode(27)}[5~`), true);
+			assert.ok(view._bodyScrollFromBottom > 0);
+
+			const pending = broker.requestCustomUi(
+				"run-1",
+				"stage-a",
+				(_tui, _theme, _keybindings, _done): PiCustomComponent => ({
+					render: () => ["custom question"],
+					handleInput: () => true,
+					invalidate: () => {},
+				}),
+				undefined,
+				abortController.signal,
+			);
+			pending.catch(() => {});
+			await flush();
+			const scrolled = stripTerminalSequences(view.render(96).join("\n"));
+			assert.ok(scrolled.includes("Jump to bottom (ctrl+e) ↓"));
+			assert.ok(scrolled.includes("custom question"));
+
+			assert.equal(view.handleInput(String.fromCharCode(5)), true);
+			assert.equal(view._bodyScrollFromBottom, 0);
+			const bottom = stripTerminalSequences(view.render(96).join("\n"));
+			assert.ok(!bottom.includes("Jump to bottom"));
+			assert.ok(bottom.includes("custom question"));
+		} finally {
+			abortController.abort();
+			view.dispose();
+			setKeybindings(previousKeybindings);
+		}
+	});
+
 	test("keeps mounted custom UI above structured stage pending prompts", async () => {
 		const store = createStore();
 		setupRun(store, "run-1", "stage-a");

--- a/test/unit/stage-chat-view-13.test.ts
+++ b/test/unit/stage-chat-view-13.test.ts
@@ -1,14 +1,51 @@
+import { stripTerminalSequences } from "@earendil-works/pi-tui";
 import { describe, test } from "vitest";
 import {
 	assert,
 	createStore,
 	deriveGraphTheme,
+	fakeFooterAgentSession,
 	flush,
 	makeHandle,
 	makeTestTui,
 	StageChatView,
 	setupRun,
 } from "./stage-chat-view-helpers.js";
+
+async function makeScrollableStageChat(
+	rows: number | (() => number | undefined) = 12,
+	withFooter = false,
+): Promise<StageChatView> {
+	const store = createStore();
+	setupRun(store, "run-1", "stage-a", "pending");
+	const { handle } = withFooter ? makeHandle(undefined, [], "pending", fakeFooterAgentSession()) : makeHandle();
+	const view = new StageChatView({
+		store,
+		graphTheme: deriveGraphTheme({}),
+		runId: "run-1",
+		stageId: "stage-a",
+		workflowName: "test-wf",
+		handle,
+		onDetach: () => {},
+		onClose: () => {},
+		piTui: makeTestTui(rows),
+		footerData: withFooter
+			? {
+					getGitBranch: () => "main",
+					getExtensionStatuses: () => new Map(),
+					getAvailableProviderCount: () => 1,
+					onBranchChange: () => () => {},
+				}
+			: undefined,
+	});
+	for (let i = 0; i < 18; i++) {
+		for (const ch of `follow-msg-${i}`) view.handleInput(ch);
+		view.handleInput("\r");
+		await flush();
+		await flush();
+	}
+	return view;
+}
 
 describe("StageChatView", () => {
 	test("expands the chat surface to the reported viewport row count", () => {
@@ -165,6 +202,66 @@ describe("StageChatView", () => {
 		const before = view._inputBuffer;
 		view.handleInput("\x1b[<0;10;10M");
 		assert.equal(view._inputBuffer, before);
+		view.dispose();
+	});
+	test("hides the follow indicator at the live end after returning without changing row count", async () => {
+		const view = await makeScrollableStageChat();
+		view.render(96);
+		view.handleInput("\x1b[5~");
+		assert.match(stripTerminalSequences(view.render(96).join("\n")), /Jump to bottom \(end\) ↓/);
+
+		assert.equal(view.handleInput("\x1b[F"), true);
+		const bottom = view.render(96);
+		const visible = stripTerminalSequences(bottom.join("\n"));
+		assert.equal(view._bodyScrollFromBottom, 0);
+		assert.doesNotMatch(visible, /Jump to bottom/);
+		assert.equal(bottom.length, 12);
+		view.dispose();
+	});
+
+	test("shows the shared follow indicator after scrolling stage-chat history", async () => {
+		const view = await makeScrollableStageChat();
+		view.render(96);
+		assert.equal(view.handleInput("\x1b[5~"), true);
+		const scrolled = view.render(96);
+		const visible = stripTerminalSequences(scrolled.join("\n"));
+
+		assert.ok(view._bodyScrollFromBottom > 0);
+		assert.match(visible, /Jump to bottom \(end\) ↓/);
+		assert.equal(scrolled.length, 12);
+		view.dispose();
+	});
+
+	test("the bound end key returns stage chat to the live end and hides the indicator", async () => {
+		const view = await makeScrollableStageChat();
+		view.render(96);
+		view.handleInput("\x1b[5~");
+		assert.match(stripTerminalSequences(view.render(96).join("\n")), /Jump to bottom \(end\) ↓/);
+
+		assert.equal(view.handleInput("\x1b[F"), true);
+		const bottom = view.render(96);
+		const visible = stripTerminalSequences(bottom.join("\n"));
+		assert.equal(view._bodyScrollFromBottom, 0);
+		assert.doesNotMatch(visible, /Jump to bottom/);
+		assert.equal(bottom.length, 12);
+		view.dispose();
+	});
+
+	test("drops the indicator before the composer and footer in a tight viewport", async () => {
+		let rows = 12;
+		const view = await makeScrollableStageChat(() => rows, true);
+		view.render(96);
+		assert.equal(view.handleInput("\x1b[5~"), true);
+		assert.match(stripTerminalSequences(view.render(96).join("\n")), /Jump to bottom \(end\) ↓/);
+
+		rows = 8;
+		const tight = view.render(96);
+		const visible = stripTerminalSequences(tight.join("\n"));
+		assert.ok(view._bodyScrollFromBottom > 0);
+		assert.doesNotMatch(visible, /Jump to bottom/);
+		assert.ok(visible.includes("❯"), "composer must survive the tight viewport");
+		assert.match(visible, /ctrl\+x return to graph/);
+		assert.equal(tight.length, 8);
 		view.dispose();
 	});
 });

--- a/test/unit/stage-chat-view-13.test.ts
+++ b/test/unit/stage-chat-view-13.test.ts
@@ -1,5 +1,6 @@
-import { stripTerminalSequences } from "@earendil-works/pi-tui";
+import { getKeybindings, setKeybindings, stripTerminalSequences } from "@earendil-works/pi-tui";
 import { describe, test } from "vitest";
+import { KeybindingsManager } from "../../packages/coding-agent/src/core/keybindings.ts";
 import {
 	assert,
 	createStore,
@@ -7,15 +8,17 @@ import {
 	fakeFooterAgentSession,
 	flush,
 	makeHandle,
+	makePendingPrompt,
 	makeTestTui,
 	StageChatView,
 	setupRun,
 } from "./stage-chat-view-helpers.js";
 
-async function makeScrollableStageChat(
+async function makeScrollableStageChatFixture(
 	rows: number | (() => number | undefined) = 12,
 	withFooter = false,
-): Promise<StageChatView> {
+	piKeybindings?: unknown,
+): Promise<{ store: ReturnType<typeof createStore>; view: StageChatView }> {
 	const store = createStore();
 	setupRun(store, "run-1", "stage-a", "pending");
 	const { handle } = withFooter ? makeHandle(undefined, [], "pending", fakeFooterAgentSession()) : makeHandle();
@@ -29,6 +32,7 @@ async function makeScrollableStageChat(
 		onDetach: () => {},
 		onClose: () => {},
 		piTui: makeTestTui(rows),
+		piKeybindings,
 		footerData: withFooter
 			? {
 					getGitBranch: () => "main",
@@ -44,7 +48,14 @@ async function makeScrollableStageChat(
 		await flush();
 		await flush();
 	}
-	return view;
+	return { store, view };
+}
+
+async function makeScrollableStageChat(
+	rows: number | (() => number | undefined) = 12,
+	withFooter = false,
+): Promise<StageChatView> {
+	return (await makeScrollableStageChatFixture(rows, withFooter)).view;
 }
 
 describe("StageChatView", () => {
@@ -204,6 +215,74 @@ describe("StageChatView", () => {
 		assert.equal(view._inputBuffer, before);
 		view.dispose();
 	});
+	test("hides the follow indicator and preserves the prompt card while awaiting input", async () => {
+		const { store, view } = await makeScrollableStageChatFixture(16);
+		view.render(96);
+		assert.equal(view.handleInput("\x1b[5~"), true);
+		assert.ok(view._bodyScrollFromBottom > 0);
+
+		assert.equal(
+			store.recordStagePendingPrompt("run-1", "stage-a", makePendingPrompt({ id: "scrolled-prompt" })),
+			true,
+		);
+		const scrolledPrompt = view.render(96).map(stripTerminalSequences);
+		assert.doesNotMatch(scrolledPrompt.join("\n"), /Jump to bottom/);
+
+		const { handle } = makeHandle();
+		const controlView = new StageChatView({
+			store,
+			graphTheme: deriveGraphTheme({}),
+			runId: "run-1",
+			stageId: "stage-a",
+			workflowName: "test-wf",
+			handle,
+			onDetach: () => {},
+			onClose: () => {},
+			piTui: makeTestTui(16),
+		});
+		const controlPrompt = controlView.render(96).map(stripTerminalSequences);
+		const controlBanner = controlPrompt.find((line) => line.includes("AWAITING INPUT"));
+		const scrolledBanner = scrolledPrompt.find((line) => line.includes("AWAITING INPUT"));
+		assert.ok(controlBanner);
+		assert.equal(scrolledBanner, controlBanner);
+		controlView.dispose();
+		view.dispose();
+	});
+
+	test("hides the follow indicator in paused stage chat", async () => {
+		const { store, view } = await makeScrollableStageChatFixture(16);
+		view.render(96);
+		assert.equal(view.handleInput("\x1b[5~"), true);
+		assert.ok(view._bodyScrollFromBottom > 0);
+		assert.equal(store.recordStagePaused("run-1", "stage-a"), true);
+
+		const paused = view.render(96).map(stripTerminalSequences).join("\n");
+		assert.doesNotMatch(paused, /Jump to bottom/);
+		assert.match(paused, /PAUSED/);
+		view.dispose();
+	});
+
+	test("uses and honors a remapped stage-chat jump-to-bottom binding", async () => {
+		const previousKeybindings = getKeybindings();
+		const keybindings = new KeybindingsManager({ "tui.altScreen.bottom": "ctrl+e" });
+		setKeybindings(keybindings);
+		let view: StageChatView | undefined;
+		try {
+			({ view } = await makeScrollableStageChatFixture(12, false, keybindings));
+			view.render(96);
+			assert.equal(view.handleInput("\x1b[5~"), true);
+			const scrolled = stripTerminalSequences(view.render(96).join("\n"));
+			assert.match(scrolled, /Jump to bottom \(ctrl\+e\) ↓/);
+
+			assert.equal(view.handleInput("\x05"), true);
+			assert.equal(view._bodyScrollFromBottom, 0);
+			assert.doesNotMatch(stripTerminalSequences(view.render(96).join("\n")), /Jump to bottom/);
+		} finally {
+			view?.dispose();
+			setKeybindings(previousKeybindings);
+		}
+	});
+
 	test("hides the follow indicator at the pristine live end without consuming a body row", async () => {
 		const view = await makeScrollableStageChat();
 		const bottom = view.render(96);

--- a/test/unit/stage-chat-view-13.test.ts
+++ b/test/unit/stage-chat-view-13.test.ts
@@ -204,17 +204,15 @@ describe("StageChatView", () => {
 		assert.equal(view._inputBuffer, before);
 		view.dispose();
 	});
-	test("hides the follow indicator at the live end after returning without changing row count", async () => {
+	test("hides the follow indicator at the pristine live end without consuming a body row", async () => {
 		const view = await makeScrollableStageChat();
-		view.render(96);
-		view.handleInput("\x1b[5~");
-		assert.match(stripTerminalSequences(view.render(96).join("\n")), /Jump to bottom \(end\) ↓/);
-
-		assert.equal(view.handleInput("\x1b[F"), true);
 		const bottom = view.render(96);
-		const visible = stripTerminalSequences(bottom.join("\n"));
+		const visibleLines = bottom.map(stripTerminalSequences);
+
 		assert.equal(view._bodyScrollFromBottom, 0);
-		assert.doesNotMatch(visible, /Jump to bottom/);
+		assert.doesNotMatch(visibleLines.join("\n"), /Jump to bottom/);
+		assert.match(visibleLines[2] ?? "", /follow-msg-16/);
+		assert.match(visibleLines[6] ?? "", /follow-msg-17/);
 		assert.equal(bottom.length, 12);
 		view.dispose();
 	});
@@ -229,6 +227,22 @@ describe("StageChatView", () => {
 		assert.ok(view._bodyScrollFromBottom > 0);
 		assert.match(visible, /Jump to bottom \(end\) ↓/);
 		assert.equal(scrolled.length, 12);
+		view.dispose();
+	});
+
+	test("keeps the transcript viewport size stable while the follow indicator is visible", async () => {
+		const view = await makeScrollableStageChat(13);
+		view.render(96);
+
+		assert.equal(view.handleInput("\x1b[5~"), true);
+		const scrolled = view.render(96);
+		assert.ok(view._bodyScrollFromBottom > 0);
+		assert.match(stripTerminalSequences(scrolled.join("\n")), /Jump to bottom \(end\) ↓/);
+		assert.equal(scrolled.length, 13);
+
+		assert.equal(view.handleInput("\x1b[6~"), true);
+		view.render(96);
+		assert.equal(view._bodyScrollFromBottom, 0);
 		view.dispose();
 	});
 


### PR DESCRIPTION
## Summary

Workflow stage chat scrolls through the same `ScrollableComponentViewport` the host transcript uses, but it gave no signal that it had detached from the live end. This adds the existing "Jump to bottom (`<key>`) ↓" affordance to that surface.

While a stage chat transcript is scrolled away from the bottom it now renders one centered indicator row showing the live `tui.altScreen.bottom` binding. At the bottom it renders nothing and consumes no row. Pressing the bound key returns the transcript to the live end and the indicator disappears.

## The shared component is reused, not reimplemented

`TranscriptFollowIndicator` is used directly. It was already exported from `packages/coding-agent/src/modes/interactive/components/transcript-follow-indicator.ts` but not from the package entry points, so this adds it to `components/index.ts` and `src/index.ts`. No rendering logic is duplicated.

## Row budget

Stage chat renders inside a clipped overlay whose rows are planned by `planStageChatFrame`. The indicator takes its row from the **body** budget only:

- It is rendered only when the body is the live transcript, and only when the body budget is greater than one row.
- When the body is already full, one body row is dropped to make space rather than growing the frame.
- The composer, footer, and status rows keep their existing priority; under a tight viewport the indicator is the first thing dropped.

## Included fixes

Four small fixes were needed to make the behaviour correct and observable rather than only unit-true:

- `fix(workflows): preserve stage chat scroll viewport` — keeps the transcript viewport size stable while the indicator is visible, so showing it does not itself shift the scroll position.
- `fix(coding-agent): propagate remote overlay height changes` — `RemoteComponent.render` compared only `width`, so an isolated overlay never re-rendered after a pure height change. Without this, the tight-viewport priority is unobservable in a real terminal after a vertical resize, and the composer and footer could stay clipped. Isolated in its own commit with its own test and changelog entry, and cleanly splittable if you would rather it land separately.
- `fix(workflows): repair stage chat follow indicator modes` — suppresses the indicator in non-transcript bodies (prompt card, paused, read-only archive) so it cannot slice their top border.
- `fix(workflows): honor remapped bottom key in custom UI` — the jump-to-bottom binding is resolved through `matchesAction`, so a remapped key works, including while an `ask_user_question` card is mounted.

## Tests

Ten new tests across `test/unit/stage-chat-view-13.test.ts`, `test/unit/stage-chat-view-03.test.ts`, and `test/unit/interactive-engine-resize-clamp.test.ts` cover the four required cases plus the mode and remapping edges:

- hidden at the pristine live end, consuming no body row
- shown after scrolling stage-chat history
- the bound end key returns to the live end and hides the indicator
- the indicator is dropped before the composer and footer in a tight viewport
- transcript viewport size stays stable while the indicator is visible
- hidden while a prompt card is mounted, and in paused stage chat
- a remapped binding is honored, including with custom UI mounted

`npm run check`, `test:unit`, `test:integration`, and `test:ci-contracts` all pass (re-run by the pre-push hooks at `3e96ac066`).

## Known limitation

Activating the indicator's OSC-8 link scrolls the **host** transcript rather than stage chat; the key binding is the working path on this surface. `TRANSCRIPT_JUMP_TO_END_URL` activation is handled in the host's `interactive-tui.ts` and has no overlay-scoped routing, so a real fix needs overlay-scoped URL activation in the host. The objective made click routing conditional on the surface being able to route it, and the changelog entry does not claim mouse activation for stage chat.

The indicator is also deliberately not shown in paused or read-only-archive stage chats. Both do render a scrollable transcript, so it is arguably legitimate there, but suppressing it is what keeps the indicator out of those callouts' own borders and instructions. A maintainer can revisit it by giving those bodies an indicator inside their transcript sub-budget.

## Changelog

- `packages/workflows/CHANGELOG.md` → `[Unreleased]` → `Added`
- `packages/coding-agent/CHANGELOG.md` → `[Unreleased]` → `Fixed` (for the overlay height fix)

No released section was modified.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789243915&installation_model_id=10562&pr_number=2368&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2368&signature=b7142cff0579c67762f98e8745700efe4ae6fb3ea29591c1a97e065adf422625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds a shared follow indicator to the workflow chat transcript, keeps it within the available terminal space, honors configured jump-to-bottom keys in standard and custom input views, and refreshes isolated overlays when terminal height changes. Focused terminal interaction and resize checks passed, including a before-and-after height-only resize comparison. Merge safety: safe to merge.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains; the changed terminal interaction and overlay-resize behavior passed focused checks.

No accepted blocking findings remain.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused stage-chat test suite on PR HEAD; the run exercised follow-indicator visibility, frame budgeting, configured ctrl+e labeling, and mounted custom input handling, and all 20 tests passed.
- Ran a second batch of unit tests including interactive-engine-resize-clamp, overlay-adapter-autowrap, overlay-adapter-hidden-render, and trex-pr-2368-height-only-probe; all 9 tests passed.
- Compared authored height-only resize probe results between pre-change commit 2a7c7998 and HEAD; before, changing terminal rows from 20 to 12 kept the prior command, while HEAD emitted a refreshed frame request with rows: 12 and a new requestId.
- Ran git diff --check 2a7c7998..HEAD; the check completed without whitespace errors.
- Presented hypotheses about stage-chat indicator behavior and height-only resize; the height-only resize evidence shows differing behavior between pre-change and HEAD, the diff check completed cleanly, and no security impact was demonstrated.

<a href="https://app.greptile.com/trex/runs/18773401/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(workflows): honor remapped bottom ke..."](https://github.com/bastani-inc/atomic/commit/3d0e162fcfecde2f0858e386883beb3bbbbc53ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53108823)</sub>

<!-- /greptile_comment -->