### PR TITLE
fix(workflows): show the jump-to-bottom indicator in paused and archived stage chats

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Added the shared "Jump to bottom" follow indicator to workflow stage chat when its transcript is scrolled away from the live end, while preserving composer and footer rows in tight overlays.
 
+### Fixed
+
+- Fixed the stage-chat jump-to-bottom follow indicator remaining hidden in paused and read-only archive chats, while keeping their callout and instruction rows intact in tight overlays.
+
 ## [0.9.13-alpha.3] - 2026-08-13
 
 ### Changed

--- a/packages/workflows/src/tui/stage-chat-view-archive-history.ts
+++ b/packages/workflows/src/tui/stage-chat-view-archive-history.ts
@@ -38,6 +38,7 @@ export function renderReadOnlyArchiveBody(
 	width: number,
 	budget: number,
 	stage: StageSnapshot | undefined,
+	indicatorLines: readonly string[] = [],
 ): string[] {
 	if (stage?.promptFootprint) {
 		return renderReadOnlyPromptArchiveBody(ctx, width, budget, stage);
@@ -69,8 +70,11 @@ export function renderReadOnlyArchiveBody(
 		).render(width),
 	);
 	const transcriptBudget = Math.max(0, budget - callout.length);
-	const lines = transcriptBudget > 0 ? ctx.chatHost.renderBody(width, transcriptBudget) : [];
-	lines.push(...callout);
+	const visibleIndicatorLines =
+		indicatorLines.length > 0 && transcriptBudget > indicatorLines.length ? indicatorLines : [];
+	const transcriptRows = transcriptBudget - visibleIndicatorLines.length;
+	const lines = transcriptRows > 0 ? ctx.chatHost.renderBody(width, transcriptRows) : [];
+	lines.push(...visibleIndicatorLines, ...callout);
 	while (lines.length < budget) lines.push(blankLine(width));
 	if (lines.length > budget) lines.length = budget;
 	return lines;
@@ -163,7 +167,12 @@ function formatReadOnlyPromptAnswer(value: unknown, kind: PendingPrompt["kind"])
 	}
 }
 
-export function renderPausedBody(ctx: StageChatViewContext, width: number, budget: number): string[] {
+export function renderPausedBody(
+	ctx: StageChatViewContext,
+	width: number,
+	budget: number,
+	indicatorLines: readonly string[] = [],
+): string[] {
 	const t = ctx.theme;
 	const callout: string[] = [];
 	callout.push(blankLine(width));
@@ -176,10 +185,13 @@ export function renderPausedBody(ctx: StageChatViewContext, width: number, budge
 		).render(width),
 	);
 
-	const calloutRows = Math.min(callout.length, Math.max(0, budget - 1));
-	const transcriptBudget = Math.max(1, budget - calloutRows);
-	const lines = ctx.chatHost.renderBody(width, transcriptBudget);
-	lines.push(...callout.slice(0, calloutRows));
+	const calloutRows = Math.min(callout.length, Math.max(0, budget));
+	const transcriptBudget = Math.max(0, budget - calloutRows);
+	const visibleIndicatorLines =
+		indicatorLines.length > 0 && transcriptBudget > indicatorLines.length ? indicatorLines : [];
+	const transcriptRows = transcriptBudget - visibleIndicatorLines.length;
+	const lines = transcriptRows > 0 ? ctx.chatHost.renderBody(width, transcriptRows) : [];
+	lines.push(...visibleIndicatorLines, ...callout.slice(0, calloutRows));
 	while (lines.length < budget) lines.push(blankLine(width));
 	if (lines.length > budget) lines.length = budget;
 	return lines;

--- a/packages/workflows/src/tui/stage-chat-view-archive-history.ts
+++ b/packages/workflows/src/tui/stage-chat-view-archive-history.ts
@@ -39,6 +39,7 @@ export function renderReadOnlyArchiveBody(
 	budget: number,
 	stage: StageSnapshot | undefined,
 	indicatorLines: readonly string[] = [],
+	renderIndicator: () => readonly string[] = () => indicatorLines,
 ): string[] {
 	if (stage?.promptFootprint) {
 		return renderReadOnlyPromptArchiveBody(ctx, width, budget, stage);
@@ -70,10 +71,13 @@ export function renderReadOnlyArchiveBody(
 		).render(width),
 	);
 	const transcriptBudget = Math.max(0, budget - callout.length);
-	const visibleIndicatorLines =
-		indicatorLines.length > 0 && transcriptBudget > indicatorLines.length ? indicatorLines : [];
-	const transcriptRows = transcriptBudget - visibleIndicatorLines.length;
+	const reservedIndicatorRows =
+		indicatorLines.length > 0 && transcriptBudget > indicatorLines.length ? indicatorLines.length : 0;
+	const transcriptRows = transcriptBudget - reservedIndicatorRows;
 	const lines = transcriptRows > 0 ? ctx.chatHost.renderBody(width, transcriptRows) : [];
+	const visibleIndicatorLines =
+		reservedIndicatorRows > 0 ? [...renderIndicator().slice(0, reservedIndicatorRows)] : [];
+	while (visibleIndicatorLines.length < reservedIndicatorRows) visibleIndicatorLines.push(blankLine(width));
 	lines.push(...visibleIndicatorLines, ...callout);
 	while (lines.length < budget) lines.push(blankLine(width));
 	if (lines.length > budget) lines.length = budget;
@@ -172,6 +176,7 @@ export function renderPausedBody(
 	width: number,
 	budget: number,
 	indicatorLines: readonly string[] = [],
+	renderIndicator: () => readonly string[] = () => indicatorLines,
 ): string[] {
 	const t = ctx.theme;
 	const callout: string[] = [];
@@ -184,13 +189,15 @@ export function renderPausedBody(
 			0,
 		).render(width),
 	);
-
 	const calloutRows = Math.min(callout.length, Math.max(0, budget));
 	const transcriptBudget = Math.max(0, budget - calloutRows);
-	const visibleIndicatorLines =
-		indicatorLines.length > 0 && transcriptBudget > indicatorLines.length ? indicatorLines : [];
-	const transcriptRows = transcriptBudget - visibleIndicatorLines.length;
+	const reservedIndicatorRows =
+		indicatorLines.length > 0 && transcriptBudget > indicatorLines.length ? indicatorLines.length : 0;
+	const transcriptRows = transcriptBudget - reservedIndicatorRows;
 	const lines = transcriptRows > 0 ? ctx.chatHost.renderBody(width, transcriptRows) : [];
+	const visibleIndicatorLines =
+		reservedIndicatorRows > 0 ? [...renderIndicator().slice(0, reservedIndicatorRows)] : [];
+	while (visibleIndicatorLines.length < reservedIndicatorRows) visibleIndicatorLines.push(blankLine(width));
 	lines.push(...visibleIndicatorLines, ...callout.slice(0, calloutRows));
 	while (lines.length < budget) lines.push(blankLine(width));
 	if (lines.length > budget) lines.length = budget;

--- a/packages/workflows/src/tui/stage-chat-view.ts
+++ b/packages/workflows/src/tui/stage-chat-view.ts
@@ -159,6 +159,11 @@ export class StageChatView implements Component, Focusable {
 
 		let bodyLines: string[];
 		let transcriptBodyActive = false;
+		const indicator = new TranscriptFollowIndicator({
+			isFollowing: () => this.chatHost.bodyScrollFromBottom() === 0,
+			keyLabel: () => keyText("tui.altScreen.bottom"),
+		});
+		const candidateIndicatorLines = bodyBudget > 1 ? indicator.render(w) : [];
 		if (bodyBudget <= 0) {
 			bodyLines = [];
 		} else if (promptActive) {
@@ -166,18 +171,14 @@ export class StageChatView implements Component, Focusable {
 		} else if (blocked) {
 			bodyLines = renderBlockedBody(ctx, w, bodyBudget, stage);
 		} else if (!readOnlyArchive && isPaused(ctx, stage)) {
-			bodyLines = renderPausedBody(ctx, w, bodyBudget);
+			bodyLines = renderPausedBody(ctx, w, bodyBudget, candidateIndicatorLines);
 		} else if (readOnlyArchive) {
-			bodyLines = renderReadOnlyArchiveBody(ctx, w, bodyBudget, stage);
+			bodyLines = renderReadOnlyArchiveBody(ctx, w, bodyBudget, stage, candidateIndicatorLines);
 		} else {
 			transcriptBodyActive = true;
 			bodyLines = this.chatHost.renderBody(w, bodyBudget);
 		}
-		const indicator = new TranscriptFollowIndicator({
-			isFollowing: () => this.chatHost.bodyScrollFromBottom() === 0,
-			keyLabel: () => keyText("tui.altScreen.bottom"),
-		});
-		const indicatorLines = transcriptBodyActive && bodyBudget > 1 ? indicator.render(w) : [];
+		const indicatorLines = transcriptBodyActive ? candidateIndicatorLines : [];
 		const indicatorVisible = indicatorLines.length > 0;
 		const dropBodyRow = transcriptBodyActive && indicatorVisible && bodyLines.length >= bodyBudget;
 		const visibleBodyLines = bodyLines.slice(dropBodyRow ? 1 : 0, bodyBudget);

--- a/packages/workflows/src/tui/stage-chat-view.ts
+++ b/packages/workflows/src/tui/stage-chat-view.ts
@@ -159,11 +159,11 @@ export class StageChatView implements Component, Focusable {
 
 		let bodyLines: string[];
 		let transcriptBodyActive = false;
+		let reservedIndicatorLines: readonly string[] = [];
 		const indicator = new TranscriptFollowIndicator({
 			isFollowing: () => this.chatHost.bodyScrollFromBottom() === 0,
 			keyLabel: () => keyText("tui.altScreen.bottom"),
 		});
-		const candidateIndicatorLines = bodyBudget > 1 ? indicator.render(w) : [];
 		if (bodyBudget <= 0) {
 			bodyLines = [];
 		} else if (promptActive) {
@@ -171,14 +171,18 @@ export class StageChatView implements Component, Focusable {
 		} else if (blocked) {
 			bodyLines = renderBlockedBody(ctx, w, bodyBudget, stage);
 		} else if (!readOnlyArchive && isPaused(ctx, stage)) {
-			bodyLines = renderPausedBody(ctx, w, bodyBudget, candidateIndicatorLines);
+			reservedIndicatorLines = bodyBudget > 1 ? indicator.render(w) : [];
+			bodyLines = renderPausedBody(ctx, w, bodyBudget, reservedIndicatorLines, () => indicator.render(w));
 		} else if (readOnlyArchive) {
-			bodyLines = renderReadOnlyArchiveBody(ctx, w, bodyBudget, stage, candidateIndicatorLines);
+			reservedIndicatorLines = bodyBudget > 1 ? indicator.render(w) : [];
+			bodyLines = renderReadOnlyArchiveBody(ctx, w, bodyBudget, stage, reservedIndicatorLines, () =>
+				indicator.render(w),
+			);
 		} else {
 			transcriptBodyActive = true;
 			bodyLines = this.chatHost.renderBody(w, bodyBudget);
 		}
-		const indicatorLines = transcriptBodyActive ? candidateIndicatorLines : [];
+		const indicatorLines = transcriptBodyActive && bodyBudget > 1 ? indicator.render(w) : [];
 		const indicatorVisible = indicatorLines.length > 0;
 		const dropBodyRow = transcriptBodyActive && indicatorVisible && bodyLines.length >= bodyBudget;
 		const visibleBodyLines = bodyLines.slice(dropBodyRow ? 1 : 0, bodyBudget);

--- a/test/unit/stage-chat-view-13.test.ts
+++ b/test/unit/stage-chat-view-13.test.ts
@@ -350,6 +350,27 @@ describe("StageChatView", () => {
 		assert.match(archive, /READ-ONLY SESSION/);
 		view.dispose();
 	});
+	test("keeps the follow indicator suppressed for a scrolled read-only prompt archive", async () => {
+		const { store, view } = await makeReadOnlyArchiveStageChatFixture(16);
+		view.render(96);
+		assert.equal(view.handleInput("\x1b[5~"), true);
+		assert.ok(view._bodyScrollFromBottom > 0);
+
+		const archivedStage = store.runs()[0]?.stages[0];
+		assert.ok(archivedStage);
+		store.recordStageEnd("run-1", { ...archivedStage, status: "running", endedAt: undefined });
+		const prompt = makePendingPrompt({ id: "archived-prompt", message: "Archived prompt question?" });
+		assert.equal(store.recordStagePendingPrompt("run-1", "stage-a", prompt), true);
+		const promptedStage = store.runs()[0]?.stages[0];
+		assert.ok(promptedStage);
+		store.recordStageEnd("run-1", { ...promptedStage, status: "completed", endedAt: Date.now() });
+
+		const archived = view.render(96).map(stripTerminalSequences).join("\n");
+		assert.doesNotMatch(archived, /Jump to bottom/);
+		assert.match(archived, /QUESTION ASKED/);
+		assert.match(archived, /Archived prompt question\?/);
+		view.dispose();
+	});
 	test("drops the read-only archive indicator before its callout rows in a tight viewport", async () => {
 		let rows = 16;
 		const { view } = await makeReadOnlyArchiveStageChatFixture(() => rows);

--- a/test/unit/stage-chat-view-13.test.ts
+++ b/test/unit/stage-chat-view-13.test.ts
@@ -18,7 +18,11 @@ async function makeScrollableStageChatFixture(
 	rows: number | (() => number | undefined) = 12,
 	withFooter = false,
 	piKeybindings?: unknown,
-): Promise<{ store: ReturnType<typeof createStore>; view: StageChatView }> {
+): Promise<{
+	store: ReturnType<typeof createStore>;
+	view: StageChatView;
+	handle: ReturnType<typeof makeHandle>["handle"];
+}> {
 	const store = createStore();
 	setupRun(store, "run-1", "stage-a", "pending");
 	const { handle } = withFooter ? makeHandle(undefined, [], "pending", fakeFooterAgentSession()) : makeHandle();
@@ -48,7 +52,7 @@ async function makeScrollableStageChatFixture(
 		await flush();
 		await flush();
 	}
-	return { store, view };
+	return { store, view, handle };
 }
 
 async function makeScrollableStageChat(
@@ -56,6 +60,16 @@ async function makeScrollableStageChat(
 	withFooter = false,
 ): Promise<StageChatView> {
 	return (await makeScrollableStageChatFixture(rows, withFooter)).view;
+}
+async function makeReadOnlyArchiveStageChatFixture(
+	rows: number | (() => number | undefined) = 12,
+): Promise<Awaited<ReturnType<typeof makeScrollableStageChatFixture>>> {
+	const fixture = await makeScrollableStageChatFixture(rows);
+	const stage = fixture.store.runs()[0]?.stages[0];
+	assert.ok(stage);
+	fixture.store.recordStageEnd("run-1", { ...stage, status: "completed", endedAt: Date.now() });
+	Object.defineProperty(fixture.handle, "isDisposed", { value: true });
+	return fixture;
 }
 
 describe("StageChatView", () => {
@@ -249,11 +263,59 @@ describe("StageChatView", () => {
 		view.dispose();
 	});
 
-	test("hides the follow indicator in paused stage chat", async () => {
+	test("keeps the follow indicator suppressed in a blocked stage chat", async () => {
 		const { store, view } = await makeScrollableStageChatFixture(16);
 		view.render(96);
 		assert.equal(view.handleInput("\x1b[5~"), true);
 		assert.ok(view._bodyScrollFromBottom > 0);
+		assert.equal(store.recordStageBlocked("run-1", "stage-a", "upstream-stage"), true);
+
+		const blocked = view.render(96).map(stripTerminalSequences).join("\n");
+		assert.doesNotMatch(blocked, /Jump to bottom/);
+		assert.match(blocked, /BLOCKED/);
+		view.dispose();
+	});
+	test("shows the follow indicator in paused stage chat when scrolled", async () => {
+		const { store, view } = await makeScrollableStageChatFixture(16);
+		view.render(96);
+		assert.equal(view.handleInput("\x1b[5~"), true);
+		assert.ok(view._bodyScrollFromBottom > 0);
+		assert.equal(store.recordStagePaused("run-1", "stage-a"), true);
+
+		const paused = view.render(96).map(stripTerminalSequences).join("\n");
+		assert.match(paused, /Jump to bottom \(end\) ↓/);
+		assert.match(paused, /PAUSED/);
+		assert.equal(view.handleInput("\x1b[F"), true);
+		assert.equal(view._bodyScrollFromBottom, 0);
+		assert.doesNotMatch(view.render(96).map(stripTerminalSequences).join("\n"), /Jump to bottom/);
+		view.dispose();
+	});
+	test("drops the paused indicator before its callout rows in a tight viewport", async () => {
+		let rows = 16;
+		const { store, view } = await makeScrollableStageChatFixture(() => rows);
+		view.render(96);
+		assert.equal(store.recordStagePaused("run-1", "stage-a"), true);
+		const control = view.render(96).map(stripTerminalSequences);
+		assert.equal(view.handleInput("\x1b[5~"), true);
+		rows = 9;
+
+		const tight = view.render(96).map(stripTerminalSequences);
+		assert.doesNotMatch(tight.join("\n"), /Jump to bottom/);
+		assert.match(tight.join("\n"), /PAUSED/);
+		assert.match(tight.join("\n"), /This workflow stage is paused\./);
+		assert.equal(tight.length, 9);
+		for (const marker of ["PAUSED", "This workflow stage is paused."]) {
+			assert.equal(
+				tight.find((line) => line.includes(marker)),
+				control.find((line) => line.includes(marker)),
+			);
+		}
+		view.dispose();
+	});
+
+	test("hides the follow indicator at the paused live end", async () => {
+		const { store, view } = await makeScrollableStageChatFixture(16);
+		view.render(96);
 		assert.equal(store.recordStagePaused("run-1", "stage-a"), true);
 
 		const paused = view.render(96).map(stripTerminalSequences).join("\n");
@@ -262,6 +324,53 @@ describe("StageChatView", () => {
 		view.dispose();
 	});
 
+	test("shows the follow indicator in a read-only archive when scrolled and returns on the bound key", async () => {
+		const { view } = await makeReadOnlyArchiveStageChatFixture(16);
+		view.render(96);
+		assert.equal(view.handleInput("\x1b[5~"), true);
+		assert.ok(view._bodyScrollFromBottom > 0);
+
+		const scrolled = view.render(96).map(stripTerminalSequences).join("\n");
+		assert.match(scrolled, /Jump to bottom \(end\) ↓/);
+		assert.match(scrolled, /READ-ONLY SESSION/);
+
+		assert.equal(view.handleInput("\x1b[F"), true);
+		assert.equal(view._bodyScrollFromBottom, 0);
+		assert.doesNotMatch(view.render(96).map(stripTerminalSequences).join("\n"), /Jump to bottom/);
+		view.dispose();
+	});
+
+	test("hides the follow indicator at the read-only archive live end", async () => {
+		const { view } = await makeReadOnlyArchiveStageChatFixture(16);
+		view.render(96);
+
+		const archive = view.render(96).map(stripTerminalSequences).join("\n");
+		assert.equal(view._bodyScrollFromBottom, 0);
+		assert.doesNotMatch(archive, /Jump to bottom/);
+		assert.match(archive, /READ-ONLY SESSION/);
+		view.dispose();
+	});
+	test("drops the read-only archive indicator before its callout rows in a tight viewport", async () => {
+		let rows = 16;
+		const { view } = await makeReadOnlyArchiveStageChatFixture(() => rows);
+		view.render(96);
+		const control = view.render(96).map(stripTerminalSequences);
+		assert.equal(view.handleInput("\x1b[5~"), true);
+		rows = 7;
+
+		const tight = view.render(96).map(stripTerminalSequences);
+		assert.doesNotMatch(tight.join("\n"), /Jump to bottom/);
+		assert.match(tight.join("\n"), /READ-ONLY SESSION/);
+		assert.match(tight.join("\n"), /This node is no longer attached/);
+		assert.equal(tight.length, 7);
+		for (const marker of ["READ-ONLY SESSION", "This node is no longer attached"]) {
+			assert.equal(
+				tight.find((line) => line.includes(marker)),
+				control.find((line) => line.includes(marker)),
+			);
+		}
+		view.dispose();
+	});
 	test("uses and honors a remapped stage-chat jump-to-bottom binding", async () => {
 		const previousKeybindings = getKeybindings();
 		const keybindings = new KeybindingsManager({ "tui.altScreen.bottom": "ctrl+e" });

--- a/test/unit/stage-chat-view-13.test.ts
+++ b/test/unit/stage-chat-view-13.test.ts
@@ -392,6 +392,52 @@ describe("StageChatView", () => {
 		}
 		view.dispose();
 	});
+	test("hides the follow indicator after a live transcript resize clamps to the end", async () => {
+		let rows = 12;
+		const view = await makeScrollableStageChat(() => rows);
+		view.render(96);
+		assert.equal(view.handleInput("\x1b[5~"), true);
+		assert.ok(view._bodyScrollFromBottom > 0);
+
+		rows = 200;
+		const grown = view.render(96).map(stripTerminalSequences);
+		assert.equal(view._bodyScrollFromBottom, 0);
+		assert.doesNotMatch(grown.join("\n"), /Jump to bottom/);
+		assert.equal(grown.length, 200);
+		view.dispose();
+	});
+
+	test("hides the follow indicator after a paused transcript resize clamps to the end", async () => {
+		let rows = 12;
+		const { store, view } = await makeScrollableStageChatFixture(() => rows);
+		view.render(96);
+		assert.equal(view.handleInput("\x1b[5~"), true);
+		assert.ok(view._bodyScrollFromBottom > 0);
+		assert.equal(store.recordStagePaused("run-1", "stage-a"), true);
+
+		rows = 200;
+		const grown = view.render(96).map(stripTerminalSequences);
+		assert.equal(view._bodyScrollFromBottom, 0);
+		assert.doesNotMatch(grown.join("\n"), /Jump to bottom/);
+		assert.equal(grown.length, 200);
+		view.dispose();
+	});
+
+	test("hides the follow indicator after an archive transcript resize clamps to the end", async () => {
+		let rows = 12;
+		const { view } = await makeReadOnlyArchiveStageChatFixture(() => rows);
+		view.render(96);
+		assert.equal(view.handleInput("\x1b[5~"), true);
+		assert.ok(view._bodyScrollFromBottom > 0);
+
+		rows = 200;
+		const grown = view.render(96).map(stripTerminalSequences);
+		assert.equal(view._bodyScrollFromBottom, 0);
+		assert.doesNotMatch(grown.join("\n"), /Jump to bottom/);
+		assert.equal(grown.length, 200);
+		view.dispose();
+	});
+
 	test("uses and honors a remapped stage-chat jump-to-bottom binding", async () => {
 		const previousKeybindings = getKeybindings();
 		const keybindings = new KeybindingsManager({ "tui.altScreen.bottom": "ctrl+e" });


### PR DESCRIPTION
## Summary

Paused and read-only-archive stage chats deliberately suppressed the jump-to-bottom follow indicator that PR #2368 added, because drawing it after the body sliced the top border of their callouts. Both modes render a real scrollable transcript, so the affordance belongs there.

This gives the indicator a reserved row **inside** the transcript sub-budget, above the callout, so the paused banner, the read-only/unavailable callout, and their instruction rows keep every row they had.

Stacked on #2368: base branch is `feat/stage-chat-jump-to-bottom`, not `main`. #2368 is untouched — its head is still `3d0e162fc` locally and on `origin`.

## What changed

- `packages/workflows/src/tui/stage-chat-view.ts` — the `TranscriptFollowIndicator` is now built before the body branch. The paused and archive branches reserve its rows and pass a `renderIndicator` callback; the plain live-transcript path renders the body first and the indicator after, exactly as at base.
- `packages/workflows/src/tui/stage-chat-view-archive-history.ts` — `renderPausedBody` and `renderReadOnlyArchiveBody` subtract the reserved rows from the transcript budget before `chatHost.renderBody(...)`, then fill that slot from the post-render callback.
- `test/unit/stage-chat-view-13.test.ts` — extends the existing suite (+182 lines).
- `packages/workflows/CHANGELOG.md` — one bullet under `## [Unreleased]` → `### Fixed`.

Out of scope and unchanged: the prompt-card and blocked bodies (neither renders a scrollable transcript, and `blocked` force-scrolls to the bottom), the host transcript dock, and OSC-8 click routing.

## Why the reserve-then-fill shape

`ScrollableComponentViewport.render()` is what clamps and re-anchors `scrollFromBottom`, so a pre-render scroll read can be stale. An earlier revision of this branch decided the indicator entirely from pre-render state; when a resize grew the viewport so `maxScroll` reached 0, one frame drew the transcript at its live end *and* a `Jump to bottom` row — and because a resize renders once while paused and archived stages stream nothing, that wrong row persisted until the next keystroke.

The two needs are now split. Reservation must happen before `renderBody`, because the transcript sub-budget shrinks by it. Visibility is decided after, from post-render state; when the frame turns out to be at the live end, the reserved slot receives a blank row. Frame height stays exactly the viewport row count on every path. The transient blank row cannot oscillate: dropping the reservation next frame only grows the transcript viewport, and growth cannot un-follow a transcript already at its end.

## Tests

`test/unit/stage-chat-view-13.test.ts` gains coverage for:

- indicator shown when a paused chat is scrolled, and when an archive chat is scrolled (archive case also asserts the bound key returns to the live end)
- nothing shown at the live end, paused and archive
- callout rows intact under a tight budget — the indicator drops first — paused and archive
- prompt-card (read-only prompt archive) and blocked bodies still suppressed
- three resize-clamp regressions: plain, paused, archive

Reverting only the two source files while keeping the new tests fails the resize-clamp trio, which is the regression this shape exists to prevent.

## Verification

- `npx vitest --run --project unit test/unit/stage-chat-view-13.test.ts test/unit/stage-chat-view-03.test.ts` — 30 passed
- `npm run test:unit` — 638 files, 6180 passed, 2 skipped
- `npm run check` — biome, `tsc --noEmit`, coding-agent `tsgo`, shrinkwrap check all clean
- Terminal E2E in a real tmux pane driving the real `StageChatView`, comparing fixed HEAD against reverted source; the affordance still carries its OSC-8 target `atomic-ui://transcript/jump-to-end`, and no such link appears in any fixed resize frame

## Known limitations

- When the pre-render read says "scrolled" but the same frame's clamp lands at the live end, the reserved row is blank-padded rather than returned to the transcript. Frame height, callout rows, and indicator visibility are all correct; the transcript is one row shorter for that single frame. Reviewers rated this P3, non-blocking.
- `renderPausedBody` and `renderReadOnlyArchiveBody` take both `indicatorLines` and a `renderIndicator` callback whose default returns those same lines. One parameter could replace two; the defaults agree, so there is no behavioral divergence.
- Tight-viewport and resize tests are pinned at width 96 with specific row counts. Other widths are covered by an ad-hoc sweep (widths 30–120), not by committed tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789249502&installation_model_id=10562&pr_number=2371&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2371&signature=de3b4c1322df6d381221f29e2b3dc137c57bd7ccbe6f880cca47fdc832eb18aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR extends the jump-to-bottom indicator to paused and read-only archived stage chats while preserving status callouts under constrained viewport budgets.
- Reserves indicator space inside the transcript budget before rendering paused and archived bodies.
- Re-evaluates indicator visibility after transcript rendering so resize-induced scroll clamping does not leave a stale indicator.
- Adds focused coverage for paused, archived, blocked, prompt-archive, tight-viewport, keybinding, and resize behavior.
- Documents the fix in the workflows changelog.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains in the reviewed follow-up scope.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/workflows/src/tui/stage-chat-view.ts | Constructs the follow indicator before body-mode dispatch and supplies reserve-then-fill rendering to paused and archived transcript paths. |
| packages/workflows/src/tui/stage-chat-view-archive-history.ts | Allocates indicator rows from the transcript sub-budget while preserving paused and archive callout rows. |
| test/unit/stage-chat-view-13.test.ts | Adds comprehensive regression coverage for indicator visibility, constrained layouts, key handling, suppressed modes, and resize clamping. |
| packages/workflows/CHANGELOG.md | Records the paused and read-only archive indicator fix under the unreleased fixes. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Compute stage-chat body budget] --> B{Body mode}
  B -->|Paused or read-only archive| C[Pre-render follow indicator]
  C --> D[Reserve indicator row inside transcript budget]
  D --> E[Render transcript and clamp scroll position]
  E --> F[Re-evaluate indicator visibility]
  F --> G[Fill reserved row with indicator or blank]
  G --> H[Append preserved callout rows]
  B -->|Plain live transcript| I[Render transcript]
  I --> J[Render indicator after body]
  B -->|Prompt or blocked| K[Render specialized body without indicator]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(workflows): refresh follow indicator..."](https://github.com/bastani-inc/atomic/commit/d8585758d4cd0c3b9ab4e0d101c2511d6ebe4c57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53142792)</sub>

**Context used:**

- Knowledge Base — [Workflows package](https://app.greptile.com/bastani-inc/-/custom-context/knowledge-base/bastani-inc/atomic/-/docs/workflows-package.md)

<!-- /greptile_comment -->