### PR TITLE
feat(coding-agent): remove the ctrl+x copy-last-message shortcut

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added a clickable, centered jump-to-bottom indicator above the fullscreen input dock when the transcript is scrolled away from the live end; it displays the live `tui.altScreen.bottom` key binding and supports mouse activation ([#2361](https://github.com/bastani-inc/atomic/issues/2361)).
 
+### Removed
+
+- Removed the Ctrl+X shortcut for copying the last agent message; the `/copy` slash command still copies the last agent message to the clipboard and confirms in the status line.
+
 ### Fixed
 
 - Fixed a stall where a message queued during a turn was shown in the transcript but never answered, leaving the session idle until you typed another message. Escape and Ctrl+C hold queued work by pausing the agent's own steering and follow-up queues, but a message the agent loop has already polled is no longer in either queue: it is written straight into the transcript, so the interrupt cancelled its reply and nothing scheduled a new one. This was most visible after answering an `ask_user_question` questionnaire, which admits the queued message and immediately opens the request the interrupt then cancels. An admitted message whose reply was cancelled before it produced any output now receives that reply, and a message you send while that reply is still streaming is delivered as soon as it finishes. Queued messages that are still held are unchanged: Escape still restores them to the editor and leaves the session paused, and a reply that had already streamed some output is never restarted ([#2362](https://github.com/bastani-inc/atomic/issues/2362)).

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -123,9 +123,6 @@ On Windows, pressing the secondary mouse button in fullscreen pastes text from t
 | `app.suspend` | `ctrl+z` (none on Windows) | Suspend to background |
 | `app.editor.external` | `ctrl+g` | Open in external editor (`$VISUAL` or `$EDITOR`) |
 | `app.clipboard.pasteImage` | `ctrl+v` (`alt+v` on Windows) | Paste image or text from clipboard |
-| `app.message.copy` | `ctrl+x` | Copy the last assistant message (or the selected message in `/tree`) |
-
-In fullscreen mode, a successful `app.message.copy` shortcut shows a short `Copied!` flash without adding a row to the fixed status dock. The `/copy` command keeps its normal status-line confirmation.
 
 When `app.clipboard.pasteImage` finds text rather than an image, Atomic inserts that clipboard text into the editor instead of reporting an image-paste failure.
 

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -25,7 +25,6 @@ export interface AppKeybindings {
 	"app.editor.external": true;
 	"app.message.followUp": true;
 	"app.message.dequeue": true;
-	"app.message.copy": true;
 	"app.clipboard.pasteImage": true;
 	"app.session.new": true;
 	"app.session.tree": true;
@@ -104,7 +103,6 @@ export const KEYBINDINGS = {
 		defaultKeys: "alt+up",
 		description: "Restore queued messages",
 	},
-	"app.message.copy": { defaultKeys: "ctrl+x", description: "Copy last agent message" },
 	"app.clipboard.pasteImage": {
 		defaultKeys: process.platform === "win32" ? "alt+v" : "ctrl+v",
 		description: "Paste image from clipboard (text fallback)",
@@ -249,7 +247,6 @@ const KEYBINDING_NAME_MIGRATIONS = {
 	externalEditor: "app.editor.external",
 	followUp: "app.message.followUp",
 	dequeue: "app.message.dequeue",
-	copyLastMessage: "app.message.copy",
 	pasteImage: "app.clipboard.pasteImage",
 	newSession: "app.session.new",
 	tree: "app.session.tree",

--- a/packages/coding-agent/src/modes/interactive/interactive-input-handling.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-input-handling.ts
@@ -117,9 +117,6 @@ InteractiveModeBase.prototype.setupKeyHandlers = function (this: InteractiveMode
 	});
 	this.defaultEditor.onAction("app.message.followUp", () => this.handleFollowUp());
 	this.defaultEditor.onAction("app.message.dequeue", () => this.handleDequeue());
-	this.defaultEditor.onAction("app.message.copy", () => {
-		void this.handleCopyCommand({ flashConfirmation: true });
-	});
 	this.defaultEditor.onAction("app.session.new", () => this.handleClearCommand());
 	this.defaultEditor.onAction("app.session.tree", () => this.showTreeSelector());
 	this.defaultEditor.onAction("app.session.fork", () => this.showUserMessageSelector());

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-surface.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-surface.ts
@@ -356,7 +356,7 @@ declare module "./interactive-mode-base.ts" {
 		getPathCommandArgument(text: string, command: "/export" | "/import"): string | undefined;
 		handleImportCommand(text: string): Promise<void>;
 		handleShareCommand(): Promise<void>;
-		handleCopyCommand(options?: { flashConfirmation?: boolean }): Promise<void>;
+		handleCopyCommand(): Promise<void>;
 		handleNameCommand(text: string): void;
 		handleSessionCommand(): void;
 		handleChangelogCommand(): void;

--- a/packages/coding-agent/src/modes/interactive/interactive-slash-commands.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-slash-commands.ts
@@ -1,4 +1,3 @@
-import type { TuiAltScreen } from "@earendil-works/pi-tui";
 import { computeCacheWaste } from "../../core/cache-stats.ts";
 import { getUsageCostBreakdown } from "../../core/usage-totals.ts";
 import { createChildProcessEnvironment } from "../../utils/child-process.ts";
@@ -321,10 +320,7 @@ InteractiveModeBase.prototype.handleShareCommand = async function (this: Interac
 	}
 };
 
-InteractiveModeBase.prototype.handleCopyCommand = async function (
-	this: InteractiveModeBase,
-	options: { flashConfirmation?: boolean } = {},
-): Promise<void> {
+InteractiveModeBase.prototype.handleCopyCommand = async function (this: InteractiveModeBase): Promise<void> {
 	const text = this.session.getLastAssistantText();
 	if (!text) {
 		this.showError("No agent messages to copy yet.");
@@ -333,8 +329,7 @@ InteractiveModeBase.prototype.handleCopyCommand = async function (
 
 	try {
 		await copyToClipboard(text);
-		if (options.flashConfirmation && this.ui.mode === "fullscreen") (this.ui as TuiAltScreen).flash("Copied!");
-		else this.showStatus("Copied last agent message to clipboard");
+		this.showStatus("Copied last agent message to clipboard");
 	} catch (error) {
 		this.showError(error instanceof Error ? error.message : String(error));
 	}

--- a/packages/coding-agent/test/interactive-tui.test.ts
+++ b/packages/coding-agent/test/interactive-tui.test.ts
@@ -481,32 +481,10 @@ type CopyCommandPrototype = Pick<InteractiveMode, "handleCopyCommand">;
 
 const copyCommandPrototype: CopyCommandPrototype = InteractiveMode.prototype;
 
-describe("InteractiveMode copy confirmation", () => {
+describe("InteractiveMode /copy confirmation", () => {
 	beforeEach(() => {
 		clipboardMocks.copyToClipboard.mockReset();
 		clipboardMocks.copyToClipboard.mockResolvedValue(undefined);
-	});
-
-	test("flashes the copy shortcut confirmation in fullscreen mode", async () => {
-		const ui = createInteractiveTui({
-			showHardwareCursor: false,
-			logDirectory: "/tmp",
-			terminal: new RecordingTerminal(),
-		});
-		const flash = vi.spyOn(ui as TuiAltScreen, "flash");
-		const context: CopyCommandContext = {
-			session: { getLastAssistantText: () => "assistant response" },
-			ui,
-			showStatus: vi.fn(),
-			showError: vi.fn(),
-		};
-
-		await copyCommandPrototype.handleCopyCommand.call(context, { flashConfirmation: true });
-
-		expect(clipboardMocks.copyToClipboard).toHaveBeenCalledWith("assistant response");
-		expect(flash).toHaveBeenCalledWith("Copied!");
-		expect(context.showStatus).not.toHaveBeenCalled();
-		expect(context.showError).not.toHaveBeenCalled();
 	});
 
 	test("keeps slash-command copy confirmation in the status line", async () => {

--- a/packages/coding-agent/test/interactive-tui.test.ts
+++ b/packages/coding-agent/test/interactive-tui.test.ts
@@ -502,6 +502,7 @@ describe("InteractiveMode /copy confirmation", () => {
 		await copyCommandPrototype.handleCopyCommand.call(context);
 
 		expect(context.showStatus).toHaveBeenCalledWith("Copied last agent message to clipboard");
+		expect(clipboardMocks.copyToClipboard).toHaveBeenCalledWith("assistant response");
 		expect(context.showError).not.toHaveBeenCalled();
 	});
 });

--- a/test/unit/pi-parity-group-5.test.ts
+++ b/test/unit/pi-parity-group-5.test.ts
@@ -63,8 +63,7 @@ function entry(id: string, message: AssistantMessage): SessionEntry {
 const prices = { getModel: () => ({ cost: { cacheRead: 0.1 } }) };
 
 describe("Group 5 parity", () => {
-	test("copy-last-message and paste fallback keybindings are registered", () => {
-		assert.equal(KEYBINDINGS["app.message.copy"].defaultKeys, "ctrl+x");
+	test("paste fallback keybinding is registered", () => {
 		assert.match(KEYBINDINGS["app.clipboard.pasteImage"].description, /text fallback/);
 	});
 


### PR DESCRIPTION
## Summary

Removes the `app.message.copy` keybinding action (`ctrl+x`, "copy last agent message") from the interactive editor. `ctrl+x` is now unbound in the main editor.

`/copy` is unchanged and still copies the last agent message to the clipboard with the normal status-line confirmation.

## What changed

- `keybindings.ts` — dropped the `app.message.copy` action id, its `KEYBINDINGS` entry, and the legacy `copyLastMessage` migration alias.
- `interactive-input-handling.ts` — dropped the `onAction("app.message.copy", ...)` registration.
- `interactive-slash-commands.ts` / `interactive-mode-surface.ts` — dropped the `flashConfirmation` option and the fullscreen `flash("Copied!")` branch it gated; `handleCopyCommand()` now takes no options and always shows the status line. Removed the orphaned `TuiAltScreen` import.
- `docs/keybindings.md` — removed the table row and the fullscreen-flash paragraph.
- Tests — removed the flash test and the parity assertion; the retained `/copy` test now asserts the clipboard write as well as the status line.

## Not touched

- `app.models.clearAll`, which separately defaults to `ctrl+x` inside the model selector.
- The workflows package `ctrl+x` hierarchy chord.

## Verification

- `npm run check` — pass
- `npm run test:unit` — 638 files, 6180 tests pass
- `npm run test --workspace=@bastani/atomic` — 445 files, 3595 tests pass
- `rg 'app\.message\.copy|copyLastMessage'` over source/tests/docs — no matches

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789258535&installation_model_id=10562&pr_number=2373&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2373&signature=5af9aabf705bc3ae7b6ad8a25b77131a94e76d3cac882cd590c7247953976a65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change removes the Ctrl+X copy-last-message shortcut, its action registration, and its legacy keybinding alias. The `/copy` command remains available and continues to copy the latest assistant response while displaying its confirmation in the status line. Focused interactive coverage exercised both behaviors successfully, and the affected interactive TUI and keybinding suites passed.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the removed shortcut no longer registers or dispatches, and the supported `/copy` workflow continues to work as intended.

The interactive flow was exercised through real handler setup and slash-command dispatch with a mocked clipboard. The focused contract check confirmed that the removed binding and legacy alias are absent, while `/copy` copies the last assistant message and reports its status-line confirmation. The relevant existing test suites also passed.

**Files Needing Attention:** No files need further attention. The validated behavior is concentrated in `packages/coding-agent/src/core/keybindings.ts`, `packages/coding-agent/src/modes/interactive/interactive-input-handling.ts`, and `packages/coding-agent/src/modes/interactive/interactive-slash-commands.ts`.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the end-to-end copy-contract test inside the coding-agent package, exercising the interactive handler setup and the /copy dispatch with a mocked clipboard, and the test passed.
- Verified that the removed binding and action are absent after the update, and that /copy writes the latest assistant text to the clipboard while showing a status-line confirmation; the focused end-to-end test also passed and validated the related UI and behavior.

<a href="https://app.greptile.com/trex/runs/18812851/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["test(coding-agent): assert clipboard wri..."](https://github.com/bastani-inc/atomic/commit/54a3cbe0d6d48f48f1b39d24912d17412aaa2b83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53185117)</sub>

<!-- /greptile_comment -->