### PR TITLE
fix(workflows): route OSC-8 jump-to-bottom activation to the stage chat that drew it

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed a stall where a message queued during a turn was shown in the transcript but never answered, leaving the session idle until you typed another message. Escape and Ctrl+C hold queued work by pausing the agent's own steering and follow-up queues, but a message the agent loop has already polled is no longer in either queue: it is written straight into the transcript, so the interrupt cancelled its reply and nothing scheduled a new one. This was most visible after answering an `ask_user_question` questionnaire, which admits the queued message and immediately opens the request the interrupt then cancels. An admitted message whose reply was cancelled before it produced any output now receives that reply, and a message you send while that reply is still streaming is delivered as soon as it finishes. Queued messages that are still held are unchanged: Escape still restores them to the editor and leaves the session paused, and a reply that had already streamed some output is never restarted ([#2362](https://github.com/bastani-inc/atomic/issues/2362)).
 - Fixed isolated overlay components such as workflow stage chat failing to re-render after a terminal height change, which could clip the composer and footer after a vertical resize.
+- Fixed OSC-8 jump-to-bottom activation to let the focused workflow overlay claim its own transcript jump before falling back to the host transcript ([#2370](https://github.com/bastani-inc/atomic/issues/2370)).
 
 ## [0.9.13-alpha.3] - 2026-08-13
 

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -84,7 +84,7 @@ The dedicated history actions always change history entries, regardless of the c
 
 ### TUI Fullscreen Viewport
 
-Interactive sessions always use this fullscreen viewport for the primary transcript scroll region. Mouse-wheel input scrolls the region under the pointer, falling back to the transcript over the fixed editor/status/footer dock. Clicking an OSC 8 hyperlink opens it in the default handler. Dragging with the primary mouse button selects text and copies it to the clipboard.
+Interactive sessions always use this fullscreen viewport for the primary transcript scroll region. Mouse-wheel input scrolls the region under the pointer, falling back to the transcript over the fixed editor/status/footer dock. Clicking an OSC 8 hyperlink opens it in the default handler; the jump-to-bottom indicator's internal OSC 8 link returns the focused transcript surface to its live end, including an attached workflow stage chat. Dragging with the primary mouse button selects text and copies it to the clipboard.
 
 
 Fullscreen text selection comes from the installed pi-tui 0.84.1 renderer. Drag with the primary button to select characters; double-click selects a word and triple-click selects a line. Focus changes and non-drag clicks clear transient selection state, preventing a stale highlight from appearing. The renderer also reduces mouse tracking in tmux, Zellij, and GNU Screen.

--- a/packages/coding-agent/src/core/extensions/ui-types.ts
+++ b/packages/coding-agent/src/core/extensions/ui-types.ts
@@ -258,6 +258,8 @@ export interface ExtensionUIContext {
 			 * never resolves can never trap the keyboard.
 			 */
 			handlesCtrlC?: boolean;
+			/** Declare that this component claims internal UI actions such as the jump-to-bottom URL. */
+			handlesInternalUiAction?: boolean;
 			/** AbortSignal to programmatically dismiss the custom UI. */
 			signal?: AbortSignal;
 			/** Overlay positioning/sizing options. Can be static or a function for dynamic updates. */

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -404,6 +404,7 @@ export {
 	ThinkingSelectorComponent,
 	ToolExecutionComponent,
 	type ToolExecutionOptions,
+	TRANSCRIPT_JUMP_TO_END_URL,
 	TranscriptFollowIndicator,
 	TreeSelectorComponent,
 	truncateToVisualLines,

--- a/packages/coding-agent/src/modes/interactive-engine/engine-custom-ui.ts
+++ b/packages/coding-agent/src/modes/interactive-engine/engine-custom-ui.ts
@@ -27,6 +27,8 @@ interface CustomUiOptions {
 	deferInlineCustomUiFocus?: boolean;
 	/** The component binds Ctrl+C itself; see ExtensionUIContext.custom options. */
 	handlesCtrlC?: boolean;
+	/** The component claims internal UI actions such as the jump-to-bottom URL. */
+	handlesInternalUiAction?: boolean;
 	overlayOptions?: OverlayOptions | (() => OverlayOptions);
 	onHandle?: (handle: OverlayHandle) => void;
 	signal?: AbortSignal;
@@ -204,6 +206,7 @@ export class EngineCustomUiService {
 			overlay: options?.overlay === true,
 			deferInlineCustomUiFocus: options?.deferInlineCustomUiFocus,
 			handlesCtrlC: options?.handlesCtrlC,
+			handlesInternalUiAction: options?.handlesInternalUiAction,
 			overlayOptions: serializableOverlayOptions(options?.overlayOptions),
 		});
 		if (options?.onHandle) options.onHandle(this.remoteHandle(componentId));

--- a/packages/coding-agent/src/modes/interactive-engine/protocol.ts
+++ b/packages/coding-agent/src/modes/interactive-engine/protocol.ts
@@ -71,6 +71,7 @@ export type InteractiveEngineMessage =
 			overlay: boolean;
 			deferInlineCustomUiFocus?: boolean;
 			handlesCtrlC?: boolean;
+			handlesInternalUiAction?: boolean;
 			overlayOptions?: SerializableOverlayOptions;
 			widgetKey?: string;
 			widgetPlacement?: "aboveEditor" | "belowEditor";
@@ -354,6 +355,7 @@ export function parseInteractiveEngineMessage(line: string): InteractiveEngineMe
 						overlay: value.overlay,
 						deferInlineCustomUiFocus: value.deferInlineCustomUiFocus === true,
 						handlesCtrlC: value.handlesCtrlC === true,
+						handlesInternalUiAction: value.handlesInternalUiAction === true,
 						overlayOptions: isJsonObject(value.overlayOptions)
 							? (value.overlayOptions as SerializableOverlayOptions)
 							: undefined,

--- a/packages/coding-agent/src/modes/interactive-engine/remote-component.ts
+++ b/packages/coding-agent/src/modes/interactive-engine/remote-component.ts
@@ -11,6 +11,8 @@ interface MountedRemoteComponent {
 	engineDone: boolean;
 	/** The extension declared that this component binds Ctrl+C itself. */
 	handlesCtrlC: boolean;
+	/** The extension declared that this component claims internal UI actions. */
+	handlesInternalUiAction: boolean;
 	handle?: OverlayHandle;
 	widgetKey?: string;
 }
@@ -28,6 +30,7 @@ interface PendingInput {
 
 class RemoteComponent implements Component {
 	wantsKeyRelease = true;
+	readonly handlesInternalUiAction: boolean;
 	private lines = ["Loading remote component…"];
 	private width = 0;
 	private rows = 0;
@@ -49,11 +52,13 @@ class RemoteComponent implements Component {
 		runtime: IsolatedInteractiveRuntime,
 		requestRender: () => void,
 		getRows: () => number,
+		handlesInternalUiAction = false,
 	) {
 		this.componentId = componentId;
 		this.runtime = runtime;
 		this.requestRender = requestRender;
 		this.getRows = getRows;
+		this.handlesInternalUiAction = handlesInternalUiAction;
 	}
 
 	render(width: number): string[] {
@@ -294,6 +299,7 @@ export class RemoteComponentController {
 					message.widgetKey,
 					message.widgetPlacement,
 					message.handlesCtrlC === true,
+					message.handlesInternalUiAction === true,
 				);
 				break;
 			case "engine_custom_close":
@@ -333,6 +339,7 @@ export class RemoteComponentController {
 		widgetKey?: string,
 		widgetPlacement?: "aboveEditor" | "belowEditor",
 		handlesCtrlC = false,
+		handlesInternalUiAction = false,
 	): void {
 		if (this.mounted.has(componentId)) return;
 		if (widgetKey) {
@@ -342,8 +349,16 @@ export class RemoteComponentController {
 				this.runtime,
 				() => this.ui.requestRender(),
 				() => rows,
+				handlesInternalUiAction,
 			);
-			this.mounted.set(componentId, { component, done: () => {}, engineDone: false, handlesCtrlC, widgetKey });
+			this.mounted.set(componentId, {
+				component,
+				done: () => {},
+				engineDone: false,
+				handlesCtrlC,
+				handlesInternalUiAction,
+				widgetKey,
+			});
 			this.ui.setWidget(
 				widgetKey,
 				(tui) => {
@@ -363,8 +378,9 @@ export class RemoteComponentController {
 						this.runtime,
 						() => this.ui.requestRender(),
 						() => tui.terminal.rows,
+						handlesInternalUiAction,
 					);
-					mounted = { component, done, engineDone: false, handlesCtrlC };
+					mounted = { component, done, engineDone: false, handlesCtrlC, handlesInternalUiAction };
 					this.mounted.set(componentId, mounted);
 					// Bind this component to the real host terminal so a buffered
 					// autowrap control emitted before the mount frame applies to the host TTY.
@@ -374,6 +390,7 @@ export class RemoteComponentController {
 				{
 					overlay,
 					deferInlineCustomUiFocus,
+					handlesInternalUiAction,
 					overlayOptions: overlayOptions(options),
 					onHandle: (handle) => {
 						if (mounted) mounted.handle = handle;

--- a/packages/coding-agent/src/modes/interactive/components/index.ts
+++ b/packages/coding-agent/src/modes/interactive/components/index.ts
@@ -62,7 +62,7 @@ export { SkillInvocationMessageComponent } from "./skill-invocation-message.ts";
 export { ThemeSelectorComponent } from "./theme-selector.ts";
 export { ThinkingSelectorComponent } from "./thinking-selector.ts";
 export { ToolExecutionComponent, type ToolExecutionOptions } from "./tool-execution.ts";
-export { TranscriptFollowIndicator } from "./transcript-follow-indicator.ts";
+export { TRANSCRIPT_JUMP_TO_END_URL, TranscriptFollowIndicator } from "./transcript-follow-indicator.ts";
 export { TreeSelectorComponent } from "./tree-selector.ts";
 export { TrustSelectorComponent } from "./trust-selector.ts";
 export { UserMessageComponent } from "./user-message.ts";

--- a/packages/coding-agent/src/modes/interactive/interactive-extension-custom-ui.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-extension-custom-ui.ts
@@ -35,6 +35,7 @@ InteractiveModeBase.prototype.showExtensionCustom = async function <T>(
 	options?: {
 		overlay?: boolean;
 		deferInlineCustomUiFocus?: boolean;
+		handlesInternalUiAction?: boolean;
 		signal?: AbortSignal;
 		overlayOptions?: OverlayOptions | (() => OverlayOptions);
 		onHandle?: (handle: OverlayHandle) => void;
@@ -150,6 +151,9 @@ InteractiveModeBase.prototype.showExtensionCustom = async function <T>(
 					return;
 				}
 				component = c;
+				if (options?.handlesInternalUiAction === true) {
+					(component as Component & { handlesInternalUiAction?: boolean }).handlesInternalUiAction = true;
+				}
 				if (isOverlay) {
 					// Resolve overlay options - can be static or dynamic function
 					const resolveOptions = (): OverlayOptions | undefined => {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-base.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-base.ts
@@ -54,7 +54,13 @@ import type {} from "./interactive-mode-surface.ts";
 import type { CompactionQueuedMessage, InteractiveModeOptions } from "./interactive-mode-types.ts";
 import { StartupChatContainer } from "./interactive-startup-chat-container.ts";
 import type { InteractiveSubmission } from "./interactive-submission.ts";
-import { createInteractiveTui, createInteractiveTuiReference, type InteractiveTui } from "./interactive-tui.ts";
+import {
+	createInteractiveTui,
+	createInteractiveTuiReference,
+	handleFocusedOverlayInternalUiAction,
+	type InteractiveTui,
+	type InternalUiActionResult,
+} from "./interactive-tui.ts";
 
 const FULLSCREEN_VIEWPORT_ACTIONS = [
 	"tui.altScreen.pageUp",
@@ -149,6 +155,8 @@ export class InteractiveModeBase {
 		);
 	};
 	private readonly onOverlayUnhandledInput = (data: string): boolean => this.handleOverlayUnhandledInput(data);
+	private readonly onOverlayInternalUiAction = (url: string): InternalUiActionResult =>
+		handleFocusedOverlayInternalUiAction(this.renderer, url);
 
 	/** Dispatch the host thinking action after a focused workflow overlay declines input. */
 	handleOverlayUnhandledInput(data: string): boolean {
@@ -495,7 +503,11 @@ export class InteractiveModeBase {
 			onRightClickPaste: this.onRightClickPaste,
 			shouldHandleViewportInput: this.shouldHandleViewportInput,
 			onOverlayUnhandledInput: this.onOverlayUnhandledInput,
-			onInternalUiAction: () => this.jumpToTranscriptEnd(),
+			onOverlayInternalUiAction: this.onOverlayInternalUiAction,
+			onInternalUiAction: () => {
+				this.jumpToTranscriptEnd();
+				return undefined;
+			},
 		});
 		this.ui = createInteractiveTuiReference(() => this.renderer);
 		this.ui.setClearOnShrink(this.settingsManager.getClearOnShrink());

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-surface.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-surface.ts
@@ -222,6 +222,7 @@ declare module "./interactive-mode-base.ts" {
 			options?: {
 				overlay?: boolean;
 				deferInlineCustomUiFocus?: boolean;
+				handlesInternalUiAction?: boolean;
 				signal?: AbortSignal;
 				overlayOptions?: OverlayOptions | (() => OverlayOptions);
 				onHandle?: (handle: OverlayHandle) => void;

--- a/packages/coding-agent/src/modes/interactive/interactive-tui.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-tui.ts
@@ -118,7 +118,9 @@ export function handleUrlActivation(url: string, handlers: UrlActivationHandlers
 	if (url.slice(0, internalUiScheme.length).toLowerCase() === internalUiScheme) {
 		const schemeEnd = url.indexOf(":");
 		const normalizedInternalUrl = `${url.slice(0, schemeEnd).toLowerCase()}${url.slice(schemeEnd)}`;
-		if (normalizedInternalUrl === TRANSCRIPT_JUMP_TO_END_URL) routeInternalUiAction(url, handlers);
+		// Forward the normalized URL: overlay-side matching is exact, so a
+		// mixed-case scheme must not reach an overlay as an unrecognized string.
+		if (normalizedInternalUrl === TRANSCRIPT_JUMP_TO_END_URL) routeInternalUiAction(normalizedInternalUrl, handlers);
 		return;
 	}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-tui.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-tui.ts
@@ -41,13 +41,32 @@ interface TuiAltScreenMouseInternals {
 }
 
 export type InteractiveTui = TuiMainScreen | TuiAltScreen;
+export function getFocusedOverlay(tui: InteractiveTui): Component | undefined {
+	const focused = tui.getFocusedComponent();
+	if (!focused) return undefined;
+	const internals = tui as unknown as Partial<TuiOverlayInternals>;
+	if (!Array.isArray(internals.overlayStack) || typeof internals.isOverlayVisible !== "function") return undefined;
+	const entry = internals.overlayStack.find((candidate) => candidate.component === focused);
+	return entry && internals.isOverlayVisible(entry) ? focused : undefined;
+}
+
+export function handleFocusedOverlayInternalUiAction(tui: InteractiveTui, url: string): InternalUiActionResult {
+	const overlay = getFocusedOverlay(tui);
+	const handleInput = overlay?.handleInput as
+		| ((data: string) => boolean | undefined | Promise<boolean | undefined>)
+		| undefined;
+	return handleInput?.call(overlay, url);
+}
+
+export type InternalUiActionResult = boolean | undefined | Promise<boolean | undefined>;
 
 export interface InteractiveTuiOptions {
 	showHardwareCursor: boolean;
 	logDirectory: string;
 	terminal?: Terminal;
 	onRightClickPaste?: () => void;
-	onInternalUiAction?: (url: string) => void;
+	onOverlayInternalUiAction?: (url: string) => InternalUiActionResult;
+	onInternalUiAction?: (url: string) => InternalUiActionResult;
 	/**
 	 * Return false to let a focused overlay receive viewport input first.
 	 * Mouse input is deferred only while the focused component belongs to an
@@ -59,8 +78,33 @@ export interface InteractiveTuiOptions {
 }
 
 export interface UrlActivationHandlers {
-	onInternalUiAction?: (url: string) => void;
+	onOverlayInternalUiAction?: (url: string) => InternalUiActionResult;
+	onInternalUiAction?: (url: string) => InternalUiActionResult;
 	openUrl: (url: string) => void;
+}
+
+function fallbackInternalUiAction(url: string, handlers: UrlActivationHandlers): void {
+	handlers.onInternalUiAction?.(url);
+}
+
+function routeInternalUiAction(url: string, handlers: UrlActivationHandlers): void {
+	let result: InternalUiActionResult;
+	try {
+		result = handlers.onOverlayInternalUiAction?.(url);
+	} catch {
+		fallbackInternalUiAction(url, handlers);
+		return;
+	}
+	if (result instanceof Promise) {
+		void result.then(
+			(handled) => {
+				if (handled !== true) fallbackInternalUiAction(url, handlers);
+			},
+			() => fallbackInternalUiAction(url, handlers),
+		);
+		return;
+	}
+	if (result !== true) fallbackInternalUiAction(url, handlers);
 }
 
 /** Route OSC 8 activation without allowing unknown internal URLs to escape to a browser. */
@@ -69,7 +113,7 @@ export function handleUrlActivation(url: string, handlers: UrlActivationHandlers
 	if (url.slice(0, internalUiScheme.length).toLowerCase() === internalUiScheme) {
 		const schemeEnd = url.indexOf(":");
 		const normalizedInternalUrl = `${url.slice(0, schemeEnd).toLowerCase()}${url.slice(schemeEnd)}`;
-		if (normalizedInternalUrl === TRANSCRIPT_JUMP_TO_END_URL) handlers.onInternalUiAction?.(url);
+		if (normalizedInternalUrl === TRANSCRIPT_JUMP_TO_END_URL) routeInternalUiAction(url, handlers);
 		return;
 	}
 
@@ -348,6 +392,7 @@ export function createInteractiveTui(options: InteractiveTuiOptions): Interactiv
 		{
 			openUrl: (url) =>
 				handleUrlActivation(url, {
+					onOverlayInternalUiAction: options.onOverlayInternalUiAction,
 					onInternalUiAction: options.onInternalUiAction,
 					openUrl: openBrowser,
 				}),

--- a/packages/coding-agent/src/modes/interactive/interactive-tui.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-tui.ts
@@ -16,6 +16,10 @@ interface TuiOverlayEntry {
 	preFocus: Component | null;
 }
 
+interface InternalUiActionOverlay extends Component {
+	handlesInternalUiAction?: boolean;
+}
+
 type TuiOverlayFocusRestore =
 	| { status: "inactive" }
 	| { status: "eligible"; overlay: TuiOverlayEntry }
@@ -52,7 +56,8 @@ export function getFocusedOverlay(tui: InteractiveTui): Component | undefined {
 
 export function handleFocusedOverlayInternalUiAction(tui: InteractiveTui, url: string): InternalUiActionResult {
 	const overlay = getFocusedOverlay(tui);
-	const handleInput = overlay?.handleInput as
+	if (!overlay || (overlay as InternalUiActionOverlay).handlesInternalUiAction !== true) return undefined;
+	const handleInput = overlay.handleInput as
 		| ((data: string) => boolean | undefined | Promise<boolean | undefined>)
 		| undefined;
 	return handleInput?.call(overlay, url);

--- a/packages/coding-agent/test/transcript-follow-indicator.test.ts
+++ b/packages/coding-agent/test/transcript-follow-indicator.test.ts
@@ -95,7 +95,12 @@ describe("handleUrlActivation", () => {
 			onInternalUiAction,
 			onOverlayInternalUiAction: (url) => handleFocusedOverlayInternalUiAction(tui, url),
 		}) as TuiAltScreen;
-		const overlay = tui.showOverlay({ render: () => [], invalidate: () => {}, handleInput: overlayInput });
+		const overlay = tui.showOverlay({
+			render: () => [],
+			invalidate: () => {},
+			handleInput: overlayInput,
+			handlesInternalUiAction: true,
+		});
 		const openUrl = Reflect.get(tui, "openUrl");
 		if (typeof openUrl !== "function") throw new Error("fullscreen TUI did not expose its URL handler");
 
@@ -118,13 +123,41 @@ describe("handleUrlActivation", () => {
 			onInternalUiAction,
 			onOverlayInternalUiAction: (url) => handleFocusedOverlayInternalUiAction(tui, url),
 		}) as TuiAltScreen;
-		const overlay = tui.showOverlay({ render: () => [], invalidate: () => {}, handleInput: overlayInput });
+		const overlay = tui.showOverlay({
+			render: () => [],
+			invalidate: () => {},
+			handleInput: overlayInput,
+			handlesInternalUiAction: true,
+		});
 		const openUrl = Reflect.get(tui, "openUrl");
 		if (typeof openUrl !== "function") throw new Error("fullscreen TUI did not expose its URL handler");
 
 		openUrl(TRANSCRIPT_JUMP_TO_END_URL);
 
 		expect(overlayInput).toHaveBeenCalledExactlyOnceWith(TRANSCRIPT_JUMP_TO_END_URL);
+		expect(onInternalUiAction).toHaveBeenCalledExactlyOnceWith(TRANSCRIPT_JUMP_TO_END_URL);
+		overlay.hide();
+		tui.stop();
+	});
+
+	test("does not offer the jump to an overlay that did not opt in", () => {
+		const onInternalUiAction = vi.fn();
+		const overlayInput = vi.fn(() => true);
+		let tui: TuiAltScreen;
+		tui = createInteractiveTui({
+			showHardwareCursor: false,
+			logDirectory: "/tmp",
+			terminal: new RecordingTerminal(),
+			onInternalUiAction,
+			onOverlayInternalUiAction: (url) => handleFocusedOverlayInternalUiAction(tui, url),
+		}) as TuiAltScreen;
+		const overlay = tui.showOverlay({ render: () => [], invalidate: () => {}, handleInput: overlayInput });
+		const openUrl = Reflect.get(tui, "openUrl");
+		if (typeof openUrl !== "function") throw new Error("fullscreen TUI did not expose its URL handler");
+
+		openUrl(TRANSCRIPT_JUMP_TO_END_URL);
+
+		expect(overlayInput).not.toHaveBeenCalled();
 		expect(onInternalUiAction).toHaveBeenCalledExactlyOnceWith(TRANSCRIPT_JUMP_TO_END_URL);
 		overlay.hide();
 		tui.stop();

--- a/packages/coding-agent/test/transcript-follow-indicator.test.ts
+++ b/packages/coding-agent/test/transcript-follow-indicator.test.ts
@@ -202,14 +202,42 @@ describe("handleUrlActivation", () => {
 		expect(openUrl).not.toHaveBeenCalled();
 	});
 
-	test("accepts case-insensitive internal schemes", () => {
+	test("normalizes a case-insensitive internal scheme before forwarding it", () => {
 		const onInternalUiAction = vi.fn();
 		const openUrl = vi.fn();
 
 		handleUrlActivation("ATOMIC-UI://transcript/jump-to-end", { onInternalUiAction, openUrl });
 
-		expect(onInternalUiAction).toHaveBeenCalledExactlyOnceWith("ATOMIC-UI://transcript/jump-to-end");
+		expect(onInternalUiAction).toHaveBeenCalledExactlyOnceWith(TRANSCRIPT_JUMP_TO_END_URL);
 		expect(openUrl).not.toHaveBeenCalled();
+	});
+
+	test("offers a mixed-case activation to an overlay as the canonical URL", () => {
+		const onInternalUiAction = vi.fn();
+		const overlayInput = vi.fn(() => true);
+		let tui: TuiAltScreen;
+		tui = createInteractiveTui({
+			showHardwareCursor: false,
+			logDirectory: "/tmp",
+			terminal: new RecordingTerminal(),
+			onInternalUiAction,
+			onOverlayInternalUiAction: (url) => handleFocusedOverlayInternalUiAction(tui, url),
+		}) as TuiAltScreen;
+		const overlay = tui.showOverlay({
+			render: () => [],
+			invalidate: () => {},
+			handleInput: overlayInput,
+			handlesInternalUiAction: true,
+		});
+		const openUrl = Reflect.get(tui, "openUrl");
+		if (typeof openUrl !== "function") throw new Error("fullscreen TUI did not expose its URL handler");
+
+		openUrl("ATOMIC-UI://transcript/jump-to-end");
+
+		expect(overlayInput).toHaveBeenCalledExactlyOnceWith(TRANSCRIPT_JUMP_TO_END_URL);
+		expect(onInternalUiAction).not.toHaveBeenCalled();
+		overlay.hide();
+		tui.stop();
 	});
 	test.each(["atomic-ui://[", "atomic-ui://a[b", "atomic-ui://tra nscript/jump-to-end", "ATOMIC-UI://tra nscript/x"])(
 		"drops malformed internal URLs without invoking either handler: %s",

--- a/packages/coding-agent/test/transcript-follow-indicator.test.ts
+++ b/packages/coding-agent/test/transcript-follow-indicator.test.ts
@@ -1,4 +1,4 @@
-import { stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
+import { stripTerminalSequences, type TuiAltScreen, visibleWidth } from "@earendil-works/pi-tui";
 import { beforeAll, describe, expect, test, vi } from "vitest";
 import {
 	TRANSCRIPT_JUMP_TO_END_URL,
@@ -6,7 +6,11 @@ import {
 } from "../src/modes/interactive/components/transcript-follow-indicator.ts";
 import { InteractiveModeBase } from "../src/modes/interactive/interactive-mode-base.ts";
 import "../src/modes/interactive/interactive-transcript-follow.ts";
-import { createInteractiveTui, handleUrlActivation } from "../src/modes/interactive/interactive-tui.ts";
+import {
+	createInteractiveTui,
+	handleFocusedOverlayInternalUiAction,
+	handleUrlActivation,
+} from "../src/modes/interactive/interactive-tui.ts";
 import { initTheme } from "../src/modes/interactive/theme/theme.ts";
 import { openBrowser } from "../src/utils/open-browser.ts";
 import { RecordingTerminal } from "./helpers/interactive-fullscreen-layout.ts";
@@ -78,6 +82,71 @@ describe("handleUrlActivation", () => {
 
 		expect(onInternalUiAction).toHaveBeenCalledExactlyOnceWith(TRANSCRIPT_JUMP_TO_END_URL);
 		expect(openUrl).not.toHaveBeenCalled();
+	});
+
+	test("lets a focused overlay claim the jump before the host transcript", () => {
+		const onInternalUiAction = vi.fn();
+		const overlayInput = vi.fn(() => true);
+		let tui: TuiAltScreen;
+		tui = createInteractiveTui({
+			showHardwareCursor: false,
+			logDirectory: "/tmp",
+			terminal: new RecordingTerminal(),
+			onInternalUiAction,
+			onOverlayInternalUiAction: (url) => handleFocusedOverlayInternalUiAction(tui, url),
+		}) as TuiAltScreen;
+		const overlay = tui.showOverlay({ render: () => [], invalidate: () => {}, handleInput: overlayInput });
+		const openUrl = Reflect.get(tui, "openUrl");
+		if (typeof openUrl !== "function") throw new Error("fullscreen TUI did not expose its URL handler");
+
+		openUrl(TRANSCRIPT_JUMP_TO_END_URL);
+
+		expect(overlayInput).toHaveBeenCalledExactlyOnceWith(TRANSCRIPT_JUMP_TO_END_URL);
+		expect(onInternalUiAction).not.toHaveBeenCalled();
+		overlay.hide();
+		tui.stop();
+	});
+
+	test("falls back to the host transcript when an overlay declines the jump", () => {
+		const onInternalUiAction = vi.fn();
+		const overlayInput = vi.fn(() => false);
+		let tui: TuiAltScreen;
+		tui = createInteractiveTui({
+			showHardwareCursor: false,
+			logDirectory: "/tmp",
+			terminal: new RecordingTerminal(),
+			onInternalUiAction,
+			onOverlayInternalUiAction: (url) => handleFocusedOverlayInternalUiAction(tui, url),
+		}) as TuiAltScreen;
+		const overlay = tui.showOverlay({ render: () => [], invalidate: () => {}, handleInput: overlayInput });
+		const openUrl = Reflect.get(tui, "openUrl");
+		if (typeof openUrl !== "function") throw new Error("fullscreen TUI did not expose its URL handler");
+
+		openUrl(TRANSCRIPT_JUMP_TO_END_URL);
+
+		expect(overlayInput).toHaveBeenCalledExactlyOnceWith(TRANSCRIPT_JUMP_TO_END_URL);
+		expect(onInternalUiAction).toHaveBeenCalledExactlyOnceWith(TRANSCRIPT_JUMP_TO_END_URL);
+		overlay.hide();
+		tui.stop();
+	});
+
+	test("waits for an asynchronous overlay claim before using the host fallback", async () => {
+		const onInternalUiAction = vi.fn();
+		let resolveClaim!: (handled: boolean) => void;
+		const claim = new Promise<boolean>((resolve) => {
+			resolveClaim = resolve;
+		});
+		handleUrlActivation(TRANSCRIPT_JUMP_TO_END_URL, {
+			onOverlayInternalUiAction: () => claim,
+			onInternalUiAction,
+			openUrl: vi.fn(),
+		});
+		expect(onInternalUiAction).not.toHaveBeenCalled();
+
+		resolveClaim(true);
+		await claim;
+		await Promise.resolve();
+		expect(onInternalUiAction).not.toHaveBeenCalled();
 	});
 
 	test("opens non-internal URLs in the browser", () => {

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Fixed the stage-chat jump-to-bottom follow indicator remaining hidden in paused and read-only archive chats, while keeping their callout and instruction rows intact in tight overlays.
+- Fixed clicking the stage-chat jump-to-bottom indicator so its OSC-8 activation returns that stage chat to the live end instead of scrolling the host transcript ([#2370](https://github.com/bastani-inc/atomic/issues/2370)).
 
 ## [0.9.13-alpha.3] - 2026-08-13
 

--- a/packages/workflows/src/extension/ui-surface.ts
+++ b/packages/workflows/src/extension/ui-surface.ts
@@ -120,6 +120,8 @@ export interface PiCustomOverlayOptions {
 	 * surface whose hint row offers `ctrl+c Skip`, `ctrl+c Close`, or cancel.
 	 */
 	handlesCtrlC?: boolean;
+	/** Declare that this component claims internal UI actions such as jump-to-bottom. */
+	handlesInternalUiAction?: boolean;
 	/**
 	 * Geometry / anchoring intended for pi-tui's `resolveOverlayLayout`.
 	 * NOT forwarded by current pi interactive `custom()` — see

--- a/packages/workflows/src/tui/overlay-adapter.ts
+++ b/packages/workflows/src/tui/overlay-adapter.ts
@@ -412,6 +412,7 @@ export function buildGraphOverlayAdapter(
 			// Ctrl+C (Skip / Close / cancel), so the host must forward it here
 			// instead of closing this overlay on the first press.
 			handlesCtrlC: true,
+			handlesInternalUiAction: true,
 			overlayOptions: FULLSCREEN_OVERLAY_OPTIONS,
 			onHandle: (handle) => {
 				currentHandle = handle;

--- a/packages/workflows/src/tui/stage-chat-view-input.ts
+++ b/packages/workflows/src/tui/stage-chat-view-input.ts
@@ -1,3 +1,5 @@
+import { TRANSCRIPT_JUMP_TO_END_URL } from "@bastani/atomic";
+
 import { APP_ACTION, isKeybindingsLike, matchesAction, TUI_ACTION } from "./keybindings-adapter.js";
 import { parseTerminalMouseInput, terminalMouseWheelDirection } from "./mouse-input.js";
 import { defaultResponseFor, handlePromptCardInput, isPromptEscapeInput } from "./prompt-card.js";
@@ -83,7 +85,8 @@ export function handleStageChatInput(ctx: StageChatViewContext, data: string): b
 
 function handleStageChatJumpToBottom(ctx: StageChatViewContext, data: string): boolean {
 	const keybindings = isKeybindingsLike(ctx.piKeybindings) ? ctx.piKeybindings : undefined;
-	if (!matchesAction(keybindings, data, TUI_ACTION.altScreenBottom)) return false;
+	if (data !== TRANSCRIPT_JUMP_TO_END_URL && !matchesAction(keybindings, data, TUI_ACTION.altScreenBottom))
+		return false;
 	ctx.chatHost.scrollToBottom();
 	return true;
 }

--- a/packages/workflows/src/tui/stage-chat-view-input.ts
+++ b/packages/workflows/src/tui/stage-chat-view-input.ts
@@ -20,6 +20,7 @@ import { PROMPT_SCROLL_STEP_ROWS, type StageChatViewContext } from "./stage-chat
 import { Key, matchesKey } from "./text-helpers.js";
 
 export function handleStageChatInput(ctx: StageChatViewContext, data: string): boolean {
+	if (data === TRANSCRIPT_JUMP_TO_END_URL) return handleStageChatJumpToBottom(ctx, data);
 	const keybindings = isKeybindingsLike(ctx.piKeybindings) ? ctx.piKeybindings : undefined;
 	// Only the default physical Ctrl+T belongs to the host thinking action. A
 	// user remap may reuse an editor key, so let that key reach the composer.

--- a/packages/workflows/src/tui/workflow-attach-pane.ts
+++ b/packages/workflows/src/tui/workflow-attach-pane.ts
@@ -8,7 +8,11 @@
  * `stage-chat-view.ts`, and `stage-control-registry.ts`.
  */
 
-import type { ChatMessageRenderOptions, ReadonlyFooterDataProvider } from "@bastani/atomic";
+import {
+	type ChatMessageRenderOptions,
+	type ReadonlyFooterDataProvider,
+	TRANSCRIPT_JUMP_TO_END_URL,
+} from "@bastani/atomic";
 import type { Component, EditorComponent, EditorTheme, TUI } from "@earendil-works/pi-tui";
 import type { StageControlRegistry } from "../runs/foreground/stage-control-registry.js";
 import { stageQueuedUserMessageCount } from "../runs/foreground/stage-queued-user-messages.js";
@@ -340,6 +344,11 @@ export class WorkflowAttachPane implements Component {
 			if (this._shouldQuarantineStagePromptEnter(data)) return true;
 			return this.chatView.handleInput(data);
 		}
+		// The overlay opts into internal UI actions for the whole adapter, so the
+		// graph view is offered the jump URL too. It draws no follow indicator and
+		// has nothing to jump to: decline so the host transcript stays the fallback
+		// instead of swallowing the activation.
+		if (data === TRANSCRIPT_JUMP_TO_END_URL) return false;
 		if (this._shouldQuarantineGraphEnter(data)) return true;
 		return this.graphView.handleInput(data);
 	}

--- a/test/unit/interactive-engine-remote-input.test.ts
+++ b/test/unit/interactive-engine-remote-input.test.ts
@@ -646,22 +646,25 @@ test("isolated stage-chat OSC-8 activation returns the remote chat to its live e
 	setupRun(store, "run-1", "stage-a");
 	const { handle } = makeHandle();
 	let stageView: StageChatView | undefined;
-	void bridge.child.custom((_tui, _theme, keybindings) => {
-		const view = new StageChatView({
-			store,
-			graphTheme: deriveGraphTheme({}),
-			runId: "run-1",
-			stageId: "stage-a",
-			workflowName: "test-wf",
-			handle,
-			onDetach: () => {},
-			onClose: () => {},
-			piTui: makeTestTui(12),
-			piKeybindings: keybindings,
-		});
-		stageView = view;
-		return view;
-	});
+	void bridge.child.custom(
+		(_tui, _theme, keybindings) => {
+			const view = new StageChatView({
+				store,
+				graphTheme: deriveGraphTheme({}),
+				runId: "run-1",
+				stageId: "stage-a",
+				workflowName: "test-wf",
+				handle,
+				onDetach: () => {},
+				onClose: () => {},
+				piTui: makeTestTui(12),
+				piKeybindings: keybindings,
+			});
+			stageView = view;
+			return view;
+		},
+		{ overlay: true, handlesInternalUiAction: true },
+	);
 	await flush(8);
 	const host = bridge.hostComponent;
 	assert.ok(host, "remote stage chat did not mount on the host");
@@ -691,6 +694,52 @@ test("isolated stage-chat OSC-8 activation returns the remote chat to its live e
 
 		assert.equal(stageView._bodyScrollFromBottom, 0, "remote stage chat did not claim the URL activation");
 		assert.equal(hostFallbacks, 0, "claimed remote activation also jumped the host transcript");
+	} finally {
+		overlay.hide();
+		tui.stop();
+	}
+});
+
+test("isolated non-opted-in overlay leaves the jump URL on the host transcript", async () => {
+	let tui: TuiAltScreen | undefined;
+	let hostFallbacks = 0;
+	const remoteInputs: string[] = [];
+	const bridge = makeBridge({
+		fullscreen: true,
+		onOverlayInternalUiAction: (url) => (tui ? handleFocusedOverlayInternalUiAction(tui, url) : undefined),
+		onInternalUiAction: () => {
+			hostFallbacks += 1;
+		},
+	});
+	tui = bridge.tui;
+	assert.ok(tui, "fullscreen renderer did not mount");
+	void bridge.child.custom(
+		() => ({
+			render: () => ["remote"],
+			handleInput: (data: string) => {
+				remoteInputs.push(data);
+				return true;
+			},
+			invalidate: () => {},
+		}),
+		{ overlay: true },
+	);
+	await flush(8);
+	const host = bridge.hostComponent;
+	assert.ok(host, "remote component did not mount on the host");
+
+	tui.setLayoutRoot(new Text("host transcript"));
+	const overlay = tui.showOverlay(host, { anchor: "center", width: "100%", maxHeight: "100%", margin: 0 });
+	tui.start();
+	tui.renderNow();
+	try {
+		const openUrl = Reflect.get(tui, "openUrl");
+		if (typeof openUrl !== "function") throw new Error("fullscreen TUI did not expose its URL handler");
+		openUrl(TRANSCRIPT_JUMP_TO_END_URL);
+		await flush(8);
+
+		assert.deepEqual(remoteInputs, []);
+		assert.equal(hostFallbacks, 1);
 	} finally {
 		overlay.hide();
 		tui.stop();

--- a/test/unit/interactive-engine-remote-input.test.ts
+++ b/test/unit/interactive-engine-remote-input.test.ts
@@ -28,7 +28,12 @@ import {
 } from "../../packages/coding-agent/src/modes/interactive/interactive-mode-base.ts";
 import "../../packages/coding-agent/src/modes/interactive/interactive-editor-actions.ts";
 import "../../packages/coding-agent/src/modes/interactive/interactive-input-handling.ts";
-import { createInteractiveTui } from "../../packages/coding-agent/src/modes/interactive/interactive-tui.ts";
+import { TRANSCRIPT_JUMP_TO_END_URL } from "../../packages/coding-agent/src/modes/interactive/components/transcript-follow-indicator.ts";
+import {
+	createInteractiveTui,
+	handleFocusedOverlayInternalUiAction,
+	type InternalUiActionResult,
+} from "../../packages/coding-agent/src/modes/interactive/interactive-tui.ts";
 import { getEditorTheme, initTheme } from "../../packages/coding-agent/src/modes/interactive/theme/theme.ts";
 import { EngineCustomUiService } from "../../packages/coding-agent/src/modes/interactive-engine/engine-custom-ui.ts";
 import type { IsolatedInteractiveRuntime } from "../../packages/coding-agent/src/modes/interactive-engine/isolated-runtime.ts";
@@ -47,7 +52,14 @@ import { RecordingTerminal } from "../../packages/coding-agent/test/helpers/inte
 import { GraphView } from "../../packages/workflows/src/tui/graph-view.js";
 import { sleep } from "../helpers/runtime.js";
 import { defaultTheme, makeSnap, makeStage, makeStore } from "./overlay-graph-helpers.js";
-import { createStore, deriveGraphTheme, makeHandle, StageChatView, setupRun } from "./stage-chat-view-helpers.ts";
+import {
+	createStore,
+	deriveGraphTheme,
+	makeHandle,
+	makeTestTui,
+	StageChatView,
+	setupRun,
+} from "./stage-chat-view-helpers.ts";
 
 type HostComponent = Omit<Component, "handleInput"> & {
 	handleInput?: (data: string) => boolean | undefined | Promise<boolean | undefined>;
@@ -66,6 +78,8 @@ interface BridgeOptions {
 	stallInput?: boolean;
 	keybindings?: KeybindingsManager;
 	onOverlayUnhandledInput?: (data: string) => boolean;
+	onOverlayInternalUiAction?: (url: string) => InternalUiActionResult;
+	onInternalUiAction?: (url: string) => InternalUiActionResult;
 }
 
 const regularTuiRendererLifecycle: TuiRendererLifecycle = {
@@ -99,6 +113,8 @@ function makeBridge(options: BridgeOptions = {}): Bridge {
 					keybindings,
 				),
 			onOverlayUnhandledInput: options.onOverlayUnhandledInput,
+			onOverlayInternalUiAction: options.onOverlayInternalUiAction,
+			onInternalUiAction: options.onInternalUiAction,
 		}) as TuiAltScreen;
 	}
 	const bridge = { hostComponent: undefined, childCommands, terminal, tui } as unknown as Bridge;
@@ -611,6 +627,74 @@ test("one Kitty Ctrl+O press/release cycle toggles an isolated stage chat once",
 	host.handleInput?.("\x1b[111;5:3u");
 	await flush();
 	assert.equal(toolsExpanded, false);
+});
+
+test("isolated stage-chat OSC-8 activation returns the remote chat to its live end", async () => {
+	let tui: TuiAltScreen | undefined;
+	let hostFallbacks = 0;
+	const bridge = makeBridge({
+		fullscreen: true,
+		onOverlayInternalUiAction: (url) => (tui ? handleFocusedOverlayInternalUiAction(tui, url) : undefined),
+		onInternalUiAction: () => {
+			hostFallbacks += 1;
+		},
+	});
+	tui = bridge.tui;
+	assert.ok(tui, "fullscreen renderer did not mount");
+
+	const store = createStore();
+	setupRun(store, "run-1", "stage-a");
+	const { handle } = makeHandle();
+	let stageView: StageChatView | undefined;
+	void bridge.child.custom((_tui, _theme, keybindings) => {
+		const view = new StageChatView({
+			store,
+			graphTheme: deriveGraphTheme({}),
+			runId: "run-1",
+			stageId: "stage-a",
+			workflowName: "test-wf",
+			handle,
+			onDetach: () => {},
+			onClose: () => {},
+			piTui: makeTestTui(12),
+			piKeybindings: keybindings,
+		});
+		stageView = view;
+		return view;
+	});
+	await flush(8);
+	const host = bridge.hostComponent;
+	assert.ok(host, "remote stage chat did not mount on the host");
+	assert.ok(stageView, "stage chat did not mount in the isolated child");
+	for (let index = 0; index < 12; index += 1) {
+		for (const character of `remote-msg-${index}`) await host.handleInput?.(character);
+		await host.handleInput?.("\r");
+		await flush(2);
+	}
+	await flush(4);
+	stageView.render(80);
+	await host.handleInput?.("\x1b[5~");
+	assert.ok(
+		stageView._bodyScrollFromBottom > 0,
+		`stage chat did not start away from its live end (entries=${stageView._transcript.length}, max=${stageView._lastBodyMaxScroll})`,
+	);
+
+	tui.setLayoutRoot(new Text("host transcript"));
+	const overlay = tui.showOverlay(host, { anchor: "center", width: "100%", maxHeight: "100%", margin: 0 });
+	tui.start();
+	tui.renderNow();
+	try {
+		const openUrl = Reflect.get(tui, "openUrl");
+		if (typeof openUrl !== "function") throw new Error("fullscreen TUI did not expose its URL handler");
+		openUrl(TRANSCRIPT_JUMP_TO_END_URL);
+		await flush(8);
+
+		assert.equal(stageView._bodyScrollFromBottom, 0, "remote stage chat did not claim the URL activation");
+		assert.equal(hostFallbacks, 0, "claimed remote activation also jumped the host transcript");
+	} finally {
+		overlay.hide();
+		tui.stop();
+	}
 });
 
 test("isolated custom UI forwards Kitty releases to an opted-in child component", async () => {

--- a/test/unit/interactive-extension-custom-ui-overlay.test.ts
+++ b/test/unit/interactive-extension-custom-ui-overlay.test.ts
@@ -153,3 +153,53 @@ test("an inline custom UI focuses the editor when nothing else owns input", asyn
 	assert.equal(stub.selectorDisposals, 1, "mounting inline must tear down the selector that owned the container");
 	assert.equal(stub.focused.at(-1), stub.mode.editor);
 });
+
+/**
+ * `handlesInternalUiAction` is what lets an overlay claim the OSC-8
+ * jump-to-bottom activation instead of scrolling the host transcript. In
+ * process it is declared as a mount option and has to reach the component
+ * itself, because that is where the host reads it.
+ */
+test("an in-process overlay declaring handlesInternalUiAction marks its component", async () => {
+	const stub = makeStub();
+	const component = { render: () => ["x"], handleInput: () => {}, invalidate: () => {} };
+	let done!: (result: unknown) => void;
+	const settled = InteractiveModeBase.prototype.showExtensionCustom.call(
+		stub.mode,
+		(_tui: unknown, _theme: unknown, _keys: unknown, complete: (result: unknown) => void) => {
+			done = complete;
+			return component;
+		},
+		{ overlay: true, handlesInternalUiAction: true },
+	);
+	await sleep(0);
+	assert.equal(
+		(component as { handlesInternalUiAction?: boolean }).handlesInternalUiAction,
+		true,
+		"the host reads the opt-in off the component, not off the mount options",
+	);
+	done(undefined);
+	await settled;
+});
+
+test("an in-process overlay that omits the opt-in leaves its component unmarked", async () => {
+	const stub = makeStub();
+	const component = { render: () => ["x"], handleInput: () => {}, invalidate: () => {} };
+	let done!: (result: unknown) => void;
+	const settled = InteractiveModeBase.prototype.showExtensionCustom.call(
+		stub.mode,
+		(_tui: unknown, _theme: unknown, _keys: unknown, complete: (result: unknown) => void) => {
+			done = complete;
+			return component;
+		},
+		{ overlay: true },
+	);
+	await sleep(0);
+	assert.equal(
+		(component as { handlesInternalUiAction?: boolean }).handlesInternalUiAction,
+		undefined,
+		"an unmarked overlay must leave the jump with the host transcript",
+	);
+	done(undefined);
+	await settled;
+});

--- a/test/unit/overlay-adapter-autowrap.test.ts
+++ b/test/unit/overlay-adapter-autowrap.test.ts
@@ -44,6 +44,7 @@ async function registerIsolatedTests(): Promise<void> {
 	mock.module("@bastani/atomic", () => ({
 		ChatSessionHost: TestComponent,
 		TranscriptFollowIndicator: TestComponent,
+		TRANSCRIPT_JUMP_TO_END_URL: "atomic-ui://transcript/jump-to-end",
 		keyHint: (key: string) => key,
 		keyText: (key: string) => key,
 		rawKeyHint: (key: string) => key,

--- a/test/unit/overlay-adapter-hidden-render.test.ts
+++ b/test/unit/overlay-adapter-hidden-render.test.ts
@@ -60,6 +60,7 @@ async function registerIsolatedTests(): Promise<void> {
 	mock.module("@bastani/atomic", () => ({
 		ChatSessionHost: TestComponent,
 		TranscriptFollowIndicator: TestComponent,
+		TRANSCRIPT_JUMP_TO_END_URL: "atomic-ui://transcript/jump-to-end",
 		keyHint: (key: string) => key,
 		keyText: (key: string) => key,
 		rawKeyHint: (key: string) => key,

--- a/test/unit/stage-chat-view-13.test.ts
+++ b/test/unit/stage-chat-view-13.test.ts
@@ -1,3 +1,5 @@
+import { TRANSCRIPT_JUMP_TO_END_URL } from "@bastani/atomic";
+
 import { getKeybindings, setKeybindings, stripTerminalSequences } from "@earendil-works/pi-tui";
 import { describe, test } from "vitest";
 import { KeybindingsManager } from "../../packages/coding-agent/src/core/keybindings.ts";
@@ -498,6 +500,18 @@ describe("StageChatView", () => {
 		assert.equal(view.handleInput("\x1b[6~"), true);
 		view.render(96);
 		assert.equal(view._bodyScrollFromBottom, 0);
+		view.dispose();
+	});
+
+	test("the OSC-8 jump URL returns stage chat to its live end", async () => {
+		const view = await makeScrollableStageChat();
+		view.render(96);
+		view.handleInput("\x1b[5~");
+		assert.ok(view._bodyScrollFromBottom > 0);
+
+		assert.equal(view.handleInput(TRANSCRIPT_JUMP_TO_END_URL), true);
+		assert.equal(view._bodyScrollFromBottom, 0);
+		assert.doesNotMatch(stripTerminalSequences(view.render(96).join("\n")), /Jump to bottom/);
 		view.dispose();
 	});
 

--- a/test/unit/stage-chat-view-13.test.ts
+++ b/test/unit/stage-chat-view-13.test.ts
@@ -3,6 +3,7 @@ import { TRANSCRIPT_JUMP_TO_END_URL } from "@bastani/atomic";
 import { getKeybindings, setKeybindings, stripTerminalSequences } from "@earendil-works/pi-tui";
 import { describe, test } from "vitest";
 import { KeybindingsManager } from "../../packages/coding-agent/src/core/keybindings.ts";
+import { StageUiBroker } from "../../packages/workflows/src/shared/stage-ui-broker.js";
 import {
 	assert,
 	createStore,
@@ -513,6 +514,85 @@ describe("StageChatView", () => {
 		assert.equal(view._bodyScrollFromBottom, 0);
 		assert.doesNotMatch(stripTerminalSequences(view.render(96).join("\n")), /Jump to bottom/);
 		view.dispose();
+	});
+
+	test("handles the OSC-8 jump before a mounted custom UI can consume it", async () => {
+		const store = createStore();
+		setupRun(store, "run-1", "stage-a", "pending");
+		const broker = new StageUiBroker(store);
+		const { handle } = makeHandle();
+		const view = new StageChatView({
+			store,
+			graphTheme: deriveGraphTheme({}),
+			runId: "run-1",
+			stageId: "stage-a",
+			workflowName: "test-wf",
+			handle,
+			onDetach: () => {},
+			onClose: () => {},
+			piTui: makeTestTui(12),
+			piTheme: {},
+			piKeybindings: new KeybindingsManager(),
+			canSubmitPrompt: () => false,
+			stageUiBroker: broker,
+		});
+		const customInputs: string[] = [];
+		const abortController = new AbortController();
+		try {
+			for (let index = 0; index < 18; index += 1) {
+				for (const character of `custom-jump-msg-${index}`) view.handleInput(character);
+				view.handleInput("\r");
+				await flush();
+			}
+			view.render(96);
+			view.handleInput("\x1b[5~");
+			assert.ok(view._bodyScrollFromBottom > 0);
+
+			const pending = broker.requestCustomUi(
+				"run-1",
+				"stage-a",
+				() => ({
+					render: () => ["custom question"],
+					handleInput: (data: string) => {
+						customInputs.push(data);
+						return true;
+					},
+					invalidate: () => {},
+				}),
+				undefined,
+				abortController.signal,
+			);
+			pending.catch(() => {});
+			await flush();
+
+			assert.match(stripTerminalSequences(view.render(96).join("\n")), /custom question/);
+			assert.equal(view.handleInput(TRANSCRIPT_JUMP_TO_END_URL), true);
+			assert.equal(view._bodyScrollFromBottom, 0);
+			assert.deepEqual(customInputs, []);
+		} finally {
+			abortController.abort();
+			view.dispose();
+		}
+	});
+
+	test("handles the OSC-8 jump before a pending prompt editor can consume it", async () => {
+		const fixture = await makeScrollableStageChatFixture();
+		const { store, view } = fixture;
+		try {
+			view.render(96);
+			view.handleInput("\x1b[5~");
+			assert.ok(view._bodyScrollFromBottom > 0);
+			assert.equal(store.recordStagePendingPrompt("run-1", "stage-a", makePendingPrompt()), true);
+			view.render(96);
+			const promptEditor = (view as unknown as { promptEditor: { getText(): string } | null }).promptEditor;
+			assert.ok(promptEditor);
+
+			assert.equal(view.handleInput(TRANSCRIPT_JUMP_TO_END_URL), true);
+			assert.equal(view._bodyScrollFromBottom, 0);
+			assert.equal(promptEditor.getText(), "");
+		} finally {
+			view.dispose();
+		}
 	});
 
 	test("the bound end key returns stage chat to the live end and hides the indicator", async () => {

--- a/test/unit/workflow-attach-pane-10.test.ts
+++ b/test/unit/workflow-attach-pane-10.test.ts
@@ -13,7 +13,7 @@
  */
 
 import assert from "node:assert/strict";
-import type { AgentSession } from "@bastani/atomic";
+import { type AgentSession, TRANSCRIPT_JUMP_TO_END_URL } from "@bastani/atomic";
 import { Key } from "@earendil-works/pi-tui";
 import { describe, test } from "vitest";
 import type { StageControlHandle } from "../../packages/workflows/src/runs/foreground/stage-control-registry.js";
@@ -234,6 +234,69 @@ describe("WorkflowAttachPane", () => {
 		assert.equal(pane._mode, "stage-chat");
 		const lines = pane.render(120);
 		assert.equal(lines.length, 44);
+		pane.dispose();
+	});
+});
+
+describe("WorkflowAttachPane internal UI actions", () => {
+	test("declines the transcript jump in graph mode, prompt card included", () => {
+		// The overlay declares `handlesInternalUiAction` for the whole adapter, so
+		// the graph view is offered the URL as well. It draws no follow indicator,
+		// so it must decline and leave the host transcript as the fallback.
+		const store = createStore();
+		setupRun(store, "run-1", [{ id: "stage-a", name: "A" }]);
+		const registry = createStageControlRegistry();
+		registry.register(makeHandle("run-1", "stage-a"));
+		const pane = new WorkflowAttachPane({
+			store,
+			graphTheme: deriveGraphTheme({}),
+			runId: "run-1",
+			stageControlRegistry: registry,
+			onClose: () => {},
+			piTui: { terminal: { rows: 40 } },
+		});
+
+		assert.equal(pane._mode, "graph");
+		assert.equal(
+			pane.handleInput(TRANSCRIPT_JUMP_TO_END_URL),
+			false,
+			"the graph view must not swallow the jump activation",
+		);
+
+		// A legacy run-level prompt card claims every keystroke, so an ungated
+		// URL reached the card and was swallowed instead of falling back.
+		assert.equal(store.recordPendingPrompt("run-1", makePendingPrompt({ id: "run-prompt" })), true);
+		pane.render(120);
+		assert.equal(
+			pane.handleInput(TRANSCRIPT_JUMP_TO_END_URL),
+			false,
+			"a run-level prompt card must not consume the jump URL",
+		);
+		assert.equal(store.snapshot().runs[0]?.pendingPrompt?.id, "run-prompt", "the prompt must stay unanswered");
+		pane.dispose();
+	});
+
+	test("claims the transcript jump in stage-chat mode", () => {
+		const store = createStore();
+		setupRun(store, "run-1", [{ id: "stage-a", name: "A" }]);
+		const registry = createStageControlRegistry();
+		registry.register(makeHandle("run-1", "stage-a"));
+		const pane = new WorkflowAttachPane({
+			store,
+			graphTheme: deriveGraphTheme({}),
+			runId: "run-1",
+			stageControlRegistry: registry,
+			onClose: () => {},
+			piTui: { terminal: { rows: 40 } },
+		});
+
+		pane.handleInput(Key.enter);
+		assert.equal(pane._mode, "stage-chat");
+		assert.equal(
+			pane.handleInput(TRANSCRIPT_JUMP_TO_END_URL),
+			true,
+			"the stage chat that drew the indicator claims its own jump",
+		);
 		pane.dispose();
 	});
 });


### PR DESCRIPTION
## Summary

Activating the jump-to-bottom indicator's OSC-8 link inside a workflow stage chat scrolled the host transcript instead of the stage chat that drew the link. The host resolved every activation of `TRANSCRIPT_JUMP_TO_END_URL` to one destination, because `interactive-mode-base.ts` wired `onInternalUiAction` unconditionally to `jumpToTranscriptEnd()`.

This adds overlay-scoped URL activation. The host now offers the activation to the focused, visible overlay first, and falls back to the transcript when no overlay claims it. Routing follows the existing `onOverlayUnhandledInput` shape rather than a parallel mechanism.

Fixes #2370.

## How it works

1. `handleUrlActivation` (`interactive-tui.ts`) recognizes the internal URL as before, then calls the new `routeInternalUiAction` instead of the host handler directly.
2. `handleFocusedOverlayInternalUiAction` resolves the focused overlay through the existing overlay stack and visibility check, and offers the URL to it — **only if that overlay opted in** with `handlesInternalUiAction: true`.
3. Anything other than a `true` return falls back to the host transcript. A returned promise is awaited; a thrown error or a rejected promise also falls back, so an overlay cannot trap the activation.
4. The workflows overlay declares the opt-in at its mount site (`overlay-adapter.ts`), and `handleStageChatInput` matches the URL in its **first** branch, before `mountedCustomUi` and `promptState` can consume it as text.

For isolated sessions, the opt-in is threaded along the existing `handlesCtrlC` path: extension UI types → engine protocol → `EngineCustomUiService` → `RemoteComponent`, so a stage chat that reaches the host as a `RemoteComponent` claims its own jump across the engine boundary.

## Behaviour

| Surface | Result |
| --- | --- |
| Stage chat (in-process) | That stage chat returns to its live end |
| Stage chat (isolated / `RemoteComponent`) | The remote chat scrolls; the host transcript does **not** (no double jump) |
| Main transcript | Host transcript scrolls, unchanged |
| Overlay that did not opt in | Declines; host transcript stays the fallback |
| Key binding (`tui.altScreen.bottom`) | Untouched on both surfaces |

## Two defects found and fixed during review

An intermediate revision shipped a working mechanism with two reachable defects, both caught by reviewing the diff rather than the summary:

- **Over-broad offer.** The URL was passed to *any* focused overlay's `handleInput`. An overlay with a text field would insert `atomic-ui://transcript/jump-to-end` as typed characters and return `true`, falsely claiming the activation and suppressing the host fallback. Fixed by the opt-in declaration.
- **Late check in stage chat.** The URL branch ran fifth, after `mountedCustomUi` and `promptState`. `stage-chat-view.ts` keeps `transcriptBodyActive` true while a custom UI is mounted, so the indicator rendered and a click fed the URL into that custom UI as text. Fixed by moving the check to the first branch.

Both are covered by regression tests.

## Tests

Extended the suites that already cover this surface:

- `packages/coding-agent/test/transcript-follow-indicator.test.ts` — both destinations, the unclaimed fallback, the non-opted-in overlay, and the async/rejected-promise fallback.
- `test/unit/stage-chat-view-13.test.ts` — the jump ordering ahead of a mounted custom UI and a pending prompt editor.
- `test/unit/interactive-engine-remote-input.test.ts` — the isolated `RemoteComponent` claim (remote chat scrolled, host did not) and the isolated non-opted-in decline.

Red-green was verified by reverting each fix and restoring:

- Removing the stage-chat first branch fails `handles the OSC-8 jump before a mounted custom UI can consume it` and `...before a pending prompt editor can consume it`.
- Removing the opt-in gate fails `does not offer the jump to an overlay that did not opt in` and `isolated non-opted-in overlay leaves the jump URL on the host transcript`.
- Disabling the overlay offer fails the three routing tests and `isolated stage-chat OSC-8 activation returns the remote chat to its live end`.

Criteria 1, 2 and 4 were also exercised in a live TUI under tmux with real SGR mouse clicks. Criterion 3 rests on the integration test, not the terminal run.

## Validation

- `npm run check` — passed (biome, `tsc --noEmit`, coding-agent `tsgo`, shrinkwrap check).
- `npm run test:unit` — 6189 passed, 1 skipped. `npm run test --workspace=@bastani/atomic` — 3600 passed, 39 skipped.
- The three touched suites re-run at the PR head: 44/44 and 19/19 passed.
- Pre-push hooks ran `test:unit`, `test:integration` and `test:ci-contracts`: all passed.

## Known residue

- The workflows fullscreen overlay declares the opt-in for the whole adapter, so the graph view also receives the URL when it is the active view. That overlay covers the screen and draws no indicator, so the link is not clickable in that state; worst case is a swallowed no-op, never text injection. Reasoned from the code, not exercised by a test.
- Reviewers flagged (P3, non-blocking) that `handleUrlActivation` matches on the case-normalized URL but forwards the raw one, while overlay-side matching is exact. A mixed-case scheme such as `ATOMIC-UI://transcript/jump-to-end` would be offered and declined. Not reachable from shipped code — the indicator always emits the canonical constant — and reviewers probed it as degrading to the pre-patch host jump with nothing injected.
- Reviewers also noted the in-process `options.handlesInternalUiAction` → component hop has no direct regression test; it was confirmed correct by probe, and the enumerated acceptance criteria are met without it.

## Changelogs

One entry each in `packages/coding-agent/CHANGELOG.md` and `packages/workflows/CHANGELOG.md`, appended under `## [Unreleased]` → `### Fixed`. No released section touched.

## Scope

Overlay-scoped URL activation plus routing the stage-chat indicator through it. The indicator, the graph view, host keybindings, and unrelated overlay input handling are unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789258561&installation_model_id=10562&pr_number=2374&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2374&signature=bafca1d08be214a1b770dd432e775d33978dc1919a996a81181a8c23d70221be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The jump-to-bottom link now prioritizes the focused workflow conversation when that surface supports the action, then returns to the host transcript when it does not. Focused routing, fallback behavior, remote components, and URL normalization are covered by the executed checks. No blocking issue remains.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the focused workflow conversation handles its own jump action without preventing the host transcript fallback.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the historical workflow-view fallback behavior in a detached checkout to validate the contract.
- Ran the focused workflow and isolated-component test suites on the current revision; all 49 tests passed.
- Ran the coding-agent transcript follow-indicator suite on the current revision; all 20 tests passed.
- Encountered and resolved a temporary blocking step that required copying the pre-built native binding before Vitest could run in the historical worktree.
- Compared before and after artifacts to confirm the post-change tests completed successfully; the after artifacts show all required tests passing.

<a href="https://app.greptile.com/trex/runs/18819544/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(workflows): close the P3 residue on ..."](https://github.com/bastani-inc/atomic/commit/7f86db076388df341b4a7712e8c8895c58146982) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53185221)</sub>

<!-- /greptile_comment -->