### PR TITLE
docs(changelog): prepare 0.9.13-alpha.4 release notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.13-alpha.4] - 2026-08-13
+
 ### Added
 
 - Added a clickable, centered jump-to-bottom indicator above the fullscreen input dock when the transcript is scrolled away from the live end; it displays the live `tui.altScreen.bottom` key binding and supports mouse activation ([#2361](https://github.com/bastani-inc/atomic/issues/2361)).

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.13-alpha.4] - 2026-08-13
+
 ### Added
 
 - Added the shared "Jump to bottom" follow indicator to workflow stage chat when its transcript is scrolled away from the live end, while preserving composer and footer rows in tight overlays.


### PR DESCRIPTION
## Summary

Prepares the release notes for prerelease **0.9.13-alpha.4**. Changelog-only change.

- `packages/coding-agent/CHANGELOG.md`: promotes the accumulated `[Unreleased]` entries into `## [0.9.13-alpha.4] - 2026-08-13` — the clickable jump-to-bottom indicator, the removed Ctrl+X copy shortcut, the queued-message stall fix, the isolated-overlay resize fix, and overlay-scoped OSC-8 jump activation.
- `packages/workflows/CHANGELOG.md`: same promotion for the shared stage-chat jump-to-bottom indicator, its paused/read-only archive fix, and its OSC-8 click routing fix.

## Versionless base

Package manifests, lockfiles, Cargo files, and generated version files stay at the `0.0.0` placeholder. `scripts/cut-release.ts` stamps the real version on the detached `Release 0.9.13-alpha.4` commit after this PR merges; pushing that tag starts `publish.yml`.

## Validation

- `bun x vitest --run --project unit test/unit/changelog.test.ts` — 12 passed
- `bun x vitest --run --project unit test/unit/package-metadata.test.ts` — 12 passed
- `bun x vitest --run --project ci test/ci/release-publisher-contracts.test.ts` — 2 passed
- Pre-commit/pre-push hooks: `npm run check`, `test:unit`, `test:integration`, `test:ci-contracts` — all passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789262618&installation_model_id=10562&pr_number=2375&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2375&signature=cffa1f550608fda008fa013841f8f7d561ac10491938c774124d3cbd9c893853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prepares the coding-agent and workflows changelogs for the `0.9.13-alpha.4` prerelease, moving accumulated release notes into dated sections while preserving empty `Unreleased` headings for future work.

The changelog and package-metadata checks passed before and after the update. The release-publisher checks also passed, confirming the revised release-note layout remains compatible with publishing.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the update is limited to release-note headings and the release metadata and publishing contracts passed.

No defects were found. Validation confirmed both changelogs retain empty `Unreleased` sections, place the `0.9.13-alpha.4` headings correctly, preserve workspace manifest versions, and satisfy release-publisher contracts.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the changelog and package-metadata unit suites against e141698e^ and against e141698e after the release-note promotion; all 24 tests passed.
- Performed a commit-specific metadata check against e141698e; confirmed empty Unreleased sections following 0.9.13-alpha.4 headings, and eight 0.0.0 workspace manifests.
- Ran the release-publisher contract suite against e141698e; both contracts passed, including staged native tarball and publication-order coverage.
- Reviewed release-metadata runtime validations across before/after artifacts; the after-run evidence confirms 24 tests passed and the commit-specific validation shows empty Unreleased sections and eight 0.0.0 manifests.

<a href="https://app.greptile.com/trex/runs/18820725/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.13-alpha.4 ..."](https://github.com/bastani-inc/atomic/commit/e141698e1a199f2b4ac8eaf42a6692c07b587c30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53200065)</sub>

<!-- /greptile_comment -->