### PR TITLE
docs(changelog): 0.9.14-alpha.1 release notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.14-alpha.1] - 2026-08-14
+
 ### Fixed
 
 - **The whole transcript stays readable while the `ask_user_question` dialog is open** ([#2378](https://github.com/bastani-inc/atomic/issues/2378)). The dialog used to mount inline in the fullscreen dock, where it is a flex sibling of the transcript viewport, so a tall side-by-side questionnaire took the transcript's rows: on a 200×40 terminal the viewport collapsed from 34 rows to 6, and because the page step is derived from that viewport, `PageUp` crawled two lines at a time through a six-line window. The dialog is now pinned to the bottom as an overlay, which is not measured into the layout, so the transcript keeps its full viewport height and full page step — a single `PageUp` moves a full page and `Home` reaches the top of the scrollback. The overlay is also bounded so at least six transcript rows always survive on a short terminal, and the rows it does cover are added back to the transcript's scroll extent, so scrolling to the end raises the newest output into the visible strip instead of leaving it stranded behind the dialog. Transcript page, Home/End, and wheel input remain available while the questionnaire's Notes editor is active. Notes keeps text and edit keys, and the dialog still owns arrows, `enter`, `tab`, `space`, `esc`, clicks, and selection.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.14-alpha.1] - 2026-08-14
+
 ### Added
 
 - Added `heartbeatIntervalMinutes` to the workflow authoring surface: an optional cadence in minutes that resolves to the `15`-minute default when omitted, treats `0` as an explicit disable, and rejects negative and non-finite values with a `TypeError` while the definition is authored, so a bad cadence fails at authoring rather than at schedule time. Every compiled definition carries the resolved value, and a distinct `workflows:workflow-heartbeat` event contract is declared alongside it — run id, workflow name, start time, scheduled time, and interval, with heartbeat identity keyed by run id plus scheduled time. The default interval constant, heartbeat custom type, and heartbeat event types are exported from the `@bastani/workflows` package root ([#1975](https://github.com/bastani-inc/atomic/issues/1975)).


### PR DESCRIPTION
## Summary

Release notes for the `0.9.14-alpha.1` prerelease. Changelog-only: the accumulated `[Unreleased]` entries in `packages/coding-agent` and `packages/workflows` move under a `## [0.9.14-alpha.1] - 2026-08-14` heading.

- `packages/coding-agent/CHANGELOG.md` — the `ask_user_question` overlay fixes (transcript viewport and page step preserved, active row kept visible) plus the `reserveTranscriptRows` and `OVERLAY_ACTIVE_ROW_MARKER` additions.
- `packages/workflows/CHANGELOG.md` — workflow heartbeats: `heartbeatIntervalMinutes` authoring surface, scheduling and queued parent delivery, terminal cleanup and restart recovery, and explicit cadences on the bundled builtin workflows.

## Versionless base

No version stamping here. Every `packages/*/package.json`, the `@bastani/atomic-natives` pin, `packages/natives/native/index.js`, `Cargo.toml`, and `Cargo.lock` stay at the `0.0.0` placeholder. `scripts/cut-release.ts` materializes `0.9.14-alpha.1` on the detached `Release 0.9.14-alpha.1` commit after this merges.

## Validation

- `npm run check` — biome, both typecheck passes, shrinkwrap check
- `npm run test:unit`, `npm run test:integration`, `npm run test:ci-contracts` — via prek pre-commit and pre-push hooks
- `test/unit/changelog.test.ts` and `test/unit/package-metadata.test.ts` — 24 passed

`bun run check` is not usable for this gate: Bun's runner re-forwards the `--workspace=@bastani/atomic` flag into each nested `npm run typecheck`, so the script recurses on itself and never terminates. The npm scripts named in `AGENTS.md` were used instead.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789324052&installation_model_id=10562&pr_number=2386&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2386&signature=04871b1e23434313e7e011446877c3666f7f15ff1c8af90f54ef9d764996bc1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `0.9.14-alpha.1` release sections to the coding-agent and workflows changelogs, grouping the accumulated prerelease notes under the release instead of leaving them in `Unreleased`.

The release contract was checked against both the parent revision and this revision. The parent revision failed because the coding-agent `0.9.14-alpha.1` section was absent; this revision passes with both headings parsed, package metadata remaining valid, and previously tagged changelog sections unchanged. No issues were found.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the release headings satisfy the tested changelog and metadata contract.

No review findings remain. The direct release-contract check distinguished the parent revision from this change and passed on the updated changelogs.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted the release-contract check with the detached HEAD parent-worktree, which failed due to parsing the 0.9.14-alpha.1 release section in the changelog.
- T-Rex re-ran the release-contract check on the current revision without the detached HEAD root, and the test suite passed with one test.
- T-Rex validated that the check correctly identified both new headings, verified the versionless package metadata, and compared released changelog tails against local tags, confirming the release sections are well-formed and do not alter published history.
- From the secondary validation, the before-state showed the exact assertion about parsing 0.9.14-alpha.1 and the after-state showed the tests passing with exit code 0.

<a href="https://app.greptile.com/trex/runs/18937901/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): add 0.9.14-alpha.1 rele..."](https://github.com/bastani-inc/atomic/commit/ece2699ab75513904e4ab6d709b5aa942406bb87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53425051)</sub>

<!-- /greptile_comment -->