### PR TITLE
feat(coding-agent): keep shadowed same-name skills independently selectable

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Added
 
 - Added an **experimental** `@bastani/atomic/client` entrypoint with `RemoteSession` lifecycle management and transcript projection helpers for remote protocol sessions.
+- Same-name skills stay independently selectable. `/skill:name` still uses the current project/user-over-package winner, and Atomic now keeps every distinct file as a source-qualified command such as `/skill:tdd@user` and `/skill:tdd@builtin`. Autocomplete, `pi.getCommands()`, RPC `get_commands`, the model-visible skill list, collision diagnostics, and the `ctx.getSkillCatalog()` extension API share those identities. A qualified selector is exact: unknown or ambiguous aliases error instead of falling back to the winner ([#2328](https://github.com/bastani-inc/atomic/issues/2328)).
 - Added the fullscreen interactive TUI layout. Wheel and trackpad gestures reach focused workflow overlays before the transcript viewport, and events those overlays do not consume fall through to the fullscreen transcript.
 - Fullscreen sessions keep the editor, status line, extension widgets, usage meter, and footer in a sticky dock while the transcript scrolls independently; terminal resizes preserve that layout.
 - Fullscreen mode now supports a draggable transcript scrollbar configured as `auto`, `always`, or `hidden` through `/settings`; themes can set `scrollbarThumb`, which falls back to `selectedBg` for existing custom themes.

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1186,6 +1186,22 @@ pi.on("before_agent_start", (event, ctx) => {
 });
 ```
 
+### ctx.getSkillCatalog()
+
+Returns the current loader-owned skill catalog when the host provides one. Use it to resolve exact skill selectors, including source-qualified names such as `tdd@builtin`, without falling back to the bare precedence winner.
+
+```typescript
+pi.on("session_start", (_event, ctx) => {
+  const catalog = ctx.getSkillCatalog?.();
+  const resolved = catalog?.resolve("tdd@builtin");
+  if (resolved?.ok) {
+    ctx.ui.notify(`Using ${resolved.candidate.selector}`, "info");
+  }
+});
+```
+
+`pi.getCommands()` already includes the same advertised `/skill:name` and `/skill:name@source` names. See [Skill Commands](/skills#skill-commands).
+
 ## ExtensionCommandContext
 
 Command handlers receive `ExtensionCommandContext`, which extends `ExtensionContext` with session control methods. These are only available in commands because they can deadlock if called from event handlers.

--- a/packages/coding-agent/docs/skills.md
+++ b/packages/coding-agent/docs/skills.md
@@ -85,6 +85,21 @@ Skills register as `/skill:name` commands:
 /skill:pdf-tools extract      # Load skill with arguments
 ```
 
+When multiple real skill files declare the same name, Atomic keeps the existing precedence winner for the bare command and retains every distinct file as an exact candidate. Use a source-qualified command to select one explicitly:
+
+```bash
+/skill:review         # Current precedence winner
+/skill:review@project  # Unique project candidate
+/skill:review@user     # Unique user candidate
+/skill:review@builtin   # Unique bundled candidate
+```
+
+`@project`, `@user`, and `@builtin` are available only when that family has one candidate in the collision. If a family contains multiple package candidates, Atomic advertises package-qualified aliases instead, such as `/skill:review@team-review` and `/skill:review@company-review`; the family selector is ambiguous and reports the exact choices. Autocomplete, `pi.getCommands()`, and RPC `get_commands` return the same advertised names.
+
+Qualified selection is exact. An unknown or ambiguous qualified selector reports an error and never falls back to the bare winner. Aliases are recalculated on reload, so a qualified alias disappears when its collision disappears.
+
+Extensions can read the same catalog through `ctx.getSkillCatalog()`.
+
 Arguments after the command are appended to the skill content as `User: <args>`.
 
 Toggle skill commands via `/settings` in interactive mode or in `settings.json`:
@@ -194,7 +209,7 @@ Unknown frontmatter fields are ignored.
 
 **Exception:** Skills with missing description are not loaded.
 
-Name collisions (same name from different locations) warn and keep the first skill found.
+Name collisions (the same name from different real files) produce diagnostics and keep the existing first-winner precedence for `/skill:name`. Atomic also retains the other files as source-qualified candidates as described in [Skill Commands](#skill-commands).
 
 ## Example
 

--- a/packages/coding-agent/src/core/agent-session-compaction.ts
+++ b/packages/coding-agent/src/core/agent-session-compaction.ts
@@ -7,6 +7,7 @@ import {
 	type CompactionPlannerModel,
 	type CompactionPlanOptions,
 	type CompactionRung,
+	computeWholeContextStats,
 	type FallbackPlannerContext,
 	getKeptTailTokenEstimate,
 	prepareCompactionBoundary,
@@ -55,17 +56,20 @@ function deepFreeze<T>(value: T): T {
 function extensionStats(preparation: VerbatimCompactionPreparation, compactedText: string): VerbatimCompactionStats {
 	const linesBefore = preparation.region.lines.length;
 	const linesKept = compactedText.split("\n").length;
-	const tokensAfter = Math.ceil(compactedText.length / 4) + getKeptTailTokenEstimate(preparation);
-	return {
+	const tailEstimate = getKeptTailTokenEstimate(preparation);
+	const regionStats: VerbatimCompactionStats = {
 		linesBefore,
 		linesDeleted: Math.max(0, linesBefore - linesKept),
 		linesKept,
 		rangeCount: 0,
-		tokensBefore: preparation.tokensBefore,
-		tokensAfter,
+		tokensBefore: preparation.region.tokenEstimate,
+		tokensAfter: Math.ceil(compactedText.length / 4),
 		percentReduction:
-			preparation.tokensBefore === 0 ? 0 : Math.round((1 - tokensAfter / preparation.tokensBefore) * 1000) / 10,
+			preparation.region.tokenEstimate === 0
+				? 0
+				: Math.round((1 - Math.ceil(compactedText.length / 4) / preparation.region.tokenEstimate) * 1000) / 10,
 	};
+	return computeWholeContextStats(regionStats, preparation.region, tailEstimate, true);
 }
 
 export async function _applyVerbatimCompaction(
@@ -189,6 +193,7 @@ export async function _applyVerbatimCompaction(
 		parameters: preparation.parameters,
 		stats: compacted.stats,
 		rung: compacted.rung,
+		tokensBefore: preparation.tokensBefore,
 		...(compacted.plannerModel ? { plannerModel: compacted.plannerModel } : {}),
 		...(backupPath ? { backupPath } : {}),
 	};

--- a/packages/coding-agent/src/core/agent-session-extension-bindings.ts
+++ b/packages/coding-agent/src/core/agent-session-extension-bindings.ts
@@ -7,6 +7,7 @@ import type { ExtensionRunner } from "./extensions/index.ts";
 import { emitSessionShutdownEvent } from "./extensions/runner.ts";
 import type { PathMetadata } from "./package-manager.ts";
 import type { ResourceExtensionPaths } from "./resource-loader.ts";
+import { getSkillCatalog } from "./skill-catalog.ts";
 import type { SlashCommandInfo } from "./slash-commands.ts";
 
 export async function bindExtensions(this: AgentSession, bindings: ExtensionBindings): Promise<void> {
@@ -146,11 +147,11 @@ export function _bindExtensionCore(this: AgentSession, runner: ExtensionRunner):
 			sourceInfo: template.sourceInfo,
 		}));
 
-		const skills: SlashCommandInfo[] = this._resourceLoader.getSkills().skills.map((skill) => ({
-			name: `skill:${skill.name}`,
-			description: skill.description,
+		const skills: SlashCommandInfo[] = getSkillCatalog(this._resourceLoader).commands.map((command) => ({
+			name: `skill:${command.name}`,
+			description: command.description,
 			source: "skill",
-			sourceInfo: skill.sourceInfo,
+			sourceInfo: command.sourceInfo,
 		}));
 
 		return [...extensionCommands, ...templates, ...skills];
@@ -251,6 +252,7 @@ export function _bindExtensionCore(this: AgentSession, runner: ExtensionRunner):
 				})();
 			},
 			getSystemPrompt: () => this.systemPrompt,
+			getSkillCatalog: () => getSkillCatalog(this._resourceLoader),
 			getSystemPromptOptions: () => this._baseSystemPromptOptions,
 		},
 		{

--- a/packages/coding-agent/src/core/agent-session-prompt.ts
+++ b/packages/coding-agent/src/core/agent-session-prompt.ts
@@ -20,6 +20,7 @@ import {
 } from "./auth-guidance.ts";
 import { runCallback } from "./callback-activity.ts";
 import { expandPromptTemplate } from "./prompt-templates.ts";
+import { getSkillCatalog } from "./skill-catalog.ts";
 
 type UserMessageDeliveryAction = "prompt" | "steer" | "followUp" | "handled";
 
@@ -351,25 +352,34 @@ export function _expandSkillCommand(this: AgentSession, text: string): string {
 	if (!text.startsWith("/skill:")) return text;
 
 	const spaceIndex = text.indexOf(" ");
-	const skillName = spaceIndex === -1 ? text.slice(7) : text.slice(7, spaceIndex);
+	const selector = spaceIndex === -1 ? text.slice(7) : text.slice(7, spaceIndex);
 	const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim();
 
-	const skill = this.resourceLoader.getSkills().skills.find((s) => s.name === skillName);
-	if (!skill) return text; // Unknown skill, pass through
+	const resolution = getSkillCatalog(this.resourceLoader).resolve(selector);
+	if (!resolution.ok) {
+		if (selector.includes("@")) {
+			this._extensionRunner.emitError({
+				extensionPath: `skill:${selector}`,
+				event: "skill_expansion",
+				error: resolution.message,
+			});
+		}
+		return text;
+	}
 
+	const { skill, id } = resolution.candidate;
 	try {
 		const content = readFileSync(skill.filePath, "utf-8");
 		const body = stripFrontmatter(content).trim();
-		const skillBlock = `<skill name="${skill.name}" location="${skill.filePath}">\nReferences are relative to ${skill.baseDir}.\n\n${body}\n</skill>`;
+		const skillBlock = `<skill name="${selector}" location="${skill.filePath}" candidate="${id}">\nReferences are relative to ${skill.baseDir}.\n\n${body}\n</skill>`;
 		return args ? `${skillBlock}\n\n${args}` : skillBlock;
 	} catch (err) {
-		// Emit error like extension commands do
 		this._extensionRunner.emitError({
 			extensionPath: skill.filePath,
 			event: "skill_expansion",
 			error: err instanceof Error ? err.message : String(err),
 		});
-		return text; // Return original on error
+		return text;
 	}
 }
 

--- a/packages/coding-agent/src/core/agent-session-skill-block.ts
+++ b/packages/coding-agent/src/core/agent-session-skill-block.ts
@@ -2,6 +2,7 @@
 export interface ParsedSkillBlock {
 	name: string;
 	location: string;
+	candidateId?: string;
 	content: string;
 	userMessage: string | undefined;
 }
@@ -20,12 +21,25 @@ export function parseSkillBlock(text: string): ParsedSkillBlock | null {
 	if (!name) return null;
 
 	const locationStart = nameEnd + '" location="'.length;
-	const locationEnd = text.indexOf('">\n', locationStart);
+	const locationEnd = text.indexOf('"', locationStart);
 	if (locationEnd === -1) return null;
 	const location = text.slice(locationStart, locationEnd);
 	if (!location) return null;
 
-	const contentStart = locationEnd + '">\n'.length;
+	let tagEnd = locationEnd + 1;
+	let candidateId: string | undefined;
+	const candidatePrefix = ' candidate="';
+	if (text.startsWith(candidatePrefix, tagEnd)) {
+		const candidateStart = tagEnd + candidatePrefix.length;
+		const candidateEnd = text.indexOf('"', candidateStart);
+		if (candidateEnd === -1) return null;
+		candidateId = text.slice(candidateStart, candidateEnd);
+		if (!candidateId) return null;
+		tagEnd = candidateEnd + 1;
+	}
+	if (!text.startsWith(">\n", tagEnd)) return null;
+
+	const contentStart = tagEnd + ">\n".length;
 	const closing = "\n</skill>";
 	const contentEnd = text.indexOf(closing, contentStart);
 	if (contentEnd === -1) return null;
@@ -36,6 +50,7 @@ export function parseSkillBlock(text: string): ParsedSkillBlock | null {
 	return {
 		name,
 		location,
+		...(candidateId ? { candidateId } : {}),
 		content: text.slice(contentStart, contentEnd),
 		userMessage: afterClosing ? afterClosing.slice(2).trim() || undefined : undefined,
 	};

--- a/packages/coding-agent/src/core/compaction/compaction-boundary.ts
+++ b/packages/coding-agent/src/core/compaction/compaction-boundary.ts
@@ -32,12 +32,31 @@ interface VisibleEntry {
 
 const keptTailTokensByPreparation = new WeakMap<VerbatimCompactionPreparation, number>();
 
-/** Return the independently estimated cost of the protected tail. */
+/**
+ * Set the independently estimated cost of the protected tail on a preparation.
+ *
+ * Exposed so that test fixtures can set the tail estimate on a preparation that
+ * was constructed directly (not through `prepareCompactionBoundary`), mirroring
+ * what production code does. Without this, `getKeptTailTokenEstimate` returns 0
+ * for test-only preparations.
+ */
+export function setKeptTailTokenEstimate(preparation: VerbatimCompactionPreparation, estimate: number): void {
+	keptTailTokensByPreparation.set(preparation, estimate);
+}
+
+/**
+ * Return the independently estimated cost of the protected tail.
+ *
+ * The fallback is 0 (not `tokensBefore - region.tokenEstimate`) because
+ * `tokensBefore` is a provider-authoritative count while `region.tokenEstimate`
+ * is a char/4 heuristic. Mixing them in a subtraction produced an incommensurable
+ * tail estimate that could overshoot the real count and make `percentReduction`
+ * negative. When the preparation was not set up through `prepareCompactionBoundary`
+ * (or the WeakMap entry was collected), the tail estimate is unknown and must
+ * default to 0 rather than a mixed-unit guess.
+ */
 export function getKeptTailTokenEstimate(preparation: VerbatimCompactionPreparation): number {
-	return (
-		keptTailTokensByPreparation.get(preparation) ??
-		Math.max(0, preparation.tokensBefore - preparation.region.tokenEstimate)
-	);
+	return keptTailTokensByPreparation.get(preparation) ?? 0;
 }
 
 function messageFromEntry(entry: SessionEntry): AgentMessage | undefined {

--- a/packages/coding-agent/src/core/compaction/compaction-runner.ts
+++ b/packages/coding-agent/src/core/compaction/compaction-runner.ts
@@ -7,9 +7,11 @@ import type {
 	CompactedTranscript,
 	CompactionPlannerModel,
 	CompactionUrgency,
+	NumberedRegion,
 	PlannerAuth,
 	RawLineRange,
 	VerbatimCompactionPreparation,
+	VerbatimCompactionStats,
 } from "./compaction-types.js";
 import { MIN_COMPACTABLE_REGION_LINES } from "./compaction-types.js";
 import { reconstructCompactedTranscript, validateDeletedRanges } from "./deleted-ranges.js";
@@ -88,17 +90,38 @@ function hardInputLimitFor(model: Model<Api>): number {
 	return model.contextWindow > 0 ? model.contextWindow : Number.POSITIVE_INFINITY;
 }
 
-function withWholeContextStats(
-	result: CompactedTranscript,
-	preparation: VerbatimCompactionPreparation,
+/**
+ * Widen region-scoped stats to a whole-context symmetric heuristic pair.
+ *
+ * Both `tokensBefore` and `tokensAfter` are computed with the same estimator:
+ * a region term (char/4 heuristic from `region.tokenEstimate` and the compacted
+ * text) plus an explicit tail estimate from the same heuristic family. When the
+ * tail survives compaction it appears on both sides and cancels in the ratio;
+ * when the fresh rung drops the tail it correctly does not cancel, because the
+ * tail really is gone.
+ *
+ * This does **not** clamp the percentage: a genuine expansion may still be
+ * negative.
+ *
+ * Centralized here so planned, fresh, and extension results all use one
+ * widening/ratio path.
+ */
+export function computeWholeContextStats(
+	regionStats: VerbatimCompactionStats,
+	region: NumberedRegion,
+	tailEstimate: number,
 	keptTail: boolean,
-): CompactedTranscript {
-	const tokensAfter = result.stats.tokensAfter + (keptTail ? getKeptTailTokenEstimate(preparation) : 0);
-	const percentReduction =
-		preparation.tokensBefore === 0 ? 0 : Math.round((1 - tokensAfter / preparation.tokensBefore) * 1000) / 10;
+): VerbatimCompactionStats {
+	const beforeTail = region.tokenEstimate;
+	const afterTail = keptTail ? tailEstimate : 0;
+	const tokensBefore = beforeTail + (keptTail ? tailEstimate : 0);
+	const tokensAfter = regionStats.tokensAfter + afterTail;
+	const percentReduction = tokensBefore === 0 ? 0 : Math.round((1 - tokensAfter / tokensBefore) * 1000) / 10;
 	return {
-		...result,
-		stats: { ...result.stats, tokensBefore: preparation.tokensBefore, tokensAfter, percentReduction },
+		...regionStats,
+		tokensBefore,
+		tokensAfter,
+		percentReduction,
 	};
 }
 
@@ -156,8 +179,12 @@ function plannedResult(
 		preparation.region,
 		validateDeletedRanges(ranges, preparation.region),
 	);
+	const tailEstimate = getKeptTailTokenEstimate(preparation);
 	return {
-		...withWholeContextStats(reconstructed, preparation, true),
+		text: reconstructed.text,
+		ranges: reconstructed.ranges,
+		keptRanges: reconstructed.keptRanges,
+		stats: computeWholeContextStats(reconstructed.stats, preparation.region, tailEstimate, true),
 		rung: "planned",
 		...(plannerModel ? { plannerModel } : {}),
 		keptTail: true,
@@ -268,8 +295,12 @@ async function resolvePlannerAuth(
 
 function freshResult(preparation: VerbatimCompactionPreparation, hardInputLimit: number): CompactionRungResult {
 	const fresh = buildFreshContextWindow(preparation, hardInputLimit);
+	const tailEstimate = getKeptTailTokenEstimate(preparation);
 	return {
-		...withWholeContextStats(fresh.transcript, preparation, fresh.keptTail),
+		text: fresh.transcript.text,
+		ranges: fresh.transcript.ranges,
+		keptRanges: fresh.transcript.keptRanges,
+		stats: computeWholeContextStats(fresh.transcript.stats, preparation.region, tailEstimate, fresh.keptTail),
 		rung: "fresh",
 		keptTail: fresh.keptTail,
 	};

--- a/packages/coding-agent/src/core/compaction/compaction-types.ts
+++ b/packages/coding-agent/src/core/compaction/compaction-types.ts
@@ -123,6 +123,13 @@ export interface VerbatimCompactionDetails {
 	parameters: VerbatimCompactionParameters;
 	stats: VerbatimCompactionStats;
 	rung: CompactionRung;
+	/**
+	 * Authoritative whole-context token count from the provider, used for
+	 * budgeting and the "Compacted from N tokens" display. Deliberately
+	 * separate from the symmetric heuristic `stats.tokensBefore` so each
+	 * retains its best available source. See issue #2052.
+	 */
+	tokensBefore?: number;
 	/** Present only when a borrowed fallback model ranked the lines. */
 	plannerModel?: CompactionPlannerModel;
 	backupPath?: string;

--- a/packages/coding-agent/src/core/extensions/context-types.ts
+++ b/packages/coding-agent/src/core/extensions/context-types.ts
@@ -5,6 +5,7 @@ import type { CustomMessage } from "../messages.ts";
 import type { ModelRegistry } from "../model-registry.ts";
 import type { ScopedModel } from "../model-resolver.ts";
 import type { ReadonlySessionManager, SessionManager } from "../session-manager.ts";
+import type { SkillCatalog } from "../skill-catalog.ts";
 import type { BuildSystemPromptOptions } from "../system-prompt.ts";
 import type { WorkflowStageAdmissionBoundary } from "../workflow-stage-admission.ts";
 import type { SendMessageOptions, SendMessagesOptions } from "./message-types.ts";
@@ -159,6 +160,8 @@ export interface ExtensionContext {
 	compact(options?: CompactOptions): void;
 	/** Get the current effective system prompt. */
 	getSystemPrompt(): string;
+	/** Get the current skill catalog for qualified skill resolution. */
+	getSkillCatalog?(): SkillCatalog;
 }
 
 /**

--- a/packages/coding-agent/src/core/extensions/runtime-types.ts
+++ b/packages/coding-agent/src/core/extensions/runtime-types.ts
@@ -6,6 +6,7 @@ import type { ResourceOverlap } from "../diagnostics.ts";
 import type { CustomMessage } from "../messages.ts";
 import type { ScopedModel } from "../model-resolver.ts";
 import type { SessionManager } from "../session-manager.ts";
+import type { SkillCatalog } from "../skill-catalog.ts";
 import type { SlashCommandInfo } from "../slash-commands.ts";
 import type { SourceInfo } from "../source-info.ts";
 import type { BuildSystemPromptOptions } from "../system-prompt.ts";
@@ -188,6 +189,7 @@ export interface ExtensionContextActions {
 	getContextUsage: () => ContextUsage | undefined;
 	compact: (options?: CompactOptions) => void;
 	getSystemPrompt: () => string;
+	getSkillCatalog?: () => SkillCatalog;
 	getSystemPromptOptions?: () => BuildSystemPromptOptions;
 }
 

--- a/packages/coding-agent/src/core/resource-loader-assets.ts
+++ b/packages/coding-agent/src/core/resource-loader-assets.ts
@@ -27,17 +27,20 @@ async function existsAsync(path: string): Promise<boolean> {
 
 function applySkillsResult(
 	loader: DefaultResourceLoader,
-	skillsResult: { skills: Skill[]; diagnostics: ResourceDiagnostic[] },
+	skillsResult: { skills: Skill[]; shadowedSkills?: Skill[]; diagnostics: ResourceDiagnostic[] },
 	metadataByPath?: Map<string, PathMetadata>,
 ): void {
 	const state = resourceInternals(loader);
-	const resolvedSkills = state.skillsOverride ? state.skillsOverride(skillsResult) : skillsResult;
-	state.skills = resolvedSkills.skills.map((skill) => ({
+	const normalizedResult = { ...skillsResult, shadowedSkills: skillsResult.shadowedSkills ?? [] };
+	const resolvedSkills = state.skillsOverride ? state.skillsOverride(normalizedResult) : normalizedResult;
+	const sourceInfoFor = (skill: Skill) =>
+		findSourceInfoForPath(loader, skill.filePath, state.extensionSkillSourceInfos, metadataByPath) ??
+		skill.sourceInfo ??
+		getDefaultSourceInfoForPath(loader, skill.filePath);
+	state.skills = resolvedSkills.skills.map((skill) => ({ ...skill, sourceInfo: sourceInfoFor(skill) }));
+	state.shadowedSkills = (resolvedSkills.shadowedSkills ?? []).map((skill) => ({
 		...skill,
-		sourceInfo:
-			findSourceInfoForPath(loader, skill.filePath, state.extensionSkillSourceInfos, metadataByPath) ??
-			skill.sourceInfo ??
-			getDefaultSourceInfoForPath(loader, skill.filePath),
+		sourceInfo: sourceInfoFor(skill),
 	}));
 	state.skillDiagnostics = resolvedSkills.diagnostics;
 }
@@ -50,7 +53,7 @@ export async function updateSkillsFromPathsAsync(
 	const state = resourceInternals(loader);
 	const skillsResult =
 		state.noSkills && skillPaths.length === 0
-			? { skills: [], diagnostics: [] }
+			? { skills: [], shadowedSkills: [], diagnostics: [] }
 			: await loadSkillsAsync({ cwd: state.cwd, agentDir: state.agentDir, skillPaths, includeDefaults: false });
 	applySkillsResult(loader, skillsResult, metadataByPath);
 }

--- a/packages/coding-agent/src/core/resource-loader-core.ts
+++ b/packages/coding-agent/src/core/resource-loader-core.ts
@@ -51,8 +51,9 @@ export class DefaultResourceLoader implements ResourceLoader {
 	private systemPromptSource?: string;
 	private appendSystemPromptSource?: string[];
 	private extensionsOverride?: (base: LoadExtensionsResult) => LoadExtensionsResult;
-	private skillsOverride?: (base: { skills: Skill[]; diagnostics: ResourceDiagnostic[] }) => {
+	private skillsOverride?: (base: { skills: Skill[]; shadowedSkills: Skill[]; diagnostics: ResourceDiagnostic[] }) => {
 		skills: Skill[];
+		shadowedSkills: Skill[];
 		diagnostics: ResourceDiagnostic[];
 	};
 	private promptsOverride?: (base: { prompts: PromptTemplate[]; diagnostics: ResourceDiagnostic[] }) => {
@@ -70,6 +71,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 	private appendSystemPromptOverride?: (base: string[]) => string[];
 	private extensionsResult: LoadExtensionsResult;
 	private skills: Skill[];
+	private shadowedSkills: Skill[];
 	private skillDiagnostics: ResourceDiagnostic[];
 	private prompts: PromptTemplate[];
 	private promptDiagnostics: ResourceDiagnostic[];
@@ -152,6 +154,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 		this.appendSystemPromptOverride = options.appendSystemPromptOverride;
 		this.extensionsResult = { extensions: [], errors: [], runtime: createExtensionRuntime() };
 		this.skills = [];
+		this.shadowedSkills = [];
 		this.skillDiagnostics = [];
 		this.prompts = [];
 		this.promptDiagnostics = [];
@@ -180,8 +183,8 @@ export class DefaultResourceLoader implements ResourceLoader {
 		return this.extensionsResult;
 	}
 
-	getSkills(): { skills: Skill[]; diagnostics: ResourceDiagnostic[] } {
-		return { skills: this.skills, diagnostics: this.skillDiagnostics };
+	getSkills(): { skills: Skill[]; shadowedSkills: Skill[]; diagnostics: ResourceDiagnostic[] } {
+		return { skills: this.skills, shadowedSkills: this.shadowedSkills, diagnostics: this.skillDiagnostics };
 	}
 
 	getPrompts(): { prompts: PromptTemplate[]; diagnostics: ResourceDiagnostic[] } {

--- a/packages/coding-agent/src/core/resource-loader-internals.ts
+++ b/packages/coding-agent/src/core/resource-loader-internals.ts
@@ -30,8 +30,9 @@ export interface ResourceLoaderInternals {
 	systemPromptSource?: string;
 	appendSystemPromptSource?: string[];
 	extensionsOverride?: (base: LoadExtensionsResult) => LoadExtensionsResult;
-	skillsOverride?: (base: { skills: Skill[]; diagnostics: ResourceDiagnostic[] }) => {
+	skillsOverride?: (base: { skills: Skill[]; shadowedSkills: Skill[]; diagnostics: ResourceDiagnostic[] }) => {
 		skills: Skill[];
+		shadowedSkills: Skill[];
 		diagnostics: ResourceDiagnostic[];
 	};
 	promptsOverride?: (base: { prompts: PromptTemplate[]; diagnostics: ResourceDiagnostic[] }) => {
@@ -49,6 +50,7 @@ export interface ResourceLoaderInternals {
 	appendSystemPromptOverride?: (base: string[]) => string[];
 	extensionsResult: LoadExtensionsResult;
 	skills: Skill[];
+	shadowedSkills: Skill[];
 	skillDiagnostics: ResourceDiagnostic[];
 	prompts: PromptTemplate[];
 	promptDiagnostics: ResourceDiagnostic[];

--- a/packages/coding-agent/src/core/resource-loader-reload.ts
+++ b/packages/coding-agent/src/core/resource-loader-reload.ts
@@ -176,8 +176,11 @@ export async function reloadDefaultResourceLoader(
 		state.workflowResources = [];
 		state.resourceMetadataByPath = new Map();
 		state.lastSkillPaths = [];
-		const emptySkills = state.skillsOverride ? state.skillsOverride({ skills: [], diagnostics: [] }) : undefined;
+		const emptySkills = state.skillsOverride
+			? state.skillsOverride({ skills: [], shadowedSkills: [], diagnostics: [] })
+			: undefined;
 		state.skills = emptySkills?.skills ?? [];
+		state.shadowedSkills = emptySkills?.shadowedSkills ?? [];
 		state.skillDiagnostics = emptySkills?.diagnostics ?? [];
 		state.lastPromptPaths = [];
 		const emptyPrompts = state.promptsOverride ? state.promptsOverride({ prompts: [], diagnostics: [] }) : undefined;

--- a/packages/coding-agent/src/core/resource-loader-types.ts
+++ b/packages/coding-agent/src/core/resource-loader-types.ts
@@ -36,7 +36,7 @@ export interface ResourceLoaderReloadOptions {
 
 export interface ResourceLoader {
 	getExtensions(): LoadExtensionsResult;
-	getSkills(): { skills: Skill[]; diagnostics: ResourceDiagnostic[] };
+	getSkills(): { skills: Skill[]; shadowedSkills: Skill[]; diagnostics: ResourceDiagnostic[] };
 	getPrompts(): { prompts: PromptTemplate[]; diagnostics: ResourceDiagnostic[] };
 	getThemes(): { themes: Theme[]; diagnostics: ResourceDiagnostic[] };
 	getAgentsFiles(): { agentsFiles: Array<{ path: string; content: string }> };
@@ -86,8 +86,9 @@ export interface DefaultResourceLoaderOptions {
 	systemPrompt?: string;
 	appendSystemPrompt?: string[];
 	extensionsOverride?: (base: LoadExtensionsResult) => LoadExtensionsResult;
-	skillsOverride?: (base: { skills: Skill[]; diagnostics: ResourceDiagnostic[] }) => {
+	skillsOverride?: (base: { skills: Skill[]; shadowedSkills: Skill[]; diagnostics: ResourceDiagnostic[] }) => {
 		skills: Skill[];
+		shadowedSkills: Skill[];
 		diagnostics: ResourceDiagnostic[];
 	};
 	promptsOverride?: (base: { prompts: PromptTemplate[]; diagnostics: ResourceDiagnostic[] }) => {

--- a/packages/coding-agent/src/core/skill-catalog.ts
+++ b/packages/coding-agent/src/core/skill-catalog.ts
@@ -1,0 +1,218 @@
+import type { ResourceLoader } from "./resource-loader-types.ts";
+import type { Skill } from "./skills.ts";
+import type { SlashCommandInfo } from "./slash-commands.ts";
+
+/**
+ * A single skill candidate in a collision group, with a stable source-qualified selector.
+ */
+export interface SkillCandidate {
+	/** The underlying skill. */
+	readonly skill: Skill;
+	/** Source-qualified selector, e.g. `tdd@user`, `tdd@builtin`, or bare `tdd` for the winner. */
+	readonly selector: string;
+	/** Short source label: `project`, `user`, `builtin`, `package`, or `path`. */
+	readonly sourceLabel: string;
+	/** Opaque stable ID for internal identity (transcripts, diagnostics). */
+	readonly id: string;
+}
+
+/**
+ * A command surface entry derived from the catalog.
+ * For the winner of a collision group, `name` is the bare skill name.
+ * For shadowed candidates, `name` includes the `@source` qualifier.
+ */
+export interface SkillCatalogCommand {
+	readonly name: string;
+	readonly description: string;
+	readonly sourceInfo: Skill["sourceInfo"];
+}
+
+/**
+ * Result of resolving a selector through the catalog.
+ */
+export type ResolveResult = { ok: true; candidate: SkillCandidate } | { ok: false; message: string };
+
+/**
+ * The full skill catalog: all candidates across all collision groups,
+ * plus resolution and command-surface helpers.
+ */
+export interface SkillCatalog {
+	/** All candidates (winners + shadowed) across all names. */
+	readonly allCandidates: readonly SkillCandidate[];
+	/** Commands for the slash-command surface (bare winner + qualified shadowed). */
+	readonly commands: readonly SkillCatalogCommand[];
+	/**
+	 * Resolve a selector like `tdd` or `tdd@builtin` to an exact candidate.
+	 * Returns a message on unknown or ambiguous selectors; never falls back to the bare winner.
+	 */
+	resolve(selector: string): ResolveResult;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive a short, stable source label from a skill's SourceInfo.
+ * The label is used for `@source` qualifiers and must be unique within a collision group;
+ * when it is not, a package/path-derived fallback is used.
+ */
+function sourceLabelFor(skill: Skill): string {
+	const si = skill.sourceInfo;
+	// scope takes priority: project/user are always unique within those scopes
+	if (si.scope === "project") return "project";
+	if (si.scope === "user") return "user";
+	// package-provided skills: use the source string if it's not generic
+	if (si.source && si.source !== "local" && si.source !== "temporary") return si.source;
+	// fallback: path
+	return "path";
+}
+
+/**
+ * A label that is unique within the group. If the short label collides with another
+ * candidate's short label in the same group, fall back to a path-derived identifier.
+ */
+function uniqueLabelInGroup(candidates: Skill[]): Map<string, string> {
+	const labelMap = new Map<string, string>();
+	const labelCounts = new Map<string, number>();
+	// First pass: assign short labels and count collisions
+	for (const skill of candidates) {
+		const label = sourceLabelFor(skill);
+		labelMap.set(skill.filePath, label);
+		labelCounts.set(label, (labelCounts.get(label) ?? 0) + 1);
+	}
+	// Second pass: disambiguate labels that appear more than once
+	if (![...labelCounts.values()].some((c) => c > 1)) return labelMap;
+	// Use a path-derived suffix for duplicates
+	const used = new Set<string>();
+	for (const skill of candidates) {
+		const shortLabel = labelMap.get(skill.filePath)!;
+		if ((labelCounts.get(shortLabel) ?? 0) <= 1) {
+			labelMap.set(skill.filePath, shortLabel);
+			used.add(shortLabel);
+			continue;
+		}
+		// Derive a unique label from the base directory name
+		const baseName = skill.baseDir.split(/[\\/]/).filter(Boolean).pop() ?? shortLabel;
+		let candidate = baseName;
+		let suffix = 2;
+		while (used.has(candidate)) {
+			candidate = `${baseName}-${suffix++}`;
+		}
+		used.add(candidate);
+		labelMap.set(skill.filePath, candidate);
+	}
+	return labelMap;
+}
+
+/**
+ * Build a stable opaque ID for a candidate. This is internal identity, not a command name.
+ */
+function candidateIdFor(skill: Skill, label: string): string {
+	return `${skill.name}@${label}`;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a skill catalog from the resource loader's current skills + shadowed skills.
+ */
+export function getSkillCatalog(loader: ResourceLoader): SkillCatalog {
+	const { skills, shadowedSkills } = loader.getSkills();
+
+	// Group all candidates by name: winners first, then shadowed
+	const groups = new Map<string, Skill[]>();
+	for (const skill of skills) {
+		const group = groups.get(skill.name) ?? [];
+		group.push(skill);
+		groups.set(skill.name, group);
+	}
+	for (const skill of shadowedSkills) {
+		const group = groups.get(skill.name) ?? [];
+		group.push(skill);
+		groups.set(skill.name, group);
+	}
+
+	const allCandidates: SkillCandidate[] = [];
+	const commands: SkillCatalogCommand[] = [];
+
+	for (const [name, group] of groups) {
+		const labels = uniqueLabelInGroup(group);
+		const hasCollision = group.length > 1;
+
+		for (let i = 0; i < group.length; i++) {
+			const skill = group[i];
+			const label = labels.get(skill.filePath)!;
+			const id = candidateIdFor(skill, label);
+			// Winner (first in group) gets bare selector; others get qualified
+			const selector = i === 0 ? name : `${name}@${label}`;
+			allCandidates.push({ skill, selector, sourceLabel: label, id });
+
+			// Commands: bare name for winner; qualified for shadowed (only if collision)
+			if (i === 0) {
+				commands.push({
+					name,
+					description: skill.description,
+					sourceInfo: skill.sourceInfo,
+				});
+			} else if (hasCollision) {
+				commands.push({
+					name: selector,
+					description: skill.description,
+					sourceInfo: skill.sourceInfo,
+				});
+			}
+		}
+	}
+
+	function resolve(selector: string): ResolveResult {
+		// Try exact selector match first (handles `name@label` and bare `name`)
+		const exact = allCandidates.find((c) => c.selector === selector);
+		if (exact) return { ok: true, candidate: exact };
+
+		// If selector contains `@`, it was an explicit qualified attempt that failed
+		if (selector.includes("@")) {
+			const atIdx = selector.indexOf("@");
+			const bareName = selector.slice(0, atIdx);
+			const qualifier = selector.slice(atIdx + 1);
+			const groupCandidates = allCandidates.filter((c) => c.skill.name === bareName);
+			if (groupCandidates.length === 0) {
+				return { ok: false, message: `no skill named "${bareName}" is loaded` };
+			}
+			// Check if any candidate has this exact label
+			const labelMatches = groupCandidates.filter((c) => c.sourceLabel === qualifier);
+			if (labelMatches.length === 1) {
+				return { ok: true, candidate: labelMatches[0] };
+			}
+			if (labelMatches.length > 1) {
+				const selectors = labelMatches.map((c) => c.selector).join(", ");
+				return { ok: false, message: `ambiguous selector "${selector}" — matches: ${selectors}` };
+			}
+			// No label match: list available selectors for this name
+			const available = groupCandidates.map((c) => `\`/skill:${c.selector}\``).join(", ");
+			return {
+				ok: false,
+				message: `no skill candidate "${selector}" — available: ${available}`,
+			};
+		}
+
+		// Bare name that isn't a winner: unknown skill
+		return { ok: false, message: `no skill named "${selector}" is loaded` };
+	}
+
+	return { allCandidates, commands, resolve };
+}
+
+/**
+ * Convert catalog commands to SlashCommandInfo array for command surfaces.
+ */
+export function catalogToSlashCommands(catalog: SkillCatalog): SlashCommandInfo[] {
+	return catalog.commands.map((cmd) => ({
+		name: `skill:${cmd.name}`,
+		description: cmd.description,
+		source: "skill" as const,
+		sourceInfo: cmd.sourceInfo,
+	}));
+}

--- a/packages/coding-agent/src/core/skills-async.ts
+++ b/packages/coding-agent/src/core/skills-async.ts
@@ -197,6 +197,7 @@ export async function loadSkillsAsync(options: LoadSkillsOptions): Promise<LoadS
 	const realPathSet = new Set<string>();
 	const allDiagnostics: ResourceDiagnostic[] = [];
 	const collisionDiagnostics: ResourceDiagnostic[] = [];
+	const shadowedSkills: Skill[] = [];
 	const userSkillsDir = join(resolvedAgentDir, "skills");
 	const projectSkillsDir = resolve(resolvedCwd, CONFIG_DIR_NAME, "skills");
 	const addSkills = (result: LoadSkillsResult) => {
@@ -217,6 +218,7 @@ export async function loadSkillsAsync(options: LoadSkillsOptions): Promise<LoadS
 						loserPath: skill.filePath,
 					},
 				});
+				shadowedSkills.push(skill);
 			} else {
 				skillMap.set(skill.name, skill);
 				realPathSet.add(realPath);
@@ -266,5 +268,9 @@ export async function loadSkillsAsync(options: LoadSkillsOptions): Promise<LoadS
 			allDiagnostics.push({ type: "warning", message, path: resolvedPath });
 		}
 	}
-	return { skills: Array.from(skillMap.values()), diagnostics: [...allDiagnostics, ...collisionDiagnostics] };
+	return {
+		skills: Array.from(skillMap.values()),
+		shadowedSkills,
+		diagnostics: [...allDiagnostics, ...collisionDiagnostics],
+	};
 }

--- a/packages/coding-agent/src/core/skills.ts
+++ b/packages/coding-agent/src/core/skills.ts
@@ -82,6 +82,8 @@ export interface Skill {
 
 export interface LoadSkillsResult {
 	skills: Skill[];
+	/** Skills that lost a name collision and are retained for qualified selection. */
+	shadowedSkills?: Skill[];
 	diagnostics: ResourceDiagnostic[];
 }
 
@@ -395,6 +397,7 @@ export function loadSkills(options: LoadSkillsOptions): LoadSkillsResult {
 	const realPathSet = new Set<string>();
 	const allDiagnostics: ResourceDiagnostic[] = [];
 	const collisionDiagnostics: ResourceDiagnostic[] = [];
+	const shadowedSkills: Skill[] = [];
 
 	function addSkills(result: LoadSkillsResult) {
 		allDiagnostics.push(...result.diagnostics);
@@ -420,6 +423,7 @@ export function loadSkills(options: LoadSkillsOptions): LoadSkillsResult {
 						loserPath: skill.filePath,
 					},
 				});
+				shadowedSkills.push(skill);
 			} else {
 				skillMap.set(skill.name, skill);
 				realPathSet.add(realPath);
@@ -482,6 +486,7 @@ export function loadSkills(options: LoadSkillsOptions): LoadSkillsResult {
 
 	return {
 		skills: Array.from(skillMap.values()),
+		shadowedSkills,
 		diagnostics: [...allDiagnostics, ...collisionDiagnostics],
 	};
 }

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -245,6 +245,7 @@ export {
 	SettingsManager,
 	type SettingsManagerCreateOptions,
 } from "./core/settings-manager.ts";
+export { getSkillCatalog, type SkillCandidate, type SkillCatalog } from "./core/skill-catalog.ts";
 // Skills
 export {
 	formatSkillsForPrompt,

--- a/packages/coding-agent/src/modes/interactive/components/chat-session-host-events.ts
+++ b/packages/coding-agent/src/modes/interactive/components/chat-session-host-events.ts
@@ -80,6 +80,7 @@ function boundaryMessageFromResult(
 		parameters: result.parameters,
 		stats: result.stats,
 		rung: result.rung,
+		tokensBefore: result.tokensBefore,
 		// Preserve the borrowed-planner identity; the event-only path is otherwise
 		// the one place it is lost.
 		...(result.plannerModel === undefined ? {} : { plannerModel: result.plannerModel }),

--- a/packages/coding-agent/src/modes/interactive/components/compaction-boundary-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/compaction-boundary-message.ts
@@ -12,6 +12,15 @@ interface BoundaryView {
 	text: string;
 	stats: VerbatimCompactionStats;
 	rung: VerbatimCompactionDetails["rung"];
+	/**
+	 * Authoritative whole-context token count for display, from the
+	 * `CompactionEntry.tokensBefore` / `VerbatimCompactionResult.tokensBefore`
+	 * field. This is the provider-aware count used for budgeting; it is
+	 * deliberately separate from the symmetric heuristic `stats.tokensBefore`
+	 * so the "Compacted from N tokens" line shows the best available number
+	 * while the reported stats pair remains internally consistent.
+	 */
+	displayTokensBefore: number;
 }
 
 /** Renders the durable verbatim compaction boundary without markdown reflow. */
@@ -22,7 +31,14 @@ export class CompactionBoundaryMessageComponent extends Box {
 	constructor(result: VerbatimCompactionResult | BoundaryView) {
 		super(1, 1, (text) => theme.bg("customMessageBg", text));
 		this.view =
-			"compactedText" in result ? { text: result.compactedText, stats: result.stats, rung: result.rung } : result;
+			"compactedText" in result
+				? {
+						text: result.compactedText,
+						stats: result.stats,
+						rung: result.rung,
+						displayTokensBefore: result.tokensBefore,
+					}
+				: result;
 		this.updateDisplay();
 	}
 
@@ -37,7 +53,7 @@ export class CompactionBoundaryMessageComponent extends Box {
 
 	private updateDisplay(): void {
 		this.clear();
-		const tokenStr = this.view.stats.tokensBefore.toLocaleString();
+		const tokenStr = this.view.displayTokensBefore.toLocaleString();
 		// The fresh rung destroyed the compactable conversation; say so plainly.
 		const label = theme.fg(
 			"customMessageLabel",
@@ -79,7 +95,25 @@ export function compactionBoundaryFromMessage(
 		text: content.startsWith(VERBATIM_COMPACTION_PREFIX) ? content.slice(VERBATIM_COMPACTION_PREFIX.length) : content,
 		stats: details.stats,
 		rung: details.rung,
+		displayTokensBefore: extractDisplayTokensBefore(details),
 	});
 	component.setExpanded(expanded);
 	return component;
+}
+
+/**
+ * Extract the authoritative token count for display from persisted details.
+ *
+ * `createVerbatimCompactionMessage` stores `tokensBefore` in `details` when no
+ * explicit details object is supplied. When details are present (the normal
+ * verbatim-compaction path), the authoritative count lives on the
+ * `CompactionEntry.tokensBefore` field that was passed to `appendCompaction`,
+ * which is mirrored in `details.stats` only by the old mixed-unit path. We
+ * prefer `details.tokensBefore` (the authoritative budgeting number) and fall
+ * back to the stats value for legacy entries.
+ */
+function extractDisplayTokensBefore(details: VerbatimCompactionDetails): number {
+	const detailsRecord = details as VerbatimCompactionDetails & { tokensBefore?: number };
+	if (typeof detailsRecord.tokensBefore === "number") return detailsRecord.tokensBefore;
+	return details.stats.tokensBefore;
 }

--- a/packages/coding-agent/src/modes/interactive/interactive-autocomplete.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-autocomplete.ts
@@ -1,3 +1,4 @@
+import { getSkillCatalog } from "../../core/skill-catalog.ts";
 import {
 	getInteractiveEngineRemoteCommandCompletions,
 	getInteractiveEngineRemoteCommands,
@@ -327,16 +328,19 @@ InteractiveModeBase.prototype.createBaseAutocompleteProvider = function (
 		})),
 	];
 
-	// Build skill commands from session.skills (if enabled)
+	// Build skill commands from the skill catalog (if enabled)
 	this.skillCommands.clear();
 	const skillCommandList: SlashCommand[] = [];
 	if (this.settingsManager.getEnableSkillCommands()) {
-		for (const skill of this.session.resourceLoader.getSkills().skills) {
-			const commandName = `skill:${skill.name}`;
-			this.skillCommands.set(commandName, skill.filePath);
+		const catalog = getSkillCatalog(this.session.resourceLoader);
+		for (const cmd of catalog.commands) {
+			const commandName = `skill:${cmd.name}`;
+			const candidate = catalog.resolve(cmd.name);
+			const filePath = candidate.ok ? candidate.candidate.skill.filePath : "";
+			this.skillCommands.set(commandName, filePath);
 			skillCommandList.push({
 				name: commandName,
-				description: this.prefixAutocompleteDescription(skill.description, skill.sourceInfo),
+				description: this.prefixAutocompleteDescription(cmd.description, cmd.sourceInfo),
 			});
 		}
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-resource-disclosure.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-resource-disclosure.ts
@@ -31,15 +31,17 @@ InteractiveModeBase.prototype.formatDiagnostics = function (
 		lines.push(
 			theme.fg(
 				"dim",
-				`    ${theme.fg("success", "✓")} ${this.formatPathWithSource(first.winnerPath, this.findSourceInfoForPath(first.winnerPath, sourceInfos))}`,
+				`    ${theme.fg("success", "✓")} ${this.formatPathWithSource(first.winnerPath, this.findSourceInfoForPath(first.winnerPath, sourceInfos))} (/${name})`,
 			),
 		);
 		for (const d of collisionList) {
 			if (d.collision) {
+				const loserSource = this.findSourceInfoForPath(d.collision.loserPath, sourceInfos);
+				const label = loserSource?.scope ?? loserSource?.source ?? "path";
 				lines.push(
 					theme.fg(
 						"dim",
-						`    ${theme.fg("warning", "✗")} ${this.formatPathWithSource(d.collision.loserPath, this.findSourceInfoForPath(d.collision.loserPath, sourceInfos))} (skipped)`,
+						`    ${theme.fg("warning", "✗")} ${this.formatPathWithSource(d.collision.loserPath, loserSource)} (/skill:${name}@${label})`,
 					),
 				);
 			}

--- a/packages/coding-agent/src/modes/rpc/rpc-command-handler.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-command-handler.ts
@@ -3,6 +3,7 @@ import type { AgentSession } from "../../core/agent-session.ts";
 import type { AgentSessionRuntime } from "../../core/agent-session-runtime.ts";
 import { runCallback } from "../../core/callback-activity.ts";
 import { KeybindingsManager } from "../../core/keybindings.ts";
+import { getSkillCatalog } from "../../core/skill-catalog.ts";
 import { RpcBashRequestOwners } from "./rpc-bash-request-owners.ts";
 import type { RpcPendingExtensionRequests } from "./rpc-extension-ui.ts";
 import type { KeybindingsReloadCoordinator } from "./rpc-keybindings-reload.ts";
@@ -501,12 +502,12 @@ export function createRpcCommandHandler({
 					});
 				}
 
-				for (const skill of session.resourceLoader.getSkills().skills) {
+				for (const cmd of getSkillCatalog(session.resourceLoader).commands) {
 					commands.push({
-						name: `skill:${skill.name}`,
-						description: skill.description,
+						name: `skill:${cmd.name}`,
+						description: cmd.description,
 						source: "skill",
-						sourceInfo: skill.sourceInfo,
+						sourceInfo: cmd.sourceInfo,
 					});
 				}
 

--- a/packages/coding-agent/test/utilities.ts
+++ b/packages/coding-agent/test/utilities.ts
@@ -152,7 +152,7 @@ export function createTestResourceLoader(options: CreateTestResourceLoaderOption
 
 	return {
 		getExtensions: () => extensionsResult,
-		getSkills: () => ({ skills: [], diagnostics: [] }),
+		getSkills: () => ({ skills: [], shadowedSkills: [], diagnostics: [] }),
 		getPrompts: () => ({ prompts: [], diagnostics: [] }),
 		getThemes: () => ({ themes: [], diagnostics: [] }),
 		getAgentsFiles: () => ({ agentsFiles: [] }),

--- a/test/integration/compaction-post-tool-chain.test.ts
+++ b/test/integration/compaction-post-tool-chain.test.ts
@@ -164,6 +164,7 @@ test("post-tool preflight: every model fails, the turn still completes on the fr
 				text: (boundary as { summary?: string }).summary ?? "",
 				stats: details!.stats,
 				rung: details!.rung,
+				displayTokensBefore: details!.tokensBefore ?? details!.stats.tokensBefore,
 			})
 				.render(200)
 				.join("\n"),

--- a/test/unit/compaction-chat-host-fresh.test.ts
+++ b/test/unit/compaction-chat-host-fresh.test.ts
@@ -124,6 +124,7 @@ test("the appended fresh boundary renders the degraded notice", () => {
 			text: "[User]: retained\n(filtered 12 lines)",
 			stats: details.stats,
 			rung: details.rung,
+			displayTokensBefore: details.tokensBefore ?? details.stats.tokensBefore,
 		})
 			.render(200)
 			.join("\n"),
@@ -172,6 +173,7 @@ test("a fresh boundary is not swallowed by an identical-text planned boundary", 
 			text: "[User]: retained\n(filtered 12 lines)",
 			stats: boundaryDetails(state)[1].stats,
 			rung: boundaryDetails(state)[1].rung,
+			displayTokensBefore: boundaryDetails(state)[1].tokensBefore ?? boundaryDetails(state)[1].stats.tokensBefore,
 		})
 			.render(200)
 			.join("\n"),
@@ -210,6 +212,7 @@ test("a committed fresh boundary stays visible when the final gate also errors",
 			text: "[User]: retained\n(filtered 12 lines)",
 			stats: details[0].stats,
 			rung: details[0].rung,
+			displayTokensBefore: details[0].tokensBefore ?? details[0].stats.tokensBefore,
 		})
 			.render(200)
 			.join("\n"),

--- a/test/unit/compaction-fresh-notice.test.ts
+++ b/test/unit/compaction-fresh-notice.test.ts
@@ -22,7 +22,12 @@ const stats: VerbatimCompactionStats = {
 };
 
 function render(rung: "planned" | "extension" | "fresh"): string {
-	const component = new CompactionBoundaryMessageComponent({ text: "[User]: retained", stats, rung });
+	const component = new CompactionBoundaryMessageComponent({
+		text: "[User]: retained",
+		stats,
+		rung,
+		displayTokensBefore: 100,
+	});
 	return stripVTControlCharacters(component.render(200).join("\n"));
 }
 

--- a/test/unit/compaction-fresh-window.test.ts
+++ b/test/unit/compaction-fresh-window.test.ts
@@ -11,7 +11,14 @@ import {
 } from "../../packages/coding-agent/src/core/compaction/compaction-runner.js";
 import type { CompactedTranscript } from "../../packages/coding-agent/src/core/compaction/compaction-types.js";
 import { RangePlanError } from "../../packages/coding-agent/src/core/compaction/range-planner.js";
-import { preparation, region, runRequest, scriptedStream, testModel } from "./compaction-rung-support.js";
+import {
+	preparation,
+	region,
+	runRequest,
+	scriptedStream,
+	setKeptTailTokenEstimate,
+	testModel,
+} from "./compaction-rung-support.js";
 
 const MARKER = /^\(filtered \d+ lines\)$/;
 
@@ -78,8 +85,12 @@ test("the preserve_recent tail is kept when it fits under the hard input limit",
 });
 
 test("the tail is dropped only when keeping it would still exceed the hard input limit", async () => {
-	// tokensBefore far exceeds the region estimate, so the tail alone is huge.
+	// Set a large tail estimate so the tail alone exceeds the hard input limit.
+	// Previously this test relied on `tokensBefore - region.tokenEstimate` as the
+	// tail estimate, which mixed authoritative and heuristic counts (issue #2052).
+	// Now the tail estimate is set explicitly through the same path production uses.
 	const prep = preparation({ region: region(40), tokensBefore: 500_000 });
+	setKeptTailTokenEstimate(prep, 500_000);
 	const stream = scriptedStream({ default: [{ errorMessage: "429 Too Many Requests" }] });
 	const result = await runVerbatimCompaction(
 		prep,
@@ -117,8 +128,10 @@ test("load-bearing urgency reaches the fresh rung when every model fails", async
 
 test("a load-bearing fresh rung reports the dropped tail so persistence clears the boundary", async () => {
 	const stream = scriptedStream({ default: [{ errorMessage: "insufficient_quota" }] });
+	const prep = preparation({ tokensBefore: 500_000 });
+	setKeptTailTokenEstimate(prep, 500_000);
 	const result = await runVerbatimCompaction(
-		preparation({ tokensBefore: 500_000 }),
+		prep,
 		testModel({ contextWindow: 1_000 }),
 		runRequest({ streamFn: stream.streamFn, urgency: "load_bearing" }),
 	);

--- a/test/unit/compaction-rung-support.ts
+++ b/test/unit/compaction-rung-support.ts
@@ -17,6 +17,10 @@ import type {
 } from "../../packages/coding-agent/src/core/compaction/compaction-types.js";
 import { resolvePlannerRequest } from "../../packages/coding-agent/src/core/compaction/range-planner.js";
 
+// Re-export so tests can set the tail estimate on a preparation the same way
+// `prepareCompactionBoundary` does, without depending on the private WeakMap.
+export { setKeptTailTokenEstimate } from "../../packages/coding-agent/src/core/compaction/compaction-boundary.js";
+
 export const PARAMETERS: VerbatimCompactionParameters = {
 	compression_ratio: 0.5,
 	preserve_recent: 2,

--- a/test/unit/compaction-stats-symmetry.test.ts
+++ b/test/unit/compaction-stats-symmetry.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Regression tests for issue #2052: compaction stats must use one symmetric
+ * heuristic estimator on both sides of the reported comparison, and the TUI
+ * display must show the authoritative `tokensBefore` rather than the heuristic
+ * stats value.
+ */
+
+import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
+import { getKeybindings, setKeybindings } from "@earendil-works/pi-tui";
+import { afterAll, beforeAll, test } from "vitest";
+import {
+	computeWholeContextStats,
+	runVerbatimCompaction,
+} from "../../packages/coding-agent/src/core/compaction/compaction-runner.js";
+import type {
+	NumberedRegion,
+	VerbatimCompactionStats,
+} from "../../packages/coding-agent/src/core/compaction/compaction-types.js";
+import type {
+	VerbatimCompactionDetails,
+	VerbatimCompactionResult,
+} from "../../packages/coding-agent/src/core/compaction/index.ts";
+import { KeybindingsManager } from "../../packages/coding-agent/src/core/keybindings.ts";
+import { CompactionBoundaryMessageComponent } from "../../packages/coding-agent/src/modes/interactive/components/compaction-boundary-message.ts";
+import { initTheme } from "../../packages/coding-agent/src/modes/interactive/theme/theme.ts";
+import {
+	preparation,
+	region,
+	runRequest,
+	scriptedStream,
+	setKeptTailTokenEstimate,
+	testModel,
+} from "./compaction-rung-support.js";
+
+const previousKeybindings = getKeybindings();
+beforeAll(() => {
+	initTheme("dark");
+	setKeybindings(new KeybindingsManager());
+});
+afterAll(() => setKeybindings(previousKeybindings));
+
+/** Build a region whose text is large enough for meaningful char/4 estimates. */
+function largeRegion(lineCount: number): NumberedRegion {
+	return region(lineCount);
+}
+
+/** Build region-scoped stats mirroring `reconstructCompactedTranscript` output. */
+function regionStats(region: NumberedRegion, compactedText: string): VerbatimCompactionStats {
+	const tokensAfter = Math.ceil(compactedText.length / 4);
+	return {
+		linesBefore: region.lines.length,
+		linesDeleted: Math.max(0, region.lines.length - compactedText.split("\n").length),
+		linesKept: compactedText.split("\n").length,
+		rangeCount: 1,
+		tokensBefore: region.tokenEstimate,
+		tokensAfter,
+		percentReduction:
+			region.tokenEstimate === 0 ? 0 : Math.round((1 - tokensAfter / region.tokenEstimate) * 1000) / 10,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// 1. Large kept tail in planned path
+// ---------------------------------------------------------------------------
+
+test("planned compaction with a large kept tail: percentReduction is not negative", async () => {
+	// Region: 40 lines, tail estimate much larger than the region.
+	const reg = largeRegion(40);
+	const prep = preparation({ region: reg, tokensBefore: 100_000 });
+	setKeptTailTokenEstimate(prep, 80_000); // tail dwarfs the region
+	const stream = scriptedStream({ default: [{ text: "1,20\n" }] });
+	const result = await runVerbatimCompaction(prep, testModel(), runRequest({ streamFn: stream.streamFn }));
+	assert.equal(result.rung, "planned");
+	assert.equal(result.keptTail, true);
+	// The tail cancels out of the symmetric ratio; a compaction that deleted
+	// lines must report a non-negative percentReduction.
+	assert.ok(
+		result.stats.percentReduction >= 0,
+		`expected percentReduction >= 0, got ${result.stats.percentReduction}`,
+	);
+});
+
+test("planned compaction with a large kept tail: both sides include the tail estimate", async () => {
+	const reg = largeRegion(40);
+	const prep = preparation({ region: reg, tokensBefore: 100_000 });
+	const tailEstimate = 80_000;
+	setKeptTailTokenEstimate(prep, tailEstimate);
+	const stream = scriptedStream({ default: [{ text: "1,20\n" }] });
+	const result = await runVerbatimCompaction(prep, testModel(), runRequest({ streamFn: stream.streamFn }));
+	// tokensBefore = region.tokenEstimate + tailEstimate
+	assert.equal(result.stats.tokensBefore, reg.tokenEstimate + tailEstimate);
+	// tokensAfter = compactedTextTokens + tailEstimate (tail kept)
+	assert.ok(result.stats.tokensAfter >= tailEstimate);
+});
+
+// ---------------------------------------------------------------------------
+// 2. Large kept tail in extension path
+// ---------------------------------------------------------------------------
+
+test("extension stats with a large kept tail: percentReduction is not negative", () => {
+	const reg = largeRegion(40);
+	const prep = preparation({ region: reg, tokensBefore: 100_000 });
+	setKeptTailTokenEstimate(prep, 80_000);
+	// Simulate an extension-supplied compacted text that is shorter than the region.
+	const compactedText = reg.lines.slice(0, 20).join("\n");
+	const stats = regionStats(reg, compactedText);
+	const widened = computeWholeContextStats(stats, reg, 80_000, true);
+	assert.ok(widened.percentReduction >= 0, `expected percentReduction >= 0, got ${widened.percentReduction}`);
+	assert.equal(widened.tokensBefore, reg.tokenEstimate + 80_000);
+	assert.ok(widened.tokensAfter >= 80_000);
+});
+
+// ---------------------------------------------------------------------------
+// 3. Fresh compaction with tail kept
+// ---------------------------------------------------------------------------
+
+test("fresh compaction with tail kept: percentReduction is not negative", async () => {
+	const reg = largeRegion(40);
+	const prep = preparation({ region: reg, tokensBefore: 100_000 });
+	// A modest tail that fits under the limit.
+	setKeptTailTokenEstimate(prep, 100);
+	const stream = scriptedStream({ default: [{ errorMessage: "429 Too Many Requests" }] });
+	const result = await runVerbatimCompaction(
+		prep,
+		testModel({ contextWindow: 200_000 }),
+		runRequest({ streamFn: stream.streamFn, urgency: "load_bearing" }),
+	);
+	assert.equal(result.rung, "fresh");
+	assert.equal(result.keptTail, true);
+	// Fresh rung retains all region lines, so tokensAfter includes the full region text plus the tail.
+	// tokensBefore = region.tokenEstimate + tail. Both sides use the same estimator.
+	assert.ok(
+		result.stats.percentReduction >= 0,
+		`expected percentReduction >= 0, got ${result.stats.percentReduction}`,
+	);
+});
+
+// ---------------------------------------------------------------------------
+// 4. Fresh compaction with tail dropped
+// ---------------------------------------------------------------------------
+
+test("fresh compaction with tail dropped: percentReduction is not negative", async () => {
+	const reg = largeRegion(40);
+	const prep = preparation({ region: reg, tokensBefore: 100_000 });
+	setKeptTailTokenEstimate(prep, 200_000);
+	const stream = scriptedStream({ default: [{ errorMessage: "429 Too Many Requests" }] });
+	const result = await runVerbatimCompaction(
+		prep,
+		testModel({ contextWindow: 1_000 }),
+		runRequest({ streamFn: stream.streamFn, urgency: "load_bearing" }),
+	);
+	assert.equal(result.rung, "fresh");
+	assert.equal(result.keptTail, false);
+	// When the tail is dropped, tokensBefore = region.tokenEstimate (no tail added)
+	// and tokensAfter = compactedTextTokens (no tail added). The region is fully
+	// retained in a fresh rung, so percentReduction should be 0 or near 0.
+	assert.ok(
+		result.stats.percentReduction >= 0,
+		`expected percentReduction >= 0, got ${result.stats.percentReduction}`,
+	);
+});
+
+// ---------------------------------------------------------------------------
+// 5. preserve_recent: 0
+// ---------------------------------------------------------------------------
+
+test("preserve_recent 0: no tail estimate, percentReduction uses region only", () => {
+	const reg = largeRegion(40);
+	const prep = preparation({ region: reg, tokensBefore: 10_000 });
+	setKeptTailTokenEstimate(prep, 0); // no tail when preserve_recent is 0
+	const compactedText = reg.lines.slice(0, 20).join("\n");
+	const stats = regionStats(reg, compactedText);
+	const widened = computeWholeContextStats(stats, reg, 0, false);
+	assert.equal(widened.tokensBefore, reg.tokenEstimate);
+	assert.equal(widened.tokensAfter, stats.tokensAfter);
+	assert.ok(widened.percentReduction > 0);
+});
+
+// ---------------------------------------------------------------------------
+// 6. Display count differs from stats count
+// ---------------------------------------------------------------------------
+
+test("display shows authoritative tokensBefore, not heuristic stats.tokensBefore", () => {
+	const authoritativeTokensBefore = 51_234;
+	const heuristicTokensBefore = 1_600; // region.tokenEstimate + tail, much smaller
+	const result: VerbatimCompactionResult = {
+		compactedText: "[User]: retained\n(filtered 12 lines)",
+		firstKeptEntryId: "m2",
+		tokensBefore: authoritativeTokensBefore,
+		parameters: { compression_ratio: 0.5, preserve_recent: 2, query: "task" },
+		promptVersion: 3,
+		rung: "planned",
+		stats: {
+			linesBefore: 20,
+			linesDeleted: 12,
+			linesKept: 8,
+			rangeCount: 1,
+			tokensBefore: heuristicTokensBefore,
+			tokensAfter: 800,
+			percentReduction: 50,
+		},
+	};
+	const component = new CompactionBoundaryMessageComponent(result);
+	const collapsed = stripVTControlCharacters(component.render(200).join("\n"));
+	assert.ok(
+		collapsed.includes(`Compacted from ${authoritativeTokensBefore.toLocaleString()} tokens`),
+		`display should show authoritative ${authoritativeTokensBefore}, not heuristic ${heuristicTokensBefore}`,
+	);
+	assert.ok(
+		!collapsed.includes(heuristicTokensBefore.toLocaleString()),
+		"heuristic stats tokensBefore should not appear in the display",
+	);
+});
+
+test("resumed rendering shows authoritative tokensBefore from details", () => {
+	const authoritativeTokensBefore = 51_234;
+	const heuristicTokensBefore = 1_600;
+	const details: VerbatimCompactionDetails = {
+		strategy: "verbatim-lines",
+		promptVersion: 3,
+		parameters: { compression_ratio: 0.5, preserve_recent: 2, query: "task" },
+		stats: {
+			linesBefore: 20,
+			linesDeleted: 12,
+			linesKept: 8,
+			rangeCount: 1,
+			tokensBefore: heuristicTokensBefore,
+			tokensAfter: 800,
+			percentReduction: 50,
+		},
+		rung: "planned",
+		tokensBefore: authoritativeTokensBefore,
+	};
+	const component = new CompactionBoundaryMessageComponent({
+		text: "[User]: retained\n(filtered 12 lines)",
+		stats: details.stats,
+		rung: details.rung,
+		displayTokensBefore: authoritativeTokensBefore,
+	});
+	const collapsed = stripVTControlCharacters(component.render(200).join("\n"));
+	assert.ok(
+		collapsed.includes(`Compacted from ${authoritativeTokensBefore.toLocaleString()} tokens`),
+		"resumed rendering should show the authoritative count",
+	);
+});
+
+test("legacy entries without details.tokensBefore fall back to stats.tokensBefore for display", () => {
+	const statsTokensBefore = 1_600;
+	const details = {
+		strategy: "verbatim-lines",
+		promptVersion: 3,
+		parameters: { compression_ratio: 0.5, preserve_recent: 2, query: "task" },
+		stats: {
+			linesBefore: 20,
+			linesDeleted: 12,
+			linesKept: 8,
+			rangeCount: 1,
+			tokensBefore: statsTokensBefore,
+			tokensAfter: 800,
+			percentReduction: 50,
+		},
+		rung: "planned",
+	} as VerbatimCompactionDetails;
+	// Simulate the fallback path in extractDisplayTokensBefore
+	const displayTokensBefore =
+		typeof (details as VerbatimCompactionDetails & { tokensBefore?: number }).tokensBefore === "number"
+			? (details as VerbatimCompactionDetails & { tokensBefore?: number }).tokensBefore!
+			: details.stats.tokensBefore;
+	assert.equal(displayTokensBefore, statsTokensBefore);
+});
+
+// ---------------------------------------------------------------------------
+// 7. computeWholeContextStats: symmetric ratio property
+// ---------------------------------------------------------------------------
+
+test("computeWholeContextStats: tail appears on both sides when kept", () => {
+	const reg = largeRegion(40);
+	const tailEstimate = 5_000;
+	const compactedText = reg.lines.slice(0, 20).join("\n");
+	const stats = regionStats(reg, compactedText);
+	const widened = computeWholeContextStats(stats, reg, tailEstimate, true);
+	// When the tail is kept, it appears on both sides: tokensBefore = R + T, tokensAfter = A + T.
+	// This is a real ratio from one estimator, not an apples-to-oranges mix.
+	assert.equal(widened.tokensBefore, reg.tokenEstimate + tailEstimate);
+	assert.equal(widened.tokensAfter, stats.tokensAfter + tailEstimate);
+	// The ratio is genuinely meaningful: percentReduction >= 0 when lines were deleted.
+	assert.ok(widened.percentReduction >= 0);
+});
+
+test("computeWholeContextStats: tail does not cancel when dropped", () => {
+	const reg = largeRegion(40);
+	const tailEstimate = 5_000;
+	const compactedText = reg.lines.join("\n"); // fresh rung: everything retained
+	const stats = regionStats(reg, compactedText);
+	const widened = computeWholeContextStats(stats, reg, tailEstimate, false);
+	// No tail on either side: tokensBefore = region.tokenEstimate, tokensAfter = region text tokens
+	assert.equal(widened.tokensBefore, reg.tokenEstimate);
+	assert.equal(widened.tokensAfter, stats.tokensAfter);
+});

--- a/test/unit/skill-block-candidate.test.ts
+++ b/test/unit/skill-block-candidate.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { parseSkillBlock } from "../../packages/coding-agent/src/core/agent-session-skill-block.ts";
+
+test("parseSkillBlock extracts candidate attribute when present", () => {
+	const block = `<skill name="tdd@builtin" location="/app/skills/tdd/SKILL.md" candidate="tdd@builtin">\nReferences are relative to /app/skills/tdd.\n\nSkill body here.\n</skill>`;
+	const parsed = parseSkillBlock(block);
+	assert.ok(parsed);
+	assert.equal(parsed!.name, "tdd@builtin");
+	assert.equal(parsed!.location, "/app/skills/tdd/SKILL.md");
+	assert.equal(parsed!.candidateId, "tdd@builtin");
+	assert.equal(parsed!.content, "References are relative to /app/skills/tdd.\n\nSkill body here.");
+});
+
+test("parseSkillBlock works without candidate attribute (backward compat)", () => {
+	const block = `<skill name="tdd" location="/home/user/skills/tdd/SKILL.md">\nReferences are relative to /home/user/skills/tdd.\n\nSkill body.\n</skill>`;
+	const parsed = parseSkillBlock(block);
+	assert.ok(parsed);
+	assert.equal(parsed!.name, "tdd");
+	assert.equal(parsed!.location, "/home/user/skills/tdd/SKILL.md");
+	assert.equal(parsed!.candidateId, undefined);
+	assert.equal(parsed!.content, "References are relative to /home/user/skills/tdd.\n\nSkill body.");
+});
+
+test("parseSkillBlock with candidate and user message", () => {
+	const block = `<skill name="review@project" location="/p/.atomic/skills/review/SKILL.md" candidate="review@project">\nBody.\n</skill>\n\nFix the tests`;
+	const parsed = parseSkillBlock(block);
+	assert.ok(parsed);
+	assert.equal(parsed!.name, "review@project");
+	assert.equal(parsed!.candidateId, "review@project");
+	assert.equal(parsed!.userMessage, "Fix the tests");
+});

--- a/test/unit/skill-catalog.test.ts
+++ b/test/unit/skill-catalog.test.ts
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import type { ResourceLoader } from "../../packages/coding-agent/src/core/resource-loader-types.ts";
+import { getSkillCatalog } from "../../packages/coding-agent/src/core/skill-catalog.ts";
+import type { Skill } from "../../packages/coding-agent/src/core/skills.ts";
+import type { SourceInfo } from "../../packages/coding-agent/src/core/source-info.ts";
+
+function makeSkill(name: string, filePath: string, scope: "user" | "project" | "temporary", source = "local"): Skill {
+	const sourceInfo: SourceInfo = {
+		path: filePath,
+		source,
+		scope,
+		origin: "top-level",
+		baseDir: filePath.replace(/\/SKILL\.md$/, ""),
+	};
+	return {
+		name,
+		description: `Skill ${name} from ${scope}`,
+		filePath,
+		baseDir: sourceInfo.baseDir!,
+		sourceInfo,
+		disableModelInvocation: false,
+	};
+}
+
+function makeLoader(skills: Skill[], shadowedSkills: Skill[]): ResourceLoader {
+	return {
+		getExtensions: () => ({
+			extensions: [],
+			errors: [],
+			runtime: { on: () => {}, off: () => {}, emit: () => {} } as never,
+		}),
+		getSkills: () => ({ skills, shadowedSkills, diagnostics: [] }),
+		getPrompts: () => ({ prompts: [], diagnostics: [] }),
+		getThemes: () => ({ themes: [], diagnostics: [] }),
+		getAgentsFiles: () => ({ agentsFiles: [] }),
+		getSystemPrompt: () => undefined,
+		getSystemPromptSource: () => undefined,
+		getAppendSystemPrompt: () => [],
+		getAppendSystemPromptSources: () => [],
+		extendResources: () => Promise.resolve(),
+		reload: () => Promise.resolve(),
+	};
+}
+
+test("bare selector resolves to the winner when there is no collision", () => {
+	const skill = makeSkill("tdd", "/home/user/skills/tdd/SKILL.md", "user");
+	const loader = makeLoader([skill], []);
+	const catalog = getSkillCatalog(loader);
+
+	const result = catalog.resolve("tdd");
+	assert.equal(result.ok, true);
+	if (result.ok) {
+		assert.equal(result.candidate.skill.filePath, "/home/user/skills/tdd/SKILL.md");
+		assert.equal(result.candidate.selector, "tdd");
+	}
+});
+
+test("bare selector resolves to the winner in a collision group", () => {
+	const userSkill = makeSkill("tdd", "/home/user/skills/tdd/SKILL.md", "user");
+	const builtinSkill = makeSkill("tdd", "/app/skills/tdd/SKILL.md", "temporary", "builtin");
+	const loader = makeLoader([userSkill], [builtinSkill]);
+	const catalog = getSkillCatalog(loader);
+
+	const result = catalog.resolve("tdd");
+	assert.equal(result.ok, true);
+	if (result.ok) {
+		assert.equal(result.candidate.skill.filePath, "/home/user/skills/tdd/SKILL.md");
+		assert.equal(result.candidate.selector, "tdd");
+	}
+});
+
+test("qualified selector resolves to the shadowed builtin candidate", () => {
+	const userSkill = makeSkill("tdd", "/home/user/skills/tdd/SKILL.md", "user");
+	const builtinSkill = makeSkill("tdd", "/app/skills/tdd/SKILL.md", "temporary", "builtin");
+	const loader = makeLoader([userSkill], [builtinSkill]);
+	const catalog = getSkillCatalog(loader);
+
+	const result = catalog.resolve("tdd@builtin");
+	assert.equal(result.ok, true);
+	if (result.ok) {
+		assert.equal(result.candidate.skill.filePath, "/app/skills/tdd/SKILL.md");
+		assert.equal(result.candidate.sourceLabel, "builtin");
+	}
+});
+
+test("qualified selector resolves to the shadowed project candidate", () => {
+	const userSkill = makeSkill("review", "/home/user/skills/review/SKILL.md", "user");
+	const projectSkill = makeSkill("review", "/project/.atomic/skills/review/SKILL.md", "project");
+	const loader = makeLoader([userSkill], [projectSkill]);
+	const catalog = getSkillCatalog(loader);
+
+	const result = catalog.resolve("review@project");
+	assert.equal(result.ok, true);
+	if (result.ok) {
+		assert.equal(result.candidate.skill.filePath, "/project/.atomic/skills/review/SKILL.md");
+		assert.equal(result.candidate.sourceLabel, "project");
+	}
+});
+
+test("unknown qualified selector does not fall back to the winner", () => {
+	const userSkill = makeSkill("tdd", "/home/user/skills/tdd/SKILL.md", "user");
+	const builtinSkill = makeSkill("tdd", "/app/skills/tdd/SKILL.md", "temporary", "builtin");
+	const loader = makeLoader([userSkill], [builtinSkill]);
+	const catalog = getSkillCatalog(loader);
+
+	const result = catalog.resolve("tdd@nonexistent");
+	assert.equal(result.ok, false);
+	if (!result.ok) {
+		assert.ok(result.message.includes("available"));
+		assert.ok(result.message.includes("tdd"));
+		assert.ok(result.message.includes("tdd@builtin"));
+	}
+});
+
+test("commands include both bare winner and qualified shadowed candidates", () => {
+	const userSkill = makeSkill("tdd", "/home/user/skills/tdd/SKILL.md", "user");
+	const builtinSkill = makeSkill("tdd", "/app/skills/tdd/SKILL.md", "temporary", "builtin");
+	const loader = makeLoader([userSkill], [builtinSkill]);
+	const catalog = getSkillCatalog(loader);
+
+	const names = catalog.commands.map((c) => c.name);
+	assert.ok(names.includes("tdd"));
+	assert.ok(names.includes("tdd@builtin"));
+});
+
+test("commands do not include qualified names when there is no collision", () => {
+	const skill = makeSkill("tdd", "/home/user/skills/tdd/SKILL.md", "user");
+	const loader = makeLoader([skill], []);
+	const catalog = getSkillCatalog(loader);
+
+	const names = catalog.commands.map((c) => c.name);
+	assert.deepEqual(names, ["tdd"]);
+});
+
+test("three-way collision: user, project, and builtin all stay selectable", () => {
+	const userSkill = makeSkill("impeccable", "/home/user/skills/impeccable/SKILL.md", "user");
+	const projectSkill = makeSkill("impeccable", "/project/.atomic/skills/impeccable/SKILL.md", "project");
+	const builtinSkill = makeSkill("impeccable", "/app/skills/impeccable/SKILL.md", "temporary", "builtin");
+	const loader = makeLoader([userSkill], [projectSkill, builtinSkill]);
+	const catalog = getSkillCatalog(loader);
+
+	const bareResult = catalog.resolve("impeccable");
+	assert.equal(bareResult.ok, true);
+	if (bareResult.ok) assert.equal(bareResult.candidate.skill.filePath, "/home/user/skills/impeccable/SKILL.md");
+
+	const projectResult = catalog.resolve("impeccable@project");
+	assert.equal(projectResult.ok, true);
+	if (projectResult.ok)
+		assert.equal(projectResult.candidate.skill.filePath, "/project/.atomic/skills/impeccable/SKILL.md");
+
+	const builtinResult = catalog.resolve("impeccable@builtin");
+	assert.equal(builtinResult.ok, true);
+	if (builtinResult.ok) assert.equal(builtinResult.candidate.skill.filePath, "/app/skills/impeccable/SKILL.md");
+
+	const names = catalog.commands.map((c) => c.name);
+	assert.ok(names.includes("impeccable"));
+	assert.ok(names.includes("impeccable@project"));
+	assert.ok(names.includes("impeccable@builtin"));
+});
+
+test("ambiguous source label is disambiguated with path-derived label", () => {
+	const user1Skill = makeSkill("tdd", "/alpha/skills/tdd/SKILL.md", "user");
+	const user2Skill = makeSkill("tdd", "/beta/skills/tdd/SKILL.md", "user");
+	const loader = makeLoader([user1Skill], [user2Skill]);
+	const catalog = getSkillCatalog(loader);
+
+	// Both have scope "user", so the second one must be disambiguated
+	const result = catalog.resolve("tdd@user");
+	// Since "user" appears twice, it should be ambiguous or resolved to a disambiguated label
+	// The catalog should NOT silently pick one
+	if (result.ok) {
+		// If it resolved, the sourceLabel should be unique
+		assert.notEqual(result.candidate.skill.filePath, user1Skill.filePath);
+	} else {
+		// If ambiguous, the message should list available selectors
+		assert.ok(result.message.includes("available"));
+	}
+});
+
+test("unknown bare selector returns error, not the winner", () => {
+	const skill = makeSkill("tdd", "/home/user/skills/tdd/SKILL.md", "user");
+	const loader = makeLoader([skill], []);
+	const catalog = getSkillCatalog(loader);
+
+	const result = catalog.resolve("nonexistent");
+	assert.equal(result.ok, false);
+	if (!result.ok) {
+		assert.ok(result.message.includes("nonexistent"));
+	}
+});
+
+test("candidate ID is stable and includes the source label", () => {
+	const userSkill = makeSkill("tdd", "/home/user/skills/tdd/SKILL.md", "user");
+	const builtinSkill = makeSkill("tdd", "/app/skills/tdd/SKILL.md", "temporary", "builtin");
+	const loader = makeLoader([userSkill], [builtinSkill]);
+	const catalog = getSkillCatalog(loader);
+
+	const userResult = catalog.resolve("tdd");
+	const builtinResult = catalog.resolve("tdd@builtin");
+	assert.equal(userResult.ok, true);
+	assert.equal(builtinResult.ok, true);
+	if (userResult.ok && builtinResult.ok) {
+		assert.equal(userResult.candidate.id, "tdd@user");
+		assert.equal(builtinResult.candidate.id, "tdd@builtin");
+		assert.notEqual(userResult.candidate.id, builtinResult.candidate.id);
+	}
+});
+
+test("catalog with no skills produces empty commands and resolves nothing", () => {
+	const loader = makeLoader([], []);
+	const catalog = getSkillCatalog(loader);
+
+	assert.equal(catalog.commands.length, 0);
+	assert.equal(catalog.allCandidates.length, 0);
+	const result = catalog.resolve("anything");
+	assert.equal(result.ok, false);
+});

--- a/test/unit/subagents-inprocess-prompt-behavior.test.ts
+++ b/test/unit/subagents-inprocess-prompt-behavior.test.ts
@@ -47,7 +47,7 @@ function testSkill(): Skill {
 function resourceLoader(): ResourceLoader {
 	return {
 		getExtensions: () => ({ extensions: [], errors: [], runtime: createExtensionRuntime() }),
-		getSkills: () => ({ skills: [testSkill()], diagnostics: [] }),
+		getSkills: () => ({ skills: [testSkill()], shadowedSkills: [], diagnostics: [] }),
 		getPrompts: () => ({ prompts: [], diagnostics: [] }),
 		getThemes: () => ({ themes: [], diagnostics: [] }),
 		getAgentsFiles: () => ({ agentsFiles: [{ path: "AGENTS.md", content: "PROJECT_CONTEXT_SENTINEL" }] }),


### PR DESCRIPTION
| Related unit tests | 18/18 pass |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789360114&installation_model_id=10562&pr_number=2409&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2409&signature=86f933ad3644e34e5a4a5856e9fdd5e729bf1d9cc4aab4b903d6ec91dc377e77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change exposes source-qualified access to shadowed skills and updates compaction statistics. Reproduced failures show that interactive collision diagnostics can advertise selectors that do not resolve, skill catalog fallback labels can duplicate another skill’s identity, and dropped protected tails are excluded from the reported pre-compaction context size and reduction percentage. These issues should be corrected before merge.

<h3>Confidence Score: 2/5</h3>

Not safe to merge until the three reproduced correctness issues are fixed.

Executable harnesses exercised the affected production paths and reproduced three independent non-security failures: invalid displayed selectors, duplicate skill identities, and inaccurate whole-context compaction statistics.

**Files Needing Attention:** packages/coding-agent/src/modes/interactive/interactive-resource-disclosure.ts, packages/coding-agent/src/core/skill-catalog.ts, and packages/coding-agent/src/core/compaction/compaction-runner.ts.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the colliding-skill selector harness to validate the posted P1 finding and reviewed the resulting logs and diagnostics.
- Executed the narrow skill catalog label collision harness to exercise control and collision scenarios, capturing results for distinct fallback and duplicate builtin labels.
- Focused harness validated that a dropped protected tail is excluded from stats, with the focused harness source captured and runtime output confirming the exclusion.
- Validated the skill-selector-disclosure harness results and production-diff checks, including an intentional failing assertion that verifies the expected behavior while the production file diff passed.
- Confirmed that labels, IDs, and selectors are unique and observed how collision handling assigns the later builtin candidate when conflicts arise.

<a href="https://app.greptile.com/trex/runs/19007284/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Collision diagnostic prints selectors that the skill catalog cannot resolve**

   - **Bug**
     - For two shadowed skills with the same name and `SourceInfo` values `scope: "temporary"` and `source: "local"`, the diagnostic displays `/skill:duplicate@temporary` for both losers. The catalog disambiguates the same candidates as `duplicate@beta` and `duplicate@gamma`; resolving either displayed selector fails rather than selecting its displayed loser.
   - **Cause**
     - `interactive-resource-disclosure.ts` derives the qualifier directly as `loserSource?.scope ?? loserSource?.source ?? "path"`, whereas `skill-catalog.ts` applies group-level uniqueness logic and replaces colliding short labels with base-directory labels.
   - **Fix**
     - Have collision disclosure obtain the selector/unique source label from `getSkillCatalog` (or share the catalog's unique-label derivation) and format the loser command from that canonical selector.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Fallback source label can duplicate a later unique source label**

   - **Bug**
     - With two initial generic `path` labels, a first candidate whose `baseDir` ends in `builtin` receives fallback label `builtin`. A later candidate with unique short source label `builtin` is processed afterward and receives the same label. The resulting catalog contains duplicate `sourceLabel` and duplicate candidate `id` values (`tdd@builtin`).
   - **Cause**
     - `uniqueLabelInGroup` records labels in `used` only while processing the second pass. A unique short label is not reserved before duplicate fallback labels are generated, so an earlier path-derived fallback can consume a later unique candidate's short label.
   - **Fix**
     - Initialize/reserve `used` with all labels whose count is one before generating any duplicate fallbacks, or otherwise ensure each fallback is checked against every short label in the group as well as generated labels.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


3. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Dropped protected tail is omitted from pre-compaction whole-context stats**

   - **Bug**
     - `computeWholeContextStats` reports `tokensBefore` as 1,000 and reduction as 75% for a 1,000-token region plus a dropped 300-token protected tail and 250 post-compaction tokens. A pre-compaction whole-context metric should instead report 1,300 tokens and 80.8% reduction.
   - **Cause**
     - At `packages/coding-agent/src/core/compaction/compaction-runner.ts:117`, `tokensBefore` conditionally adds `tailEstimate` only when `keptTail` is true, even though the tail was present before compaction.
   - **Fix**
     - Always include `tailEstimate` in `tokensBefore`; continue to conditionally include it only in `tokensAfter` based on `keptTail`, then calculate the percentage from those whole-context values.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/src/modes/interactive/interactive-resource-disclosure.ts:39-44
**Collision diagnostics print unresolvable selectors**

Collision disclosure derives each losing skill's qualifier from `scope` or `source`, instead of using the catalog's collision-specific `sourceLabel`. For colliding temporary/local skills, this displays `/skill:duplicate@temporary` for both losers, while the catalog only resolves unique selectors such as `duplicate@beta` and `duplicate@gamma`. Copying the displayed command therefore cannot select the identified skill. Format the command from the catalog's canonical selector, or share its unique-label calculation.

### Issue 2
packages/coding-agent/src/core/skill-catalog.ts:86-104
**Fallback labels collide with reserved source labels**

A duplicate generic-path group can generate a fallback label equal to a later candidate's unique short label. For example, a path candidate under a `builtin` directory is assigned `builtin` before a later uniquely builtin-sourced candidate is processed, so both receive `sourceLabel` and ID `tdd@builtin`. Qualified resolution selects only one of the two while transcript and catalog identity metadata cannot distinguish them. Reserve every unique short label before assigning path-derived fallbacks.

### Issue 3
packages/coding-agent/src/core/compaction/compaction-runner.ts:117
**Dropped tails are omitted from pre-compaction stats**

When fresh compaction drops a protected tail, `tokensBefore` excludes `tailEstimate` even though that tail was present in the original context. A 1,000-token region with a dropped 300-token tail and 250-token result is reported as 1,000 tokens and 75% reduction instead of 1,300 tokens and 80.8%. Include the tail in `tokensBefore` unconditionally while retaining the conditional inclusion in `tokensAfter`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(coding-agent): keep shadowed same-n..."](https://github.com/bastani-inc/atomic/commit/ec7d418adc23d9b16833496b32ed7eea6085ea44) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53565169)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->