### PR TITLE
pi 0.84.2/release preflight

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -232,6 +232,10 @@ bun run scripts/cut-release.ts 0.9.10 --base main --push --allow-new
 
 `--allow-new` covers only "npm has never heard of this name". A registry that cannot answer — unreachable, unauthorized, no npm at all, or a probe killed by a signal — stops the cut regardless, because an unreadable answer is not evidence that a package is new.
 
+### Inherited git environment
+
+`cut-release.ts` deletes every repository-local git variable — `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, and the rest of `git rev-parse --local-env-vars` — from its own process before its first git command. Git honors those over `-C <path>` and over a literal path argument alike, and the cut addresses every repository it touches by path: the checkout it reads, and the temporary worktree it stamps, commits, and tags. Running the script from a git hook, or from a workflow that runs under one, would otherwise stamp and tag a repository nobody is releasing.
+
 ## Build and validation jobs
 
 ### Native NAPI matrix

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -218,6 +218,20 @@ bun run scripts/cut-release.ts 0.9.10-alpha.1 --base main --push
 
 The tag push is the publication signal. Do not bump package versions directly on a release base.
 
+### npm registration preflight
+
+Before it touches anything, `scripts/cut-release.ts` asks npm whether every package the publisher publishes already exists. The payload is read from the `packages=(…)` array in `.github/workflows/publish.yml`, so the check follows the publisher rather than a second list, and each name is probed with `npm view` against `npm_config_registry` (default `https://registry.npmjs.org`).
+
+An unregistered name aborts the cut with nothing to unwind — no prune, no worktree, no version stamp, no tag. `publish.yml`'s own `npm view` call is an idempotency check that runs after the binaries are built, so without this preflight a name npm has never seen fails at the very end of a release.
+
+A genuine first publish is still possible, but only deliberately:
+
+```sh
+bun run scripts/cut-release.ts 0.9.10 --base main --push --allow-new
+```
+
+`--allow-new` covers only "npm has never heard of this name". A registry that cannot answer — unreachable, unauthorized, or no npm at all — stops the cut regardless, because an unreadable answer is not evidence that a package is new.
+
 ## Build and validation jobs
 
 ### Native NAPI matrix

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -220,7 +220,7 @@ The tag push is the publication signal. Do not bump package versions directly on
 
 ### npm registration preflight
 
-Before it touches anything, `scripts/cut-release.ts` asks npm whether every package the publisher publishes already exists. The payload is read from the `packages=(…)` array in `.github/workflows/publish.yml`, so the check follows the publisher rather than a second list, and each name is probed with `npm view` against `npm_config_registry` (default `https://registry.npmjs.org`).
+Before it touches anything, `scripts/cut-release.ts` asks npm whether every package the publisher publishes already exists. Both halves of the question come from `.github/workflows/publish.yml`, read out of the **release base commit** the cut is about to tag rather than out of the caller's checkout — `--base` names another branch as often as not, and that branch's workflow is the one that will publish. The payload is the `packages=(…)` array, and the registry is the `--registry` the publisher pins on its own npm commands (`https://registry.npmjs.org`). npm's `npm_config_registry` is deliberately ignored: a mirror answering "yes" for a name that does not exist on npmjs would clear a check whose whole job is to predict the publish.
 
 An unregistered name aborts the cut with nothing to unwind — no prune, no worktree, no version stamp, no tag. `publish.yml`'s own `npm view` call is an idempotency check that runs after the binaries are built, so without this preflight a name npm has never seen fails at the very end of a release.
 
@@ -230,7 +230,7 @@ A genuine first publish is still possible, but only deliberately:
 bun run scripts/cut-release.ts 0.9.10 --base main --push --allow-new
 ```
 
-`--allow-new` covers only "npm has never heard of this name". A registry that cannot answer — unreachable, unauthorized, or no npm at all — stops the cut regardless, because an unreadable answer is not evidence that a package is new.
+`--allow-new` covers only "npm has never heard of this name". A registry that cannot answer — unreachable, unauthorized, no npm at all, or a probe killed by a signal — stops the cut regardless, because an unreadable answer is not evidence that a package is new.
 
 ## Build and validation jobs
 

--- a/scripts/cut-release.ts
+++ b/scripts/cut-release.ts
@@ -12,20 +12,22 @@
  *
  * Mechanically:
  *   1. validate the version + a clean working tree
- *   2. resolve the current attached branch (or `--base`) to its exact remote branch SHA
- *   3. stamp the real version into the worktree via scripts/bump-version.ts
+ *   2. verify every package publish.yml publishes is already registered on npm,
+ *      before anything in the repository is touched (see --allow-new)
+ *   3. resolve the current attached branch (or `--base`) to its exact remote branch SHA
+ *   4. stamp the real version into the worktree via scripts/bump-version.ts
  *      (including package-lock.json's workspace entries: `npm ci` refuses to
  *      install when the lockfile and a package.json disagree)
- *   4. regenerate release artifacts that must carry the stamped version, including
+ *   5. regenerate release artifacts that must carry the stamped version, including
  *      packages/coding-agent/npm-shrinkwrap.json
- *   5. commit `Release <version>` and tag `<version>` inside the worktree
- *   6. remove the worktree — the tag (and its commit) persist in the repo
+ *   6. commit `Release <version>` and tag `<version>` inside the worktree
+ *   7. remove the worktree — the tag (and its commit) persist in the repo
  *
  * Pushing the version tag directly starts publish.yml, which verifies the tag
  * commit identity before building and publishing the release.
  *
  * Usage:
- *   bun run scripts/cut-release.ts <version> [--base <ref>] [--push] [--yes]
+ *   bun run scripts/cut-release.ts <version> [--base <ref>] [--push] [--yes] [--allow-new]
  *
  * Examples:
  *   bun run scripts/cut-release.ts 0.8.31
@@ -38,6 +40,14 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { $ } from "bun";
 import { canonicalReleaseBaseRef } from "./release-base.js";
+import {
+	classifyNpmViewOutcome,
+	type NpmRegistrationProbe,
+	type RegistrationPreflightResult,
+	readReleasePayloadPackages,
+	resolveNpmRegistry,
+	verifyReleasePackagesRegistered,
+} from "./release-npm-preflight.js";
 
 const STRICT_RELEASE_VERSION_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-alpha\.([1-9]\d*))?$/;
 const PLACEHOLDER_VERSIONS = new Set(["0.0.0", "0.0.0-dev"]);
@@ -49,6 +59,7 @@ interface Options {
 	base: string | undefined;
 	push: boolean;
 	yes: boolean;
+	allowNew: boolean;
 }
 
 function parseArgs(): Options {
@@ -57,6 +68,7 @@ function parseArgs(): Options {
 	let base: string | undefined;
 	let push = false;
 	let yes = false;
+	let allowNew = false;
 
 	for (let i = 0; i < argv.length; i++) {
 		const arg = argv[i] as string;
@@ -66,6 +78,8 @@ function parseArgs(): Options {
 			base = candidate;
 		} else if (arg === "--push") {
 			push = true;
+		} else if (arg === "--allow-new") {
+			allowNew = true;
 		} else if (arg === "--yes" || arg === "-y") {
 			yes = true;
 		} else if (arg.startsWith("-")) {
@@ -78,10 +92,10 @@ function parseArgs(): Options {
 	}
 
 	if (!version) {
-		fail("Usage: bun run scripts/cut-release.ts <version> [--base <ref>] [--push] [--yes]");
+		fail("Usage: bun run scripts/cut-release.ts <version> [--base <ref>] [--push] [--yes] [--allow-new]");
 	}
 
-	return { version: version as string, base, push, yes };
+	return { version: version as string, base, push, yes, allowNew };
 }
 
 function fail(message: string): never {
@@ -104,8 +118,55 @@ async function gitText(args: string[], cwd: string = ROOT): Promise<string> {
 	return (await $`git -C ${cwd} ${args}`.text()).trim();
 }
 
+/**
+ * Ask npm whether it knows a package name.
+ *
+ * `--registry` is pinned to the registry publish.yml publishes to, unless npm's
+ * own `npm_config_registry` points somewhere else. Any answer that is neither
+ * "yes" nor a 404 throws rather than counting as a new package.
+ */
+function createNpmRegistrationProbe(registry: string): NpmRegistrationProbe {
+	return async (packageName) => {
+		const result = await $`npm view ${packageName} name --registry ${registry}`.nothrow().quiet();
+		return classifyNpmViewOutcome(packageName, {
+			exitCode: result.exitCode,
+			stdout: result.stdout.toString(),
+			stderr: result.stderr.toString(),
+		});
+	};
+}
+
+/**
+ * The registration preflight, run before the first repository mutation.
+ *
+ * publish.yml publishes ten npm packages from one tag and its own `npm view`
+ * call only skips versions that already exist — a name npm has never seen is
+ * discovered at the end of the release, after the tag is pushed and the
+ * binaries are built. Checking here costs one concurrent registry round-trip
+ * and fails with nothing to unwind.
+ */
+async function preflightNpmRegistration(allowNew: boolean): Promise<RegistrationPreflightResult> {
+	const registry = resolveNpmRegistry();
+	try {
+		const packages = readReleasePayloadPackages(ROOT);
+		const registration = await verifyReleasePackagesRegistered({
+			packages,
+			isRegistered: createNpmRegistrationProbe(registry),
+			allowNew,
+		});
+		if (registration.unregistered.length > 0) {
+			console.log(`--allow-new: first publish for ${registration.unregistered.length} package(s):`);
+			for (const name of registration.unregistered) console.log(`  + ${name}`);
+			console.log("");
+		}
+		return registration;
+	} catch (error) {
+		return fail((error as Error).message);
+	}
+}
+
 async function main(): Promise<void> {
-	const { version, base, push, yes } = parseArgs();
+	const { version, base, push, yes, allowNew } = parseArgs();
 	validateVersion(version);
 
 	// Refuse to operate on a dirty tree — the worktree is created from committed
@@ -120,6 +181,11 @@ async function main(): Promise<void> {
 	if (existingTag.trim()) {
 		fail(`Tag ${version} already exists.`);
 	}
+
+	// Every mutation below this line — the prune, the worktree, the stamp, the
+	// tag — is preceded by the registry check, so an unregistered package name
+	// aborts a release that has changed nothing.
+	const registration = await preflightNpmRegistration(allowNew);
 
 	await $`git -C ${ROOT} worktree prune`.quiet();
 
@@ -148,8 +214,10 @@ async function main(): Promise<void> {
 	const email =
 		(await $`git -C ${ROOT} config user.email`.nothrow().text()).trim() || "atomic-release@users.noreply.github.com";
 
+	const registered = registration.checked.length - registration.unregistered.length;
 	console.log(`Cutting release ${version}`);
 	console.log(`  base:   ${baseRef} (${baseSha.slice(0, 9)})`);
+	console.log(`  npm:    ${registered}/${registration.checked.length} publish-payload packages registered`);
 	console.log(`  branch: ${branch} (left untouched)\n`);
 
 	if (!yes) console.log("Proceeding immediately; pass --yes to suppress this notice.\n");

--- a/scripts/cut-release.ts
+++ b/scripts/cut-release.ts
@@ -12,9 +12,10 @@
  *
  * Mechanically:
  *   1. validate the version + a clean working tree
- *   2. verify every package publish.yml publishes is already registered on npm,
- *      before anything in the repository is touched (see --allow-new)
- *   3. resolve the current attached branch (or `--base`) to its exact remote branch SHA
+ *   2. resolve the current attached branch (or `--base`) to its exact remote branch SHA
+ *   3. read publish.yml **out of that base commit** and verify every package it
+ *      publishes is already registered on npm, before anything in the
+ *      repository is touched (see --allow-new)
  *   4. stamp the real version into the worktree via scripts/bump-version.ts
  *      (including package-lock.json's workspace entries: `npm ci` refuses to
  *      install when the lockfile and a package.json disagree)
@@ -43,9 +44,10 @@ import { canonicalReleaseBaseRef } from "./release-base.js";
 import {
 	classifyNpmViewOutcome,
 	type NpmRegistrationProbe,
+	PUBLISH_WORKFLOW_PATH,
+	parseReleasePublisher,
 	type RegistrationPreflightResult,
-	readReleasePayloadPackages,
-	resolveNpmRegistry,
+	type ReleasePublisher,
 	verifyReleasePackagesRegistered,
 } from "./release-npm-preflight.js";
 
@@ -121,19 +123,57 @@ async function gitText(args: string[], cwd: string = ROOT): Promise<string> {
 /**
  * Ask npm whether it knows a package name.
  *
- * `--registry` is pinned to the registry publish.yml publishes to, unless npm's
- * own `npm_config_registry` points somewhere else. Any answer that is neither
- * "yes" nor a 404 throws rather than counting as a new package.
+ * The registry is pinned twice. `--registry` sets the default, and
+ * `--<scope>:registry` overrides any scope-specific redirect an `.npmrc` on
+ * this machine declares — npm resolves a scoped name through that redirect in
+ * preference to `--registry`, so without the second flag the preflight could
+ * vouch for a mirror while the release publishes somewhere else. npm's own
+ * `npm_config_registry` is deliberately not consulted for the same reason.
+ *
+ * Any answer that is neither "yes" nor a 404 throws rather than counting as a
+ * new package.
  */
 function createNpmRegistrationProbe(registry: string): NpmRegistrationProbe {
 	return async (packageName) => {
-		const result = await $`npm view ${packageName} name --registry ${registry}`.nothrow().quiet();
+		const scope = packageName.startsWith("@") ? packageName.split("/")[0] : undefined;
+		const args = [
+			"view",
+			packageName,
+			"name",
+			`--registry=${registry}`,
+			...(scope ? [`--${scope}:registry=${registry}`] : []),
+		];
+		const result = await $`npm ${args}`.nothrow().quiet();
 		return classifyNpmViewOutcome(packageName, {
 			exitCode: result.exitCode,
 			stdout: result.stdout.toString(),
 			stderr: result.stderr.toString(),
 		});
 	};
+}
+
+/**
+ * Read publish.yml out of the commit that is about to be tagged.
+ *
+ * The caller's checkout is not the release. `--base` names another branch as
+ * often as not, and the worktree, the version stamp, and the tag all come from
+ * that branch's remote SHA — so a payload or a registry read from the working
+ * tree would describe a release nobody is cutting.
+ */
+async function readPublisherAtBase(baseRef: string, baseSha: string): Promise<ReleasePublisher> {
+	const shown = await $`git -C ${ROOT} show ${`${baseSha}:${PUBLISH_WORKFLOW_PATH}`}`.nothrow().quiet();
+	if (shown.exitCode !== 0) {
+		const detail = shown.stderr.toString().trim().split(/\r?\n/u)[0] ?? "git show failed";
+		return fail(
+			`Cannot read ${PUBLISH_WORKFLOW_PATH} from ${baseRef} (${baseSha.slice(0, 9)}): ${detail}. ` +
+				`Fetch the base commit first: git fetch origin ${baseRef}`,
+		);
+	}
+	try {
+		return parseReleasePublisher(shown.stdout.toString());
+	} catch (error) {
+		return fail(`${(error as Error).message} (read from ${baseRef} at ${baseSha.slice(0, 9)})`);
+	}
 }
 
 /**
@@ -145,13 +185,14 @@ function createNpmRegistrationProbe(registry: string): NpmRegistrationProbe {
  * binaries are built. Checking here costs one concurrent registry round-trip
  * and fails with nothing to unwind.
  */
-async function preflightNpmRegistration(allowNew: boolean): Promise<RegistrationPreflightResult> {
-	const registry = resolveNpmRegistry();
+async function preflightNpmRegistration(
+	publisher: ReleasePublisher,
+	allowNew: boolean,
+): Promise<RegistrationPreflightResult> {
 	try {
-		const packages = readReleasePayloadPackages(ROOT);
 		const registration = await verifyReleasePackagesRegistered({
-			packages,
-			isRegistered: createNpmRegistrationProbe(registry),
+			packages: publisher.packages,
+			isRegistered: createNpmRegistrationProbe(publisher.registry),
 			allowNew,
 		});
 		if (registration.unregistered.length > 0) {
@@ -182,13 +223,8 @@ async function main(): Promise<void> {
 		fail(`Tag ${version} already exists.`);
 	}
 
-	// Every mutation below this line — the prune, the worktree, the stamp, the
-	// tag — is preceded by the registry check, so an unregistered package name
-	// aborts a release that has changed nothing.
-	const registration = await preflightNpmRegistration(allowNew);
-
-	await $`git -C ${ROOT} worktree prune`.quiet();
-
+	// Resolve the base before anything is checked against it: the release is cut
+	// from this commit, so this is the publish.yml the preflight must read.
 	const branch = await gitText(["rev-parse", "--abbrev-ref", "HEAD"]);
 	const baseBranch = base ?? branch;
 	if (baseBranch === "HEAD") {
@@ -210,6 +246,9 @@ async function main(): Promise<void> {
 		fail(`Base ref "${baseRef}" did not resolve to exactly one immutable remote commit.`);
 	}
 
+	const publisher = await readPublisherAtBase(baseRef, baseSha);
+	const registration = await preflightNpmRegistration(publisher, allowNew);
+
 	const name = (await $`git -C ${ROOT} config user.name`.nothrow().text()).trim() || "atomic-release";
 	const email =
 		(await $`git -C ${ROOT} config user.email`.nothrow().text()).trim() || "atomic-release@users.noreply.github.com";
@@ -217,10 +256,17 @@ async function main(): Promise<void> {
 	const registered = registration.checked.length - registration.unregistered.length;
 	console.log(`Cutting release ${version}`);
 	console.log(`  base:   ${baseRef} (${baseSha.slice(0, 9)})`);
-	console.log(`  npm:    ${registered}/${registration.checked.length} publish-payload packages registered`);
+	console.log(
+		`  npm:    ${registered}/${registration.checked.length} publish-payload packages registered on ${publisher.registry}`,
+	);
 	console.log(`  branch: ${branch} (left untouched)\n`);
 
 	if (!yes) console.log("Proceeding immediately; pass --yes to suppress this notice.\n");
+
+	// Every mutation below this line — the prune, the worktree, the stamp, the
+	// tag — is preceded by the registry check, so an unregistered package name
+	// aborts a release that has changed nothing.
+	await $`git -C ${ROOT} worktree prune`.quiet();
 
 	const tmpRoot = mkdtempSync(join(tmpdir(), "atomic-release-"));
 	const worktreeDir = join(tmpRoot, "wt");

--- a/scripts/cut-release.ts
+++ b/scripts/cut-release.ts
@@ -11,7 +11,8 @@
  * merged back into `main`. This mirrors how openai/codex tags releases.
  *
  * Mechanically:
- *   1. validate the version + a clean working tree
+ *   1. validate the version, drop the inherited repository-local git
+ *      environment, and require a clean working tree
  *   2. resolve the current attached branch (or `--base`) to its exact remote branch SHA
  *   3. read publish.yml **out of that base commit** and verify every package it
  *      publishes is already registered on npm, before anything in the
@@ -116,6 +117,42 @@ function validateVersion(version: string): void {
 	}
 }
 
+/**
+ * Git's repository-local environment variables, named by git itself.
+ *
+ * The fallback is only for a git too old to print the list; it names the six
+ * that actually redirect a command.
+ */
+const FALLBACK_GIT_LOCAL_ENV_VARS = [
+	"GIT_DIR",
+	"GIT_WORK_TREE",
+	"GIT_INDEX_FILE",
+	"GIT_COMMON_DIR",
+	"GIT_OBJECT_DIRECTORY",
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+];
+
+/**
+ * Remove the inherited repository-local git environment from this process.
+ *
+ * Git honors `GIT_DIR` and its siblings over `-C <path>` and over a literal
+ * path argument alike, and every repository this script touches is addressed
+ * by path: the checkout it reads, and the temporary worktree it stamps,
+ * commits, and tags. A caller that exports them — a git hook, or the
+ * publish-release workflow running under one — would otherwise redirect all of
+ * that into a repository nobody is releasing. `git rev-parse --local-env-vars`
+ * is the list's own source, so this cannot drift as git adds to it.
+ *
+ * Every child is spawned after this runs, so deleting the keys here is what
+ * scrubs `git`, `npm`, and the nested `bun` alike.
+ */
+async function scrubGitEnvironment(): Promise<void> {
+	const listed = await $`git rev-parse --local-env-vars`.nothrow().quiet();
+	const names =
+		listed.exitCode === 0 ? listed.stdout.toString().split(/\s+/u).filter(Boolean) : FALLBACK_GIT_LOCAL_ENV_VARS;
+	for (const name of names) delete process.env[name];
+}
+
 async function gitText(args: string[], cwd: string = ROOT): Promise<string> {
 	return (await $`git -C ${cwd} ${args}`.text()).trim();
 }
@@ -209,6 +246,7 @@ async function preflightNpmRegistration(
 async function main(): Promise<void> {
 	const { version, base, push, yes, allowNew } = parseArgs();
 	validateVersion(version);
+	await scrubGitEnvironment();
 
 	// Refuse to operate on a dirty tree — the worktree is created from committed
 	// state, so uncommitted edits would silently be excluded from the release.

--- a/scripts/release-npm-preflight.ts
+++ b/scripts/release-npm-preflight.ts
@@ -13,32 +13,41 @@
  * This module answers that question while it is still cheap to answer — before
  * `cut-release.ts` touches a worktree, stamps a version, or writes a tag.
  *
- * The payload is read from `publish.yml` rather than restated here. The
+ * Both halves of the question are read out of `publish.yml` rather than
+ * restated here: which names ship, and which registry they ship to. The
  * publisher is the thing that publishes; a second hand-maintained list would
  * drift from it silently, and the preflight would then vouch for a payload
- * nobody ships. The count is deliberately *not* enforced at cut time — the
- * workflow already fails a run whose packed tarballs do not number ten, and
- * `test/ci/release-publisher-contracts.test.ts` pins the ten names this
- * repository expects.
+ * nobody ships or for a registry nobody publishes to. The count is deliberately
+ * *not* enforced at cut time — the workflow already fails a run whose packed
+ * tarballs do not number ten, and `test/unit/release-npm-preflight.test.ts`
+ * pins the ten names this repository expects.
+ *
+ * The source is a string, never a path: `cut-release.ts` reads `publish.yml`
+ * out of the *release base commit* it is about to tag, not out of the caller's
+ * checkout, and those two differ whenever `--base` names another branch.
  *
  * No Bun import: the probe is injected, so the whole module runs under Node in
  * the test suites while `cut-release.ts` supplies the real `npm view` call.
  */
 
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-
 /** The publisher that owns the release payload, relative to the repository root. */
 export const PUBLISH_WORKFLOW_PATH = ".github/workflows/publish.yml";
 
-/** The registry `publish.yml` publishes to, and the default this preflight asks. */
-export const DEFAULT_NPM_REGISTRY = "https://registry.npmjs.org";
+/**
+ * The registry `publish.yml` publishes to.
+ *
+ * Documentation and a unit-test anchor, **not** a fallback: the registry the
+ * preflight asks is always parsed from the publisher, so this constant going
+ * stale fails a test rather than quietly redirecting a probe.
+ */
+export const PUBLISHER_NPM_REGISTRY = "https://registry.npmjs.org";
 
-/** Number of npm packages one release tag publishes; asserted against `publish.yml` by contract test. */
+/** Number of npm packages one release tag publishes; asserted against `publish.yml` by unit test. */
 export const RELEASE_PAYLOAD_PACKAGE_COUNT = 10;
 
 const PACKAGES_ARRAY_RE = /^[ \t]*packages=\(([^)]*)\)[ \t]*$/gmu;
 const PACKAGE_NAME_RE = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/u;
+const REGISTRY_FLAG_RE = /--registry[= \t]+([^\s"'|;&]+)/gu;
 
 /** The raw result of one `npm view <name>` invocation. */
 export interface NpmViewOutcome {
@@ -49,6 +58,12 @@ export interface NpmViewOutcome {
 
 /** Resolves to `true` when npm knows the package name, `false` when it does not. */
 export type NpmRegistrationProbe = (packageName: string) => Promise<boolean>;
+
+/** What `publish.yml` publishes, and where. */
+export interface ReleasePublisher {
+	readonly packages: readonly string[];
+	readonly registry: string;
+}
 
 export interface RegistrationPreflightOptions {
 	/** Package names to check. Defaults to whatever `publish.yml` publishes. */
@@ -62,18 +77,6 @@ export interface RegistrationPreflightResult {
 	readonly checked: readonly string[];
 	/** Names npm has never seen. Non-empty only when `allowNew` was passed. */
 	readonly unregistered: readonly string[];
-}
-
-/**
- * The registry to ask.
- *
- * `npm_config_registry` is npm's own configuration variable, so a mirror or an
- * enterprise proxy is honored rather than probed around. Anything else falls
- * back to the registry `publish.yml` names.
- */
-export function resolveNpmRegistry(env: NodeJS.ProcessEnv = process.env): string {
-	const configured = env.npm_config_registry?.trim();
-	return configured && configured.length > 0 ? configured : DEFAULT_NPM_REGISTRY;
 }
 
 /** Extract the publish payload from `publish.yml`'s `packages=(…)` array. */
@@ -102,33 +105,85 @@ export function parseReleasePayloadPackages(workflowSource: string): string[] {
 	return names;
 }
 
-/** Read the publish payload package names out of the repository at `root`. */
-export function readReleasePayloadPackages(root: string): string[] {
-	const path = join(root, PUBLISH_WORKFLOW_PATH);
-	let source: string;
-	try {
-		source = readFileSync(path, "utf8");
-	} catch (error) {
-		throw new Error(`Cannot read the release payload from ${path}: ${(error as Error).message}`);
+/**
+ * The registry to ask: the one `publish.yml` pins on its own npm commands.
+ *
+ * npm's `npm_config_registry` is deliberately **not** consulted. A mirror or a
+ * proxy can answer "yes" for a name that does not exist on the registry the
+ * release will actually publish to, and that answer would clear a preflight
+ * whose entire job is to predict the publish. The publisher passes `--registry`
+ * explicitly on every npm command it runs, so the flag is parsed from the same
+ * file — and the same commit — the payload comes from.
+ */
+export function parsePublisherNpmRegistry(workflowSource: string): string {
+	const values = [...new Set([...workflowSource.matchAll(REGISTRY_FLAG_RE)].map((match) => match[1] as string))];
+	if (values.length === 0) {
+		throw new Error(
+			`${PUBLISH_WORKFLOW_PATH} pins no \`--registry\` on its npm commands, so the registry the release ` +
+				"publishes to cannot be determined. The preflight refuses to guess one.",
+		);
 	}
-	return parseReleasePayloadPackages(source);
+	if (values.length > 1) {
+		throw new Error(
+			`${PUBLISH_WORKFLOW_PATH} pins more than one \`--registry\`: ${values.join(", ")}. ` +
+				"The preflight cannot tell which one the release publishes to.",
+		);
+	}
+	const registry = values[0] as string;
+	let parsed: URL;
+	try {
+		parsed = new URL(registry);
+	} catch {
+		throw new Error(`${PUBLISH_WORKFLOW_PATH} pins \`--registry ${registry}\`, which is not an absolute URL.`);
+	}
+	if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+		throw new Error(`${PUBLISH_WORKFLOW_PATH} pins \`--registry ${registry}\`, which is not an http(s) registry.`);
+	}
+	return registry;
+}
+
+/** Read both halves of the publisher's contract out of one `publish.yml` source. */
+export function parseReleasePublisher(workflowSource: string): ReleasePublisher {
+	return {
+		packages: parseReleasePayloadPackages(workflowSource),
+		registry: parsePublisherNpmRegistry(workflowSource),
+	};
 }
 
 /**
  * Decide what one `npm view` invocation actually said.
  *
- * Exit 0 is registered and a 404 is not registered. **Every other failure is
+ * Exit 0 is registered and a 404 is not registered. **Every other outcome is
  * indeterminate and throws**: an unreachable registry, a missing npm, or an
  * auth error says nothing about whether the name exists, and reading it as
  * "new" would let `--allow-new` wave through a broken probe.
+ *
+ * A null exit code is checked *first*, before any output is read. It means the
+ * command was killed by a signal, so whatever it had printed by then is a
+ * fragment of an answer it never finished giving — a 404 in that fragment is
+ * not a registry verdict, and treating it as one would let a timeout or a
+ * Ctrl-C register as "this package is new".
  */
 export function classifyNpmViewOutcome(packageName: string, outcome: NpmViewOutcome): boolean {
-	if (outcome.exitCode === 0) return true;
 	const answer = `${outcome.stdout}\n${outcome.stderr}`;
+	if (outcome.exitCode === null) {
+		throw new Error(
+			`\`npm view ${packageName}\` was terminated by a signal, so its registration is unknown` +
+				`${describeNpmViewAnswer(answer)}`,
+		);
+	}
+	if (outcome.exitCode === 0) return true;
 	if (answer.includes("E404") || answer.includes("404 Not Found") || answer.includes("is not in this registry")) {
 		return false;
 	}
-	// The first lines carry npm's error code; the tail is a log path and proxy advice.
+	throw new Error(
+		`\`npm view ${packageName}\` exited ${outcome.exitCode} without a 404, so its registration is unknown` +
+			`${describeNpmViewAnswer(answer)}`,
+	);
+}
+
+/** The first lines carry npm's error code; the tail is a log path and proxy advice. */
+function describeNpmViewAnswer(answer: string): string {
 	const detail = answer
 		.split(/\r?\n/u)
 		.map((line) => line.trim())
@@ -136,10 +191,7 @@ export function classifyNpmViewOutcome(packageName: string, outcome: NpmViewOutc
 		.slice(0, 3)
 		.join(" | ")
 		.slice(0, 300);
-	throw new Error(
-		`\`npm view ${packageName}\` exited ${outcome.exitCode ?? "with a signal"} without a 404, so its registration is unknown` +
-			`${detail ? `: ${detail}` : "."}`,
-	);
+	return detail ? `: ${detail}` : ".";
 }
 
 /** The abort message for names npm has never seen. */

--- a/scripts/release-npm-preflight.ts
+++ b/scripts/release-npm-preflight.ts
@@ -1,0 +1,196 @@
+/**
+ * npm registration preflight for `scripts/cut-release.ts`.
+ *
+ * `publish.yml` publishes a fixed payload from one tag: the eight native
+ * platform packages, `@bastani/atomic-natives`, and `@bastani/atomic`. Its own
+ * `npm view` call is an *idempotency* check that runs after the binaries are
+ * built — it skips a version that already exists. Nothing before that point
+ * asks whether the package **name** exists at all, so a name npm has never seen
+ * fails at the last step of a long release: the tag is pushed, the draft is
+ * staged, and the publish job dies on a registry the runner cannot create a new
+ * name on unattended.
+ *
+ * This module answers that question while it is still cheap to answer — before
+ * `cut-release.ts` touches a worktree, stamps a version, or writes a tag.
+ *
+ * The payload is read from `publish.yml` rather than restated here. The
+ * publisher is the thing that publishes; a second hand-maintained list would
+ * drift from it silently, and the preflight would then vouch for a payload
+ * nobody ships. The count is deliberately *not* enforced at cut time — the
+ * workflow already fails a run whose packed tarballs do not number ten, and
+ * `test/ci/release-publisher-contracts.test.ts` pins the ten names this
+ * repository expects.
+ *
+ * No Bun import: the probe is injected, so the whole module runs under Node in
+ * the test suites while `cut-release.ts` supplies the real `npm view` call.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** The publisher that owns the release payload, relative to the repository root. */
+export const PUBLISH_WORKFLOW_PATH = ".github/workflows/publish.yml";
+
+/** The registry `publish.yml` publishes to, and the default this preflight asks. */
+export const DEFAULT_NPM_REGISTRY = "https://registry.npmjs.org";
+
+/** Number of npm packages one release tag publishes; asserted against `publish.yml` by contract test. */
+export const RELEASE_PAYLOAD_PACKAGE_COUNT = 10;
+
+const PACKAGES_ARRAY_RE = /^[ \t]*packages=\(([^)]*)\)[ \t]*$/gmu;
+const PACKAGE_NAME_RE = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/u;
+
+/** The raw result of one `npm view <name>` invocation. */
+export interface NpmViewOutcome {
+	readonly exitCode: number | null;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+/** Resolves to `true` when npm knows the package name, `false` when it does not. */
+export type NpmRegistrationProbe = (packageName: string) => Promise<boolean>;
+
+export interface RegistrationPreflightOptions {
+	/** Package names to check. Defaults to whatever `publish.yml` publishes. */
+	readonly packages: readonly string[];
+	readonly isRegistered: NpmRegistrationProbe;
+	/** Permit names npm has never seen — a deliberate first publish. */
+	readonly allowNew: boolean;
+}
+
+export interface RegistrationPreflightResult {
+	readonly checked: readonly string[];
+	/** Names npm has never seen. Non-empty only when `allowNew` was passed. */
+	readonly unregistered: readonly string[];
+}
+
+/**
+ * The registry to ask.
+ *
+ * `npm_config_registry` is npm's own configuration variable, so a mirror or an
+ * enterprise proxy is honored rather than probed around. Anything else falls
+ * back to the registry `publish.yml` names.
+ */
+export function resolveNpmRegistry(env: NodeJS.ProcessEnv = process.env): string {
+	const configured = env.npm_config_registry?.trim();
+	return configured && configured.length > 0 ? configured : DEFAULT_NPM_REGISTRY;
+}
+
+/** Extract the publish payload from `publish.yml`'s `packages=(…)` array. */
+export function parseReleasePayloadPackages(workflowSource: string): string[] {
+	const matches = [...workflowSource.matchAll(PACKAGES_ARRAY_RE)];
+	if (matches.length !== 1) {
+		throw new Error(
+			`${PUBLISH_WORKFLOW_PATH} must declare exactly one \`packages=(…)\` publish payload array; found ${matches.length}.`,
+		);
+	}
+	const names = (matches[0]?.[1] ?? "").split(/\s+/u).filter((name) => name.length > 0);
+	if (names.length === 0) {
+		throw new Error(`${PUBLISH_WORKFLOW_PATH} declares an empty \`packages=(…)\` publish payload array.`);
+	}
+	for (const name of names) {
+		if (!PACKAGE_NAME_RE.test(name)) {
+			throw new Error(`${PUBLISH_WORKFLOW_PATH} declares "${name}", which is not a publishable npm package name.`);
+		}
+	}
+	const duplicates = names.filter((name, index) => names.indexOf(name) !== index);
+	if (duplicates.length > 0) {
+		throw new Error(
+			`${PUBLISH_WORKFLOW_PATH} declares duplicate publish payload packages: ${duplicates.join(", ")}.`,
+		);
+	}
+	return names;
+}
+
+/** Read the publish payload package names out of the repository at `root`. */
+export function readReleasePayloadPackages(root: string): string[] {
+	const path = join(root, PUBLISH_WORKFLOW_PATH);
+	let source: string;
+	try {
+		source = readFileSync(path, "utf8");
+	} catch (error) {
+		throw new Error(`Cannot read the release payload from ${path}: ${(error as Error).message}`);
+	}
+	return parseReleasePayloadPackages(source);
+}
+
+/**
+ * Decide what one `npm view` invocation actually said.
+ *
+ * Exit 0 is registered and a 404 is not registered. **Every other failure is
+ * indeterminate and throws**: an unreachable registry, a missing npm, or an
+ * auth error says nothing about whether the name exists, and reading it as
+ * "new" would let `--allow-new` wave through a broken probe.
+ */
+export function classifyNpmViewOutcome(packageName: string, outcome: NpmViewOutcome): boolean {
+	if (outcome.exitCode === 0) return true;
+	const answer = `${outcome.stdout}\n${outcome.stderr}`;
+	if (answer.includes("E404") || answer.includes("404 Not Found") || answer.includes("is not in this registry")) {
+		return false;
+	}
+	// The first lines carry npm's error code; the tail is a log path and proxy advice.
+	const detail = answer
+		.split(/\r?\n/u)
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0)
+		.slice(0, 3)
+		.join(" | ")
+		.slice(0, 300);
+	throw new Error(
+		`\`npm view ${packageName}\` exited ${outcome.exitCode ?? "with a signal"} without a 404, so its registration is unknown` +
+			`${detail ? `: ${detail}` : "."}`,
+	);
+}
+
+/** The abort message for names npm has never seen. */
+export function describeUnregisteredPackages(unregistered: readonly string[], checkedCount: number): string {
+	const listed = unregistered.map((name) => `  - ${name}`).join("\n");
+	return (
+		`Refusing to cut a release: ${unregistered.length} of ${checkedCount} publish-payload packages ` +
+		`${unregistered.length === 1 ? "is" : "are"} not registered on npm:\n${listed}\n` +
+		"One tag publishes the whole payload, so a name npm has never seen fails after the binaries are built. " +
+		"Re-run with --allow-new to publish these names for the first time deliberately."
+	);
+}
+
+/**
+ * Probe every payload package and refuse the release unless each one exists.
+ *
+ * Throws — the caller aborts on it — when a name is unregistered without
+ * `--allow-new`, or when any probe could not determine an answer. `--allow-new`
+ * relaxes only the first case.
+ */
+export async function verifyReleasePackagesRegistered(
+	options: RegistrationPreflightOptions,
+): Promise<RegistrationPreflightResult> {
+	const packages = [...options.packages];
+	if (packages.length === 0) {
+		throw new Error("Release payload preflight requires at least one package name.");
+	}
+	const outcomes = await Promise.allSettled(
+		packages.map(async (name) => ({ name, registered: await options.isRegistered(name) })),
+	);
+
+	const indeterminate: string[] = [];
+	const unregistered: string[] = [];
+	for (const [index, outcome] of outcomes.entries()) {
+		if (outcome.status === "rejected") {
+			const reason = outcome.reason instanceof Error ? outcome.reason.message : String(outcome.reason);
+			indeterminate.push(`  - ${packages[index]}: ${reason}`);
+		} else if (!outcome.value.registered) {
+			unregistered.push(outcome.value.name);
+		}
+	}
+
+	if (indeterminate.length > 0) {
+		throw new Error(
+			`Refusing to cut a release: npm registration could not be determined for ${indeterminate.length} of ` +
+				`${packages.length} publish-payload packages:\n${indeterminate.join("\n")}\n` +
+				"--allow-new does not cover an unreadable registry answer.",
+		);
+	}
+	if (unregistered.length > 0 && !options.allowNew) {
+		throw new Error(describeUnregisteredPackages(unregistered, packages.length));
+	}
+	return { checked: packages, unregistered };
+}

--- a/test/integration/cut-release-npm-preflight.test.ts
+++ b/test/integration/cut-release-npm-preflight.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, describe, test } from "vitest";
+import { createGitEnvironment } from "../../packages/coding-agent/src/utils/git-env.js";
 import { bunExecutable, readStreamText, spawnProcess, spawnSyncCollect } from "../helpers/runtime.js";
 
 const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
@@ -82,9 +83,90 @@ afterAll(async () => {
 	await Promise.all([missing.close(), mirror.close()]);
 });
 
+/**
+ * Every git child this fixture spawns runs with the repository-local part of
+ * the environment removed.
+ *
+ * Git hooks export `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`,
+ * `GIT_COMMON_DIR`, `GIT_OBJECT_DIRECTORY` and
+ * `GIT_ALTERNATE_OBJECT_DIRECTORIES`, and git honors them over `-C <path>` and
+ * over a literal path argument alike. `git init --bare <path>` under an
+ * inherited `GIT_DIR` therefore does not initialize `<path>`: it re-initializes
+ * the repository `GIT_DIR` names — this checkout, which is a linked worktree —
+ * as bare, and every worktree sharing that git dir stops resolving. This suite
+ * did exactly that when it ran under the repository's own pre-push hook.
+ *
+ * `createGitEnvironment` is the repository's existing scrubber and mirrors
+ * `git rev-parse --local-env-vars`, so it covers those six and the rest.
+ * `git-fixture-cannot-reach-the-repository-under-test` is what proves the
+ * scrub is wired to every spawn rather than merely available.
+ */
+function gitEnvironment(): NodeJS.ProcessEnv {
+	return createGitEnvironment();
+}
+
 function git(root: string, args: string[]): void {
-	const result = spawnSyncCollect(["git", "-C", root, ...args], { stdout: "pipe", stderr: "pipe" });
+	const result = spawnSyncCollect(["git", "-C", root, ...args], {
+		stdout: "pipe",
+		stderr: "pipe",
+		env: gitEnvironment(),
+	});
 	assert.equal(result.exitCode, 0, `git ${args.join(" ")}: ${result.stderr.toString()}`);
+}
+
+/** One git query, trimmed. Failures return "" so a snapshot can record them rather than throw. */
+function gitOutput(root: string, args: string[]): string {
+	return spawnSyncCollect(["git", "-C", root, ...args], { stdout: "pipe", stderr: "pipe", env: gitEnvironment() })
+		.stdout.toString()
+		.trim();
+}
+
+/**
+ * Everything a stray git command would disturb in a repository that is not the
+ * fixture: whether it is still a working checkout rather than a bare one, which
+ * git dir it resolves to, what it has checked out, and its local configuration.
+ */
+function foreignRepositorySnapshot(root: string): Record<string, string> {
+	return {
+		bare: gitOutput(root, ["rev-parse", "--is-bare-repository"]),
+		gitDir: gitOutput(root, ["rev-parse", "--absolute-git-dir"]),
+		head: gitOutput(root, ["rev-parse", "HEAD"]),
+		config: gitOutput(root, ["config", "--list", "--local"]),
+	};
+}
+
+/** The same, plus the refs — used for a repository this file owns outright. */
+function repositoryFingerprint(root: string): Record<string, string> {
+	return { ...foreignRepositorySnapshot(root), refs: gitOutput(root, ["show-ref"]) };
+}
+
+/**
+ * A repository standing in for the checkout that runs this suite, and the
+ * hook-style environment aimed at it.
+ *
+ * Asserting the hostile case against the real checkout would mean risking it;
+ * this one is owned by the test, so it can be compared byte for byte.
+ */
+function createSentinel(): { stage: string; path: string; hostile: Record<string, string> } {
+	const stage = mkdtempSync(join(tmpdir(), "atomic-cut-release-sentinel-"));
+	const path = join(stage, "checkout");
+	mkdirSync(path, { recursive: true });
+	git(path, ["init", "-b", "main"]);
+	writeFileSync(join(path, "tracked.txt"), "sentinel\n");
+	commit(path, "sentinel");
+	// Exactly what a git hook exports.
+	return {
+		stage,
+		path,
+		hostile: {
+			GIT_DIR: join(path, ".git"),
+			GIT_WORK_TREE: path,
+			GIT_INDEX_FILE: join(path, ".git", "index"),
+			GIT_COMMON_DIR: join(path, ".git"),
+			GIT_OBJECT_DIRECTORY: join(path, ".git", "objects"),
+			GIT_ALTERNATE_OBJECT_DIRECTORIES: join(path, ".git", "objects"),
+		},
+	};
 }
 
 function commit(root: string, message: string): void {
@@ -168,7 +250,14 @@ function createFixture(options: FixtureOptions): Fixture {
 	writeFileSync(workflow, publishWorkflow(options.packages, options.registry));
 	git(root, ["init", "-b", "main"]);
 	commit(root, "fixture");
-	spawnSyncCollect(["git", "init", "--bare", origin], { stdout: "pipe", stderr: "pipe" });
+	// The path argument, and only the path argument, decides what becomes bare.
+	const bare = spawnSyncCollect(["git", "init", "--bare", origin], {
+		stdout: "pipe",
+		stderr: "pipe",
+		env: gitEnvironment(),
+	});
+	assert.equal(bare.exitCode, 0, bare.stderr.toString());
+	assert.equal(gitOutput(origin, ["rev-parse", "--is-bare-repository"]), "true", "the origin was not initialized");
 	git(root, ["remote", "add", "origin", origin]);
 	git(root, ["push", "origin", "main"]);
 
@@ -190,8 +279,16 @@ interface CutResult {
  * Spawned asynchronously on purpose: `spawnSync` would block this process's
  * event loop, and the loopback registries npm is talking to live in it.
  */
-async function runCutRelease(fixture: Fixture, args: string[]): Promise<CutResult> {
-	const environment: Record<string, string | undefined> = { ...process.env };
+async function runCutRelease(
+	fixture: Fixture,
+	args: string[],
+	extraEnv: Record<string, string> = {},
+): Promise<CutResult> {
+	// Scrubbed for the same reason as every git child above: the script's own
+	// git commands are what create the worktree and write the tag, and an
+	// inherited GIT_DIR would aim them at this checkout instead of the fixture.
+	// `extraEnv` is how the one case that puts those variables *back* does it.
+	const environment: Record<string, string | undefined> = { ...gitEnvironment() };
 	// npm's own configuration, pointed at the mirror that answers "yes" to
 	// everything — including the scope-specific form, which npm prefers over
 	// `--registry`. The preflight must ignore both and ask the registry
@@ -217,6 +314,8 @@ async function runCutRelease(fixture: Fixture, args: string[]): Promise<CutResul
 	]) {
 		environment[key] = undefined;
 	}
+
+	Object.assign(environment, extraEnv);
 
 	const child = spawnProcess({
 		cmd: [bunExecutable(), "run", join(fixture.root, "scripts", "cut-release.ts"), ...args],
@@ -256,11 +355,7 @@ function gitCommands(fixture: Fixture): string[] {
 
 /** Everything the script could have mutated, read back after it exits. */
 function repositoryState(root: string): { tags: string; status: string } {
-	const read = (args: string[]): string =>
-		spawnSyncCollect(["git", "-C", root, ...args], { stdout: "pipe", stderr: "pipe" })
-			.stdout.toString()
-			.trim();
-	return { tags: read(["tag", "--list"]), status: read(["status", "--porcelain"]) };
+	return { tags: gitOutput(root, ["tag", "--list"]), status: gitOutput(root, ["status", "--porcelain"]) };
 }
 
 describe("cut-release npm registration preflight", () => {
@@ -280,6 +375,7 @@ describe("cut-release npm registration preflight", () => {
 				// and the publisher and then stopped. It never pruned, added a
 				// worktree, stamped a version, committed, or wrote a tag.
 				assert.deepEqual(gitCommands(fixture), [
+					"rev-parse --local-env-vars",
 					"status --porcelain",
 					"tag --list 9.9.9",
 					"rev-parse --abbrev-ref HEAD",
@@ -396,6 +492,88 @@ describe("cut-release npm registration preflight", () => {
 				assert.deepEqual(repositoryState(fixture.root), { tags: "", status: "" });
 			} finally {
 				rmSync(fixture.stage, { recursive: true, force: true });
+			}
+		},
+		CUT_RELEASE_FIXTURE_TIMEOUT_MS,
+	);
+
+	test(
+		"git-fixture-cannot-reach-the-repository-under-test",
+		async () => {
+			// `GIT_DIR` overrides `-C <path>` and the path argument of `git init
+			// --bare` alike, so an unscrubbed fixture builds itself inside — and on
+			// top of — whichever repository the ambient environment names. Under
+			// this repository's own pre-push hook that repository is this checkout,
+			// which is a linked worktree: initializing it bare detaches all of them.
+			const sentinel = createSentinel();
+			const sentinelBefore = repositoryFingerprint(sentinel.path);
+			const selfBefore = foreignRepositorySnapshot(repoRoot);
+			assert.equal(selfBefore.bare, "false", "the repository under test is already bare");
+
+			const saved = new Map(Object.keys(sentinel.hostile).map((key) => [key, process.env[key]] as const));
+			Object.assign(process.env, sentinel.hostile);
+
+			let fixture: Fixture | undefined;
+			try {
+				try {
+					fixture = createFixture({ packages: fixturePackages, registry: missing.url });
+					const result = await runCutRelease(fixture, ["9.9.9", "--base", "main", "--yes"]);
+
+					// The whole run still landed on the fixture: it resolved its own
+					// base, read its own publisher, and aborted on its own payload.
+					assert.equal(result.exitCode, 1, result.stdout + result.stderr);
+					assert.match(result.stderr, /2 of 2 publish-payload packages are not registered on npm/u);
+					assert.equal(gitOutput(fixture.root, ["rev-parse", "--abbrev-ref", "HEAD"]), "main");
+					assert.deepEqual(repositoryState(fixture.root), { tags: "", status: "" });
+				} finally {
+					for (const [key, value] of saved) {
+						if (value === undefined) delete process.env[key];
+						else process.env[key] = value;
+					}
+					if (fixture) rmSync(fixture.stage, { recursive: true, force: true });
+				}
+
+				// Neither repository was initialized, committed into, or turned bare.
+				assert.deepEqual(
+					repositoryFingerprint(sentinel.path),
+					sentinelBefore,
+					"the fixture wrote to the ambient repository",
+				);
+				assert.deepEqual(foreignRepositorySnapshot(repoRoot), selfBefore, "the fixture wrote to this checkout");
+			} finally {
+				rmSync(sentinel.stage, { recursive: true, force: true });
+			}
+		},
+		CUT_RELEASE_FIXTURE_TIMEOUT_MS,
+	);
+
+	test(
+		"an exported GIT_DIR cannot redirect the cut into another repository",
+		async () => {
+			// The same hook environment, handed to the script itself rather than
+			// erased by the fixture. `cut-release.ts` addresses every repository it
+			// touches by path — the checkout it reads, and the temporary worktree it
+			// stamps and tags — so it scrubs the inherited variables before its
+			// first git command. Without that, the run reads the sentinel's state
+			// and would stamp and tag the sentinel.
+			const sentinel = createSentinel();
+			const sentinelBefore = repositoryFingerprint(sentinel.path);
+			const fixture = createFixture({ packages: fixturePackages, registry: missing.url });
+			try {
+				const result = await runCutRelease(fixture, ["9.9.9", "--base", "main", "--yes"], sentinel.hostile);
+
+				// It read the fixture's base and the fixture's publisher: the
+				// sentinel has no origin, so a redirected run dies on the base
+				// instead, and never names a payload package at all.
+				assert.equal(result.exitCode, 1, result.stdout + result.stderr);
+				assert.match(result.stderr, /2 of 2 publish-payload packages are not registered on npm/u);
+				for (const name of fixturePackages) assert.ok(result.stderr.includes(name), `missing ${name}`);
+				assert.doesNotMatch(result.stderr, /does not exist on origin/u);
+				assert.deepEqual(repositoryFingerprint(sentinel.path), sentinelBefore, "the cut wrote to the sentinel");
+				assert.deepEqual(repositoryState(fixture.root), { tags: "", status: "" });
+			} finally {
+				rmSync(fixture.stage, { recursive: true, force: true });
+				rmSync(sentinel.stage, { recursive: true, force: true });
 			}
 		},
 		CUT_RELEASE_FIXTURE_TIMEOUT_MS,

--- a/test/integration/cut-release-npm-preflight.test.ts
+++ b/test/integration/cut-release-npm-preflight.test.ts
@@ -1,43 +1,85 @@
 import assert from "node:assert/strict";
-import { copyFileSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, describe, test } from "vitest";
-import { bunExecutable, spawnProcess, spawnSyncCollect } from "../helpers/runtime.js";
+import { bunExecutable, readStreamText, spawnProcess, spawnSyncCollect } from "../helpers/runtime.js";
 
 const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 
 /**
- * Two package names no registry has ever seen. The fixture's `publish.yml`
- * declares them as its publish payload, so the real script asks the real `npm`
- * about them — the preflight runs end to end rather than against a stub.
+ * Package names no registry has ever seen. The fixture's `publish.yml` declares
+ * them as its publish payload, so the real script asks the real `npm` about
+ * them — the preflight runs end to end rather than against a stub.
  */
 const fixturePackages = ["@atomic-release-preflight-fixture/one", "@atomic-release-preflight-fixture/two"] as const;
+/** The payload of a *different* branch, used to prove which commit is read. */
+const basePackages = ["@atomic-release-preflight-base/one", "@atomic-release-preflight-base/two"] as const;
+const localOnlyPackage = "@atomic-release-preflight-local/only";
 
 /**
- * A registry that answers 404 to everything.
- *
- * It replaces the public registry for these runs, which keeps the test
+ * Structural: every case spawns Bun, which transforms three `.ts` scripts on a
+ * cold start, then one real `npm` child per payload package — npm's own cold
+ * start dominates — plus a dozen `git` children; the cases that clear the
+ * preflight spawn a second Bun for the version stamp. The cost is process
+ * startup rather than a slow assertion, so the budget is named here per the
+ * per-test timeout policy in AGENTS.md.
+ */
+const CUT_RELEASE_FIXTURE_TIMEOUT_MS = 120_000;
+
+/** A registry, and every package path it was asked about. */
+interface FakeRegistry {
+	readonly url: string;
+	readonly requests: string[];
+	close(): Promise<void>;
+}
+
+/**
+ * Two loopback registries replace the public one, which keeps these runs
  * hermetic — offline, behind a mirror, and on Windows, where a shell-script
  * `npm` stub on PATH would not be executed at all.
+ *
+ * `missing` answers 404 to everything; `mirror` answers "this package exists"
+ * to everything. Which one the preflight asks is the whole point of two.
  */
-let registry: Server;
-let registryUrl: string;
+let missing: FakeRegistry;
+let mirror: FakeRegistry;
+
+async function startRegistry(respond: (name: string) => { status: number; body: string }): Promise<FakeRegistry> {
+	const requests: string[] = [];
+	const server: Server = createServer((request, response) => {
+		const path = (request.url ?? "").split("?")[0] ?? "";
+		const name = decodeURIComponent(path.replace(/^\//u, ""));
+		requests.push(name);
+		const { status, body } = respond(name);
+		response.writeHead(status, { "content-type": "application/json" });
+		response.end(body);
+	});
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	return {
+		url: `http://127.0.0.1:${(server.address() as AddressInfo).port}/`,
+		requests,
+		close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+	};
+}
 
 beforeAll(async () => {
-	registry = createServer((_request, response) => {
-		response.writeHead(404, { "content-type": "application/json" });
-		response.end('{"error":"Not found"}');
-	});
-	await new Promise<void>((resolve) => registry.listen(0, "127.0.0.1", resolve));
-	registryUrl = `http://127.0.0.1:${(registry.address() as AddressInfo).port}/`;
+	missing = await startRegistry(() => ({ status: 404, body: '{"error":"Not found"}' }));
+	mirror = await startRegistry((name) => ({
+		status: 200,
+		body: JSON.stringify({
+			name,
+			"dist-tags": { latest: "1.0.0" },
+			versions: { "1.0.0": { name, version: "1.0.0" } },
+		}),
+	}));
 });
 
 afterAll(async () => {
-	await new Promise<void>((resolve) => registry.close(() => resolve()));
+	await Promise.all([missing.close(), mirror.close()]);
 });
 
 function git(root: string, args: string[]): void {
@@ -45,36 +87,7 @@ function git(root: string, args: string[]): void {
 	assert.equal(result.exitCode, 0, `git ${args.join(" ")}: ${result.stderr.toString()}`);
 }
 
-interface Fixture {
-	/** Removed wholesale by the test; holds the repository and npm's cache. */
-	readonly stage: string;
-	readonly root: string;
-	readonly npmCache: string;
-}
-
-/**
- * A repository whose only content is the release script under test, its two
- * modules, and a `publish.yml` declaring the fixture payload. `ROOT` inside
- * `cut-release.ts` resolves to the parent of its own directory, so the copied
- * script operates on this fixture and never on the real checkout.
- *
- * npm's cache lives beside the repository rather than inside it: a cache
- * written under the working tree would leave it dirty, which is a different
- * refusal from the one under test.
- */
-function createFixture(): Fixture {
-	const stage = mkdtempSync(join(tmpdir(), "atomic-cut-release-preflight-"));
-	const root = join(stage, "repo");
-	mkdirSync(join(root, "scripts"), { recursive: true });
-	mkdirSync(join(root, ".github", "workflows"), { recursive: true });
-	for (const script of ["cut-release.ts", "release-base.ts", "release-npm-preflight.ts"]) {
-		copyFileSync(join(repoRoot, "scripts", script), join(root, "scripts", script));
-	}
-	writeFileSync(
-		join(root, ".github", "workflows", "publish.yml"),
-		["jobs:", "  publish-npm:", "    run: |", `      packages=(${fixturePackages.join(" ")})`, ""].join("\n"),
-	);
-	git(root, ["init", "-b", "main"]);
+function commit(root: string, message: string): void {
 	git(root, ["add", "-A"]);
 	git(root, [
 		"-c",
@@ -86,9 +99,85 @@ function createFixture(): Fixture {
 		"commit.gpgsign=false",
 		"commit",
 		"-m",
-		"fixture",
+		message,
 	]);
-	return { stage, root, npmCache: join(stage, "npm-cache") };
+}
+
+/** A `publish.yml` that publishes `packages` to `registry`, in the publisher's own shape. */
+function publishWorkflow(packages: readonly string[], registry: string): string {
+	return [
+		"jobs:",
+		"  publish-npm:",
+		"    run: |",
+		`      packages=(${packages.join(" ")})`,
+		`      for name in "\${packages[@]}"; do`,
+		`        npm publish "\${tarballs[$name]}" --access public --registry ${registry}`,
+		"      done",
+		"",
+	].join("\n");
+}
+
+interface FixtureOptions {
+	/** The payload declared on `main`, which is what a `--base main` cut publishes. */
+	readonly packages: readonly string[];
+	/** The registry `publish.yml` pins. */
+	readonly registry: string;
+	/** When set, a second branch is checked out whose `publish.yml` declares these instead. */
+	readonly localPackages?: readonly string[];
+}
+
+interface Fixture {
+	/** Removed wholesale by the test; holds the repository, its origin, and npm's cache. */
+	readonly stage: string;
+	readonly root: string;
+	readonly npmCache: string;
+	readonly traceLog: string;
+}
+
+/**
+ * A repository whose only content is the release script under test, its
+ * modules, a stub version stamper, and a `publish.yml` declaring the fixture
+ * payload. `ROOT` inside `cut-release.ts` resolves to the parent of its own
+ * directory, so the copied script operates on this fixture and never on the
+ * real checkout.
+ *
+ * It has a real `origin`, because base resolution now runs *before* the
+ * preflight: the release is cut from the base commit, so that commit is what
+ * the preflight has to read.
+ *
+ * npm's cache lives beside the repository rather than inside it: a cache
+ * written under the working tree would leave it dirty, which is a different
+ * refusal from the one under test.
+ */
+function createFixture(options: FixtureOptions): Fixture {
+	const stage = mkdtempSync(join(tmpdir(), "atomic-cut-release-preflight-"));
+	const root = join(stage, "repo");
+	const origin = join(stage, "origin.git");
+	mkdirSync(join(root, "scripts"), { recursive: true });
+	mkdirSync(join(root, ".github", "workflows"), { recursive: true });
+	for (const script of ["cut-release.ts", "release-base.ts", "release-npm-preflight.ts"]) {
+		copyFileSync(join(repoRoot, "scripts", script), join(root, "scripts", script));
+	}
+	// The real stamper is out of scope here; a stub ends the run at the first
+	// step after the preflight, which is what the cleared-gate cases assert.
+	writeFileSync(
+		join(root, "scripts", "bump-version.ts"),
+		'console.error("stub bump-version: the preflight was cleared");\nprocess.exit(3);\n',
+	);
+	const workflow = join(root, ".github", "workflows", "publish.yml");
+	writeFileSync(workflow, publishWorkflow(options.packages, options.registry));
+	git(root, ["init", "-b", "main"]);
+	commit(root, "fixture");
+	spawnSyncCollect(["git", "init", "--bare", origin], { stdout: "pipe", stderr: "pipe" });
+	git(root, ["remote", "add", "origin", origin]);
+	git(root, ["push", "origin", "main"]);
+
+	if (options.localPackages) {
+		git(root, ["checkout", "-b", "local"]);
+		writeFileSync(workflow, publishWorkflow(options.localPackages, options.registry));
+		commit(root, "local-only payload");
+	}
+	return { stage, root, npmCache: join(stage, "npm-cache"), traceLog: join(stage, "git-trace.log") };
 }
 
 interface CutResult {
@@ -96,20 +185,28 @@ interface CutResult {
 	stdout: string;
 	stderr: string;
 }
+
 /**
  * Spawned asynchronously on purpose: `spawnSync` would block this process's
- * event loop, and the loopback registry npm is talking to lives in it.
+ * event loop, and the loopback registries npm is talking to live in it.
  */
-async function runCutRelease(fixture: Fixture, args: string[], registryOverride?: string): Promise<CutResult> {
+async function runCutRelease(fixture: Fixture, args: string[]): Promise<CutResult> {
 	const environment: Record<string, string | undefined> = { ...process.env };
-	// npm's own configuration variable, which the preflight resolves before it
-	// pins `--registry`. Retries are disabled so an unreachable registry fails
+	// npm's own configuration, pointed at the mirror that answers "yes" to
+	// everything — including the scope-specific form, which npm prefers over
+	// `--registry`. The preflight must ignore both and ask the registry
+	// `publish.yml` pins. Retries are disabled so an unreachable registry fails
 	// now instead of after npm's minute-long backoff, and the proxy keys are
-	// cleared so a developer proxy cannot intercept the loopback registry.
-	environment.npm_config_registry = registryOverride ?? registryUrl;
+	// cleared so a developer proxy cannot intercept a loopback registry.
+	environment.npm_config_registry = mirror.url;
+	for (const scope of new Set([...fixturePackages, ...basePackages, localOnlyPackage].map((n) => n.split("/")[0]))) {
+		environment[`npm_config_${scope}:registry`] = mirror.url;
+	}
 	environment.npm_config_cache = fixture.npmCache;
 	environment.npm_config_fetch_retries = "0";
 	environment.NO_UPDATE_NOTIFIER = "1";
+	// Git's own record of every command the script ran, in order.
+	environment.GIT_TRACE = fixture.traceLog;
 	for (const key of [
 		"npm_config_proxy",
 		"npm_config_https_proxy",
@@ -129,82 +226,178 @@ async function runCutRelease(fixture: Fixture, args: string[], registryOverride?
 		stderr: "pipe",
 	});
 	const [stdout, stderr, exitCode] = await Promise.all([
-		child.stdout ? new Response(child.stdout).text() : Promise.resolve(""),
-		child.stderr ? new Response(child.stderr).text() : Promise.resolve(""),
+		readStreamText(child.stdout),
+		readStreamText(child.stderr),
 		child.exited,
 	]);
 	return { exitCode, stdout, stderr };
 }
 
+/**
+ * Every git command the script ran, in order, with commit ids normalized.
+ *
+ * Residual state alone cannot tell an untouched repository from one that added
+ * a worktree and removed it again, so the ordering claim is checked against
+ * what git was actually asked to do.
+ *
+ * `upload-pack` is git's own child of `ls-remote` over a local path — the
+ * transport answering the query, not a command the script issued — so it is
+ * dropped rather than pinned into the expected sequence.
+ */
+function gitCommands(fixture: Fixture): string[] {
+	if (!existsSync(fixture.traceLog)) return [];
+	return readFileSync(fixture.traceLog, "utf8")
+		.split(/\r?\n/u)
+		.map((line) => /trace: built-in: git (.*)$/u.exec(line)?.[1])
+		.filter((command): command is string => command !== undefined)
+		.map((command) => command.replace(/\b[0-9a-f]{40}\b/gu, "<sha>").trim())
+		.filter((command) => !/^(?:upload-pack|receive-pack|index-pack|pack-objects) /u.test(command));
+}
+
 /** Everything the script could have mutated, read back after it exits. */
-function repositoryState(root: string): { tags: string; status: string; worktrees: boolean } {
+function repositoryState(root: string): { tags: string; status: string } {
 	const read = (args: string[]): string =>
 		spawnSyncCollect(["git", "-C", root, ...args], { stdout: "pipe", stderr: "pipe" })
 			.stdout.toString()
 			.trim();
-	return {
-		tags: read(["tag", "--list"]),
-		status: read(["status", "--porcelain"]),
-		worktrees: existsSync(join(root, ".git", "worktrees")),
-	};
+	return { tags: read(["tag", "--list"]), status: read(["status", "--porcelain"]) };
 }
 
-/**
- * Each case spawns Bun, two real `npm view` processes, and several `git`
- * invocations, and lands near half a second — well inside the shared per-test
- * budget, so no explicit timeout is declared here.
- */
 describe("cut-release npm registration preflight", () => {
-	test("cut-release-aborts-on-unregistered-package", async () => {
-		const fixture = createFixture();
-		try {
-			const result = await runCutRelease(fixture, ["9.9.9", "--base", "main", "--yes"]);
+	test(
+		"cut-release-aborts-on-unregistered-package",
+		async () => {
+			const fixture = createFixture({ packages: fixturePackages, registry: missing.url });
+			try {
+				const result = await runCutRelease(fixture, ["9.9.9", "--base", "main", "--yes"]);
 
-			assert.equal(result.exitCode, 1, result.stdout + result.stderr);
-			assert.match(result.stderr, /2 of 2 publish-payload packages are not registered on npm/u);
-			for (const name of fixturePackages) assert.ok(result.stderr.includes(name), `missing ${name}`);
-			assert.match(result.stderr, /Re-run with --allow-new/u);
+				assert.equal(result.exitCode, 1, result.stdout + result.stderr);
+				assert.match(result.stderr, /2 of 2 publish-payload packages are not registered on npm/u);
+				for (const name of fixturePackages) assert.ok(result.stderr.includes(name), `missing ${name}`);
+				assert.match(result.stderr, /Re-run with --allow-new/u);
 
-			// The abort lands before the script announces the cut, and before it
-			// prunes, adds a worktree, stamps a version, or writes a tag.
-			assert.doesNotMatch(result.stdout, /Cutting release/u);
-			assert.deepEqual(repositoryState(fixture.root), { tags: "", status: "", worktrees: false });
-		} finally {
-			rmSync(fixture.stage, { recursive: true, force: true });
-		}
-	});
+				// The ordering claim, from git's own record: the run read the base
+				// and the publisher and then stopped. It never pruned, added a
+				// worktree, stamped a version, committed, or wrote a tag.
+				assert.deepEqual(gitCommands(fixture), [
+					"status --porcelain",
+					"tag --list 9.9.9",
+					"rev-parse --abbrev-ref HEAD",
+					"ls-remote --exit-code --refs origin refs/heads/main",
+					"show <sha>:.github/workflows/publish.yml",
+				]);
+				assert.doesNotMatch(result.stdout, /Cutting release/u);
+				assert.deepEqual(repositoryState(fixture.root), { tags: "", status: "" });
+			} finally {
+				rmSync(fixture.stage, { recursive: true, force: true });
+			}
+		},
+		CUT_RELEASE_FIXTURE_TIMEOUT_MS,
+	);
 
-	test("--allow-new is required for a first publish and lets the cut proceed", async () => {
-		const fixture = createFixture();
-		try {
-			const result = await runCutRelease(fixture, ["9.9.9", "--base", "main", "--yes", "--allow-new"]);
+	test(
+		"the registry asked is the one publish.yml pins, not the one npm is configured with",
+		async () => {
+			// publish.yml pins the registry that says every name exists, while npm's
+			// own configuration points at the one that 404s. The publisher decides:
+			// a mirror's answer is not evidence about the registry the release
+			// actually publishes to.
+			const fixture = createFixture({ packages: fixturePackages, registry: mirror.url });
+			const missingBefore = missing.requests.length;
+			try {
+				const result = await runCutRelease(fixture, ["9.9.9", "--base", "main", "--yes"]);
 
-			// Past the preflight: the run now fails on the fixture's missing
-			// origin, which is the next check after the registry one.
-			assert.doesNotMatch(result.stderr, /not registered on npm/u);
-			assert.match(result.stdout, /--allow-new: first publish for 2 package\(s\)/u);
-			for (const name of fixturePackages) assert.ok(result.stdout.includes(`+ ${name}`), `missing ${name}`);
-			assert.match(result.stderr, /Base ref "refs\/heads\/main" does not exist on origin\./u);
-			assert.equal(result.exitCode, 1);
-			assert.deepEqual(repositoryState(fixture.root), { tags: "", status: "", worktrees: false });
-		} finally {
-			rmSync(fixture.stage, { recursive: true, force: true });
-		}
-	});
+				assert.doesNotMatch(result.stderr, /not registered on npm/u);
+				assert.match(result.stdout, new RegExp(`2/2 publish-payload packages registered on ${mirror.url}`, "u"));
+				for (const name of fixturePackages) assert.ok(mirror.requests.includes(name), `unasked ${name}`);
+				assert.equal(missing.requests.length, missingBefore, "the configured registry was asked");
+				// Cleared gate: the run reached the first mutation and died in the
+				// stub stamper, so the tag was never written.
+				assert.ok(
+					gitCommands(fixture).some((command) => command.startsWith("worktree add")),
+					"the cut never reached the worktree",
+				);
+				assert.match(result.stderr, /stub bump-version: the preflight was cleared/u);
+				assert.equal(repositoryState(fixture.root).tags, "");
+			} finally {
+				rmSync(fixture.stage, { recursive: true, force: true });
+			}
+		},
+		CUT_RELEASE_FIXTURE_TIMEOUT_MS,
+	);
 
-	test("a registry that cannot answer stops the release even with --allow-new", async () => {
-		const fixture = createFixture();
-		try {
+	test(
+		"the payload is read from the base commit, not from the caller's checkout",
+		async () => {
+			// `--base main` is cut from main, so main's publish.yml is the one that
+			// will publish. The checked-out branch declares a different payload and
+			// must not be consulted at all.
+			const fixture = createFixture({
+				packages: basePackages,
+				registry: missing.url,
+				localPackages: [localOnlyPackage],
+			});
+			try {
+				const result = await runCutRelease(fixture, ["9.9.9", "--base", "main", "--yes"]);
+
+				assert.equal(result.exitCode, 1, result.stdout + result.stderr);
+				for (const name of basePackages) assert.ok(result.stderr.includes(name), `missing ${name}`);
+				assert.ok(!result.stderr.includes(localOnlyPackage), "the checked-out payload was checked");
+				for (const name of basePackages) assert.ok(missing.requests.includes(name), `unasked ${name}`);
+				assert.ok(!missing.requests.includes(localOnlyPackage), "the checked-out payload was probed");
+				assert.deepEqual(repositoryState(fixture.root), { tags: "", status: "" });
+			} finally {
+				rmSync(fixture.stage, { recursive: true, force: true });
+			}
+		},
+		CUT_RELEASE_FIXTURE_TIMEOUT_MS,
+	);
+
+	test(
+		"--allow-new is required for a first publish and lets the cut proceed",
+		async () => {
+			const fixture = createFixture({ packages: fixturePackages, registry: missing.url });
+			try {
+				const result = await runCutRelease(fixture, ["9.9.9", "--base", "main", "--yes", "--allow-new"]);
+
+				assert.doesNotMatch(result.stderr, /not registered on npm/u);
+				assert.match(result.stdout, /--allow-new: first publish for 2 package\(s\)/u);
+				for (const name of fixturePackages) assert.ok(result.stdout.includes(`+ ${name}`), `missing ${name}`);
+				assert.match(result.stdout, /Cutting release 9\.9\.9/u);
+				assert.ok(
+					gitCommands(fixture).some((command) => command.startsWith("worktree add")),
+					"the cut never reached the worktree",
+				);
+				assert.match(result.stderr, /stub bump-version: the preflight was cleared/u);
+				assert.equal(repositoryState(fixture.root).tags, "");
+			} finally {
+				rmSync(fixture.stage, { recursive: true, force: true });
+			}
+		},
+		CUT_RELEASE_FIXTURE_TIMEOUT_MS,
+	);
+
+	test(
+		"a registry that cannot answer stops the release even with --allow-new",
+		async () => {
 			// Port 1 refuses the connection, so `npm view` fails without a 404 —
 			// the one answer the escape hatch deliberately does not cover.
-			const result = await runCutRelease(fixture, ["9.9.9", "--yes", "--allow-new"], "http://127.0.0.1:1/");
+			const fixture = createFixture({ packages: fixturePackages, registry: "http://127.0.0.1:1/" });
+			try {
+				const result = await runCutRelease(fixture, ["9.9.9", "--base", "main", "--yes", "--allow-new"]);
 
-			assert.equal(result.exitCode, 1, result.stdout);
-			assert.match(result.stderr, /npm registration could not be determined for 2 of 2/u);
-			assert.match(result.stderr, /--allow-new does not cover an unreadable registry answer/u);
-			assert.deepEqual(repositoryState(fixture.root), { tags: "", status: "", worktrees: false });
-		} finally {
-			rmSync(fixture.stage, { recursive: true, force: true });
-		}
-	});
+				assert.equal(result.exitCode, 1, result.stdout);
+				assert.match(result.stderr, /npm registration could not be determined for 2 of 2/u);
+				assert.match(result.stderr, /--allow-new does not cover an unreadable registry answer/u);
+				assert.ok(
+					!gitCommands(fixture).some((command) => command.startsWith("worktree")),
+					"the failed probe still touched a worktree",
+				);
+				assert.deepEqual(repositoryState(fixture.root), { tags: "", status: "" });
+			} finally {
+				rmSync(fixture.stage, { recursive: true, force: true });
+			}
+		},
+		CUT_RELEASE_FIXTURE_TIMEOUT_MS,
+	);
 });

--- a/test/integration/cut-release-npm-preflight.test.ts
+++ b/test/integration/cut-release-npm-preflight.test.ts
@@ -1,5 +1,15 @@
 import assert from "node:assert/strict";
-import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
@@ -81,11 +91,41 @@ beforeAll(async () => {
 
 afterAll(async () => {
 	await Promise.all([missing.close(), mirror.close()]);
+	if (neutralGitHome) rmSync(neutralGitHome, { recursive: true, force: true });
 });
 
 /**
+ * A git configuration that says nothing, and a hook directory that holds
+ * nothing.
+ *
+ * Scrubbing `GIT_DIR` and its siblings is not enough on its own: git still
+ * reads the *global* and *system* configuration, and one line of it —
+ * `core.hooksPath` — hands every fixture `git commit`, `git checkout` and
+ * `git push` an arbitrary program to run, inside whatever repository the rest
+ * of the ambient environment points at. Both files are replaced with an empty
+ * one so no configuration this machine happens to carry reaches a fixture
+ * child or the release script it launches.
+ */
+let neutralGitHome: string | undefined;
+
+function neutralGitPaths(): { config: string; hooks: string } {
+	if (neutralGitHome === undefined) {
+		neutralGitHome = mkdtempSync(join(tmpdir(), "atomic-cut-release-git-neutral-"));
+		writeFileSync(join(neutralGitHome, "gitconfig"), "");
+		mkdirSync(join(neutralGitHome, "hooks"), { recursive: true });
+	}
+	return { config: join(neutralGitHome, "gitconfig"), hooks: join(neutralGitHome, "hooks") };
+}
+
+/** Git reads a config value literally, so a Windows path needs forward slashes. */
+function configPath(path: string): string {
+	return path.replace(/\\/gu, "/");
+}
+
+/**
  * Every git child this fixture spawns runs with the repository-local part of
- * the environment removed.
+ * the environment removed, and with the machine's own git configuration
+ * replaced by an empty one.
  *
  * Git hooks export `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`,
  * `GIT_COMMON_DIR`, `GIT_OBJECT_DIRECTORY` and
@@ -97,34 +137,60 @@ afterAll(async () => {
  * did exactly that when it ran under the repository's own pre-push hook.
  *
  * `createGitEnvironment` is the repository's existing scrubber and mirrors
- * `git rev-parse --local-env-vars`, so it covers those six and the rest.
- * `git-fixture-cannot-reach-the-repository-under-test` is what proves the
- * scrub is wired to every spawn rather than merely available.
+ * `git rev-parse --local-env-vars`, so it covers those six and the rest. It
+ * deliberately keeps `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM`, which the
+ * agent needs, so the fixture pins both at an empty file itself — otherwise an
+ * ambient `core.hooksPath` makes every fixture commit and push run someone
+ * else's program.
+ *
+ * `git-fixture-cannot-reach-the-repository-under-test` is what proves both are
+ * wired to every spawn rather than merely available.
  */
 function gitEnvironment(): NodeJS.ProcessEnv {
-	return createGitEnvironment();
+	const neutral = neutralGitPaths();
+	return createGitEnvironment({
+		GIT_CONFIG_GLOBAL: neutral.config,
+		GIT_CONFIG_SYSTEM: neutral.config,
+		// For a git too old to honor GIT_CONFIG_SYSTEM (< 2.32).
+		GIT_CONFIG_NOSYSTEM: "1",
+	});
 }
 
-function git(root: string, args: string[]): void {
-	const result = spawnSyncCollect(["git", "-C", root, ...args], {
+/**
+ * Git's own options, ahead of every fixture subcommand.
+ *
+ * `core.hooksPath` on the command line outranks every configuration file, so
+ * this holds even if a file the fixture does not control is read after all.
+ * `--no-optional-locks` keeps a read-only query from writing an index.
+ */
+function gitOptions(): string[] {
+	return ["--no-optional-locks", "-c", `core.hooksPath=${configPath(neutralGitPaths().hooks)}`];
+}
+
+function gitSpawn(args: string[]): { exitCode: number; stdout: string; stderr: string } {
+	const result = spawnSyncCollect(["git", ...gitOptions(), ...args], {
 		stdout: "pipe",
 		stderr: "pipe",
 		env: gitEnvironment(),
 	});
-	assert.equal(result.exitCode, 0, `git ${args.join(" ")}: ${result.stderr.toString()}`);
+	return { exitCode: result.exitCode, stdout: result.stdout.toString(), stderr: result.stderr.toString() };
+}
+
+function git(root: string, args: string[]): void {
+	const result = gitSpawn(["-C", root, ...args]);
+	assert.equal(result.exitCode, 0, `git ${args.join(" ")}: ${result.stderr}`);
 }
 
 /** One git query, trimmed. Failures return "" so a snapshot can record them rather than throw. */
 function gitOutput(root: string, args: string[]): string {
-	return spawnSyncCollect(["git", "-C", root, ...args], { stdout: "pipe", stderr: "pipe", env: gitEnvironment() })
-		.stdout.toString()
-		.trim();
+	return gitSpawn(["-C", root, ...args]).stdout.trim();
 }
 
 /**
  * Everything a stray git command would disturb in a repository that is not the
  * fixture: whether it is still a working checkout rather than a bare one, which
- * git dir it resolves to, what it has checked out, and its local configuration.
+ * git dir it resolves to, what it has checked out, its local configuration, and
+ * the state of its working tree.
  */
 function foreignRepositorySnapshot(root: string): Record<string, string> {
 	return {
@@ -132,12 +198,124 @@ function foreignRepositorySnapshot(root: string): Record<string, string> {
 		gitDir: gitOutput(root, ["rev-parse", "--absolute-git-dir"]),
 		head: gitOutput(root, ["rev-parse", "HEAD"]),
 		config: gitOutput(root, ["config", "--list", "--local"]),
+		// The working tree itself, tracked and untracked alike. Every field
+		// above is identical after a hook drops a marker file into the
+		// checkout, so without this the guard passes while the exploit lands.
+		status: gitOutput(root, ["status", "--porcelain", "--untracked-files=all"]),
 	};
 }
 
 /** The same, plus the refs — used for a repository this file owns outright. */
 function repositoryFingerprint(root: string): Record<string, string> {
 	return { ...foreignRepositorySnapshot(root), refs: gitOutput(root, ["show-ref"]) };
+}
+
+/**
+ * Hooks a fixture git child could trigger, on either side of a local push.
+ *
+ * `reference-transaction` is the broad one: git runs it for every ref update,
+ * so an init, a commit, a tag and a push all reach it.
+ */
+const CANARY_HOOKS = [
+	"pre-commit",
+	"prepare-commit-msg",
+	"commit-msg",
+	"post-commit",
+	"post-checkout",
+	"pre-push",
+	"reference-transaction",
+	"pre-receive",
+	"update",
+	"post-receive",
+] as const;
+
+interface HookCanary {
+	/** Removed wholesale by the test; holds the config, the hooks, and their markers. */
+	readonly stage: string;
+	/** A global/system git config that points `core.hooksPath` at the canary hooks. */
+	readonly config: string;
+	/** Which hooks ran, by name. */
+	fired(): string[];
+	reset(): void;
+}
+
+/**
+ * A global git configuration carrying `core.hooksPath`, and hooks that record
+ * that they ran.
+ *
+ * Scrubbing `GIT_DIR` alone leaves this open: `GIT_CONFIG_GLOBAL` (or a plain
+ * `~/.gitconfig`) can name a hook directory, and git then runs those programs
+ * for every fixture commit, checkout and push. Each hook writes a marker and
+ * exits 0, so nothing is prevented — the run proceeds exactly as it would
+ * have, and the marker is the evidence that it did.
+ */
+function createHookCanary(): HookCanary {
+	const stage = mkdtempSync(join(tmpdir(), "atomic-cut-release-hook-canary-"));
+	const hooks = join(stage, "hooks");
+	const markers = join(stage, "fired");
+	mkdirSync(hooks, { recursive: true });
+	mkdirSync(markers, { recursive: true });
+	for (const hook of CANARY_HOOKS) {
+		const path = join(hooks, hook);
+		writeFileSync(path, `#!/bin/sh\nprintf 'fired\\n' > "${configPath(markers)}/${hook}"\nexit 0\n`);
+		chmodSync(path, 0o755);
+	}
+	const config = join(stage, "gitconfig");
+	writeFileSync(config, `[core]\n\thooksPath = ${configPath(hooks)}\n`);
+	return {
+		stage,
+		config,
+		fired: () => readdirSync(markers).sort(),
+		reset: () => {
+			for (const marker of readdirSync(markers)) rmSync(join(markers, marker), { force: true });
+		},
+	};
+}
+
+/**
+ * Prove the canary can fire before trusting its silence.
+ *
+ * A hook that never runs under any circumstance — an unset executable bit, a
+ * platform that ignores the shebang — would make the guard assert nothing at
+ * all. So one throwaway repository is committed to with the canary config left
+ * in place and only the repository-local redirect scrubbed: precisely the
+ * environment this suite ran with before, which is what the guard now closes.
+ */
+function assertHookCanaryFires(canary: HookCanary): void {
+	const stage = mkdtempSync(join(tmpdir(), "atomic-cut-release-canary-control-"));
+	const root = join(stage, "checkout");
+	mkdirSync(root, { recursive: true });
+	// Deliberately NOT gitEnvironment(): the config and the hooks it names are
+	// left reachable. GIT_DIR and its siblings are still scrubbed, because a
+	// control that wrote into the ambient repository would be the very bug
+	// this file exists to prevent.
+	const armed = createGitEnvironment({ GIT_CONFIG_GLOBAL: canary.config, GIT_CONFIG_SYSTEM: canary.config });
+	const run = (args: string[]): void => {
+		const result = spawnSyncCollect(["git", "-C", root, ...args], { stdout: "pipe", stderr: "pipe", env: armed });
+		assert.equal(result.exitCode, 0, `git ${args.join(" ")}: ${result.stderr.toString()}`);
+	};
+	try {
+		run(["init", "-b", "main"]);
+		writeFileSync(join(root, "tracked.txt"), "control\n");
+		run(["add", "-A"]);
+		run([
+			"-c",
+			"user.name=atomic-release-test",
+			"-c",
+			"user.email=atomic-release-test@users.noreply.github.com",
+			"-c",
+			"commit.gpgsign=false",
+			"commit",
+			"-m",
+			"control",
+		]);
+		assert.ok(
+			canary.fired().includes("pre-commit"),
+			`the hook canary never fired, so its silence proves nothing: [${canary.fired().join(", ")}]`,
+		);
+	} finally {
+		rmSync(stage, { recursive: true, force: true });
+	}
 }
 
 /**
@@ -251,12 +429,8 @@ function createFixture(options: FixtureOptions): Fixture {
 	git(root, ["init", "-b", "main"]);
 	commit(root, "fixture");
 	// The path argument, and only the path argument, decides what becomes bare.
-	const bare = spawnSyncCollect(["git", "init", "--bare", origin], {
-		stdout: "pipe",
-		stderr: "pipe",
-		env: gitEnvironment(),
-	});
-	assert.equal(bare.exitCode, 0, bare.stderr.toString());
+	const bare = gitSpawn(["init", "--bare", origin]);
+	assert.equal(bare.exitCode, 0, bare.stderr);
 	assert.equal(gitOutput(origin, ["rev-parse", "--is-bare-repository"]), "true", "the origin was not initialized");
 	git(root, ["remote", "add", "origin", origin]);
 	git(root, ["push", "origin", "main"]);
@@ -497,6 +671,28 @@ describe("cut-release npm registration preflight", () => {
 		CUT_RELEASE_FIXTURE_TIMEOUT_MS,
 	);
 
+	test("the repository guard notices a file written into a working tree", () => {
+		// The guard below compares two snapshots, so what a snapshot omits it
+		// cannot claim. A hook that drops one untracked marker into a checkout
+		// changes no ref, no HEAD, no configuration and no bareness — every field
+		// the guard originally read comes back byte-identical, and only the
+		// working-tree field moves.
+		const sentinel = createSentinel();
+		try {
+			const before = repositoryFingerprint(sentinel.path);
+			writeFileSync(join(sentinel.path, "hook-marker.txt"), "written by something the test did not run\n");
+			const after = repositoryFingerprint(sentinel.path);
+
+			for (const field of ["bare", "gitDir", "head", "config", "refs"] as const) {
+				assert.equal(after[field], before[field], `${field} moved, so it is not the field under test`);
+			}
+			assert.notDeepEqual(after, before, "a marker file left every guarded field identical");
+			assert.match(after.status, /hook-marker\.txt/u);
+		} finally {
+			rmSync(sentinel.stage, { recursive: true, force: true });
+		}
+	});
+
 	test(
 		"git-fixture-cannot-reach-the-repository-under-test",
 		async () => {
@@ -505,16 +701,32 @@ describe("cut-release npm registration preflight", () => {
 			// top of — whichever repository the ambient environment names. Under
 			// this repository's own pre-push hook that repository is this checkout,
 			// which is a linked worktree: initializing it bare detaches all of them.
+			//
+			// The ambient *configuration* is the second half of the same hole:
+			// `GIT_CONFIG_GLOBAL` survives the local-variable scrub by design, and
+			// a `core.hooksPath` in it makes every fixture commit, checkout and
+			// push run a program this file never wrote, in a repository it does not
+			// own. So the hostile environment carries both, and the run has to come
+			// back with the hooks never fired.
+			const canary = createHookCanary();
 			const sentinel = createSentinel();
-			const sentinelBefore = repositoryFingerprint(sentinel.path);
-			const selfBefore = foreignRepositorySnapshot(repoRoot);
-			assert.equal(selfBefore.bare, "false", "the repository under test is already bare");
-
-			const saved = new Map(Object.keys(sentinel.hostile).map((key) => [key, process.env[key]] as const));
-			Object.assign(process.env, sentinel.hostile);
-
-			let fixture: Fixture | undefined;
 			try {
+				assertHookCanaryFires(canary);
+				canary.reset();
+
+				const sentinelBefore = repositoryFingerprint(sentinel.path);
+				const selfBefore = foreignRepositorySnapshot(repoRoot);
+				assert.equal(selfBefore.bare, "false", "the repository under test is already bare");
+
+				const hostile: Record<string, string> = {
+					...sentinel.hostile,
+					GIT_CONFIG_GLOBAL: canary.config,
+					GIT_CONFIG_SYSTEM: canary.config,
+				};
+				const saved = new Map(Object.keys(hostile).map((key) => [key, process.env[key]] as const));
+				Object.assign(process.env, hostile);
+
+				let fixture: Fixture | undefined;
 				try {
 					fixture = createFixture({ packages: fixturePackages, registry: missing.url });
 					const result = await runCutRelease(fixture, ["9.9.9", "--base", "main", "--yes"]);
@@ -533,7 +745,11 @@ describe("cut-release npm registration preflight", () => {
 					if (fixture) rmSync(fixture.stage, { recursive: true, force: true });
 				}
 
-				// Neither repository was initialized, committed into, or turned bare.
+				// Not one hook ran — not for a fixture git child, and not for a git
+				// child of the release script the fixture launched.
+				assert.deepEqual(canary.fired(), [], "an ambient core.hooksPath ran during the fixture run");
+				// Neither repository was initialized, committed into, turned bare,
+				// or written to in its working tree.
 				assert.deepEqual(
 					repositoryFingerprint(sentinel.path),
 					sentinelBefore,
@@ -542,6 +758,7 @@ describe("cut-release npm registration preflight", () => {
 				assert.deepEqual(foreignRepositorySnapshot(repoRoot), selfBefore, "the fixture wrote to this checkout");
 			} finally {
 				rmSync(sentinel.stage, { recursive: true, force: true });
+				rmSync(canary.stage, { recursive: true, force: true });
 			}
 		},
 		CUT_RELEASE_FIXTURE_TIMEOUT_MS,

--- a/test/integration/cut-release-npm-preflight.test.ts
+++ b/test/integration/cut-release-npm-preflight.test.ts
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, test } from "vitest";
+import { bunExecutable, spawnProcess, spawnSyncCollect } from "../helpers/runtime.js";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+/**
+ * Two package names no registry has ever seen. The fixture's `publish.yml`
+ * declares them as its publish payload, so the real script asks the real `npm`
+ * about them — the preflight runs end to end rather than against a stub.
+ */
+const fixturePackages = ["@atomic-release-preflight-fixture/one", "@atomic-release-preflight-fixture/two"] as const;
+
+/**
+ * A registry that answers 404 to everything.
+ *
+ * It replaces the public registry for these runs, which keeps the test
+ * hermetic — offline, behind a mirror, and on Windows, where a shell-script
+ * `npm` stub on PATH would not be executed at all.
+ */
+let registry: Server;
+let registryUrl: string;
+
+beforeAll(async () => {
+	registry = createServer((_request, response) => {
+		response.writeHead(404, { "content-type": "application/json" });
+		response.end('{"error":"Not found"}');
+	});
+	await new Promise<void>((resolve) => registry.listen(0, "127.0.0.1", resolve));
+	registryUrl = `http://127.0.0.1:${(registry.address() as AddressInfo).port}/`;
+});
+
+afterAll(async () => {
+	await new Promise<void>((resolve) => registry.close(() => resolve()));
+});
+
+function git(root: string, args: string[]): void {
+	const result = spawnSyncCollect(["git", "-C", root, ...args], { stdout: "pipe", stderr: "pipe" });
+	assert.equal(result.exitCode, 0, `git ${args.join(" ")}: ${result.stderr.toString()}`);
+}
+
+interface Fixture {
+	/** Removed wholesale by the test; holds the repository and npm's cache. */
+	readonly stage: string;
+	readonly root: string;
+	readonly npmCache: string;
+}
+
+/**
+ * A repository whose only content is the release script under test, its two
+ * modules, and a `publish.yml` declaring the fixture payload. `ROOT` inside
+ * `cut-release.ts` resolves to the parent of its own directory, so the copied
+ * script operates on this fixture and never on the real checkout.
+ *
+ * npm's cache lives beside the repository rather than inside it: a cache
+ * written under the working tree would leave it dirty, which is a different
+ * refusal from the one under test.
+ */
+function createFixture(): Fixture {
+	const stage = mkdtempSync(join(tmpdir(), "atomic-cut-release-preflight-"));
+	const root = join(stage, "repo");
+	mkdirSync(join(root, "scripts"), { recursive: true });
+	mkdirSync(join(root, ".github", "workflows"), { recursive: true });
+	for (const script of ["cut-release.ts", "release-base.ts", "release-npm-preflight.ts"]) {
+		copyFileSync(join(repoRoot, "scripts", script), join(root, "scripts", script));
+	}
+	writeFileSync(
+		join(root, ".github", "workflows", "publish.yml"),
+		["jobs:", "  publish-npm:", "    run: |", `      packages=(${fixturePackages.join(" ")})`, ""].join("\n"),
+	);
+	git(root, ["init", "-b", "main"]);
+	git(root, ["add", "-A"]);
+	git(root, [
+		"-c",
+		"user.name=atomic-release-test",
+		"-c",
+		"user.email=atomic-release-test@users.noreply.github.com",
+		// A developer's global `commit.gpgsign` would otherwise ask for a key.
+		"-c",
+		"commit.gpgsign=false",
+		"commit",
+		"-m",
+		"fixture",
+	]);
+	return { stage, root, npmCache: join(stage, "npm-cache") };
+}
+
+interface CutResult {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+}
+/**
+ * Spawned asynchronously on purpose: `spawnSync` would block this process's
+ * event loop, and the loopback registry npm is talking to lives in it.
+ */
+async function runCutRelease(fixture: Fixture, args: string[], registryOverride?: string): Promise<CutResult> {
+	const environment: Record<string, string | undefined> = { ...process.env };
+	// npm's own configuration variable, which the preflight resolves before it
+	// pins `--registry`. Retries are disabled so an unreachable registry fails
+	// now instead of after npm's minute-long backoff, and the proxy keys are
+	// cleared so a developer proxy cannot intercept the loopback registry.
+	environment.npm_config_registry = registryOverride ?? registryUrl;
+	environment.npm_config_cache = fixture.npmCache;
+	environment.npm_config_fetch_retries = "0";
+	environment.NO_UPDATE_NOTIFIER = "1";
+	for (const key of [
+		"npm_config_proxy",
+		"npm_config_https_proxy",
+		"http_proxy",
+		"https_proxy",
+		"HTTP_PROXY",
+		"HTTPS_PROXY",
+	]) {
+		environment[key] = undefined;
+	}
+
+	const child = spawnProcess({
+		cmd: [bunExecutable(), "run", join(fixture.root, "scripts", "cut-release.ts"), ...args],
+		cwd: fixture.root,
+		env: environment,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		child.stdout ? new Response(child.stdout).text() : Promise.resolve(""),
+		child.stderr ? new Response(child.stderr).text() : Promise.resolve(""),
+		child.exited,
+	]);
+	return { exitCode, stdout, stderr };
+}
+
+/** Everything the script could have mutated, read back after it exits. */
+function repositoryState(root: string): { tags: string; status: string; worktrees: boolean } {
+	const read = (args: string[]): string =>
+		spawnSyncCollect(["git", "-C", root, ...args], { stdout: "pipe", stderr: "pipe" })
+			.stdout.toString()
+			.trim();
+	return {
+		tags: read(["tag", "--list"]),
+		status: read(["status", "--porcelain"]),
+		worktrees: existsSync(join(root, ".git", "worktrees")),
+	};
+}
+
+/**
+ * Each case spawns Bun, two real `npm view` processes, and several `git`
+ * invocations, and lands near half a second — well inside the shared per-test
+ * budget, so no explicit timeout is declared here.
+ */
+describe("cut-release npm registration preflight", () => {
+	test("cut-release-aborts-on-unregistered-package", async () => {
+		const fixture = createFixture();
+		try {
+			const result = await runCutRelease(fixture, ["9.9.9", "--base", "main", "--yes"]);
+
+			assert.equal(result.exitCode, 1, result.stdout + result.stderr);
+			assert.match(result.stderr, /2 of 2 publish-payload packages are not registered on npm/u);
+			for (const name of fixturePackages) assert.ok(result.stderr.includes(name), `missing ${name}`);
+			assert.match(result.stderr, /Re-run with --allow-new/u);
+
+			// The abort lands before the script announces the cut, and before it
+			// prunes, adds a worktree, stamps a version, or writes a tag.
+			assert.doesNotMatch(result.stdout, /Cutting release/u);
+			assert.deepEqual(repositoryState(fixture.root), { tags: "", status: "", worktrees: false });
+		} finally {
+			rmSync(fixture.stage, { recursive: true, force: true });
+		}
+	});
+
+	test("--allow-new is required for a first publish and lets the cut proceed", async () => {
+		const fixture = createFixture();
+		try {
+			const result = await runCutRelease(fixture, ["9.9.9", "--base", "main", "--yes", "--allow-new"]);
+
+			// Past the preflight: the run now fails on the fixture's missing
+			// origin, which is the next check after the registry one.
+			assert.doesNotMatch(result.stderr, /not registered on npm/u);
+			assert.match(result.stdout, /--allow-new: first publish for 2 package\(s\)/u);
+			for (const name of fixturePackages) assert.ok(result.stdout.includes(`+ ${name}`), `missing ${name}`);
+			assert.match(result.stderr, /Base ref "refs\/heads\/main" does not exist on origin\./u);
+			assert.equal(result.exitCode, 1);
+			assert.deepEqual(repositoryState(fixture.root), { tags: "", status: "", worktrees: false });
+		} finally {
+			rmSync(fixture.stage, { recursive: true, force: true });
+		}
+	});
+
+	test("a registry that cannot answer stops the release even with --allow-new", async () => {
+		const fixture = createFixture();
+		try {
+			// Port 1 refuses the connection, so `npm view` fails without a 404 —
+			// the one answer the escape hatch deliberately does not cover.
+			const result = await runCutRelease(fixture, ["9.9.9", "--yes", "--allow-new"], "http://127.0.0.1:1/");
+
+			assert.equal(result.exitCode, 1, result.stdout);
+			assert.match(result.stderr, /npm registration could not be determined for 2 of 2/u);
+			assert.match(result.stderr, /--allow-new does not cover an unreadable registry answer/u);
+			assert.deepEqual(repositoryState(fixture.root), { tags: "", status: "", worktrees: false });
+		} finally {
+			rmSync(fixture.stage, { recursive: true, force: true });
+		}
+	});
+});

--- a/test/unit/release-npm-preflight.test.ts
+++ b/test/unit/release-npm-preflight.test.ts
@@ -1,22 +1,28 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import {
 	classifyNpmViewOutcome,
-	DEFAULT_NPM_REGISTRY,
 	describeUnregisteredPackages,
 	PUBLISH_WORKFLOW_PATH,
+	PUBLISHER_NPM_REGISTRY,
+	parsePublisherNpmRegistry,
 	parseReleasePayloadPackages,
+	parseReleasePublisher,
 	RELEASE_PAYLOAD_PACKAGE_COUNT,
-	readReleasePayloadPackages,
-	resolveNpmRegistry,
 	verifyReleasePackagesRegistered,
 } from "../../scripts/release-npm-preflight.js";
 
 const root = fileURLToPath(new URL("../..", import.meta.url));
+const publishWorkflow = readFileSync(join(root, PUBLISH_WORKFLOW_PATH), "utf8");
 
 const payload = (names: readonly string[]): string =>
 	`          packages=(${names.join(" ")})\n          for name in "\${packages[@]}"; do\n`;
+
+const publishes = (names: readonly string[], registry = PUBLISHER_NPM_REGISTRY): string =>
+	`${payload(names)}          npm publish "$file" --access public --registry ${registry}\n`;
 
 /** A probe that answers from a set, and records every name it was asked about. */
 function probeFrom(registered: Set<string>, asked: string[] = []) {
@@ -31,7 +37,7 @@ function probeFrom(registered: Set<string>, asked: string[] = []) {
 
 describe("scripts/release-npm-preflight.ts", () => {
 	test("the publish payload is read from the workflow that publishes it", () => {
-		const names = readReleasePayloadPackages(root);
+		const names = parseReleasePayloadPackages(publishWorkflow);
 		assert.equal(names.length, RELEASE_PAYLOAD_PACKAGE_COUNT);
 		assert.deepEqual(names, [
 			"@bastani/atomic-natives-darwin-arm64",
@@ -67,19 +73,36 @@ describe("scripts/release-npm-preflight.ts", () => {
 		);
 	});
 
-	test("a missing publisher names the file it could not read", () => {
-		assert.throws(
-			() => readReleasePayloadPackages(fileURLToPath(new URL("./fixtures-that-do-not-exist", import.meta.url))),
-			new RegExp(`Cannot read the release payload from .*${PUBLISH_WORKFLOW_PATH.replace(/[./]/gu, ".")}`, "u"),
+	test("the registry probed is the one the publisher pins, not a machine's npm configuration", () => {
+		// The publisher hardcodes it on both its `npm view` and `npm publish`
+		// calls; a mirror answering "yes" is not evidence the publish will work.
+		assert.equal(parsePublisherNpmRegistry(publishWorkflow), PUBLISHER_NPM_REGISTRY);
+		assert.equal(
+			parsePublisherNpmRegistry(publishes(["@bastani/atomic"], "https://npm.example.com/")),
+			"https://npm.example.com/",
 		);
+		assert.deepEqual(parseReleasePublisher(publishes(["@bastani/atomic"], "http://127.0.0.1:4873/")), {
+			packages: ["@bastani/atomic"],
+			registry: "http://127.0.0.1:4873/",
+		});
 	});
 
-	test("npm's own registry configuration is honored, and nothing else changes the default", () => {
-		assert.equal(resolveNpmRegistry({}), DEFAULT_NPM_REGISTRY);
-		assert.equal(resolveNpmRegistry({ npm_config_registry: "   " }), DEFAULT_NPM_REGISTRY);
-		assert.equal(
-			resolveNpmRegistry({ npm_config_registry: " https://npm.example.com/ " }),
-			"https://npm.example.com/",
+	test("a publisher with no, conflicting, or unusable `--registry` is refused rather than guessed at", () => {
+		assert.throws(() => parsePublisherNpmRegistry(payload(["@bastani/atomic"])), /pins no `--registry`/u);
+		assert.throws(
+			() =>
+				parsePublisherNpmRegistry(
+					`${publishes(["@bastani/atomic"])}          npm view x --registry https://mirror.example.com\n`,
+				),
+			/pins more than one `--registry`: https:\/\/registry\.npmjs\.org, https:\/\/mirror\.example\.com/u,
+		);
+		assert.throws(
+			() => parsePublisherNpmRegistry(publishes(["@bastani/atomic"], "registry.npmjs.org")),
+			/is not an absolute URL/u,
+		);
+		assert.throws(
+			() => parsePublisherNpmRegistry(publishes(["@bastani/atomic"], "file:///tmp/registry")),
+			/is not an http\(s\) registry/u,
 		);
 	});
 
@@ -114,14 +137,29 @@ describe("scripts/release-npm-preflight.ts", () => {
 				}),
 			/`npm view @bastani\/atomic` exited 1 without a 404, so its registration is unknown.*ENOTFOUND/su,
 		);
+	});
+
+	test("a killed `npm view` is never an answer, even when it printed a 404 first", async () => {
+		// A signal means the command never finished; whatever it had written is a
+		// fragment. Reading a 404 out of that fragment would let a timeout or a
+		// Ctrl-C register as "this package is new" and clear --allow-new.
+		const killed = { exitCode: null, stdout: "", stderr: "npm error code E404\n" } as const;
 		assert.throws(
-			() => classifyNpmViewOutcome("@bastani/atomic", { exitCode: null, stdout: "", stderr: "" }),
-			/exited with a signal without a 404/u,
+			() => classifyNpmViewOutcome("@bastani/atomic-new", killed),
+			/`npm view @bastani\/atomic-new` was terminated by a signal, so its registration is unknown.*E404/su,
+		);
+		await assert.rejects(
+			verifyReleasePackagesRegistered({
+				packages: ["@bastani/atomic-new"],
+				isRegistered: async (name) => classifyNpmViewOutcome(name, killed),
+				allowNew: true,
+			}),
+			/could not be determined for 1 of 1 publish-payload packages/u,
 		);
 	});
 
 	test("a fully registered payload passes and probes every package exactly once", async () => {
-		const names = readReleasePayloadPackages(root);
+		const names = parseReleasePayloadPackages(publishWorkflow);
 		const probe = probeFrom(new Set(names));
 		const result = await verifyReleasePackagesRegistered({
 			packages: names,
@@ -134,7 +172,7 @@ describe("scripts/release-npm-preflight.ts", () => {
 	});
 
 	test("an unregistered package aborts, naming every missing package and the escape", async () => {
-		const names = readReleasePayloadPackages(root);
+		const names = parseReleasePayloadPackages(publishWorkflow);
 		const registered = new Set(names);
 		registered.delete("@bastani/atomic-natives-win32-arm64-msvc");
 		registered.delete("@bastani/atomic");

--- a/test/unit/release-npm-preflight.test.ts
+++ b/test/unit/release-npm-preflight.test.ts
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import {
+	classifyNpmViewOutcome,
+	DEFAULT_NPM_REGISTRY,
+	describeUnregisteredPackages,
+	PUBLISH_WORKFLOW_PATH,
+	parseReleasePayloadPackages,
+	RELEASE_PAYLOAD_PACKAGE_COUNT,
+	readReleasePayloadPackages,
+	resolveNpmRegistry,
+	verifyReleasePackagesRegistered,
+} from "../../scripts/release-npm-preflight.js";
+
+const root = fileURLToPath(new URL("../..", import.meta.url));
+
+const payload = (names: readonly string[]): string =>
+	`          packages=(${names.join(" ")})\n          for name in "\${packages[@]}"; do\n`;
+
+/** A probe that answers from a set, and records every name it was asked about. */
+function probeFrom(registered: Set<string>, asked: string[] = []) {
+	return {
+		asked,
+		isRegistered: async (name: string): Promise<boolean> => {
+			asked.push(name);
+			return registered.has(name);
+		},
+	};
+}
+
+describe("scripts/release-npm-preflight.ts", () => {
+	test("the publish payload is read from the workflow that publishes it", () => {
+		const names = readReleasePayloadPackages(root);
+		assert.equal(names.length, RELEASE_PAYLOAD_PACKAGE_COUNT);
+		assert.deepEqual(names, [
+			"@bastani/atomic-natives-darwin-arm64",
+			"@bastani/atomic-natives-darwin-x64",
+			"@bastani/atomic-natives-linux-arm64-gnu",
+			"@bastani/atomic-natives-linux-arm64-musl",
+			"@bastani/atomic-natives-linux-x64-gnu",
+			"@bastani/atomic-natives-linux-x64-musl",
+			"@bastani/atomic-natives-win32-arm64-msvc",
+			"@bastani/atomic-natives-win32-x64-msvc",
+			"@bastani/atomic-natives",
+			"@bastani/atomic",
+		]);
+	});
+
+	test("a payload array that is missing, doubled, empty, malformed, or duplicated is refused", () => {
+		assert.throws(
+			() => parseReleasePayloadPackages("jobs:\n  publish-npm:\n"),
+			/must declare exactly one `packages=\(…\)` publish payload array; found 0/u,
+		);
+		assert.throws(
+			() => parseReleasePayloadPackages(payload(["@bastani/atomic"]) + payload(["@bastani/atomic-natives"])),
+			/found 2/u,
+		);
+		assert.throws(() => parseReleasePayloadPackages(payload([])), /empty `packages=\(…\)`/u);
+		assert.throws(
+			() => parseReleasePayloadPackages(payload(["@bastani/atomic", '"$name"'])),
+			/is not a publishable npm package name/u,
+		);
+		assert.throws(
+			() => parseReleasePayloadPackages(payload(["@bastani/atomic", "@bastani/atomic"])),
+			/duplicate publish payload packages: @bastani\/atomic/u,
+		);
+	});
+
+	test("a missing publisher names the file it could not read", () => {
+		assert.throws(
+			() => readReleasePayloadPackages(fileURLToPath(new URL("./fixtures-that-do-not-exist", import.meta.url))),
+			new RegExp(`Cannot read the release payload from .*${PUBLISH_WORKFLOW_PATH.replace(/[./]/gu, ".")}`, "u"),
+		);
+	});
+
+	test("npm's own registry configuration is honored, and nothing else changes the default", () => {
+		assert.equal(resolveNpmRegistry({}), DEFAULT_NPM_REGISTRY);
+		assert.equal(resolveNpmRegistry({ npm_config_registry: "   " }), DEFAULT_NPM_REGISTRY);
+		assert.equal(
+			resolveNpmRegistry({ npm_config_registry: " https://npm.example.com/ " }),
+			"https://npm.example.com/",
+		);
+	});
+
+	test("only exit 0 and a 404 are answers; everything else is unknown and throws", () => {
+		assert.equal(
+			classifyNpmViewOutcome("@bastani/atomic", { exitCode: 0, stdout: "@bastani/atomic\n", stderr: "" }),
+			true,
+		);
+		assert.equal(
+			classifyNpmViewOutcome("@bastani/atomic-new", {
+				exitCode: 1,
+				stdout: "",
+				stderr:
+					"npm error code E404\nnpm error 404 Not Found - GET https://registry.npmjs.org/@bastani%2fatomic-new\n",
+			}),
+			false,
+		);
+		assert.equal(
+			classifyNpmViewOutcome("@bastani/atomic-new", {
+				exitCode: 1,
+				stdout: "",
+				stderr: "npm ERR! 404 '@bastani/atomic-new@latest' is not in this registry.\n",
+			}),
+			false,
+		);
+		assert.throws(
+			() =>
+				classifyNpmViewOutcome("@bastani/atomic", {
+					exitCode: 1,
+					stdout: "",
+					stderr: "npm error code ENOTFOUND\nnpm error network request to https://registry.npmjs.org failed\n",
+				}),
+			/`npm view @bastani\/atomic` exited 1 without a 404, so its registration is unknown.*ENOTFOUND/su,
+		);
+		assert.throws(
+			() => classifyNpmViewOutcome("@bastani/atomic", { exitCode: null, stdout: "", stderr: "" }),
+			/exited with a signal without a 404/u,
+		);
+	});
+
+	test("a fully registered payload passes and probes every package exactly once", async () => {
+		const names = readReleasePayloadPackages(root);
+		const probe = probeFrom(new Set(names));
+		const result = await verifyReleasePackagesRegistered({
+			packages: names,
+			isRegistered: probe.isRegistered,
+			allowNew: false,
+		});
+		assert.deepEqual(result.unregistered, []);
+		assert.deepEqual(result.checked, names);
+		assert.deepEqual([...probe.asked].sort(), [...names].sort());
+	});
+
+	test("an unregistered package aborts, naming every missing package and the escape", async () => {
+		const names = readReleasePayloadPackages(root);
+		const registered = new Set(names);
+		registered.delete("@bastani/atomic-natives-win32-arm64-msvc");
+		registered.delete("@bastani/atomic");
+		await assert.rejects(
+			verifyReleasePackagesRegistered({
+				packages: names,
+				isRegistered: probeFrom(registered).isRegistered,
+				allowNew: false,
+			}),
+			(error: Error) => {
+				assert.match(error.message, /2 of 10 publish-payload packages are not registered on npm/u);
+				assert.match(error.message, /^ {2}- @bastani\/atomic-natives-win32-arm64-msvc$/mu);
+				assert.match(error.message, /^ {2}- @bastani\/atomic$/mu);
+				assert.match(error.message, /Re-run with --allow-new/u);
+				return true;
+			},
+		);
+	});
+
+	test("--allow-new permits a first publish and reports which names are new", async () => {
+		const result = await verifyReleasePackagesRegistered({
+			packages: ["@bastani/atomic", "@bastani/atomic-natives-new"],
+			isRegistered: probeFrom(new Set(["@bastani/atomic"])).isRegistered,
+			allowNew: true,
+		});
+		assert.deepEqual(result.unregistered, ["@bastani/atomic-natives-new"]);
+		assert.deepEqual(result.checked, ["@bastani/atomic", "@bastani/atomic-natives-new"]);
+	});
+
+	test("--allow-new does not cover a probe that could not answer", async () => {
+		await assert.rejects(
+			verifyReleasePackagesRegistered({
+				packages: ["@bastani/atomic", "@bastani/atomic-natives"],
+				isRegistered: async (name) => {
+					if (name === "@bastani/atomic-natives") throw new Error("registry unreachable");
+					return true;
+				},
+				allowNew: true,
+			}),
+			(error: Error) => {
+				assert.match(error.message, /could not be determined for 1 of 2 publish-payload packages/u);
+				assert.match(error.message, /@bastani\/atomic-natives: registry unreachable/u);
+				assert.match(error.message, /--allow-new does not cover an unreadable registry answer/u);
+				return true;
+			},
+		);
+	});
+
+	test("an empty payload is refused rather than vacuously passing", async () => {
+		await assert.rejects(
+			verifyReleasePackagesRegistered({ packages: [], isRegistered: async () => true, allowNew: true }),
+			/requires at least one package name/u,
+		);
+	});
+
+	test("one missing package reads as singular", () => {
+		assert.match(describeUnregisteredPackages(["@bastani/atomic"], 10), /1 of 10 publish-payload packages is not/u);
+	});
+});


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789360895&installation_model_id=10562&pr_number=2410&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2410&signature=e4cb98fd7ed30db2104791ccfcb6428fc5b18b8c5eb4a7f758e3f8aa9a2edcb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an npm registration preflight before release mutations begin, including support for intentionally publishing new packages and coverage for registry outcomes. The new preflight test suites import filesystem APIs directly rather than using the repository’s shared runtime compatibility layer; update those tests to use the prescribed helper before merging.

<h3>Confidence Score: 4/5</h3>

Not merge-safe until the root test suites comply with the required runtime-helper convention.

There is one non-security P2 repository-rule finding. Under the scoring policy, P2-only findings result in a score of 4.

**Files Needing Attention:** `test/integration/cut-release-npm-preflight.test.ts` and `test/unit/release-npm-preflight.test.ts` should route filesystem behavior through `test/helpers/runtime.ts`.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
test/integration/cut-release-npm-preflight.test.ts:2-15
**Root tests bypass runtime helpers**

The new root tests import `node:fs` directly instead of using `test/helpers/runtime.ts`, bypassing the repository's prescribed compatibility layer and duplicating filesystem behavior that must remain consistent across test runtimes. The same pattern also occurs in `test/unit/release-npm-preflight.test.ts`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(release): close the fixture&#39;s ambie..."](https://github.com/bastani-inc/atomic/commit/a080cc87df656a9ed564b3dc0abcb9a6815cc7e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53723694)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->