### PR TITLE
pi 0.84.2/core fixes

### DIFF
--- a/packages/coding-agent/src/core/agent-session-custom-message-commit.ts
+++ b/packages/coding-agent/src/core/agent-session-custom-message-commit.ts
@@ -52,7 +52,7 @@ export async function commitAdmittedCustomMessage<T>(
 		);
 	} else if (self.isStreaming && options?.persistWhenStreaming === true) {
 		self._appendCustomMessage(appMessage);
-	} else if (self.isStreaming) {
+	} else if (self.isStreaming && options?.triggerTurn !== false) {
 		self._queueAgentMessage(appMessage, options?.deliverAs === "followUp" ? "followUp" : "steer");
 	} else if (options?.triggerTurn) {
 		const promptMessage = useProtectedReconciliation
@@ -129,7 +129,7 @@ export async function commitAdmittedCustomMessages<T>(
 		await queueProtectedStreamingCustomMessages(self, appMessages, delivery);
 	} else if (self.isStreaming && options?.persistWhenStreaming === true) {
 		for (const item of appMessages) self._appendCustomMessage(item);
-	} else if (self.isStreaming) {
+	} else if (self.isStreaming && options?.triggerTurn !== false) {
 		for (const item of appMessages) self._queueAgentMessage(item, delivery);
 	} else if (options?.triggerTurn) {
 		if (useProtectedReconciliation) {

--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -640,6 +640,17 @@ export class ModelRuntime implements Models {
 		await this.refreshRemainingAuthAfterLogout(providerId, logoutGeneration);
 	}
 
+	/**
+	 * The network policy a refresh with an omitted `allowNetwork` resolves to.
+	 *
+	 * Callers that share one in-flight refresh key on the effective policy, so
+	 * they need the same answer `runRefresh` computes rather than a second guess
+	 * at the offline setting this runtime was created under.
+	 */
+	isNetworkRefreshEnabled(): boolean {
+		return this.modelNetworkEnabled;
+	}
+
 	async refresh(options: ModelsRefreshOptions = {}): Promise<ModelsRefreshResult> {
 		return this.runRefresh(options, ++this.refreshSequence);
 	}
@@ -668,7 +679,7 @@ export class ModelRuntime implements Models {
 			for (const providerId of new Set(options.providers)) this.recomposeProvider(providerId);
 			this.updateModelSnapshot();
 		} else this.rebuildProviders();
-		const refreshOptions = { ...options, allowNetwork: options.allowNetwork ?? this.modelNetworkEnabled };
+		const refreshOptions = { ...options, allowNetwork: options.allowNetwork ?? this.isNetworkRefreshEnabled() };
 		const result = await this.models.refresh(refreshOptions);
 		const errors = new Map(result.errors);
 		this.updateModelSnapshot();

--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import {
 	type Api,
@@ -28,6 +30,7 @@ import {
 import * as builtinProviderCatalog from "@earendil-works/pi-ai/providers/all";
 import { getAgentDir } from "../config.ts";
 import { operationSignal, raceWithAbortSignal } from "../utils/abort.ts";
+import { normalizePath } from "../utils/paths.ts";
 import { AuthStorage as DefaultAuthStorage } from "./auth-storage.ts";
 import { ModelConfig } from "./model-config.ts";
 import { POST_LOGOUT_AUTH_CHECK_TIMEOUT_MS } from "./model-refresh-timeout.ts";
@@ -677,6 +680,37 @@ export class ModelRuntime implements Models {
 	 */
 	isNetworkRefreshEnabled(): boolean {
 		return this.modelNetworkEnabled;
+	}
+
+	/**
+	 * Identity of the models.json content the next refresh would load.
+	 *
+	 * Every refresh reloads models.json and applies it, so a pass that started
+	 * before that file changed answers for provider `apiKey`s and model
+	 * definitions that no longer exist. Callers that share one in-flight pass
+	 * read this to tell a pass that predates an edit from one that can answer
+	 * for the current file, which is what keeps hot reload honest when a shared
+	 * refresh is already running.
+	 *
+	 * The token is the file's content hash, read synchronously so the answer
+	 * belongs to the same tick as the decision to share. An mtime is not enough:
+	 * a same-size rewrite inside one filesystem timestamp tick — an edited key or
+	 * a renamed model — is exactly the change a shared pass must not hide, and
+	 * models.json is a small user-authored file that `runRefresh` reads in full
+	 * on every pass anyway.
+	 */
+	getModelConfigFingerprint(): string {
+		if (!this.modelsPath) return "none";
+		try {
+			return createHash("sha1")
+				.update(readFileSync(normalizePath(this.modelsPath)))
+				.digest("hex");
+		} catch (error) {
+			const code = (error as NodeJS.ErrnoException).code;
+			// An absent file is a stable state a refresh can share; any other read
+			// failure keys on its own code rather than pretending the file is empty.
+			return code === "ENOENT" ? "absent" : `unreadable:${code ?? "unknown"}`;
+		}
 	}
 
 	async refresh(options: ModelsRefreshOptions = {}): Promise<ModelsRefreshResult> {

--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -27,6 +27,7 @@ import {
 } from "@earendil-works/pi-ai";
 import * as builtinProviderCatalog from "@earendil-works/pi-ai/providers/all";
 import { getAgentDir } from "../config.ts";
+import { operationSignal, raceWithAbortSignal } from "../utils/abort.ts";
 import { AuthStorage as DefaultAuthStorage } from "./auth-storage.ts";
 import { ModelConfig } from "./model-config.ts";
 import { POST_LOGOUT_AUTH_CHECK_TIMEOUT_MS } from "./model-refresh-timeout.ts";
@@ -101,20 +102,6 @@ export class CredentialSynchronizationError extends Error {
 			configurable: true,
 		});
 	}
-}
-
-function operationSignal(signal: AbortSignal | undefined): AbortSignal {
-	return signal ?? new AbortController().signal;
-}
-
-function raceWithAbortSignal<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
-	if (signal.aborted)
-		return Promise.reject(signal.reason ?? new DOMException("The operation was aborted", "AbortError"));
-	return new Promise<T>((resolve, reject) => {
-		const onAbort = () => reject(signal.reason ?? new DOMException("The operation was aborted", "AbortError"));
-		signal.addEventListener("abort", onAbort, { once: true });
-		promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", onAbort));
-	});
 }
 
 /** Configured pi-ai Models collection used by coding-agent and SDK consumers. */

--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -119,6 +119,7 @@ export class ModelRuntime implements Models {
 	private config: ModelConfig;
 	private snapshot: ModelRuntimeSnapshot = createEmptyModelRuntimeSnapshot();
 	private snapshotGeneration = 0;
+	private credentialGeneration = 0;
 	private readonly externalProviderAuthStatuses = new Map<string, AuthStatus>();
 	private availabilityRefreshSeq = 0;
 	private availabilityErrorSeq = 0;
@@ -421,9 +422,30 @@ export class ModelRuntime implements Models {
 			overrides,
 		);
 	}
+	/**
+	 * Count of credential mutations this runtime has applied.
+	 *
+	 * A catalog refresh resolves credentials as it runs, so its result belongs to
+	 * the credential state it started under. Callers that share one in-flight pass
+	 * read this to tell a pass that predates a login, logout, or key change from
+	 * one that can answer for the current credentials.
+	 */
+	getCredentialGeneration(): number {
+		return this.credentialGeneration;
+	}
+
+	/**
+	 * Record that stored, runtime, or external credentials changed. Every catalog
+	 * pass started before this call answers for credentials that no longer exist.
+	 */
+	private markCredentialsChanged(): void {
+		this.credentialGeneration += 1;
+	}
+
 	/** Reload credentials changed by the authoritative isolated engine and update auth status snapshots. */
 	async reloadCredentials(options: { refreshAvailability?: boolean } = {}): Promise<void> {
 		await this.credentials.reload();
+		this.markCredentialsChanged();
 		if (options.refreshAvailability === false) {
 			const credentials = await this.credentials.list();
 			for (const credential of credentials) this.externalProviderAuthStatuses.delete(credential.providerId);
@@ -505,6 +527,7 @@ export class ModelRuntime implements Models {
 		const signal = operationSignal(undefined);
 		await this.enqueueCredentialOperation(providerId, signal, async () => {
 			await this.credentials.modify(providerId, async () => credential);
+			this.markCredentialsChanged();
 			await this.synchronizeCredentialState(providerId, "saveCredential", credential, async () => {
 				const result = await this.refresh({ providers: [providerId] });
 				this.assertCredentialRefreshSucceeded(providerId, result);
@@ -521,6 +544,7 @@ export class ModelRuntime implements Models {
 		const signal = operationSignal(options.signal);
 		await this.enqueueCredentialOperation(providerId, signal, async () => {
 			this.credentials.setRuntimeApiKey(providerId, apiKey);
+			this.markCredentialsChanged();
 			await this.synchronizeCredentialState(providerId, "setRuntimeApiKey", { type: "api_key", key: apiKey }, () => {
 				this.snapshot = addRuntimeApiKeyProvider(this.snapshot, providerId);
 			});
@@ -531,6 +555,7 @@ export class ModelRuntime implements Models {
 		const signal = operationSignal(options.signal);
 		await this.enqueueCredentialOperation(providerId, signal, async () => {
 			this.credentials.removeRuntimeApiKey(providerId);
+			this.markCredentialsChanged();
 			await this.synchronizeCredentialState(providerId, "removeRuntimeApiKey", undefined, async () => {
 				const result = await this.refresh({ allowNetwork: this.modelNetworkEnabled, signal });
 				this.assertCredentialRefreshSucceeded(providerId, result, signal);
@@ -559,6 +584,7 @@ export class ModelRuntime implements Models {
 
 	/** Apply authoritative auth state returned by an isolated engine mutation. */
 	applyExternalProviderAuthStatus(providerId: string, status: AuthStatus): void {
+		this.markCredentialsChanged();
 		this.snapshotGeneration += 1;
 		const remainingAuth =
 			status.configured && status.source === "environment"
@@ -608,6 +634,7 @@ export class ModelRuntime implements Models {
 		const signal = operationSignal(interaction.signal);
 		return this.enqueueCredentialOperation(providerId, signal, async () => {
 			const credential = await this.models.login(providerId, type, { ...interaction, signal });
+			this.markCredentialsChanged();
 			await this.synchronizeCredentialState(providerId, "login", credential, () => {
 				// Credential acquisition and persistence are the login transaction. Publish
 				// the provider against the current snapshot immediately; catalog restoration,
@@ -625,6 +652,7 @@ export class ModelRuntime implements Models {
 		const signal = operationSignal(options.signal);
 		const logoutGeneration = await this.enqueueCredentialOperation(providerId, signal, async () => {
 			await this.models.logout(providerId, { signal });
+			this.markCredentialsChanged();
 			let generation = 0;
 			await this.synchronizeCredentialState(providerId, "logout", undefined, () => {
 				// Reset credential-dependent compatibility projections, then publish the

--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -122,7 +122,8 @@ export class ModelRuntime implements Models {
 	private config: ModelConfig;
 	private snapshot: ModelRuntimeSnapshot = createEmptyModelRuntimeSnapshot();
 	private snapshotGeneration = 0;
-	private credentialGeneration = 0;
+	private catalogInputsGeneration = 0;
+	private observedModelsFileToken: string | undefined;
 	private readonly externalProviderAuthStatuses = new Map<string, AuthStatus>();
 	private availabilityRefreshSeq = 0;
 	private availabilityErrorSeq = 0;
@@ -426,29 +427,77 @@ export class ModelRuntime implements Models {
 		);
 	}
 	/**
-	 * Count of credential mutations this runtime has applied.
+	 * Monotonic count of changes to any input a catalog refresh reads.
 	 *
-	 * A catalog refresh resolves credentials as it runs, so its result belongs to
-	 * the credential state it started under. Callers that share one in-flight pass
-	 * read this to tell a pass that predates a login, logout, or key change from
-	 * one that can answer for the current credentials.
+	 * `refresh()` reloads models.json, recomposes every provider from it, the
+	 * extension registrations, and the builtin catalog, resolves credentials as
+	 * it runs, and publishes ONE snapshot at the end. So a pass belongs to the
+	 * inputs it started under, and joining a pass across a bump is unsound in
+	 * both directions: the joiner reads models and credentials the user has
+	 * already replaced, and the pass's late publish overwrites the newer state
+	 * with them.
+	 *
+	 * Every mutation source bumps this counter, which is why callers need only
+	 * this one number rather than a growing tuple of per-input keys:
+	 *
+	 * - credential writes — `login`, `logout`, `saveCredential`,
+	 *   `setRuntimeApiKey`, `removeRuntimeApiKey`, an external
+	 *   `reloadCredentials`, and an applied external auth status;
+	 * - provider registrations — `registerProvider`, `registerNativeProvider`,
+	 *   and `unregisterProvider`, through the refresh they schedule;
+	 * - models.json content — provider `baseUrl`, `apiKey`, `api`, headers,
+	 *   model definitions, and overrides, which every pass reloads.
+	 *
+	 * The first two are this runtime's own writes and bump where they happen.
+	 * The third is an external edit nothing here observes, so reading the
+	 * generation samples the file and bumps when its content moved since the
+	 * last sample. That read is synchronous so the answer belongs to the same
+	 * tick as the decision that depends on it, and it hashes content rather
+	 * than trusting an mtime: a same-size rewrite inside one filesystem
+	 * timestamp tick — an edited key, a renamed model — is exactly the change a
+	 * shared pass must not hide.
 	 */
-	getCredentialGeneration(): number {
-		return this.credentialGeneration;
+	getCatalogInputsGeneration(): number {
+		this.observeModelsFile();
+		return this.catalogInputsGeneration;
 	}
 
 	/**
-	 * Record that stored, runtime, or external credentials changed. Every catalog
-	 * pass started before this call answers for credentials that no longer exist.
+	 * Record that an input a catalog refresh reads changed. Every pass started
+	 * before this call answers for inputs that no longer exist.
 	 */
-	private markCredentialsChanged(): void {
-		this.credentialGeneration += 1;
+	private markCatalogInputsChanged(): void {
+		this.catalogInputsGeneration += 1;
+	}
+
+	/** Bump the generation when models.json changed since the last observation. */
+	private observeModelsFile(): void {
+		const token = this.readModelsFileToken();
+		if (this.observedModelsFileToken === token) return;
+		const first = this.observedModelsFileToken === undefined;
+		this.observedModelsFileToken = token;
+		// The first observation is a baseline, not a change: no pass can predate it.
+		if (!first) this.markCatalogInputsChanged();
+	}
+
+	private readModelsFileToken(): string {
+		if (!this.modelsPath) return "none";
+		try {
+			return createHash("sha1")
+				.update(readFileSync(normalizePath(this.modelsPath)))
+				.digest("hex");
+		} catch (error) {
+			const code = (error as NodeJS.ErrnoException).code;
+			// An absent file is a stable state passes can share; any other read
+			// failure keys on its own code rather than pretending the file is empty.
+			return code === "ENOENT" ? "absent" : `unreadable:${code ?? "unknown"}`;
+		}
 	}
 
 	/** Reload credentials changed by the authoritative isolated engine and update auth status snapshots. */
 	async reloadCredentials(options: { refreshAvailability?: boolean } = {}): Promise<void> {
 		await this.credentials.reload();
-		this.markCredentialsChanged();
+		this.markCatalogInputsChanged();
 		if (options.refreshAvailability === false) {
 			const credentials = await this.credentials.list();
 			for (const credential of credentials) this.externalProviderAuthStatuses.delete(credential.providerId);
@@ -530,7 +579,7 @@ export class ModelRuntime implements Models {
 		const signal = operationSignal(undefined);
 		await this.enqueueCredentialOperation(providerId, signal, async () => {
 			await this.credentials.modify(providerId, async () => credential);
-			this.markCredentialsChanged();
+			this.markCatalogInputsChanged();
 			await this.synchronizeCredentialState(providerId, "saveCredential", credential, async () => {
 				const result = await this.refresh({ providers: [providerId] });
 				this.assertCredentialRefreshSucceeded(providerId, result);
@@ -547,7 +596,7 @@ export class ModelRuntime implements Models {
 		const signal = operationSignal(options.signal);
 		await this.enqueueCredentialOperation(providerId, signal, async () => {
 			this.credentials.setRuntimeApiKey(providerId, apiKey);
-			this.markCredentialsChanged();
+			this.markCatalogInputsChanged();
 			await this.synchronizeCredentialState(providerId, "setRuntimeApiKey", { type: "api_key", key: apiKey }, () => {
 				this.snapshot = addRuntimeApiKeyProvider(this.snapshot, providerId);
 			});
@@ -558,7 +607,7 @@ export class ModelRuntime implements Models {
 		const signal = operationSignal(options.signal);
 		await this.enqueueCredentialOperation(providerId, signal, async () => {
 			this.credentials.removeRuntimeApiKey(providerId);
-			this.markCredentialsChanged();
+			this.markCatalogInputsChanged();
 			await this.synchronizeCredentialState(providerId, "removeRuntimeApiKey", undefined, async () => {
 				const result = await this.refresh({ allowNetwork: this.modelNetworkEnabled, signal });
 				this.assertCredentialRefreshSucceeded(providerId, result, signal);
@@ -587,7 +636,7 @@ export class ModelRuntime implements Models {
 
 	/** Apply authoritative auth state returned by an isolated engine mutation. */
 	applyExternalProviderAuthStatus(providerId: string, status: AuthStatus): void {
-		this.markCredentialsChanged();
+		this.markCatalogInputsChanged();
 		this.snapshotGeneration += 1;
 		const remainingAuth =
 			status.configured && status.source === "environment"
@@ -637,7 +686,7 @@ export class ModelRuntime implements Models {
 		const signal = operationSignal(interaction.signal);
 		return this.enqueueCredentialOperation(providerId, signal, async () => {
 			const credential = await this.models.login(providerId, type, { ...interaction, signal });
-			this.markCredentialsChanged();
+			this.markCatalogInputsChanged();
 			await this.synchronizeCredentialState(providerId, "login", credential, () => {
 				// Credential acquisition and persistence are the login transaction. Publish
 				// the provider against the current snapshot immediately; catalog restoration,
@@ -655,7 +704,7 @@ export class ModelRuntime implements Models {
 		const signal = operationSignal(options.signal);
 		const logoutGeneration = await this.enqueueCredentialOperation(providerId, signal, async () => {
 			await this.models.logout(providerId, { signal });
-			this.markCredentialsChanged();
+			this.markCatalogInputsChanged();
 			let generation = 0;
 			await this.synchronizeCredentialState(providerId, "logout", undefined, () => {
 				// Reset credential-dependent compatibility projections, then publish the
@@ -681,38 +730,6 @@ export class ModelRuntime implements Models {
 	isNetworkRefreshEnabled(): boolean {
 		return this.modelNetworkEnabled;
 	}
-
-	/**
-	 * Identity of the models.json content the next refresh would load.
-	 *
-	 * Every refresh reloads models.json and applies it, so a pass that started
-	 * before that file changed answers for provider `apiKey`s and model
-	 * definitions that no longer exist. Callers that share one in-flight pass
-	 * read this to tell a pass that predates an edit from one that can answer
-	 * for the current file, which is what keeps hot reload honest when a shared
-	 * refresh is already running.
-	 *
-	 * The token is the file's content hash, read synchronously so the answer
-	 * belongs to the same tick as the decision to share. An mtime is not enough:
-	 * a same-size rewrite inside one filesystem timestamp tick — an edited key or
-	 * a renamed model — is exactly the change a shared pass must not hide, and
-	 * models.json is a small user-authored file that `runRefresh` reads in full
-	 * on every pass anyway.
-	 */
-	getModelConfigFingerprint(): string {
-		if (!this.modelsPath) return "none";
-		try {
-			return createHash("sha1")
-				.update(readFileSync(normalizePath(this.modelsPath)))
-				.digest("hex");
-		} catch (error) {
-			const code = (error as NodeJS.ErrnoException).code;
-			// An absent file is a stable state a refresh can share; any other read
-			// failure keys on its own code rather than pretending the file is empty.
-			return code === "ENOENT" ? "absent" : `unreadable:${code ?? "unknown"}`;
-		}
-	}
-
 	async refresh(options: ModelsRefreshOptions = {}): Promise<ModelsRefreshResult> {
 		return this.runRefresh(options, ++this.refreshSequence);
 	}
@@ -720,8 +737,13 @@ export class ModelRuntime implements Models {
 	/**
 	 * A registration's offline catalog pass must not publish after a newer refresh
 	 * that resolves configured credentials.
+	 *
+	 * The registration is also a catalog-input change: it adds, replaces, or drops
+	 * a provider every later pass composes from, so no pass that predates it can
+	 * answer for the provider set a caller now sees.
 	 */
 	private scheduleRegistrationRefresh(): void {
+		this.markCatalogInputsChanged();
 		const sequence = ++this.refreshSequence;
 		void this.runRefresh({ allowNetwork: false }, sequence, true);
 	}

--- a/packages/coding-agent/src/core/project-trust.ts
+++ b/packages/coding-agent/src/core/project-trust.ts
@@ -26,6 +26,19 @@ function formatProjectTrustPrompt(cwd: string): string {
 	return `Trust project folder?\n${cwd}\n\nThis allows ${APP_TITLE} to load ${CONFIG_DIR_NAME} settings and resources, install missing project packages, and execute project extensions.`;
 }
 
+/**
+ * The prompt shown for a `-e` extension source outside the project.
+ *
+ * Named through `APP_TITLE` for the same reason as the project-folder prompt
+ * above: branding is configurable, so a hardcoded product name lies in a
+ * rebranded distribution. The `.atomic/.pi` directory names stay literal —
+ * they are the two compatibility paths the resource loader reads from that
+ * source, not a product name.
+ */
+export function formatBorrowedExtensionSourceTrustPrompt(source: string): string {
+	return `Trust extension source?\n${source}\n\nThis allows ${APP_TITLE} to load project-local .atomic/.pi resources and .agents/skills from this -e source, including extensions and workflows that can execute code.`;
+}
+
 async function selectProjectTrustOption(
 	cwd: string,
 	ctx: ProjectTrustContext,

--- a/packages/coding-agent/src/core/session-manager-core.ts
+++ b/packages/coding-agent/src/core/session-manager-core.ts
@@ -1,6 +1,7 @@
 import type { ImageContent, Message, TextContent, Usage } from "@earendil-works/pi-ai/compat";
 import { existsSync, statSync } from "fs";
 import { resolve } from "path";
+import { APP_TITLE } from "../config.ts";
 import { normalizePath, resolvePath } from "../utils/paths.ts";
 import type { VerbatimCompactionDetails } from "./compaction/compaction-types.js";
 import type { BashExecutionMessage, CustomMessage } from "./messages.ts";
@@ -93,11 +94,11 @@ export class SessionManager {
 		if (existsSync(this.sessionFile)) {
 			this.fileEntries = preloadedFileEntries ?? loadEntriesFromFile(this.sessionFile);
 
-			// If file was empty, initialize it with a valid session header. If it was non-empty but did not parse as an Atomic session, fail without modifying it.
+			// If file was empty, initialize it with a valid session header. If it was non-empty but did not parse as a session, fail without modifying it.
 			if (this.fileEntries.length === 0) {
 				const explicitPath = this.sessionFile;
 				if (statSync(explicitPath).size > 0) {
-					throw new Error(`Session file is not a valid Atomic session: ${explicitPath}`);
+					throw new Error(`Session file is not a valid ${APP_TITLE} session: ${explicitPath}`);
 				}
 				this.newSession();
 				this.sessionFile = explicitPath;

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -109,7 +109,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
 		prompt += `\nModel name (used for commit attribution): ${modelName}`;
 		prompt += `\nModel reasoning level: ${modelReasoningLevel}`;
 		prompt += `\nCurrent date: ${date}`;
-		prompt += `\nCurrent working directory: ${promptCwd}`;
+		prompt += `\nCurrent working directory: ${promptCwd}\n`;
 
 		return prompt;
 	}
@@ -213,7 +213,7 @@ Atomic documentation (read only when the user asks about customizing Atomic itse
 	prompt += `\nModel name (used for commit attribution): ${modelName}`;
 	prompt += `\nModel reasoning level: ${modelReasoningLevel}`;
 	prompt += `\nCurrent date: ${date}`;
-	prompt += `\nCurrent working directory: ${promptCwd}`;
+	prompt += `\nCurrent working directory: ${promptCwd}\n`;
 
 	return prompt;
 }

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -52,7 +52,7 @@ import { INTERACTIVE_MODEL_REFRESH_TIMEOUT_MS } from "./core/model-refresh-timeo
 import { resolveModelScope, resolveModelScopeWithDiagnostics } from "./core/model-resolver.ts";
 import { ModelRuntime } from "./core/model-runtime.ts";
 import { flushRawStdout, restoreStdout, takeOverStdout, writeRawStdout } from "./core/output-guard.ts";
-import { resolveProjectTrusted } from "./core/project-trust.ts";
+import { formatBorrowedExtensionSourceTrustPrompt, resolveProjectTrusted } from "./core/project-trust.ts";
 import { getMissingSessionCwdIssue, MissingSessionCwdError } from "./core/session-cwd.ts";
 import { SessionManager } from "./core/session-manager.ts";
 import { SettingsManager } from "./core/settings-manager.ts";
@@ -532,7 +532,7 @@ export async function main(argv: string[], options?: MainOptions) {
 									defaultProjectTrust: runtimeSettingsManager.getDefaultProjectTrust(),
 									extensionsResult,
 									projectTrustContext: getProjectTrustContext(),
-									promptMessage: `Trust extension source?\n${source}\n\nThis allows Atomic to load project-local .atomic/.pi resources and .agents/skills from this -e source, including extensions and workflows that can execute code.`,
+									promptMessage: formatBorrowedExtensionSourceTrustPrompt(source),
 									onExtensionError: (message) => console.error(chalk.yellow(`Warning: ${message}`)),
 								});
 								borrowedExtensionSourceTrustByPath.set(source, trusted);

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -12,6 +12,7 @@ import {
 import { boundedInteractiveModelRefresh } from "../../../core/bounded-model-refresh.ts";
 import type { ModelRuntime } from "../../../core/model-runtime.ts";
 import type { SettingsManager } from "../../../core/settings-manager.ts";
+import { refreshModelCatalogs } from "../model-catalog-refresh.ts";
 import { getModelSelectorSearchText } from "../model-search.ts";
 import { theme } from "../theme/theme.ts";
 import { DynamicBorder } from "./dynamic-border.ts";
@@ -161,7 +162,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 
 	private async refreshModels(): Promise<void> {
 		const outcome = await boundedInteractiveModelRefresh(
-			(options) => this.modelRuntime.refresh(options),
+			(options) => refreshModelCatalogs(this.modelRuntime, options),
 			{},
 			this.refreshAbortController.signal,
 		);

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -6,6 +6,10 @@ import { createAllToolDefinitions, type ToolName } from "../../../core/tools/ind
 import { getTextOutput as getRenderedTextOutput } from "../../../core/tools/render-utils.ts";
 import { convertToPng } from "../../../utils/image-convert.ts";
 import { theme } from "../theme/theme.ts";
+import { parenthesizedKeyHint } from "./keybinding-hints.ts";
+
+/** Extension tools without a renderer show this many output lines before collapsing. */
+const FALLBACK_PREVIEW_LINES = 10;
 
 export interface ToolExecutionOptions {
 	showImages?: boolean;
@@ -156,7 +160,16 @@ export class ToolExecutionComponent extends Container {
 		if (!output) {
 			return undefined;
 		}
-		return new Text(theme.fg("toolOutput", output), 0, 0);
+
+		const lines = output.split("\n");
+		const displayLines = this.expanded ? lines : lines.slice(0, FALLBACK_PREVIEW_LINES);
+		const remaining = lines.length - displayLines.length;
+		let text = displayLines.map((line) => theme.fg("toolOutput", line)).join("\n");
+		if (remaining > 0) {
+			text +=
+				theme.fg("muted", "\n... ") + parenthesizedKeyHint("app.tools.expand", "Expand", `${remaining} more lines`);
+		}
+		return new Text(text, 0, 0);
 	}
 
 	updateArgs(args: unknown): void {

--- a/packages/coding-agent/src/modes/interactive/interactive-model-catalog-startup.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-model-catalog-startup.ts
@@ -1,4 +1,5 @@
 import type { InteractiveModeBase } from "./interactive-mode-base.ts";
+import { refreshModelCatalogs } from "./model-catalog-refresh.ts";
 
 /** Update the footer from the current catalog without initiating network work. */
 export function updateProviderCountFromSnapshot(mode: InteractiveModeBase): void {
@@ -14,11 +15,15 @@ export function updateProviderCountFromSnapshot(mode: InteractiveModeBase): void
  *
  * Mirrors upstream pi's post-startup behavior: the registry refresh runs
  * unconditionally so users get an automatic network model-catalog refresh
- * (the caller already gates on offline mode).
+ * (the caller already gates on offline mode). It joins the shared coordinator
+ * so a model selector opened during startup reuses this pass instead of
+ * starting a second one.
  */
 export function refreshCatalogsAfterTuiStartup(mode: InteractiveModeBase): Promise<void> {
-	return mode.session.modelRuntime
-		.refresh({ allowNetwork: true })
+	return refreshModelCatalogs(mode.session.modelRuntime, {
+		allowNetwork: true,
+		signal: new AbortController().signal,
+	})
 		.catch(() => {})
 		.then(() => updateProviderCountFromSnapshot(mode))
 		.catch(() => {});

--- a/packages/coding-agent/src/modes/interactive/interactive-model-catalog-startup.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-model-catalog-startup.ts
@@ -1,3 +1,4 @@
+import { boundedInteractiveModelRefresh } from "../../core/bounded-model-refresh.ts";
 import type { InteractiveModeBase } from "./interactive-mode-base.ts";
 import { refreshModelCatalogs } from "./model-catalog-refresh.ts";
 
@@ -18,11 +19,15 @@ export function updateProviderCountFromSnapshot(mode: InteractiveModeBase): void
  * (the caller already gates on offline mode). It joins the shared coordinator
  * so a model selector opened during startup reuses this pass instead of
  * starting a second one.
+ *
+ * The join is bounded by the same deadline every other interactive refresh
+ * uses. An unbounded startup waiter would hold the shared entry open for the
+ * lifetime of a stalled pass, so a selector that timed out and reopened would
+ * rejoin the stall instead of starting a fresh refresh.
  */
 export function refreshCatalogsAfterTuiStartup(mode: InteractiveModeBase): Promise<void> {
-	return refreshModelCatalogs(mode.session.modelRuntime, {
+	return boundedInteractiveModelRefresh((options) => refreshModelCatalogs(mode.session.modelRuntime, options), {
 		allowNetwork: true,
-		signal: new AbortController().signal,
 	})
 		.catch(() => {})
 		.then(() => updateProviderCountFromSnapshot(mode))

--- a/packages/coding-agent/src/modes/interactive/interactive-model-routing.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-model-routing.ts
@@ -11,6 +11,7 @@ import {
 	UserMessageSelectorComponent,
 } from "./interactive-mode-deps.ts";
 import { ANTHROPIC_SUBSCRIPTION_AUTH_WARNING, isAnthropicSubscriptionAuthKey } from "./interactive-mode-helpers.ts";
+import { refreshModelCatalogs } from "./model-catalog-refresh.ts";
 
 InteractiveModeBase.prototype.handleModelCommand = async function (
 	this: InteractiveModeBase,
@@ -69,9 +70,10 @@ InteractiveModeBase.prototype.getModelCandidates = async function (this: Interac
 	}
 
 	const allowNetwork = !isOfflineModeEnabled();
-	await boundedInteractiveModelRefresh((refreshOptions) => this.session.modelRuntime.refresh(refreshOptions), {
-		allowNetwork,
-	});
+	await boundedInteractiveModelRefresh(
+		(refreshOptions) => refreshModelCatalogs(this.session.modelRuntime, refreshOptions),
+		{ allowNetwork },
+	);
 	try {
 		return [...this.session.modelRuntime.getAvailableSnapshot()];
 	} catch {
@@ -232,7 +234,7 @@ InteractiveModeBase.prototype.showModelsSelector = function (this: InteractiveMo
 			},
 		);
 		void boundedInteractiveModelRefresh(
-			(options) => this.session.modelRuntime.refresh(options),
+			(options) => refreshModelCatalogs(this.session.modelRuntime, options),
 			{ allowNetwork: !isOfflineModeEnabled() },
 			refreshAbortController.signal,
 		)

--- a/packages/coding-agent/src/modes/interactive/model-catalog-refresh.ts
+++ b/packages/coding-agent/src/modes/interactive/model-catalog-refresh.ts
@@ -2,7 +2,7 @@ import type { ModelsRefreshOptions, ModelsRefreshResult } from "@earendil-works/
 import type { ModelRuntime } from "../../core/model-runtime.ts";
 import { raceWithAbortSignal } from "../../utils/abort.ts";
 
-type ModelCatalogRuntime = Pick<ModelRuntime, "refresh">;
+type ModelCatalogRuntime = Pick<ModelRuntime, "refresh" | "isNetworkRefreshEnabled">;
 
 /**
  * The whole-catalog options interactive refreshes vary. `providers` and `force`
@@ -23,12 +23,14 @@ interface ActiveModelCatalogRefresh {
 }
 
 /**
- * `allowNetwork: undefined` resolves to the runtime's own network policy, which
- * is not the same request as an explicit `true` or `false`, so it keys apart.
+ * Key on the policy the runtime will actually apply, not on how the caller spelled
+ * it. Startup asks for `allowNetwork: true` while the `/model` selector omits the
+ * option and lets the runtime decide; on an online runtime those are one pass, and
+ * keying the spelling started two. An explicit value that disagrees with the
+ * runtime's own policy is still different work and still keys apart.
  */
-function refreshKey(options: ModelCatalogRefreshOptions): string {
-	if (options.allowNetwork === undefined) return "runtime-default";
-	return options.allowNetwork ? "network" : "cache";
+function refreshKey(modelRuntime: ModelCatalogRuntime, options: ModelCatalogRefreshOptions): string {
+	return (options.allowNetwork ?? modelRuntime.isNetworkRefreshEnabled()) ? "network" : "cache";
 }
 
 class ModelCatalogRefreshCoordinator {
@@ -44,7 +46,7 @@ class ModelCatalogRefreshCoordinator {
 			this.activeByRuntime.set(modelRuntime, byKey);
 		}
 		const active = byKey;
-		const key = refreshKey(options);
+		const key = refreshKey(modelRuntime, options);
 
 		let shared = active.get(key);
 		if (!shared) {

--- a/packages/coding-agent/src/modes/interactive/model-catalog-refresh.ts
+++ b/packages/coding-agent/src/modes/interactive/model-catalog-refresh.ts
@@ -2,7 +2,7 @@ import type { ModelsRefreshOptions, ModelsRefreshResult } from "@earendil-works/
 import type { ModelRuntime } from "../../core/model-runtime.ts";
 import { raceWithAbortSignal } from "../../utils/abort.ts";
 
-type ModelCatalogRuntime = Pick<ModelRuntime, "refresh" | "isNetworkRefreshEnabled">;
+type ModelCatalogRuntime = Pick<ModelRuntime, "refresh" | "isNetworkRefreshEnabled" | "getCredentialGeneration">;
 
 /**
  * The whole-catalog options interactive refreshes vary. `providers` and `force`
@@ -28,9 +28,17 @@ interface ActiveModelCatalogRefresh {
  * option and lets the runtime decide; on an online runtime those are one pass, and
  * keying the spelling started two. An explicit value that disagrees with the
  * runtime's own policy is still different work and still keys apart.
+ *
+ * The credential generation is part of the key because a catalog pass resolves
+ * credentials as it runs. A refresh started before an API-key login answers for
+ * credentials that no longer exist, and Atomic's login path deliberately leaves
+ * the post-login catalog refresh to the selector (`interactive-auth-login.ts`).
+ * Without the generation the selector joined the pre-login pass and showed no
+ * models for the provider the user had just authenticated.
  */
 function refreshKey(modelRuntime: ModelCatalogRuntime, options: ModelCatalogRefreshOptions): string {
-	return (options.allowNetwork ?? modelRuntime.isNetworkRefreshEnabled()) ? "network" : "cache";
+	const policy = (options.allowNetwork ?? modelRuntime.isNetworkRefreshEnabled()) ? "network" : "cache";
+	return `${policy}:${modelRuntime.getCredentialGeneration()}`;
 }
 
 class ModelCatalogRefreshCoordinator {
@@ -72,9 +80,13 @@ class ModelCatalogRefreshCoordinator {
 			released = true;
 			signal.removeEventListener("abort", release);
 			joined.waiters--;
-			if (joined.waiters === 0 && active.get(key) === joined) {
-				joined.controller.abort();
-			}
+			if (joined.waiters > 0) return;
+			if (active.get(key) !== joined) return;
+			// Evict before aborting. The abort is synchronous while the shared promise's
+			// own cleanup is a microtask, so a caller retrying in this same tick would
+			// otherwise join an entry that is already aborted and reject without work.
+			active.delete(key);
+			joined.controller.abort();
 		};
 		signal.addEventListener("abort", release);
 		return raceWithAbortSignal(joined.promise, signal).finally(release);

--- a/packages/coding-agent/src/modes/interactive/model-catalog-refresh.ts
+++ b/packages/coding-agent/src/modes/interactive/model-catalog-refresh.ts
@@ -1,0 +1,90 @@
+import type { ModelsRefreshOptions, ModelsRefreshResult } from "@earendil-works/pi-ai";
+import type { ModelRuntime } from "../../core/model-runtime.ts";
+import { raceWithAbortSignal } from "../../utils/abort.ts";
+
+type ModelCatalogRuntime = Pick<ModelRuntime, "refresh">;
+
+/**
+ * The whole-catalog options interactive refreshes vary. `providers` and `force`
+ * are deliberately absent: a scoped or forced refresh asks for different work
+ * and must never be answered by another caller's in-flight pass.
+ */
+export type ModelCatalogRefreshOptions = Pick<ModelsRefreshOptions, "allowNetwork">;
+
+export interface ModelCatalogRefreshRequest extends ModelCatalogRefreshOptions {
+	/** Caller's cancellation, independent of the shared refresh it joins. */
+	signal: AbortSignal;
+}
+
+interface ActiveModelCatalogRefresh {
+	controller: AbortController;
+	promise: Promise<ModelsRefreshResult>;
+	waiters: number;
+}
+
+/**
+ * `allowNetwork: undefined` resolves to the runtime's own network policy, which
+ * is not the same request as an explicit `true` or `false`, so it keys apart.
+ */
+function refreshKey(options: ModelCatalogRefreshOptions): string {
+	if (options.allowNetwork === undefined) return "runtime-default";
+	return options.allowNetwork ? "network" : "cache";
+}
+
+class ModelCatalogRefreshCoordinator {
+	private readonly activeByRuntime = new WeakMap<ModelCatalogRuntime, Map<string, ActiveModelCatalogRefresh>>();
+
+	refresh(modelRuntime: ModelCatalogRuntime, request: ModelCatalogRefreshRequest): Promise<ModelsRefreshResult> {
+		const { signal, ...options } = request;
+		signal.throwIfAborted();
+
+		let byKey = this.activeByRuntime.get(modelRuntime);
+		if (!byKey) {
+			byKey = new Map<string, ActiveModelCatalogRefresh>();
+			this.activeByRuntime.set(modelRuntime, byKey);
+		}
+		const active = byKey;
+		const key = refreshKey(options);
+
+		let shared = active.get(key);
+		if (!shared) {
+			const controller = new AbortController();
+			let created!: ActiveModelCatalogRefresh;
+			const operation = modelRuntime.refresh({ ...options, signal: controller.signal });
+			const promise = raceWithAbortSignal(operation, controller.signal).finally(() => {
+				if (active.get(key) === created) active.delete(key);
+			});
+			created = { controller, promise, waiters: 0 };
+			shared = created;
+			active.set(key, shared);
+		}
+
+		const joined = shared;
+		joined.waiters++;
+		// Release on the caller's abort rather than only on settlement: a selector
+		// that closes must cancel the underlying refresh in the same tick, which is
+		// what Atomic's callers already observe.
+		let released = false;
+		const release = () => {
+			if (released) return;
+			released = true;
+			signal.removeEventListener("abort", release);
+			joined.waiters--;
+			if (joined.waiters === 0 && active.get(key) === joined) {
+				joined.controller.abort();
+			}
+		};
+		signal.addEventListener("abort", release);
+		return raceWithAbortSignal(joined.promise, signal).finally(release);
+	}
+}
+
+const modelCatalogRefreshCoordinator = new ModelCatalogRefreshCoordinator();
+
+/** Share concurrent interactive all-catalog refreshes while keeping each caller's cancellation independent. */
+export function refreshModelCatalogs(
+	modelRuntime: ModelCatalogRuntime,
+	request: ModelCatalogRefreshRequest,
+): Promise<ModelsRefreshResult> {
+	return modelCatalogRefreshCoordinator.refresh(modelRuntime, request);
+}

--- a/packages/coding-agent/src/modes/interactive/model-catalog-refresh.ts
+++ b/packages/coding-agent/src/modes/interactive/model-catalog-refresh.ts
@@ -2,7 +2,10 @@ import type { ModelsRefreshOptions, ModelsRefreshResult } from "@earendil-works/
 import type { ModelRuntime } from "../../core/model-runtime.ts";
 import { raceWithAbortSignal } from "../../utils/abort.ts";
 
-type ModelCatalogRuntime = Pick<ModelRuntime, "refresh" | "isNetworkRefreshEnabled" | "getCredentialGeneration">;
+type ModelCatalogRuntime = Pick<
+	ModelRuntime,
+	"refresh" | "isNetworkRefreshEnabled" | "getCredentialGeneration" | "getModelConfigFingerprint"
+>;
 
 /**
  * The whole-catalog options interactive refreshes vary. `providers` and `force`
@@ -35,10 +38,17 @@ interface ActiveModelCatalogRefresh {
  * the post-login catalog refresh to the selector (`interactive-auth-login.ts`).
  * Without the generation the selector joined the pre-login pass and showed no
  * models for the provider the user had just authenticated.
+ *
+ * The models.json fingerprint is part of the key for the same reason in the
+ * other direction: every pass reloads that file and applies it, so a pass that
+ * started before an edit answers with the provider keys and model definitions
+ * the user just replaced. Without it, a `/model` picker opened after an edit
+ * joined the older pass and the edit did not take effect until a third refresh,
+ * silently revoking the hot reload `model-registry-hot-reload.test.ts` states.
  */
 function refreshKey(modelRuntime: ModelCatalogRuntime, options: ModelCatalogRefreshOptions): string {
 	const policy = (options.allowNetwork ?? modelRuntime.isNetworkRefreshEnabled()) ? "network" : "cache";
-	return `${policy}:${modelRuntime.getCredentialGeneration()}`;
+	return `${policy}:${modelRuntime.getCredentialGeneration()}:${modelRuntime.getModelConfigFingerprint()}`;
 }
 
 class ModelCatalogRefreshCoordinator {

--- a/packages/coding-agent/src/modes/interactive/model-catalog-refresh.ts
+++ b/packages/coding-agent/src/modes/interactive/model-catalog-refresh.ts
@@ -2,10 +2,7 @@ import type { ModelsRefreshOptions, ModelsRefreshResult } from "@earendil-works/
 import type { ModelRuntime } from "../../core/model-runtime.ts";
 import { raceWithAbortSignal } from "../../utils/abort.ts";
 
-type ModelCatalogRuntime = Pick<
-	ModelRuntime,
-	"refresh" | "isNetworkRefreshEnabled" | "getCredentialGeneration" | "getModelConfigFingerprint"
->;
+type ModelCatalogRuntime = Pick<ModelRuntime, "refresh" | "isNetworkRefreshEnabled" | "getCatalogInputsGeneration">;
 
 /**
  * The whole-catalog options interactive refreshes vary. `providers` and `force`
@@ -26,29 +23,28 @@ interface ActiveModelCatalogRefresh {
 }
 
 /**
- * Key on the policy the runtime will actually apply, not on how the caller spelled
+ * A key names WHICH work a caller is asking for, plus WHEN the inputs that work
+ * reads last changed. Both halves are needed and neither grows a third term.
+ *
+ * Which: the policy the runtime will actually apply, not how the caller spelled
  * it. Startup asks for `allowNetwork: true` while the `/model` selector omits the
  * option and lets the runtime decide; on an online runtime those are one pass, and
  * keying the spelling started two. An explicit value that disagrees with the
  * runtime's own policy is still different work and still keys apart.
  *
- * The credential generation is part of the key because a catalog pass resolves
- * credentials as it runs. A refresh started before an API-key login answers for
- * credentials that no longer exist, and Atomic's login path deliberately leaves
- * the post-login catalog refresh to the selector (`interactive-auth-login.ts`).
- * Without the generation the selector joined the pre-login pass and showed no
- * models for the provider the user had just authenticated.
- *
- * The models.json fingerprint is part of the key for the same reason in the
- * other direction: every pass reloads that file and applies it, so a pass that
- * started before an edit answers with the provider keys and model definitions
- * the user just replaced. Without it, a `/model` picker opened after an edit
- * joined the older pass and the edit did not take effect until a third refresh,
- * silently revoking the hot reload `model-registry-hot-reload.test.ts` states.
+ * When: `ModelRuntime.getCatalogInputsGeneration()` — one monotonic counter over
+ * every input a pass reads (credential writes, provider registrations, and
+ * models.json content; see its doc comment). A pass publishes one snapshot built
+ * from the inputs it started under, so joining across a bump serves the joiner
+ * models and credentials the user already replaced and then overwrites the newer
+ * state with them. Keying on the generation makes a request that arrives after
+ * any such change start its own pass, and it is deliberately ONE number: this
+ * coordinator previously keyed input by input — first the network policy, then
+ * credentials, then models.json — and each round left the next input unkeyed.
  */
 function refreshKey(modelRuntime: ModelCatalogRuntime, options: ModelCatalogRefreshOptions): string {
 	const policy = (options.allowNetwork ?? modelRuntime.isNetworkRefreshEnabled()) ? "network" : "cache";
-	return `${policy}:${modelRuntime.getCredentialGeneration()}:${modelRuntime.getModelConfigFingerprint()}`;
+	return `${policy}:${modelRuntime.getCatalogInputsGeneration()}`;
 }
 
 class ModelCatalogRefreshCoordinator {

--- a/packages/coding-agent/src/modes/json-event.ts
+++ b/packages/coding-agent/src/modes/json-event.ts
@@ -1,3 +1,4 @@
+import type { Usage } from "@earendil-works/pi-ai";
 import type { AgentSessionEvent } from "../core/agent-session.ts";
 
 type WithoutPartial<T> = T extends { partial: unknown } ? Omit<T, "partial"> : T;
@@ -8,6 +9,7 @@ type ToJsonEvent<T> = T extends {
 }
 	? {
 			type: "message_update";
+			usage: Usage;
 			assistantMessageEvent: WithoutPartial<TAssistantMessageEvent>;
 		}
 	: T;
@@ -21,7 +23,8 @@ type JsonMessageUpdateEvent = Extract<JsonAgentSessionEvent, { type: "message_up
 /**
  * Remove cumulative assistant snapshots from streaming wire events.
  * `message_start` provides the initial message, deltas build it, and
- * `message_end` provides the final authoritative message.
+ * `message_end` provides the final authoritative message. Cumulative usage
+ * remains available because its size is constant.
  */
 export function toJsonEvent(event: MessageUpdateEvent): JsonMessageUpdateEvent;
 export function toJsonEvent(event: AgentSessionEvent): JsonAgentSessionEvent;
@@ -29,12 +32,15 @@ export function toJsonEvent(event: AgentSessionEvent): JsonAgentSessionEvent {
 	if (event.type !== "message_update") {
 		return event;
 	}
+	if (event.message.role !== "assistant") {
+		throw new Error("message_update message is not an assistant message");
+	}
 
 	const assistantMessageEvent = event.assistantMessageEvent;
 	if (!("partial" in assistantMessageEvent)) {
-		return { type: "message_update", assistantMessageEvent };
+		return { type: "message_update", usage: event.message.usage, assistantMessageEvent };
 	}
 
 	const { partial: _partial, ...deltaEvent } = assistantMessageEvent;
-	return { type: "message_update", assistantMessageEvent: deltaEvent };
+	return { type: "message_update", usage: event.message.usage, assistantMessageEvent: deltaEvent };
 }

--- a/packages/coding-agent/src/utils/abort.ts
+++ b/packages/coding-agent/src/utils/abort.ts
@@ -1,0 +1,20 @@
+/** Abort-signal helpers shared by the model runtime and its interactive callers. */
+
+/** Create an operation-local signal for public APIs whose signal is optional. */
+export function operationSignal(signal?: AbortSignal): AbortSignal {
+	return signal ?? new AbortController().signal;
+}
+
+/**
+ * Stop waiting for an operation when its signal aborts while continuing to
+ * observe the abandoned promise so a later rejection is always handled.
+ */
+export function raceWithAbortSignal<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+	if (signal.aborted)
+		return Promise.reject(signal.reason ?? new DOMException("The operation was aborted", "AbortError"));
+	return new Promise<T>((resolve, reject) => {
+		const onAbort = () => reject(signal.reason ?? new DOMException("The operation was aborted", "AbortError"));
+		signal.addEventListener("abort", onAbort, { once: true });
+		operation.then(resolve, reject).finally(() => signal.removeEventListener("abort", onAbort));
+	});
+}

--- a/packages/coding-agent/test/extension-source-trust-branding.test.ts
+++ b/packages/coding-agent/test/extension-source-trust-branding.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { APP_TITLE } from "../src/config.ts";
+import { formatBorrowedExtensionSourceTrustPrompt } from "../src/core/project-trust.ts";
+
+const mainSource = readFileSync(fileURLToPath(new URL("../src/main.ts", import.meta.url)), "utf-8");
+
+afterEach(() => {
+	vi.resetModules();
+	vi.doUnmock("../src/config.ts");
+});
+
+describe("extension-source trust prompt branding", () => {
+	it("names the product through the branding constant", () => {
+		const prompt = formatBorrowedExtensionSourceTrustPrompt("/tmp/borrowed-source");
+		expect(prompt).toContain(`This allows ${APP_TITLE} to load`);
+		expect(prompt).toContain("/tmp/borrowed-source");
+	});
+
+	it("follows a rebranded distribution instead of a hardcoded name", async () => {
+		vi.resetModules();
+		vi.doMock("../src/config.ts", async () => {
+			const actual = await vi.importActual<typeof import("../src/config.ts")>("../src/config.ts");
+			return { ...actual, APP_TITLE: "Rebrand" };
+		});
+
+		const rebranded = await import("../src/core/project-trust.ts");
+		const prompt = rebranded.formatBorrowedExtensionSourceTrustPrompt("/tmp/borrowed-source");
+
+		expect(prompt).toContain("This allows Rebrand to load");
+		expect(prompt).not.toContain("Atomic");
+		// The two compatibility directories the loader reads from that source are
+		// paths, not branding, and must survive the rename.
+		expect(prompt).toContain("project-local .atomic/.pi resources and .agents/skills");
+		expect(prompt).toContain("extensions and workflows that can execute code");
+	});
+
+	it("keeps the prompt out of main.ts, where no branding constant is in scope", () => {
+		// The literal lived here and named Atomic regardless of the configured
+		// branding. A trust prompt assembled at this call site cannot use APP_TITLE
+		// without importing it, so the prompt belongs to core/project-trust.ts.
+		expect(mainSource).toContain("formatBorrowedExtensionSourceTrustPrompt(source)");
+		expect(mainSource).not.toContain("This allows");
+	});
+});

--- a/packages/coding-agent/test/interactive-catalog-startup-refresh.test.ts
+++ b/packages/coding-agent/test/interactive-catalog-startup-refresh.test.ts
@@ -19,6 +19,7 @@ function fakeMode(overrides?: { refreshRejects?: boolean }): { mode: Interactive
 					if (overrides?.refreshRejects) throw new Error("network refresh failed");
 					return { aborted: false, errors: new Map() };
 				},
+				isNetworkRefreshEnabled: () => true,
 				getAvailableSnapshot: () => [{ provider: "anthropic" }, { provider: "openai" }, { provider: "openai" }],
 			},
 		},

--- a/packages/coding-agent/test/interactive-catalog-startup-refresh.test.ts
+++ b/packages/coding-agent/test/interactive-catalog-startup-refresh.test.ts
@@ -20,8 +20,7 @@ function fakeMode(overrides?: { refreshRejects?: boolean }): { mode: Interactive
 					return { aborted: false, errors: new Map() };
 				},
 				isNetworkRefreshEnabled: () => true,
-				getCredentialGeneration: () => 0,
-				getModelConfigFingerprint: () => "models",
+				getCatalogInputsGeneration: () => 0,
 				getAvailableSnapshot: () => [{ provider: "anthropic" }, { provider: "openai" }, { provider: "openai" }],
 			},
 		},

--- a/packages/coding-agent/test/interactive-catalog-startup-refresh.test.ts
+++ b/packages/coding-agent/test/interactive-catalog-startup-refresh.test.ts
@@ -21,6 +21,7 @@ function fakeMode(overrides?: { refreshRejects?: boolean }): { mode: Interactive
 				},
 				isNetworkRefreshEnabled: () => true,
 				getCredentialGeneration: () => 0,
+				getModelConfigFingerprint: () => "models",
 				getAvailableSnapshot: () => [{ provider: "anthropic" }, { provider: "openai" }, { provider: "openai" }],
 			},
 		},

--- a/packages/coding-agent/test/interactive-catalog-startup-refresh.test.ts
+++ b/packages/coding-agent/test/interactive-catalog-startup-refresh.test.ts
@@ -20,6 +20,7 @@ function fakeMode(overrides?: { refreshRejects?: boolean }): { mode: Interactive
 					return { aborted: false, errors: new Map() };
 				},
 				isNetworkRefreshEnabled: () => true,
+				getCredentialGeneration: () => 0,
 				getAvailableSnapshot: () => [{ provider: "anthropic" }, { provider: "openai" }, { provider: "openai" }],
 			},
 		},

--- a/packages/coding-agent/test/interactive-catalog-startup-refresh.test.ts
+++ b/packages/coding-agent/test/interactive-catalog-startup-refresh.test.ts
@@ -4,7 +4,7 @@ import type { InteractiveModeBase } from "../src/modes/interactive/interactive-m
 import { refreshCatalogsAfterTuiStartup } from "../src/modes/interactive/interactive-model-catalog-startup.ts";
 
 interface FakeCalls {
-	refreshOptions: Array<{ allowNetwork?: boolean }>;
+	refreshOptions: Array<{ allowNetwork?: boolean; signal?: AbortSignal }>;
 	providerCounts: number[];
 }
 
@@ -14,7 +14,7 @@ function fakeMode(overrides?: { refreshRejects?: boolean }): { mode: Interactive
 		session: {
 			scopedModels: [],
 			modelRuntime: {
-				refresh: async (options: { allowNetwork?: boolean } = {}) => {
+				refresh: async (options: { allowNetwork?: boolean; signal?: AbortSignal } = {}) => {
 					calls.refreshOptions.push(options);
 					if (overrides?.refreshRejects) throw new Error("network refresh failed");
 					return { aborted: false, errors: new Map() };
@@ -34,7 +34,11 @@ function fakeMode(overrides?: { refreshRejects?: boolean }): { mode: Interactive
 test("post-TUI startup refresh performs a network registry refresh", async () => {
 	const { mode, calls } = fakeMode();
 	await refreshCatalogsAfterTuiStartup(mode);
-	assert.deepEqual(calls.refreshOptions, [{ allowNetwork: true }]);
+	assert.equal(calls.refreshOptions.length, 1);
+	assert.equal(calls.refreshOptions[0]?.allowNetwork, true);
+	// The refresh joins the shared coordinator, which supplies its own signal so
+	// a selector opened during startup reuses this pass instead of starting one.
+	assert.ok(calls.refreshOptions[0]?.signal instanceof AbortSignal);
 	assert.deepEqual(calls.providerCounts, [2]);
 });
 

--- a/packages/coding-agent/test/interactive-catalog-startup-selector-refresh.test.ts
+++ b/packages/coding-agent/test/interactive-catalog-startup-selector-refresh.test.ts
@@ -51,8 +51,7 @@ function createHarness(networkEnabled = true): Harness {
 	const modelRuntime = {
 		refresh,
 		isNetworkRefreshEnabled: () => networkEnabled,
-		getCredentialGeneration: () => 0,
-		getModelConfigFingerprint: () => "models",
+		getCatalogInputsGeneration: () => 0,
 		getError: () => undefined,
 		getAvailableSnapshot: () => [model],
 		getModel: () => model,

--- a/packages/coding-agent/test/interactive-catalog-startup-selector-refresh.test.ts
+++ b/packages/coding-agent/test/interactive-catalog-startup-selector-refresh.test.ts
@@ -51,6 +51,7 @@ function createHarness(networkEnabled = true): Harness {
 	const modelRuntime = {
 		refresh,
 		isNetworkRefreshEnabled: () => networkEnabled,
+		getCredentialGeneration: () => 0,
 		getError: () => undefined,
 		getAvailableSnapshot: () => [model],
 		getModel: () => model,

--- a/packages/coding-agent/test/interactive-catalog-startup-selector-refresh.test.ts
+++ b/packages/coding-agent/test/interactive-catalog-startup-selector-refresh.test.ts
@@ -1,0 +1,142 @@
+import type { ModelsRefreshOptions, ModelsRefreshResult } from "@earendil-works/pi-ai";
+import type { Api, Model } from "@earendil-works/pi-ai/compat";
+import type { TUI } from "@earendil-works/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import type { ModelRuntime } from "../src/core/model-runtime.ts";
+import type { SettingsManager } from "../src/core/settings-manager.ts";
+import { ModelSelectorComponent } from "../src/modes/interactive/components/model-selector.ts";
+import type { InteractiveModeBase } from "../src/modes/interactive/interactive-mode-base.ts";
+import { refreshCatalogsAfterTuiStartup } from "../src/modes/interactive/interactive-model-catalog-startup.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+
+const model = {
+	id: "cached-model",
+	name: "Cached Model",
+	api: "openai-completions",
+	provider: "configured",
+	baseUrl: "https://example.test",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 4096,
+	maxTokens: 1024,
+} as Model<Api>;
+
+interface Harness {
+	mode: InteractiveModeBase;
+	modelRuntime: ModelRuntime;
+	refreshOptions: ModelsRefreshOptions[];
+	refreshCalls: () => number;
+	resolveRefresh: () => void;
+	providerCounts: number[];
+}
+
+/**
+ * One runtime behind both callers, with the network policy an omitted
+ * `allowNetwork` resolves to — which is what startup and the selector must agree
+ * on for their two spellings to share a pass.
+ */
+function createHarness(networkEnabled = true): Harness {
+	initTheme("dark");
+	const refreshOptions: ModelsRefreshOptions[] = [];
+	let release!: () => void;
+	const pending = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	const refresh = vi.fn(async (options: ModelsRefreshOptions = {}): Promise<ModelsRefreshResult> => {
+		refreshOptions.push(options);
+		await pending;
+		return { aborted: false, errors: new Map() };
+	});
+	const modelRuntime = {
+		refresh,
+		isNetworkRefreshEnabled: () => networkEnabled,
+		getError: () => undefined,
+		getAvailableSnapshot: () => [model],
+		getModel: () => model,
+	} as unknown as ModelRuntime;
+	const providerCounts: number[] = [];
+	const mode = {
+		session: { scopedModels: [], modelRuntime },
+		footerDataProvider: {
+			setAvailableProviderCount: (count: number) => {
+				providerCounts.push(count);
+			},
+		},
+	} as unknown as InteractiveModeBase;
+	return {
+		mode,
+		modelRuntime,
+		refreshOptions,
+		refreshCalls: () => refresh.mock.calls.length,
+		resolveRefresh: release,
+		providerCounts,
+	};
+}
+
+function openSelector(modelRuntime: ModelRuntime): ModelSelectorComponent {
+	return new ModelSelectorComponent(
+		{ requestRender: () => {} } as unknown as TUI,
+		model,
+		{ setDefaultModelAndProvider: () => {} } as unknown as SettingsManager,
+		modelRuntime,
+		[],
+		() => {},
+		() => {},
+	);
+}
+
+async function settleMicrotasks(): Promise<void> {
+	for (let attempt = 0; attempt < 20; attempt++) await Promise.resolve();
+}
+
+describe("startup and /model selector catalog refresh", () => {
+	it("answers a selector opened during startup with the startup pass", async () => {
+		const harness = createHarness();
+		const startup = refreshCatalogsAfterTuiStartup(harness.mode);
+		const selector = openSelector(harness.modelRuntime);
+		await settleMicrotasks();
+
+		expect(harness.refreshCalls()).toBe(1);
+		expect(harness.refreshOptions[0]?.allowNetwork).toBe(true);
+
+		harness.resolveRefresh();
+		await startup;
+		await settleMicrotasks();
+		expect(harness.providerCounts).toEqual([1]);
+		expect(selector.render(100).join("\n")).toContain("Model catalogs refreshed.");
+		expect(harness.refreshCalls()).toBe(1);
+	});
+
+	it("answers startup with the pass an already-open selector started", async () => {
+		const harness = createHarness();
+		const selector = openSelector(harness.modelRuntime);
+		await settleMicrotasks();
+		expect(harness.refreshCalls()).toBe(1);
+
+		const startup = refreshCatalogsAfterTuiStartup(harness.mode);
+		await settleMicrotasks();
+		expect(harness.refreshCalls()).toBe(1);
+
+		harness.resolveRefresh();
+		await startup;
+		await settleMicrotasks();
+		expect(harness.providerCounts).toEqual([1]);
+		expect(selector.render(100).join("\n")).toContain("Model catalogs refreshed.");
+	});
+
+	it("keeps a forced network startup apart from a cache-only runtime's selector", async () => {
+		const harness = createHarness(false);
+		const startup = refreshCatalogsAfterTuiStartup(harness.mode);
+		openSelector(harness.modelRuntime);
+		await settleMicrotasks();
+
+		// The selector's omitted option resolves to `false` here, which is different
+		// work from the network pass startup asked for, so it must not be shared.
+		expect(harness.refreshCalls()).toBe(2);
+		expect(harness.refreshOptions.map((options) => options.allowNetwork)).toEqual([true, undefined]);
+
+		harness.resolveRefresh();
+		await startup;
+	});
+});

--- a/packages/coding-agent/test/interactive-catalog-startup-selector-refresh.test.ts
+++ b/packages/coding-agent/test/interactive-catalog-startup-selector-refresh.test.ts
@@ -52,6 +52,7 @@ function createHarness(networkEnabled = true): Harness {
 		refresh,
 		isNetworkRefreshEnabled: () => networkEnabled,
 		getCredentialGeneration: () => 0,
+		getModelConfigFingerprint: () => "models",
 		getError: () => undefined,
 		getAvailableSnapshot: () => [model],
 		getModel: () => model,

--- a/packages/coding-agent/test/interactive-catalog-startup-stalled-refresh.test.ts
+++ b/packages/coding-agent/test/interactive-catalog-startup-stalled-refresh.test.ts
@@ -10,8 +10,7 @@ interface Harness {
 	modelRuntime: {
 		refresh: ReturnType<typeof vi.fn>;
 		isNetworkRefreshEnabled: () => boolean;
-		getCredentialGeneration: () => number;
-		getModelConfigFingerprint: () => string;
+		getCatalogInputsGeneration: () => number;
 	};
 	refreshSignals: AbortSignal[];
 	refreshCalls: () => number;
@@ -28,8 +27,7 @@ function createStalledHarness(): Harness {
 	const modelRuntime = {
 		refresh,
 		isNetworkRefreshEnabled: () => true,
-		getCredentialGeneration: () => 0,
-		getModelConfigFingerprint: () => "models",
+		getCatalogInputsGeneration: () => 0,
 		getAvailableSnapshot: () => [{ provider: "anthropic" }, { provider: "openai" }],
 	};
 	const providerCounts: number[] = [];

--- a/packages/coding-agent/test/interactive-catalog-startup-stalled-refresh.test.ts
+++ b/packages/coding-agent/test/interactive-catalog-startup-stalled-refresh.test.ts
@@ -1,0 +1,98 @@
+import type { ModelsRefreshOptions, ModelsRefreshResult } from "@earendil-works/pi-ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { INTERACTIVE_MODEL_REFRESH_TIMEOUT_MS } from "../src/core/model-refresh-timeout.ts";
+import type { InteractiveModeBase } from "../src/modes/interactive/interactive-mode-base.ts";
+import { refreshCatalogsAfterTuiStartup } from "../src/modes/interactive/interactive-model-catalog-startup.ts";
+import { refreshModelCatalogs } from "../src/modes/interactive/model-catalog-refresh.ts";
+
+interface Harness {
+	mode: InteractiveModeBase;
+	modelRuntime: { refresh: ReturnType<typeof vi.fn>; isNetworkRefreshEnabled: () => boolean };
+	refreshSignals: AbortSignal[];
+	refreshCalls: () => number;
+	providerCounts: number[];
+}
+
+/** A runtime whose network refresh never settles, which is what a stalled registry looks like. */
+function createStalledHarness(): Harness {
+	const refreshSignals: AbortSignal[] = [];
+	const refresh = vi.fn((options: ModelsRefreshOptions = {}): Promise<ModelsRefreshResult> => {
+		if (options.signal) refreshSignals.push(options.signal);
+		return new Promise<ModelsRefreshResult>(() => {});
+	});
+	const modelRuntime = {
+		refresh,
+		isNetworkRefreshEnabled: () => true,
+		getAvailableSnapshot: () => [{ provider: "anthropic" }, { provider: "openai" }],
+	};
+	const providerCounts: number[] = [];
+	const mode = {
+		session: { scopedModels: [], modelRuntime },
+		footerDataProvider: {
+			setAvailableProviderCount: (count: number) => {
+				providerCounts.push(count);
+			},
+		},
+	} as unknown as InteractiveModeBase;
+	return {
+		mode,
+		modelRuntime,
+		refreshSignals,
+		refreshCalls: () => refresh.mock.calls.length,
+		providerCounts,
+	};
+}
+
+describe("startup catalog refresh against a stalled registry", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("bounds its join so a later selector escapes a stalled pass", async () => {
+		const harness = createStalledHarness();
+		const startup = refreshCatalogsAfterTuiStartup(harness.mode);
+		await vi.advanceTimersByTimeAsync(0);
+		expect(harness.refreshCalls()).toBe(1);
+
+		// A selector opened during startup joins the same pass, times out, and
+		// releases only its own waiter.
+		const selector = new AbortController();
+		const selectorRefresh = refreshModelCatalogs(harness.modelRuntime, { signal: selector.signal });
+		expect(harness.refreshCalls()).toBe(1);
+		selector.abort();
+		await expect(selectorRefresh).rejects.toMatchObject({ name: "AbortError" });
+		expect(harness.refreshSignals[0]?.aborted).toBe(false);
+
+		// While startup is still legitimately waiting, a retry shares its pass.
+		const rejoin = new AbortController();
+		const rejoined = refreshModelCatalogs(harness.modelRuntime, { signal: rejoin.signal });
+		expect(harness.refreshCalls()).toBe(1);
+		rejoin.abort();
+		await expect(rejoined).rejects.toMatchObject({ name: "AbortError" });
+
+		// Once startup's own deadline passes, the last waiter leaves and the stalled
+		// pass is cancelled instead of being handed to every later caller.
+		await vi.advanceTimersByTimeAsync(INTERACTIVE_MODEL_REFRESH_TIMEOUT_MS);
+		await startup;
+		expect(harness.refreshSignals[0]?.aborted).toBe(true);
+		expect(harness.providerCounts).toEqual([2]);
+
+		const retry = new AbortController();
+		const retried = refreshModelCatalogs(harness.modelRuntime, { signal: retry.signal });
+		expect(harness.refreshCalls()).toBe(2);
+		retry.abort();
+		await expect(retried).rejects.toMatchObject({ name: "AbortError" });
+	});
+
+	it("leaves no timer pending once the startup refresh settles", async () => {
+		const harness = createStalledHarness();
+		const startup = refreshCatalogsAfterTuiStartup(harness.mode);
+		await vi.advanceTimersByTimeAsync(INTERACTIVE_MODEL_REFRESH_TIMEOUT_MS);
+		await startup;
+		expect(vi.getTimerCount()).toBe(0);
+	});
+});

--- a/packages/coding-agent/test/interactive-catalog-startup-stalled-refresh.test.ts
+++ b/packages/coding-agent/test/interactive-catalog-startup-stalled-refresh.test.ts
@@ -11,6 +11,7 @@ interface Harness {
 		refresh: ReturnType<typeof vi.fn>;
 		isNetworkRefreshEnabled: () => boolean;
 		getCredentialGeneration: () => number;
+		getModelConfigFingerprint: () => string;
 	};
 	refreshSignals: AbortSignal[];
 	refreshCalls: () => number;
@@ -28,6 +29,7 @@ function createStalledHarness(): Harness {
 		refresh,
 		isNetworkRefreshEnabled: () => true,
 		getCredentialGeneration: () => 0,
+		getModelConfigFingerprint: () => "models",
 		getAvailableSnapshot: () => [{ provider: "anthropic" }, { provider: "openai" }],
 	};
 	const providerCounts: number[] = [];

--- a/packages/coding-agent/test/interactive-catalog-startup-stalled-refresh.test.ts
+++ b/packages/coding-agent/test/interactive-catalog-startup-stalled-refresh.test.ts
@@ -7,7 +7,11 @@ import { refreshModelCatalogs } from "../src/modes/interactive/model-catalog-ref
 
 interface Harness {
 	mode: InteractiveModeBase;
-	modelRuntime: { refresh: ReturnType<typeof vi.fn>; isNetworkRefreshEnabled: () => boolean };
+	modelRuntime: {
+		refresh: ReturnType<typeof vi.fn>;
+		isNetworkRefreshEnabled: () => boolean;
+		getCredentialGeneration: () => number;
+	};
 	refreshSignals: AbortSignal[];
 	refreshCalls: () => number;
 	providerCounts: number[];
@@ -23,6 +27,7 @@ function createStalledHarness(): Harness {
 	const modelRuntime = {
 		refresh,
 		isNetworkRefreshEnabled: () => true,
+		getCredentialGeneration: () => 0,
 		getAvailableSnapshot: () => [{ provider: "anthropic" }, { provider: "openai" }],
 	};
 	const providerCounts: number[] = [];

--- a/packages/coding-agent/test/interactive-model-routing-offline.test.ts
+++ b/packages/coding-agent/test/interactive-model-routing-offline.test.ts
@@ -31,8 +31,7 @@ test("offline model candidate startup restores caches without catalog network re
 			modelRuntime: {
 				refresh,
 				getAvailableSnapshot: () => [],
-				getCredentialGeneration: () => 0,
-				getModelConfigFingerprint: () => "models",
+				getCatalogInputsGeneration: () => 0,
 			},
 		},
 	};
@@ -52,8 +51,7 @@ test("footer provider count uses the current snapshot without refreshing catalog
 			modelRuntime: {
 				refresh,
 				getAvailableSnapshot: () => [{ provider: "one" }, { provider: "one" }, { provider: "two" }],
-				getCredentialGeneration: () => 0,
-				getModelConfigFingerprint: () => "models",
+				getCatalogInputsGeneration: () => 0,
 			},
 		},
 		footerDataProvider: { setAvailableProviderCount },
@@ -81,8 +79,7 @@ test("offline scoped-model selector starts a cache-only background refresh", asy
 			modelRuntime: {
 				refresh,
 				getAvailableSnapshot: () => [],
-				getCredentialGeneration: () => 0,
-				getModelConfigFingerprint: () => "models",
+				getCatalogInputsGeneration: () => 0,
 			},
 		},
 		settingsManager: { getEnabledModels: () => undefined },

--- a/packages/coding-agent/test/interactive-model-routing-offline.test.ts
+++ b/packages/coding-agent/test/interactive-model-routing-offline.test.ts
@@ -32,6 +32,7 @@ test("offline model candidate startup restores caches without catalog network re
 				refresh,
 				getAvailableSnapshot: () => [],
 				getCredentialGeneration: () => 0,
+				getModelConfigFingerprint: () => "models",
 			},
 		},
 	};
@@ -52,6 +53,7 @@ test("footer provider count uses the current snapshot without refreshing catalog
 				refresh,
 				getAvailableSnapshot: () => [{ provider: "one" }, { provider: "one" }, { provider: "two" }],
 				getCredentialGeneration: () => 0,
+				getModelConfigFingerprint: () => "models",
 			},
 		},
 		footerDataProvider: { setAvailableProviderCount },
@@ -76,7 +78,12 @@ test("offline scoped-model selector starts a cache-only background refresh", asy
 	const mode = {
 		session: {
 			scopedModels: [],
-			modelRuntime: { refresh, getAvailableSnapshot: () => [], getCredentialGeneration: () => 0 },
+			modelRuntime: {
+				refresh,
+				getAvailableSnapshot: () => [],
+				getCredentialGeneration: () => 0,
+				getModelConfigFingerprint: () => "models",
+			},
 		},
 		settingsManager: { getEnabledModels: () => undefined },
 		showSelector,

--- a/packages/coding-agent/test/interactive-model-routing-offline.test.ts
+++ b/packages/coding-agent/test/interactive-model-routing-offline.test.ts
@@ -31,6 +31,7 @@ test("offline model candidate startup restores caches without catalog network re
 			modelRuntime: {
 				refresh,
 				getAvailableSnapshot: () => [],
+				getCredentialGeneration: () => 0,
 			},
 		},
 	};
@@ -50,6 +51,7 @@ test("footer provider count uses the current snapshot without refreshing catalog
 			modelRuntime: {
 				refresh,
 				getAvailableSnapshot: () => [{ provider: "one" }, { provider: "one" }, { provider: "two" }],
+				getCredentialGeneration: () => 0,
 			},
 		},
 		footerDataProvider: { setAvailableProviderCount },
@@ -72,7 +74,10 @@ test("offline scoped-model selector starts a cache-only background refresh", asy
 		},
 	);
 	const mode = {
-		session: { scopedModels: [], modelRuntime: { refresh, getAvailableSnapshot: () => [] } },
+		session: {
+			scopedModels: [],
+			modelRuntime: { refresh, getAvailableSnapshot: () => [], getCredentialGeneration: () => 0 },
+		},
 		settingsManager: { getEnabledModels: () => undefined },
 		showSelector,
 		ui: { requestRender: vi.fn() },

--- a/packages/coding-agent/test/interactive-model-routing-refresh.test.ts
+++ b/packages/coding-agent/test/interactive-model-routing-refresh.test.ts
@@ -34,7 +34,7 @@ function createMode(
 		getModelCandidates: InteractiveModeBase.prototype.getModelCandidates,
 		session: {
 			scopedModels,
-			modelRuntime: { refresh, getAvailableSnapshot },
+			modelRuntime: { refresh, getAvailableSnapshot, getCredentialGeneration: () => 0 },
 		},
 	};
 }

--- a/packages/coding-agent/test/interactive-model-routing-refresh.test.ts
+++ b/packages/coding-agent/test/interactive-model-routing-refresh.test.ts
@@ -37,8 +37,7 @@ function createMode(
 			modelRuntime: {
 				refresh,
 				getAvailableSnapshot,
-				getCredentialGeneration: () => 0,
-				getModelConfigFingerprint: () => "models",
+				getCatalogInputsGeneration: () => 0,
 			},
 		},
 	};

--- a/packages/coding-agent/test/interactive-model-routing-refresh.test.ts
+++ b/packages/coding-agent/test/interactive-model-routing-refresh.test.ts
@@ -34,7 +34,12 @@ function createMode(
 		getModelCandidates: InteractiveModeBase.prototype.getModelCandidates,
 		session: {
 			scopedModels,
-			modelRuntime: { refresh, getAvailableSnapshot, getCredentialGeneration: () => 0 },
+			modelRuntime: {
+				refresh,
+				getAvailableSnapshot,
+				getCredentialGeneration: () => 0,
+				getModelConfigFingerprint: () => "models",
+			},
 		},
 	};
 }

--- a/packages/coding-agent/test/interactive-scoped-models-refresh.test.ts
+++ b/packages/coding-agent/test/interactive-scoped-models-refresh.test.ts
@@ -55,6 +55,7 @@ async function openSelector(initialModels: readonly Model<Api>[], options: OpenS
 					return snapshot;
 				},
 				refresh,
+				getCredentialGeneration: () => 0,
 			},
 			setScopedModels,
 		},

--- a/packages/coding-agent/test/interactive-scoped-models-refresh.test.ts
+++ b/packages/coding-agent/test/interactive-scoped-models-refresh.test.ts
@@ -55,8 +55,7 @@ async function openSelector(initialModels: readonly Model<Api>[], options: OpenS
 					return snapshot;
 				},
 				refresh,
-				getCredentialGeneration: () => 0,
-				getModelConfigFingerprint: () => "models",
+				getCatalogInputsGeneration: () => 0,
 			},
 			setScopedModels,
 		},

--- a/packages/coding-agent/test/interactive-scoped-models-refresh.test.ts
+++ b/packages/coding-agent/test/interactive-scoped-models-refresh.test.ts
@@ -56,6 +56,7 @@ async function openSelector(initialModels: readonly Model<Api>[], options: OpenS
 				},
 				refresh,
 				getCredentialGeneration: () => 0,
+				getModelConfigFingerprint: () => "models",
 			},
 			setScopedModels,
 		},

--- a/packages/coding-agent/test/model-catalog-refresh-config-change.test.ts
+++ b/packages/coding-agent/test/model-catalog-refresh-config-change.test.ts
@@ -1,0 +1,141 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ModelsRefreshResult } from "@earendil-works/pi-ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthStorage } from "../src/core/auth-storage.ts";
+import { ModelRuntime } from "../src/core/model-runtime.ts";
+import { refreshModelCatalogs } from "../src/modes/interactive/model-catalog-refresh.ts";
+
+/**
+ * Reach the catalog pass a `ModelRuntime.refresh()` runs. `runRefresh` loads
+ * models.json and applies it *before* this call, so gating here holds a pass
+ * open that has already consumed the old file.
+ */
+interface RuntimeInternals {
+	models: { refresh(options?: { signal?: AbortSignal }): Promise<ModelsRefreshResult> };
+}
+
+const tempDirs: string[] = [];
+
+function writeModels(path: string, apiKey: string, modelId: string): void {
+	writeFileSync(
+		path,
+		JSON.stringify({
+			providers: {
+				configured: {
+					api: "openai-completions",
+					baseUrl: "https://example.test/v1",
+					apiKey,
+					models: [{ id: modelId }],
+				},
+			},
+		}),
+	);
+}
+
+async function createRuntime(modelsPath: string): Promise<ModelRuntime> {
+	return ModelRuntime.create({ credentials: AuthStorage.inMemory(), modelsPath, allowModelNetwork: false });
+}
+
+function createModelsPath(): string {
+	const directory = mkdtempSync(join(tmpdir(), "atomic-catalog-config-"));
+	tempDirs.push(directory);
+	return join(directory, "models.json");
+}
+
+async function waitForPasses(counter: () => number, count: number): Promise<void> {
+	for (let attempt = 0; attempt < 200 && counter() < count; attempt++) {
+		await new Promise((resolve) => setTimeout(resolve, 1));
+	}
+}
+
+beforeEach(() => {
+	// Every catalog pass here is local: the assertions are about which pass a
+	// caller joins and which models.json it read, never about a live endpoint.
+	vi.stubEnv("ATOMIC_OFFLINE", "1");
+});
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllEnvs();
+	for (const directory of tempDirs.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+describe("model catalog refresh across a models.json change", () => {
+	it("does not answer a post-edit request with the pass that loaded the old models.json", async () => {
+		const modelsPath = createModelsPath();
+		writeModels(modelsPath, "old-key", "old-model");
+		const runtime = await createRuntime(modelsPath);
+		expect(runtime.getModel("configured", "old-model")).toBeDefined();
+
+		const internals = runtime as unknown as RuntimeInternals;
+		let passes = 0;
+		let releaseFirstPass!: () => void;
+		const firstPassGate = new Promise<void>((resolve) => {
+			releaseFirstPass = resolve;
+		});
+		vi.spyOn(internals.models, "refresh").mockImplementation(async () => {
+			passes++;
+			if (passes === 1) await firstPassGate;
+			return { aborted: false, errors: new Map<string, Error>() };
+		});
+
+		const startupController = new AbortController();
+		const startupRefresh = refreshModelCatalogs(runtime, { signal: startupController.signal });
+		await waitForPasses(() => passes, 1);
+		expect(passes).toBe(1);
+
+		// The user edits models.json while that pass is still running: a new model
+		// id and a new provider key, both of which the running pass cannot know.
+		writeModels(modelsPath, "new-key", "new-model");
+
+		const selectorController = new AbortController();
+		const selectorRefresh = refreshModelCatalogs(runtime, { signal: selectorController.signal });
+		// A joined request would leave this at one pass forever; the wait fails loudly
+		// rather than racing a second pass that never starts.
+		await waitForPasses(() => passes, 2);
+		expect(passes).toBe(2);
+
+		await expect(selectorRefresh).resolves.toMatchObject({ aborted: false });
+		expect(runtime.getModel("configured", "new-model")).toBeDefined();
+		expect(runtime.getModel("configured", "old-model")).toBeUndefined();
+		await expect(runtime.getAuth("configured")).resolves.toMatchObject({ auth: { apiKey: "new-key" } });
+
+		releaseFirstPass();
+		await expect(startupRefresh).resolves.toMatchObject({ aborted: false });
+		// The abandoned pass republishes from the runtime's current config rather
+		// than restoring the file it read.
+		expect(runtime.getModel("configured", "new-model")).toBeDefined();
+	});
+
+	it("still shares one pass between concurrent callers while models.json is unchanged", async () => {
+		const modelsPath = createModelsPath();
+		writeModels(modelsPath, "stable-key", "stable-model");
+		const runtime = await createRuntime(modelsPath);
+
+		const internals = runtime as unknown as RuntimeInternals;
+		let passes = 0;
+		let releasePass!: () => void;
+		const passGate = new Promise<void>((resolve) => {
+			releasePass = resolve;
+		});
+		vi.spyOn(internals.models, "refresh").mockImplementation(async () => {
+			passes++;
+			await passGate;
+			return { aborted: false, errors: new Map<string, Error>() };
+		});
+
+		const startupController = new AbortController();
+		const selectorController = new AbortController();
+		const startupRefresh = refreshModelCatalogs(runtime, { signal: startupController.signal });
+		await waitForPasses(() => passes, 1);
+		const selectorRefresh = refreshModelCatalogs(runtime, { signal: selectorController.signal });
+
+		expect(passes).toBe(1);
+
+		releasePass();
+		await expect(startupRefresh).resolves.toMatchObject({ aborted: false });
+		await expect(selectorRefresh).resolves.toMatchObject({ aborted: false });
+		expect(passes).toBe(1);
+	});
+});

--- a/packages/coding-agent/test/model-catalog-refresh-config-change.test.ts
+++ b/packages/coding-agent/test/model-catalog-refresh-config-change.test.ts
@@ -62,6 +62,24 @@ afterEach(() => {
 });
 
 describe("model catalog refresh across a models.json change", () => {
+	it("counts an external models.json edit as a catalog-input change", async () => {
+		const modelsPath = createModelsPath();
+		writeModels(modelsPath, "old-key", "old-model");
+		const runtime = await createRuntime(modelsPath);
+		const start = runtime.getCatalogInputsGeneration();
+
+		// Nothing in the runtime writes this file, so the generation samples it. A
+		// same-length rewrite is the case an mtime or a size would miss.
+		expect(runtime.getCatalogInputsGeneration()).toBe(start);
+		writeModels(modelsPath, "new-key", "new-model");
+		const afterEdit = runtime.getCatalogInputsGeneration();
+		expect(afterEdit).toBeGreaterThan(start);
+
+		// Rewriting the same content is not a change, so repeated reads keep sharing.
+		writeModels(modelsPath, "new-key", "new-model");
+		expect(runtime.getCatalogInputsGeneration()).toBe(afterEdit);
+	});
+
 	it("does not answer a post-edit request with the pass that loaded the old models.json", async () => {
 		const modelsPath = createModelsPath();
 		writeModels(modelsPath, "old-key", "old-model");

--- a/packages/coding-agent/test/model-catalog-refresh-credential-change.test.ts
+++ b/packages/coding-agent/test/model-catalog-refresh-credential-change.test.ts
@@ -34,21 +34,48 @@ afterEach(() => {
 });
 
 describe("model catalog refresh across a credential change", () => {
-	it("counts a login, a logout, and a runtime key as credential changes", async () => {
+	it("counts a login, a logout, and a runtime key as catalog-input changes", async () => {
 		const credentials = AuthStorage.inMemory();
 		const runtime = await createOfflineRuntime(credentials);
-		const start = runtime.getCredentialGeneration();
+		const start = runtime.getCatalogInputsGeneration();
 
 		await loginWithApiKey(runtime, "anthropic", "sk-login-key");
-		const afterLogin = runtime.getCredentialGeneration();
+		const afterLogin = runtime.getCatalogInputsGeneration();
 		expect(afterLogin).toBeGreaterThan(start);
 
 		await runtime.setRuntimeApiKey("openai", "sk-runtime-key", {});
-		const afterRuntimeKey = runtime.getCredentialGeneration();
+		const afterRuntimeKey = runtime.getCatalogInputsGeneration();
 		expect(afterRuntimeKey).toBeGreaterThan(afterLogin);
 
 		await runtime.logout("anthropic");
-		expect(runtime.getCredentialGeneration()).toBeGreaterThan(afterRuntimeKey);
+		const afterLogout = runtime.getCatalogInputsGeneration();
+		expect(afterLogout).toBeGreaterThan(afterRuntimeKey);
+
+		// A registration replaces a provider every later pass composes from, so it
+		// is the same class of change as a credential write and bumps the same
+		// counter rather than needing a key field of its own.
+		runtime.registerProvider("registered", {
+			api: "openai-completions",
+			baseUrl: "https://example.test/v1",
+			apiKey: "sk-registered",
+			models: [{ id: "registered-model" }],
+		});
+		const afterRegistration = runtime.getCatalogInputsGeneration();
+		expect(afterRegistration).toBeGreaterThan(afterLogout);
+
+		runtime.unregisterProvider("registered");
+		expect(runtime.getCatalogInputsGeneration()).toBeGreaterThan(afterRegistration);
+	});
+
+	it("holds the generation still when nothing changed", async () => {
+		const runtime = await createOfflineRuntime(AuthStorage.inMemory());
+		const generation = runtime.getCatalogInputsGeneration();
+
+		await runtime.refresh({ allowNetwork: false });
+
+		// A refresh reads the inputs; it does not change them. If it bumped, no two
+		// callers could ever share a pass.
+		expect(runtime.getCatalogInputsGeneration()).toBe(generation);
 	});
 
 	it("does not answer a post-login selector with the pass that was running during login", async () => {

--- a/packages/coding-agent/test/model-catalog-refresh-credential-change.test.ts
+++ b/packages/coding-agent/test/model-catalog-refresh-credential-change.test.ts
@@ -1,0 +1,94 @@
+import type { ModelsRefreshResult } from "@earendil-works/pi-ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthStorage } from "../src/core/auth-storage.ts";
+import { ModelRuntime } from "../src/core/model-runtime.ts";
+import { refreshModelCatalogs } from "../src/modes/interactive/model-catalog-refresh.ts";
+
+/** Reach the catalog pass a `ModelRuntime.refresh()` runs, without a network. */
+interface RuntimeInternals {
+	models: { refresh(options?: { signal?: AbortSignal }): Promise<ModelsRefreshResult> };
+}
+
+async function createOfflineRuntime(credentials: AuthStorage): Promise<ModelRuntime> {
+	return ModelRuntime.create({ credentials, modelsPath: null, allowModelNetwork: false });
+}
+
+async function loginWithApiKey(runtime: ModelRuntime, providerId: string, key: string): Promise<void> {
+	await runtime.login(providerId, "api_key", { prompt: async () => key, notify: () => {} });
+}
+
+async function waitForPasses(observed: readonly unknown[], count: number): Promise<void> {
+	for (let attempt = 0; attempt < 200 && observed.length < count; attempt++) {
+		await new Promise((resolve) => setTimeout(resolve, 1));
+	}
+}
+
+beforeEach(() => {
+	// Every catalog pass here is local: the assertions are about which pass a
+	// caller joins, never about a live endpoint.
+	vi.stubEnv("ATOMIC_OFFLINE", "1");
+});
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllEnvs();
+});
+
+describe("model catalog refresh across a credential change", () => {
+	it("counts a login, a logout, and a runtime key as credential changes", async () => {
+		const credentials = AuthStorage.inMemory();
+		const runtime = await createOfflineRuntime(credentials);
+		const start = runtime.getCredentialGeneration();
+
+		await loginWithApiKey(runtime, "anthropic", "sk-login-key");
+		const afterLogin = runtime.getCredentialGeneration();
+		expect(afterLogin).toBeGreaterThan(start);
+
+		await runtime.setRuntimeApiKey("openai", "sk-runtime-key", {});
+		const afterRuntimeKey = runtime.getCredentialGeneration();
+		expect(afterRuntimeKey).toBeGreaterThan(afterLogin);
+
+		await runtime.logout("anthropic");
+		expect(runtime.getCredentialGeneration()).toBeGreaterThan(afterRuntimeKey);
+	});
+
+	it("does not answer a post-login selector with the pass that was running during login", async () => {
+		const credentials = AuthStorage.inMemory();
+		const runtime = await createOfflineRuntime(credentials);
+		const internals = runtime as unknown as RuntimeInternals;
+
+		// What each catalog pass would resolve for the provider being logged in.
+		// The pre-login pass sees nothing; only a pass started after the credential
+		// lands can put that provider's models in front of the user.
+		const credentialPerPass: Array<string | undefined> = [];
+		let releaseFirstPass!: () => void;
+		const firstPassGate = new Promise<void>((resolve) => {
+			releaseFirstPass = resolve;
+		});
+		vi.spyOn(internals.models, "refresh").mockImplementation(async () => {
+			const stored = await credentials.read("anthropic");
+			credentialPerPass.push(stored?.type === "api_key" ? stored.key : undefined);
+			if (credentialPerPass.length === 1) await firstPassGate;
+			return { aborted: false, errors: new Map<string, Error>() };
+		});
+
+		const startupController = new AbortController();
+		const startupRefresh = refreshModelCatalogs(runtime, { signal: startupController.signal });
+		await waitForPasses(credentialPerPass, 1);
+		expect(credentialPerPass).toEqual([undefined]);
+
+		// Atomic's API-key login publishes the credential and deliberately skips its
+		// own catalog refresh (interactive-auth-login.ts), so the next selector's
+		// refresh is the only thing that can surface the provider's models.
+		await loginWithApiKey(runtime, "anthropic", "sk-new-key");
+
+		const selectorController = new AbortController();
+		const selectorRefresh = refreshModelCatalogs(runtime, { signal: selectorController.signal });
+		await waitForPasses(credentialPerPass, 2);
+
+		expect(credentialPerPass).toEqual([undefined, "sk-new-key"]);
+		await expect(selectorRefresh).resolves.toMatchObject({ aborted: false });
+
+		releaseFirstPass();
+		await expect(startupRefresh).resolves.toMatchObject({ aborted: false });
+	});
+});

--- a/packages/coding-agent/test/model-catalog-refresh.test.ts
+++ b/packages/coding-agent/test/model-catalog-refresh.test.ts
@@ -19,10 +19,18 @@ function successfulRefresh(): ModelsRefreshResult {
 	return { aborted: false, errors: new Map() };
 }
 
+/** A runtime stub carrying the network policy an omitted `allowNetwork` resolves to. */
+function createRuntime(
+	refresh: (options?: ModelsRefreshOptions) => Promise<ModelsRefreshResult>,
+	networkEnabled = true,
+) {
+	return { refresh: vi.fn(refresh), isNetworkRefreshEnabled: () => networkEnabled };
+}
+
 describe("interactive model catalog refresh", () => {
 	it("shares one runtime refresh between concurrent callers", async () => {
 		const deferred = createDeferred<ModelsRefreshResult>();
-		const runtime = { refresh: vi.fn((_options?: ModelsRefreshOptions) => deferred.promise) };
+		const runtime = createRuntime(() => deferred.promise);
 		const firstController = new AbortController();
 		const secondController = new AbortController();
 
@@ -38,12 +46,10 @@ describe("interactive model catalog refresh", () => {
 	it("keeps the shared refresh alive when one caller stops waiting", async () => {
 		const deferred = createDeferred<ModelsRefreshResult>();
 		let refreshSignal: AbortSignal | undefined;
-		const runtime = {
-			refresh: vi.fn((options?: ModelsRefreshOptions) => {
-				refreshSignal = options?.signal;
-				return deferred.promise;
-			}),
-		};
+		const runtime = createRuntime((options?: ModelsRefreshOptions) => {
+			refreshSignal = options?.signal;
+			return deferred.promise;
+		});
 		const firstController = new AbortController();
 		const secondController = new AbortController();
 		const first = refreshModelCatalogs(runtime, { signal: firstController.signal });
@@ -59,12 +65,10 @@ describe("interactive model catalog refresh", () => {
 
 	it("aborts an abandoned refresh in the aborting tick and allows a later refresh to start", async () => {
 		const refreshSignals: AbortSignal[] = [];
-		const runtime = {
-			refresh: vi.fn((options?: ModelsRefreshOptions) => {
-				if (options?.signal) refreshSignals.push(options.signal);
-				return new Promise<ModelsRefreshResult>(() => {});
-			}),
-		};
+		const runtime = createRuntime((options?: ModelsRefreshOptions) => {
+			if (options?.signal) refreshSignals.push(options.signal);
+			return new Promise<ModelsRefreshResult>(() => {});
+		});
 		const firstController = new AbortController();
 		const first = refreshModelCatalogs(runtime, { signal: firstController.signal });
 
@@ -84,29 +88,50 @@ describe("interactive model catalog refresh", () => {
 	it("refuses to answer a different catalog request with an in-flight one", async () => {
 		const deferred = createDeferred<ModelsRefreshResult>();
 		const requested: Array<boolean | undefined> = [];
-		const runtime = {
-			refresh: vi.fn((options?: ModelsRefreshOptions) => {
-				requested.push(options?.allowNetwork);
-				return deferred.promise;
-			}),
-		};
+		const runtime = createRuntime((options?: ModelsRefreshOptions) => {
+			requested.push(options?.allowNetwork);
+			return deferred.promise;
+		});
 		const controller = new AbortController();
 
 		const networked = refreshModelCatalogs(runtime, { allowNetwork: true, signal: controller.signal });
 		const cached = refreshModelCatalogs(runtime, { allowNetwork: false, signal: controller.signal });
-		const runtimeDefault = refreshModelCatalogs(runtime, { signal: controller.signal });
 
-		expect(runtime.refresh).toHaveBeenCalledTimes(3);
-		expect(requested).toEqual([true, false, undefined]);
+		expect(runtime.refresh).toHaveBeenCalledTimes(2);
+		expect(requested).toEqual([true, false]);
 
 		deferred.resolve(successfulRefresh());
-		await Promise.all([networked, cached, runtimeDefault]);
+		await Promise.all([networked, cached]);
+	});
+
+	it("joins the pass matching the policy an omitted allowNetwork resolves to", async () => {
+		const deferred = createDeferred<ModelsRefreshResult>();
+		const online = createRuntime(() => deferred.promise, true);
+		const offline = createRuntime(() => deferred.promise, false);
+		const controller = new AbortController();
+
+		// Startup spells the policy out; the /model selector omits it. On an online
+		// runtime both mean the same pass, so the second must not start work.
+		const onlineNetworked = refreshModelCatalogs(online, { allowNetwork: true, signal: controller.signal });
+		const onlineDefault = refreshModelCatalogs(online, { signal: controller.signal });
+		expect(online.refresh).toHaveBeenCalledOnce();
+
+		// The same omitted request on a cache-only runtime resolves to `false`, so it
+		// joins the cached pass and leaves an explicit network request its own.
+		const offlineCached = refreshModelCatalogs(offline, { allowNetwork: false, signal: controller.signal });
+		const offlineDefault = refreshModelCatalogs(offline, { signal: controller.signal });
+		expect(offline.refresh).toHaveBeenCalledOnce();
+		const offlineNetworked = refreshModelCatalogs(offline, { allowNetwork: true, signal: controller.signal });
+		expect(offline.refresh).toHaveBeenCalledTimes(2);
+
+		deferred.resolve(successfulRefresh());
+		await Promise.all([onlineNetworked, onlineDefault, offlineCached, offlineDefault, offlineNetworked]);
 	});
 
 	it("shares nothing across separate runtimes", async () => {
 		const deferred = createDeferred<ModelsRefreshResult>();
-		const first = { refresh: vi.fn((_options?: ModelsRefreshOptions) => deferred.promise) };
-		const second = { refresh: vi.fn((_options?: ModelsRefreshOptions) => deferred.promise) };
+		const first = createRuntime(() => deferred.promise);
+		const second = createRuntime(() => deferred.promise);
 		const controller = new AbortController();
 
 		const firstRefresh = refreshModelCatalogs(first, { signal: controller.signal });
@@ -120,7 +145,7 @@ describe("interactive model catalog refresh", () => {
 	});
 
 	it("rejects a caller whose signal already aborted without starting work", async () => {
-		const runtime = { refresh: vi.fn((_options?: ModelsRefreshOptions) => Promise.resolve(successfulRefresh())) };
+		const runtime = createRuntime(() => Promise.resolve(successfulRefresh()));
 		const controller = new AbortController();
 		controller.abort();
 
@@ -132,9 +157,7 @@ describe("interactive model catalog refresh", () => {
 		const first = createDeferred<ModelsRefreshResult>();
 		const second = createDeferred<ModelsRefreshResult>();
 		const deferrals = [first, second];
-		const runtime = {
-			refresh: vi.fn((_options?: ModelsRefreshOptions) => (deferrals.shift() ?? first).promise),
-		};
+		const runtime = createRuntime(() => (deferrals.shift() ?? first).promise);
 		const controller = new AbortController();
 
 		const firstRefresh = refreshModelCatalogs(runtime, { signal: controller.signal });

--- a/packages/coding-agent/test/model-catalog-refresh.test.ts
+++ b/packages/coding-agent/test/model-catalog-refresh.test.ts
@@ -19,12 +19,24 @@ function successfulRefresh(): ModelsRefreshResult {
 	return { aborted: false, errors: new Map() };
 }
 
-/** A runtime stub carrying the network policy an omitted `allowNetwork` resolves to. */
+/**
+ * A runtime stub carrying the network policy an omitted `allowNetwork` resolves to
+ * and the credential generation a real `ModelRuntime` bumps on every login, logout,
+ * or key change.
+ */
 function createRuntime(
 	refresh: (options?: ModelsRefreshOptions) => Promise<ModelsRefreshResult>,
 	networkEnabled = true,
 ) {
-	return { refresh: vi.fn(refresh), isNetworkRefreshEnabled: () => networkEnabled };
+	let credentialGeneration = 0;
+	return {
+		refresh: vi.fn(refresh),
+		isNetworkRefreshEnabled: () => networkEnabled,
+		getCredentialGeneration: () => credentialGeneration,
+		mutateCredentials: () => {
+			credentialGeneration += 1;
+		},
+	};
 }
 
 describe("interactive model catalog refresh", () => {
@@ -63,7 +75,7 @@ describe("interactive model catalog refresh", () => {
 		await expect(second).resolves.toEqual(successfulRefresh());
 	});
 
-	it("aborts an abandoned refresh in the aborting tick and allows a later refresh to start", async () => {
+	it("starts new work for a caller that retries in the aborting tick", async () => {
 		const refreshSignals: AbortSignal[] = [];
 		const runtime = createRuntime((options?: ModelsRefreshOptions) => {
 			if (options?.signal) refreshSignals.push(options.signal);
@@ -76,6 +88,30 @@ describe("interactive model catalog refresh", () => {
 		// Synchronous: a closing selector cancels the network work it started
 		// before the next render, exactly as a direct runtime.refresh() did.
 		expect(refreshSignals[0]?.aborted).toBe(true);
+
+		// Same tick, before the abandoned entry's own cleanup microtask runs. A
+		// reopened selector must start a refresh rather than join a dead one.
+		const secondController = new AbortController();
+		const second = refreshModelCatalogs(runtime, { signal: secondController.signal });
+		expect(runtime.refresh).toHaveBeenCalledTimes(2);
+		expect(refreshSignals[1]?.aborted).toBe(false);
+
+		await expect(first).rejects.toMatchObject({ name: "AbortError" });
+		secondController.abort();
+		await expect(second).rejects.toMatchObject({ name: "AbortError" });
+	});
+
+	it("aborts an abandoned refresh in the aborting tick and allows a later refresh to start", async () => {
+		const refreshSignals: AbortSignal[] = [];
+		const runtime = createRuntime((options?: ModelsRefreshOptions) => {
+			if (options?.signal) refreshSignals.push(options.signal);
+			return new Promise<ModelsRefreshResult>(() => {});
+		});
+		const firstController = new AbortController();
+		const first = refreshModelCatalogs(runtime, { signal: firstController.signal });
+
+		firstController.abort();
+		expect(refreshSignals[0]?.aborted).toBe(true);
 		await expect(first).rejects.toMatchObject({ name: "AbortError" });
 
 		const secondController = new AbortController();
@@ -83,6 +119,47 @@ describe("interactive model catalog refresh", () => {
 		expect(runtime.refresh).toHaveBeenCalledTimes(2);
 		secondController.abort();
 		await expect(second).rejects.toMatchObject({ name: "AbortError" });
+	});
+
+	it("refuses to answer a post-credential-change request with a pass that predates it", async () => {
+		const beforeLoginPass = createDeferred<ModelsRefreshResult>();
+		const afterLoginPass = createDeferred<ModelsRefreshResult>();
+		let starts = 0;
+		const runtime = createRuntime(() => (starts++ === 0 ? beforeLoginPass.promise : afterLoginPass.promise));
+		const controller = new AbortController();
+
+		// The pre-login pass is still in flight when the credential lands, which is
+		// exactly what Atomic's API-key login produces: it skips its own refresh and
+		// leaves the catalog to the selector that opens next.
+		const beforeLogin = refreshModelCatalogs(runtime, { signal: controller.signal });
+		runtime.mutateCredentials();
+		const afterLogin = refreshModelCatalogs(runtime, { signal: controller.signal });
+
+		expect(runtime.refresh).toHaveBeenCalledTimes(2);
+
+		// The abandoned pre-login waiter still gets the answer it asked for.
+		beforeLoginPass.resolve(successfulRefresh());
+		afterLoginPass.resolve(successfulRefresh());
+		await expect(beforeLogin).resolves.toEqual(successfulRefresh());
+		await expect(afterLogin).resolves.toEqual(successfulRefresh());
+	});
+
+	it("still shares one pass between callers on the same credential generation", async () => {
+		const deferred = createDeferred<ModelsRefreshResult>();
+		const runtime = createRuntime(() => deferred.promise);
+		const controller = new AbortController();
+
+		const first = refreshModelCatalogs(runtime, { signal: controller.signal });
+		const second = refreshModelCatalogs(runtime, { signal: controller.signal });
+		expect(runtime.refresh).toHaveBeenCalledOnce();
+
+		runtime.mutateCredentials();
+		const third = refreshModelCatalogs(runtime, { signal: controller.signal });
+		const fourth = refreshModelCatalogs(runtime, { signal: controller.signal });
+		expect(runtime.refresh).toHaveBeenCalledTimes(2);
+
+		deferred.resolve(successfulRefresh());
+		await Promise.all([first, second, third, fourth]);
 	});
 
 	it("refuses to answer a different catalog request with an in-flight one", async () => {

--- a/packages/coding-agent/test/model-catalog-refresh.test.ts
+++ b/packages/coding-agent/test/model-catalog-refresh.test.ts
@@ -1,0 +1,149 @@
+import type { ModelsRefreshOptions, ModelsRefreshResult } from "@earendil-works/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { refreshModelCatalogs } from "../src/modes/interactive/model-catalog-refresh.ts";
+
+interface Deferred<T> {
+	promise: Promise<T>;
+	resolve(value: T): void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+	let resolvePromise!: (value: T) => void;
+	const promise = new Promise<T>((resolve) => {
+		resolvePromise = resolve;
+	});
+	return { promise, resolve: resolvePromise };
+}
+
+function successfulRefresh(): ModelsRefreshResult {
+	return { aborted: false, errors: new Map() };
+}
+
+describe("interactive model catalog refresh", () => {
+	it("shares one runtime refresh between concurrent callers", async () => {
+		const deferred = createDeferred<ModelsRefreshResult>();
+		const runtime = { refresh: vi.fn((_options?: ModelsRefreshOptions) => deferred.promise) };
+		const firstController = new AbortController();
+		const secondController = new AbortController();
+
+		const first = refreshModelCatalogs(runtime, { signal: firstController.signal });
+		const second = refreshModelCatalogs(runtime, { signal: secondController.signal });
+
+		expect(runtime.refresh).toHaveBeenCalledOnce();
+		deferred.resolve(successfulRefresh());
+		await expect(first).resolves.toEqual(successfulRefresh());
+		await expect(second).resolves.toEqual(successfulRefresh());
+	});
+
+	it("keeps the shared refresh alive when one caller stops waiting", async () => {
+		const deferred = createDeferred<ModelsRefreshResult>();
+		let refreshSignal: AbortSignal | undefined;
+		const runtime = {
+			refresh: vi.fn((options?: ModelsRefreshOptions) => {
+				refreshSignal = options?.signal;
+				return deferred.promise;
+			}),
+		};
+		const firstController = new AbortController();
+		const secondController = new AbortController();
+		const first = refreshModelCatalogs(runtime, { signal: firstController.signal });
+		const second = refreshModelCatalogs(runtime, { signal: secondController.signal });
+
+		firstController.abort();
+		await expect(first).rejects.toMatchObject({ name: "AbortError" });
+		expect(refreshSignal?.aborted).toBe(false);
+
+		deferred.resolve(successfulRefresh());
+		await expect(second).resolves.toEqual(successfulRefresh());
+	});
+
+	it("aborts an abandoned refresh in the aborting tick and allows a later refresh to start", async () => {
+		const refreshSignals: AbortSignal[] = [];
+		const runtime = {
+			refresh: vi.fn((options?: ModelsRefreshOptions) => {
+				if (options?.signal) refreshSignals.push(options.signal);
+				return new Promise<ModelsRefreshResult>(() => {});
+			}),
+		};
+		const firstController = new AbortController();
+		const first = refreshModelCatalogs(runtime, { signal: firstController.signal });
+
+		firstController.abort();
+		// Synchronous: a closing selector cancels the network work it started
+		// before the next render, exactly as a direct runtime.refresh() did.
+		expect(refreshSignals[0]?.aborted).toBe(true);
+		await expect(first).rejects.toMatchObject({ name: "AbortError" });
+
+		const secondController = new AbortController();
+		const second = refreshModelCatalogs(runtime, { signal: secondController.signal });
+		expect(runtime.refresh).toHaveBeenCalledTimes(2);
+		secondController.abort();
+		await expect(second).rejects.toMatchObject({ name: "AbortError" });
+	});
+
+	it("refuses to answer a different catalog request with an in-flight one", async () => {
+		const deferred = createDeferred<ModelsRefreshResult>();
+		const requested: Array<boolean | undefined> = [];
+		const runtime = {
+			refresh: vi.fn((options?: ModelsRefreshOptions) => {
+				requested.push(options?.allowNetwork);
+				return deferred.promise;
+			}),
+		};
+		const controller = new AbortController();
+
+		const networked = refreshModelCatalogs(runtime, { allowNetwork: true, signal: controller.signal });
+		const cached = refreshModelCatalogs(runtime, { allowNetwork: false, signal: controller.signal });
+		const runtimeDefault = refreshModelCatalogs(runtime, { signal: controller.signal });
+
+		expect(runtime.refresh).toHaveBeenCalledTimes(3);
+		expect(requested).toEqual([true, false, undefined]);
+
+		deferred.resolve(successfulRefresh());
+		await Promise.all([networked, cached, runtimeDefault]);
+	});
+
+	it("shares nothing across separate runtimes", async () => {
+		const deferred = createDeferred<ModelsRefreshResult>();
+		const first = { refresh: vi.fn((_options?: ModelsRefreshOptions) => deferred.promise) };
+		const second = { refresh: vi.fn((_options?: ModelsRefreshOptions) => deferred.promise) };
+		const controller = new AbortController();
+
+		const firstRefresh = refreshModelCatalogs(first, { signal: controller.signal });
+		const secondRefresh = refreshModelCatalogs(second, { signal: controller.signal });
+
+		expect(first.refresh).toHaveBeenCalledOnce();
+		expect(second.refresh).toHaveBeenCalledOnce();
+
+		deferred.resolve(successfulRefresh());
+		await Promise.all([firstRefresh, secondRefresh]);
+	});
+
+	it("rejects a caller whose signal already aborted without starting work", async () => {
+		const runtime = { refresh: vi.fn((_options?: ModelsRefreshOptions) => Promise.resolve(successfulRefresh())) };
+		const controller = new AbortController();
+		controller.abort();
+
+		expect(() => refreshModelCatalogs(runtime, { signal: controller.signal })).toThrow();
+		expect(runtime.refresh).not.toHaveBeenCalled();
+	});
+
+	it("starts a fresh refresh once the shared one has settled", async () => {
+		const first = createDeferred<ModelsRefreshResult>();
+		const second = createDeferred<ModelsRefreshResult>();
+		const deferrals = [first, second];
+		const runtime = {
+			refresh: vi.fn((_options?: ModelsRefreshOptions) => (deferrals.shift() ?? first).promise),
+		};
+		const controller = new AbortController();
+
+		const firstRefresh = refreshModelCatalogs(runtime, { signal: controller.signal });
+		first.resolve(successfulRefresh());
+		await expect(firstRefresh).resolves.toEqual(successfulRefresh());
+
+		const secondRefresh = refreshModelCatalogs(runtime, { signal: controller.signal });
+		expect(runtime.refresh).toHaveBeenCalledTimes(2);
+		second.resolve(successfulRefresh());
+		await expect(secondRefresh).resolves.toEqual(successfulRefresh());
+	});
+});

--- a/packages/coding-agent/test/model-catalog-refresh.test.ts
+++ b/packages/coding-agent/test/model-catalog-refresh.test.ts
@@ -20,21 +20,27 @@ function successfulRefresh(): ModelsRefreshResult {
 }
 
 /**
- * A runtime stub carrying the network policy an omitted `allowNetwork` resolves to
- * and the credential generation a real `ModelRuntime` bumps on every login, logout,
- * or key change.
+ * A runtime stub carrying the network policy an omitted `allowNetwork` resolves to,
+ * the credential generation a real `ModelRuntime` bumps on every login, logout,
+ * or key change, and the models.json fingerprint a real `ModelRuntime` derives
+ * from the file every refresh reloads.
  */
 function createRuntime(
 	refresh: (options?: ModelsRefreshOptions) => Promise<ModelsRefreshResult>,
 	networkEnabled = true,
 ) {
 	let credentialGeneration = 0;
+	let modelConfigFingerprint = "models-a";
 	return {
 		refresh: vi.fn(refresh),
 		isNetworkRefreshEnabled: () => networkEnabled,
 		getCredentialGeneration: () => credentialGeneration,
+		getModelConfigFingerprint: () => modelConfigFingerprint,
 		mutateCredentials: () => {
 			credentialGeneration += 1;
+		},
+		editModelsJson: (fingerprint: string) => {
+			modelConfigFingerprint = fingerprint;
 		},
 	};
 }
@@ -160,6 +166,46 @@ describe("interactive model catalog refresh", () => {
 
 		deferred.resolve(successfulRefresh());
 		await Promise.all([first, second, third, fourth]);
+	});
+
+	it("refuses to answer a post-models.json-edit request with a pass that predates the edit", async () => {
+		const beforeEditPass = createDeferred<ModelsRefreshResult>();
+		const afterEditPass = createDeferred<ModelsRefreshResult>();
+		let starts = 0;
+		const runtime = createRuntime(() => (starts++ === 0 ? beforeEditPass.promise : afterEditPass.promise));
+		const controller = new AbortController();
+
+		// Every pass reloads models.json and applies it, so the in-flight pass carries
+		// the provider key and model list the user just replaced.
+		const beforeEdit = refreshModelCatalogs(runtime, { signal: controller.signal });
+		runtime.editModelsJson("models-b");
+		const afterEdit = refreshModelCatalogs(runtime, { signal: controller.signal });
+
+		expect(runtime.refresh).toHaveBeenCalledTimes(2);
+
+		beforeEditPass.resolve(successfulRefresh());
+		afterEditPass.resolve(successfulRefresh());
+		await expect(beforeEdit).resolves.toEqual(successfulRefresh());
+		await expect(afterEdit).resolves.toEqual(successfulRefresh());
+	});
+
+	it("still shares one pass between callers reading the same models.json", async () => {
+		const deferred = createDeferred<ModelsRefreshResult>();
+		const runtime = createRuntime(() => deferred.promise);
+		const controller = new AbortController();
+
+		const first = refreshModelCatalogs(runtime, { signal: controller.signal });
+		const second = refreshModelCatalogs(runtime, { signal: controller.signal });
+		expect(runtime.refresh).toHaveBeenCalledOnce();
+
+		// An edit that restores the previous content is the same work again, so a
+		// caller after it still joins rather than paying for a duplicate pass.
+		runtime.editModelsJson("models-a");
+		const third = refreshModelCatalogs(runtime, { signal: controller.signal });
+		expect(runtime.refresh).toHaveBeenCalledOnce();
+
+		deferred.resolve(successfulRefresh());
+		await Promise.all([first, second, third]);
 	});
 
 	it("refuses to answer a different catalog request with an in-flight one", async () => {

--- a/packages/coding-agent/test/model-catalog-refresh.test.ts
+++ b/packages/coding-agent/test/model-catalog-refresh.test.ts
@@ -20,30 +20,31 @@ function successfulRefresh(): ModelsRefreshResult {
 }
 
 /**
- * A runtime stub carrying the network policy an omitted `allowNetwork` resolves to,
- * the credential generation a real `ModelRuntime` bumps on every login, logout,
- * or key change, and the models.json fingerprint a real `ModelRuntime` derives
- * from the file every refresh reloads.
+ * A runtime stub carrying the network policy an omitted `allowNetwork` resolves
+ * to and the single catalog-inputs generation a real `ModelRuntime` bumps for
+ * every input a pass reads. The mutators below stand for the three sources that
+ * bump it — a credential write, a provider registration, and a models.json edit
+ * — and the coordinator cannot tell them apart, which is the point.
  */
 function createRuntime(
 	refresh: (options?: ModelsRefreshOptions) => Promise<ModelsRefreshResult>,
 	networkEnabled = true,
 ) {
-	let credentialGeneration = 0;
-	let modelConfigFingerprint = "models-a";
+	let catalogInputsGeneration = 0;
+	const bump = () => {
+		catalogInputsGeneration += 1;
+	};
 	return {
 		refresh: vi.fn(refresh),
 		isNetworkRefreshEnabled: () => networkEnabled,
-		getCredentialGeneration: () => credentialGeneration,
-		getModelConfigFingerprint: () => modelConfigFingerprint,
-		mutateCredentials: () => {
-			credentialGeneration += 1;
-		},
-		editModelsJson: (fingerprint: string) => {
-			modelConfigFingerprint = fingerprint;
-		},
+		getCatalogInputsGeneration: () => catalogInputsGeneration,
+		mutateCredentials: bump,
+		registerProvider: bump,
+		editModelsJson: bump,
 	};
 }
+
+type CatalogRuntimeStub = ReturnType<typeof createRuntime>;
 
 describe("interactive model catalog refresh", () => {
 	it("shares one runtime refresh between concurrent callers", async () => {
@@ -150,60 +151,43 @@ describe("interactive model catalog refresh", () => {
 		await expect(afterLogin).resolves.toEqual(successfulRefresh());
 	});
 
-	it("still shares one pass between callers on the same credential generation", async () => {
-		const deferred = createDeferred<ModelsRefreshResult>();
-		const runtime = createRuntime(() => deferred.promise);
-		const controller = new AbortController();
-
-		const first = refreshModelCatalogs(runtime, { signal: controller.signal });
-		const second = refreshModelCatalogs(runtime, { signal: controller.signal });
-		expect(runtime.refresh).toHaveBeenCalledOnce();
-
-		runtime.mutateCredentials();
-		const third = refreshModelCatalogs(runtime, { signal: controller.signal });
-		const fourth = refreshModelCatalogs(runtime, { signal: controller.signal });
-		expect(runtime.refresh).toHaveBeenCalledTimes(2);
-
-		deferred.resolve(successfulRefresh());
-		await Promise.all([first, second, third, fourth]);
-	});
-
-	it("refuses to answer a post-models.json-edit request with a pass that predates the edit", async () => {
-		const beforeEditPass = createDeferred<ModelsRefreshResult>();
-		const afterEditPass = createDeferred<ModelsRefreshResult>();
+	it.each([
+		["a credential write", (runtime: CatalogRuntimeStub) => runtime.mutateCredentials()],
+		["a provider registration", (runtime: CatalogRuntimeStub) => runtime.registerProvider()],
+		["a models.json edit", (runtime: CatalogRuntimeStub) => runtime.editModelsJson()],
+	])("refuses to answer a request made after %s with a pass that predates it", async (_label, mutate) => {
+		const beforeChange = createDeferred<ModelsRefreshResult>();
+		const afterChange = createDeferred<ModelsRefreshResult>();
 		let starts = 0;
-		const runtime = createRuntime(() => (starts++ === 0 ? beforeEditPass.promise : afterEditPass.promise));
+		const runtime = createRuntime(() => (starts++ === 0 ? beforeChange.promise : afterChange.promise));
 		const controller = new AbortController();
 
-		// Every pass reloads models.json and applies it, so the in-flight pass carries
-		// the provider key and model list the user just replaced.
-		const beforeEdit = refreshModelCatalogs(runtime, { signal: controller.signal });
-		runtime.editModelsJson("models-b");
-		const afterEdit = refreshModelCatalogs(runtime, { signal: controller.signal });
+		// One counter covers all three, so the coordinator needs no case analysis
+		// and cannot be left blind to the next input someone adds.
+		const first = refreshModelCatalogs(runtime, { signal: controller.signal });
+		mutate(runtime);
+		const second = refreshModelCatalogs(runtime, { signal: controller.signal });
 
 		expect(runtime.refresh).toHaveBeenCalledTimes(2);
 
-		beforeEditPass.resolve(successfulRefresh());
-		afterEditPass.resolve(successfulRefresh());
-		await expect(beforeEdit).resolves.toEqual(successfulRefresh());
-		await expect(afterEdit).resolves.toEqual(successfulRefresh());
+		beforeChange.resolve(successfulRefresh());
+		afterChange.resolve(successfulRefresh());
+		await expect(first).resolves.toEqual(successfulRefresh());
+		await expect(second).resolves.toEqual(successfulRefresh());
 	});
 
-	it("still shares one pass between callers reading the same models.json", async () => {
+	it("still shares one pass while the catalog inputs hold still", async () => {
 		const deferred = createDeferred<ModelsRefreshResult>();
 		const runtime = createRuntime(() => deferred.promise);
 		const controller = new AbortController();
 
 		const first = refreshModelCatalogs(runtime, { signal: controller.signal });
 		const second = refreshModelCatalogs(runtime, { signal: controller.signal });
-		expect(runtime.refresh).toHaveBeenCalledOnce();
-
-		// An edit that restores the previous content is the same work again, so a
-		// caller after it still joins rather than paying for a duplicate pass.
-		runtime.editModelsJson("models-a");
 		const third = refreshModelCatalogs(runtime, { signal: controller.signal });
 		expect(runtime.refresh).toHaveBeenCalledOnce();
 
+		// Only a change bumps the generation, so the startup pass a selector opens
+		// against still answers it — the dedupe this coordinator exists for.
 		deferred.resolve(successfulRefresh());
 		await Promise.all([first, second, third]);
 	});

--- a/packages/coding-agent/test/model-registry-hot-reload.test.ts
+++ b/packages/coding-agent/test/model-registry-hot-reload.test.ts
@@ -58,6 +58,7 @@ describe("model config hot reload", () => {
 			getAvailableSnapshot: () => [],
 			getModel: () => undefined,
 			isNetworkRefreshEnabled: () => false,
+			getCredentialGeneration: () => 0,
 			refresh,
 		} as unknown as ModelRuntime;
 		const tui = { requestRender: vi.fn() } as unknown as TUI;

--- a/packages/coding-agent/test/model-registry-hot-reload.test.ts
+++ b/packages/coding-agent/test/model-registry-hot-reload.test.ts
@@ -58,8 +58,7 @@ describe("model config hot reload", () => {
 			getAvailableSnapshot: () => [],
 			getModel: () => undefined,
 			isNetworkRefreshEnabled: () => false,
-			getCredentialGeneration: () => 0,
-			getModelConfigFingerprint: () => "models",
+			getCatalogInputsGeneration: () => 0,
 			refresh,
 		} as unknown as ModelRuntime;
 		const tui = { requestRender: vi.fn() } as unknown as TUI;

--- a/packages/coding-agent/test/model-registry-hot-reload.test.ts
+++ b/packages/coding-agent/test/model-registry-hot-reload.test.ts
@@ -59,6 +59,7 @@ describe("model config hot reload", () => {
 			getModel: () => undefined,
 			isNetworkRefreshEnabled: () => false,
 			getCredentialGeneration: () => 0,
+			getModelConfigFingerprint: () => "models",
 			refresh,
 		} as unknown as ModelRuntime;
 		const tui = { requestRender: vi.fn() } as unknown as TUI;

--- a/packages/coding-agent/test/model-registry-hot-reload.test.ts
+++ b/packages/coding-agent/test/model-registry-hot-reload.test.ts
@@ -57,6 +57,7 @@ describe("model config hot reload", () => {
 			getError: () => undefined,
 			getAvailableSnapshot: () => [],
 			getModel: () => undefined,
+			isNetworkRefreshEnabled: () => false,
 			refresh,
 		} as unknown as ModelRuntime;
 		const tui = { requestRender: vi.fn() } as unknown as TUI;

--- a/packages/coding-agent/test/model-selector-refresh-status.test.ts
+++ b/packages/coding-agent/test/model-selector-refresh-status.test.ts
@@ -31,8 +31,7 @@ function createSelector(refresh: ModelRuntime["refresh"]): ModelSelectorComponen
 	const runtime = {
 		refresh,
 		isNetworkRefreshEnabled: () => true,
-		getCredentialGeneration: () => 0,
-		getModelConfigFingerprint: () => "models",
+		getCatalogInputsGeneration: () => 0,
 		getError: () => undefined,
 		getAvailableSnapshot: () => [model],
 		getModel: () => model,

--- a/packages/coding-agent/test/model-selector-refresh-status.test.ts
+++ b/packages/coding-agent/test/model-selector-refresh-status.test.ts
@@ -31,6 +31,7 @@ function createSelector(refresh: ModelRuntime["refresh"]): ModelSelectorComponen
 	const runtime = {
 		refresh,
 		isNetworkRefreshEnabled: () => true,
+		getCredentialGeneration: () => 0,
 		getError: () => undefined,
 		getAvailableSnapshot: () => [model],
 		getModel: () => model,

--- a/packages/coding-agent/test/model-selector-refresh-status.test.ts
+++ b/packages/coding-agent/test/model-selector-refresh-status.test.ts
@@ -30,6 +30,7 @@ function createSelector(refresh: ModelRuntime["refresh"]): ModelSelectorComponen
 	initTheme("dark");
 	const runtime = {
 		refresh,
+		isNetworkRefreshEnabled: () => true,
 		getError: () => undefined,
 		getAvailableSnapshot: () => [model],
 		getModel: () => model,

--- a/packages/coding-agent/test/model-selector-refresh-status.test.ts
+++ b/packages/coding-agent/test/model-selector-refresh-status.test.ts
@@ -32,6 +32,7 @@ function createSelector(refresh: ModelRuntime["refresh"]): ModelSelectorComponen
 		refresh,
 		isNetworkRefreshEnabled: () => true,
 		getCredentialGeneration: () => 0,
+		getModelConfigFingerprint: () => "models",
 		getError: () => undefined,
 		getAvailableSnapshot: () => [model],
 		getModel: () => model,

--- a/packages/coding-agent/test/session-manager/file-operations.test.ts
+++ b/packages/coding-agent/test/session-manager/file-operations.test.ts
@@ -3,6 +3,7 @@ import { appendFileSync, closeSync, mkdirSync, openSync, readFileSync, rmSync, w
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { APP_TITLE } from "../../src/config.ts";
 import { findMostRecentSession, loadEntriesFromFile, SessionManager } from "../../src/core/session-manager.ts";
 
 describe("loadEntriesFromFile", () => {
@@ -289,7 +290,7 @@ describe("SessionManager.setSessionFile with corrupted files", () => {
 		writeFileSync(noHeaderFile, originalContent);
 
 		expect(() => SessionManager.open(noHeaderFile, tempDir)).toThrow(
-			`Session file is not a valid Atomic session: ${noHeaderFile}`,
+			`Session file is not a valid ${APP_TITLE} session: ${noHeaderFile}`,
 		);
 
 		// The corrupted file must be left untouched.

--- a/packages/coding-agent/test/session-manager/invalid-session-file.test.ts
+++ b/packages/coding-agent/test/session-manager/invalid-session-file.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { APP_TITLE } from "../../src/config.ts";
 import { SessionManager } from "../../src/core/session-manager.ts";
 
 describe("SessionManager.open rejects invalid non-empty session files", () => {
@@ -12,7 +13,7 @@ describe("SessionManager.open rejects invalid non-empty session files", () => {
 		writeFileSync(sessionFile, originalContent);
 
 		expect(() => SessionManager.open(sessionFile, tempDir)).toThrow(
-			`Session file is not a valid Atomic session: ${sessionFile}`,
+			`Session file is not a valid ${APP_TITLE} session: ${sessionFile}`,
 		);
 		// The invalid file must not be modified or truncated.
 		expect(readFileSync(sessionFile, "utf8")).toBe(originalContent);

--- a/packages/coding-agent/test/suite/regressions/7887-system-prompt-cwd-newline.test.ts
+++ b/packages/coding-agent/test/suite/regressions/7887-system-prompt-cwd-newline.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { buildSystemPrompt } from "../../../src/core/system-prompt.ts";
+
+/**
+ * The working directory is the last line of the prompt. Without a trailing
+ * newline the next block a provider concatenates lands on the same line as the
+ * path, so the path itself reads as something other than a path.
+ */
+describe("regression #7887: the system prompt ends with a newline after the cwd", () => {
+	const cwd = process.cwd();
+	const promptCwd = cwd.replace(/\\/g, "/");
+
+	it("terminates the default prompt after the working directory", () => {
+		const prompt = buildSystemPrompt({ selectedTools: [], contextFiles: [], skills: [], cwd });
+
+		expect(prompt.endsWith(`\nCurrent working directory: ${promptCwd}\n`)).toBe(true);
+	});
+
+	it("terminates a custom prompt after the working directory", () => {
+		const prompt = buildSystemPrompt({
+			customPrompt: "You are a custom assistant.",
+			contextFiles: [],
+			skills: [],
+			cwd,
+		});
+
+		expect(prompt).toContain("You are a custom assistant.");
+		expect(prompt.endsWith(`\nCurrent working directory: ${promptCwd}\n`)).toBe(true);
+	});
+
+	it("keeps exactly one trailing newline", () => {
+		const prompt = buildSystemPrompt({ selectedTools: [], contextFiles: [], skills: [], cwd });
+
+		expect(prompt.endsWith("\n\n")).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/7979-fallback-tool-output-collapse.test.ts
+++ b/packages/coding-agent/test/suite/regressions/7979-fallback-tool-output-collapse.test.ts
@@ -1,0 +1,110 @@
+import { getKeybindings, setKeybindings, type TUI } from "@earendil-works/pi-tui";
+import { Type } from "typebox";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { ToolDefinition } from "../../../src/core/extensions/types.ts";
+import { KeybindingsManager } from "../../../src/core/keybindings.ts";
+import { ToolExecutionComponent } from "../../../src/modes/interactive/components/tool-execution.ts";
+import { initTheme } from "../../../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../../../src/utils/ansi.ts";
+
+const previousKeybindings = getKeybindings();
+
+const PREVIEW_LINES = 10;
+const OUTPUT_LINES = 42;
+
+/** An extension tool with no renderer falls back to printing its raw text output. */
+function createRendererlessToolDefinition(): ToolDefinition {
+	return {
+		name: "custom_tool",
+		label: "custom_tool",
+		description: "custom tool",
+		parameters: Type.Unknown(),
+		execute: async () => ({ content: [{ type: "text", text: "ok" }], details: {} }),
+	};
+}
+
+function createFakeTui(): TUI {
+	return { requestRender: () => {} } as unknown as TUI;
+}
+
+function renderFallback(expanded: boolean): string {
+	const component = new ToolExecutionComponent(
+		"custom_tool",
+		"tool-fallback",
+		{},
+		{},
+		createRendererlessToolDefinition(),
+		createFakeTui(),
+		process.cwd(),
+	);
+	component.updateResult(
+		{
+			content: [
+				{
+					type: "text",
+					text: Array.from({ length: OUTPUT_LINES }, (_, index) => `line ${index + 1}`).join("\n"),
+				},
+			],
+			details: {},
+			isError: false,
+		},
+		false,
+	);
+	if (expanded) component.setExpanded(true);
+	return stripAnsi(component.render(120).join("\n"));
+}
+
+/**
+ * A rendererless extension tool used to print its entire output, so one verbose
+ * call pushed the whole conversation off the screen.
+ */
+describe("regression #7979: fallback extension tool output collapses", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	afterEach(() => {
+		setKeybindings(previousKeybindings);
+	});
+
+	it("previews ten lines and offers the bound expand key", () => {
+		setKeybindings(new KeybindingsManager({ "app.tools.expand": ["ctrl+r"] }));
+		const rendered = renderFallback(false);
+
+		expect(rendered).toContain(`line ${PREVIEW_LINES}`);
+		expect(rendered).not.toContain(`line ${PREVIEW_LINES + 1}`);
+		expect(rendered).toContain(`(${OUTPUT_LINES - PREVIEW_LINES} more lines, ctrl+r Expand)`);
+	});
+
+	it("keeps the hidden-line count when the expand action is unbound", () => {
+		setKeybindings(new KeybindingsManager({ "app.tools.expand": [] }));
+		const rendered = renderFallback(false);
+
+		expect(rendered).toContain(`(${OUTPUT_LINES - PREVIEW_LINES} more lines)`);
+		expect(rendered).not.toMatch(/\b(?:Expand|Collapse)\b/);
+	});
+
+	it("prints every line once expanded, with no remaining-lines hint", () => {
+		const rendered = renderFallback(true);
+
+		expect(rendered).toContain(`line ${OUTPUT_LINES}`);
+		expect(rendered).not.toContain("more lines");
+	});
+
+	it("leaves output shorter than the preview untouched", () => {
+		const component = new ToolExecutionComponent(
+			"custom_tool",
+			"tool-short",
+			{},
+			{},
+			createRendererlessToolDefinition(),
+			createFakeTui(),
+			process.cwd(),
+		);
+		component.updateResult({ content: [{ type: "text", text: "only line" }], details: {}, isError: false }, false);
+
+		const rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rendered).toContain("only line");
+		expect(rendered).not.toContain("more lines");
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/7982-json-stream-usage.test.ts
+++ b/packages/coding-agent/test/suite/regressions/7982-json-stream-usage.test.ts
@@ -1,0 +1,66 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai/compat";
+import { afterEach, describe, expect, it } from "vitest";
+import type { AgentSessionEvent } from "../../../src/core/agent-session.ts";
+import { toJsonEvent } from "../../../src/modes/json-event.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+describe("regression #7982: JSON message updates retain usage", () => {
+	let harness: Harness | undefined;
+
+	afterEach(() => {
+		harness?.cleanup();
+		harness = undefined;
+	});
+
+	it("includes cumulative usage without cumulative message snapshots", async () => {
+		harness = await createHarness();
+		harness.setResponses([fauxAssistantMessage("hello")]);
+
+		await harness.session.prompt("respond");
+
+		// #2221's delta-only wire projection dropped this fixed-size metadata with the snapshots.
+		const update = harness
+			.eventsOfType("message_update")
+			.find((event) => event.message.role === "assistant" && event.message.usage.totalTokens > 0);
+		if (update?.message.role !== "assistant") {
+			throw new Error("Expected an assistant update with populated usage");
+		}
+
+		const wireUpdate = toJsonEvent(update);
+		expect(wireUpdate.usage).toEqual(update.message.usage);
+		expect(wireUpdate).not.toHaveProperty("message");
+		expect(wireUpdate.assistantMessageEvent).not.toHaveProperty("partial");
+	});
+
+	it("carries usage on every streamed update rather than only the last", async () => {
+		harness = await createHarness();
+		harness.setResponses([fauxAssistantMessage("hello there, wire")]);
+
+		await harness.session.prompt("respond");
+
+		const updates = harness.eventsOfType("message_update").map((event) => toJsonEvent(event));
+		expect(updates.length).toBeGreaterThan(0);
+		for (const update of updates) {
+			expect(update.usage).toBeDefined();
+			expect(typeof update.usage.totalTokens).toBe("number");
+		}
+	});
+
+	it("throws on a non-assistant message_update instead of emitting zeroed usage", async () => {
+		harness = await createHarness();
+		harness.setResponses([fauxAssistantMessage("hello")]);
+		await harness.session.prompt("respond");
+
+		const update = harness.eventsOfType("message_update")[0];
+		if (!update) throw new Error("Expected at least one message_update event");
+
+		// A user message on this event is a protocol violation: usage would have to
+		// be invented, and an invented zero is indistinguishable from a real one.
+		const violation = {
+			...update,
+			message: { role: "user", content: "not an assistant message", timestamp: 1 },
+		} as unknown as AgentSessionEvent;
+
+		expect(() => toJsonEvent(violation)).toThrow("message_update message is not an assistant message");
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/8022-trigger-turn-false.test.ts
+++ b/packages/coding-agent/test/suite/regressions/8022-trigger-turn-false.test.ts
@@ -1,0 +1,177 @@
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai/compat";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import { convertToLlm } from "../../../src/core/messages.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+/**
+ * `triggerTurn: false` promises the caller that the message does not drive the
+ * agent. Before this fix the generic streaming branch queued it as a steering
+ * message anyway, so a status card sent during a turn silently became input the
+ * model acted on.
+ */
+async function createWaitingHarness(): Promise<{
+	harness: Harness;
+	releaseToolExecution: () => void;
+	promptPromise: Promise<void>;
+	waitForToolStart: Promise<void>;
+}> {
+	let releaseToolExecution: (() => void) | undefined;
+	const toolRelease = new Promise<void>((resolve) => {
+		releaseToolExecution = resolve;
+	});
+	const waitTool: AgentTool = {
+		name: "wait",
+		label: "Wait",
+		description: "Wait for release",
+		parameters: Type.Object({}),
+		execute: async () => {
+			await toolRelease;
+			return { content: [{ type: "text", text: "released" }], details: {} };
+		},
+	};
+	const harness = await createHarness({ tools: [waitTool] });
+	const waitForToolStart = new Promise<void>((resolve) => {
+		const unsubscribe = harness.session.subscribe((event) => {
+			if (event.type === "tool_execution_start" && event.toolName === "wait") {
+				unsubscribe();
+				resolve();
+			}
+		});
+	});
+
+	return {
+		harness,
+		releaseToolExecution: () => releaseToolExecution?.(),
+		promptPromise: harness.session.prompt("start"),
+		waitForToolStart,
+	};
+}
+
+function sawText(harness: Harness, text: string): boolean {
+	return convertToLlm(harness.session.messages).some(
+		(message) =>
+			message.role === "user" &&
+			typeof message.content !== "string" &&
+			message.content.some((part) => part.type === "text" && part.text === text),
+	);
+}
+
+describe("regression #8022: triggerTurn false never steers an active run", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("appends a single custom message instead of steering the streaming turn", async () => {
+		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = await createWaitingHarness();
+		harnesses.push(harness);
+		let steeredIntoTurn = false;
+
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+			(context) => {
+				steeredIntoTurn = context.messages.some(
+					(message) =>
+						message.role === "user" &&
+						typeof message.content !== "string" &&
+						message.content.some((part) => part.type === "text" && part.text === "status only"),
+				);
+				return fauxAssistantMessage("done");
+			},
+		]);
+
+		await waitForToolStart;
+		await harness.session.sendCustomMessage(
+			{ customType: "trigger-turn-test", content: "status only", display: true, details: { value: 1 } },
+			{ triggerTurn: false },
+		);
+		releaseToolExecution();
+		await promptPromise;
+
+		expect(steeredIntoTurn).toBe(false);
+		// The card is still recorded and still reaches the model on a later turn.
+		expect(
+			harness.session.messages.filter(
+				(message) => message.role === "custom" && message.customType === "trigger-turn-test",
+			),
+		).toHaveLength(1);
+		expect(sawText(harness, "status only")).toBe(true);
+		expect(harness.getPendingResponseCount()).toBe(0);
+	});
+
+	it("appends a batch instead of steering the streaming turn", async () => {
+		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = await createWaitingHarness();
+		harnesses.push(harness);
+		let steeredIntoTurn = false;
+
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+			(context) => {
+				steeredIntoTurn = context.messages.some(
+					(message) =>
+						message.role === "user" &&
+						typeof message.content !== "string" &&
+						message.content.some((part) => part.type === "text" && part.text.startsWith("batch status")),
+				);
+				return fauxAssistantMessage("done");
+			},
+		]);
+
+		await waitForToolStart;
+		await harness.session.sendCustomMessages(
+			[
+				{ customType: "trigger-turn-test", content: "batch status 1", display: true, details: { value: 1 } },
+				{ customType: "trigger-turn-test", content: "batch status 2", display: true, details: { value: 2 } },
+			],
+			{ triggerTurn: false },
+		);
+		releaseToolExecution();
+		await promptPromise;
+
+		expect(steeredIntoTurn).toBe(false);
+		expect(
+			harness.session.messages.filter(
+				(message) => message.role === "custom" && message.customType === "trigger-turn-test",
+			),
+		).toHaveLength(2);
+		expect(sawText(harness, "batch status 1")).toBe(true);
+		expect(sawText(harness, "batch status 2")).toBe(true);
+		expect(harness.getPendingResponseCount()).toBe(0);
+	});
+
+	it("still steers when triggerTurn is left unset", async () => {
+		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = await createWaitingHarness();
+		harnesses.push(harness);
+		let steeredIntoTurn = false;
+
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+			(context) => {
+				steeredIntoTurn = context.messages.some(
+					(message) =>
+						message.role === "user" &&
+						typeof message.content !== "string" &&
+						message.content.some((part) => part.type === "text" && part.text === "steer me"),
+				);
+				return fauxAssistantMessage("done");
+			},
+		]);
+
+		await waitForToolStart;
+		await harness.session.sendCustomMessage({
+			customType: "trigger-turn-test",
+			content: "steer me",
+			display: true,
+			details: { value: 1 },
+		});
+		releaseToolExecution();
+		await promptPromise;
+
+		expect(steeredIntoTurn).toBe(true);
+	});
+});

--- a/test/unit/pi-0.83.0-pending-stop-reason-probes.test.ts
+++ b/test/unit/pi-0.83.0-pending-stop-reason-probes.test.ts
@@ -31,6 +31,7 @@ import {
 	parseInteractiveEngineCommand,
 	serializeInteractiveEngineFrame,
 } from "../../packages/coding-agent/src/modes/interactive-engine/protocol.js";
+import { toJsonEvent } from "../../packages/coding-agent/src/modes/json-event.js";
 import { attachJsonlLineReader, serializeJsonLine } from "../../packages/coding-agent/src/modes/rpc/jsonl.js";
 import type { RpcEvent } from "../../packages/coding-agent/src/modes/rpc/rpc-types.js";
 import { createHarness } from "../../packages/coding-agent/test/suite/harness.js";
@@ -119,13 +120,17 @@ test("a whole pending-carrying turn survives the RPC projection unchanged", asyn
 		harness.setResponses([fauxAssistantMessage("done", { stopReason: "stop" })]);
 		await harness.session.prompt("hi");
 
-		const received = await projectThroughRpcWire(harness.events);
+		// RPC mode writes the wire projection, not the raw session event: since
+		// #7982 a `message_update` frame carries cumulative usage instead of the
+		// cumulative message snapshot.
+		const wireEvents = harness.events.map((event) => toJsonEvent(event));
+		const received = await projectThroughRpcWire(wireEvents);
 
 		assert.deepEqual(
 			received.map((event) => event.type),
 			harness.events.map((event) => event.type),
 		);
-		assert.deepEqual(received, JSON.parse(JSON.stringify(harness.events)) as RpcEvent[]);
+		assert.deepEqual(received, JSON.parse(JSON.stringify(wireEvents)) as RpcEvent[]);
 	} finally {
 		harness.cleanup();
 	}


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789373307&installation_model_id=10562&pr_number=2418&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2418&signature=7a6c98b5fb6c815b5d4524f2ec51da22fd67e7d63377c72c32142d25f809a15d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change coordinates interactive model-catalog refreshes, tracks catalog input changes, and updates session, streamed-usage, prompt, trust, and tool-rendering behavior. A controlled refresh interleaving shows that an older configuration load can overwrite a newer published model catalog, so this should be fixed before merge. The new catalog-refresh module also needs to follow the repository’s required `.js` relative-import convention.

<h3>Confidence Score: 4/5</h3>

Not ready to merge until superseded catalog refreshes are prevented from publishing stale configuration.

The stale-publication failure was reproduced deterministically using real runtime code, file-backed configuration input, and two public refresh calls. The import-extension issue is directly visible in the changed module and is covered by a repository rule.

**Files Needing Attention:** packages/coding-agent/src/core/model-runtime.ts needs stale-refresh publication protection; packages/coding-agent/src/modes/interactive/model-catalog-refresh.ts needs ESM-compatible relative import specifiers.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding and linked it to the review comment.
- Artifacts supporting the finding were attached, including a controlled stale-refresh reproduction source and two logs.
- The general-contract-validation-proof shows that before the delayed old load release, refresh #2 published new-model; after the release, refresh #1 completed and published old-model, with new-model being null.

<a href="https://app.greptile.com/trex/runs/19084858/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/coding-agent/src/core/model-runtime.ts`, line 733-760 ([link](https://github.com/bastani-inc/atomic/blob/491ea86288f008f9a4769d32bce072159bc455e5/packages/coding-agent/src/core/model-runtime.ts#L733-L760)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Older refresh can republish stale configuration**

   A public `refresh()` starts `runRefresh` without supersession protection. If an older `ModelConfig.load()` resolves after a later refresh has loaded newer catalog input, the older pass reaches `this.config = config` and rebuilds the published model snapshot. A controlled runtime reproduction observed `new-model` after the newer refresh, then `old-model` with `new-model` absent when the delayed older load completed. Discard public refreshes whose sequence is no longer current before assigning and publishing configuration.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Controlled stale-refresh reproduction source](https://app.greptile.com/trex/artifacts/2a528126-8922-47de-8089-8f7285fe30ff)**

   - This focused Vitest source delays the first old configuration load, completes a newer refresh against rewritten input, and then releases the old load; the takeaway is that the interleaving is deterministic and reproducible.

   **[Newer refresh publication before old load release](https://app.greptile.com/trex/artifacts/6a77263b-7af3-44c5-bf3e-5285c2606605)**

   - This executed before-phase log shows the newer public refresh published \`new-model\` while the old load remained blocked; the takeaway is that the newer generation initially publishes correctly.

   **[Stale older refresh overwrite after release](https://app.greptile.com/trex/artifacts/ad005aa4-6846-4ed9-925a-33194e238dd3)**

   - This executed completion-phase log shows the released older refresh published \`old-model\` and left \`new-model\` absent; the takeaway is that stale configuration overwrites the newer publication.

   <a href="https://app.greptile.com/trex/runs/19084858/artifacts?artifact=2a528126-8922-47de-8089-8f7285fe30ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/coding-agent/src/core/model-runtime.ts
   Line: 733-760

   Comment:
   **Older refresh can republish stale configuration**

   A public `refresh()` starts `runRefresh` without supersession protection. If an older `ModelConfig.load()` resolves after a later refresh has loaded newer catalog input, the older pass reaches `this.config = config` and rebuilds the published model snapshot. A controlled runtime reproduction observed `new-model` after the newer refresh, then `old-model` with `new-model` absent when the delayed older load completed. Discard public refreshes whose sequence is no longer current before assigning and publishing configuration.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Older public refresh can republish stale models.json configuration**

   - **Bug**
     - A delayed older `ModelConfig.load` completion overwrote the `new-model` published by a newer public refresh with `old-model`.
   - **Cause**
     - `ModelRuntime.refresh()` calls `runRefresh(options, ++this.refreshSequence)` without enabling `discardIfSuperseded`, so the stale pass reaches `this.config = config` at line 760.
   - **Fix**
     - Enable supersession discard for public refreshes, then retain the controlled interleaving regression test.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/src/core/model-runtime.ts:733-760
**Older refresh can republish stale configuration**

A public `refresh()` starts `runRefresh` without supersession protection. If an older `ModelConfig.load()` resolves after a later refresh has loaded newer catalog input, the older pass reaches `this.config = config` and rebuilds the published model snapshot. A controlled runtime reproduction observed `new-model` after the newer refresh, then `old-model` with `new-model` absent when the delayed older load completed. Discard public refreshes whose sequence is no longer current before assigning and publishing configuration.

### Issue 2
packages/coding-agent/src/modes/interactive/model-catalog-refresh.ts:2-3
**Relative imports use wrong extension**

These new relative imports use `.ts` specifiers instead of the repository-required `.js` ESM convention; the same pattern appears in several other changed source and test files, leaving the new module graph inconsistent with the package's supported emitted-module layout.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): name the extension-source trus..."](https://github.com/bastani-inc/atomic/commit/491ea86288f008f9a4769d32bce072159bc455e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53723703)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->