### PR TITLE
fix(json-event): carry the provider end-of-turn signal on the wire

### DIFF
--- a/packages/coding-agent/src/modes/json-event.ts
+++ b/packages/coding-agent/src/modes/json-event.ts
@@ -10,6 +10,7 @@ type ToJsonEvent<T> = T extends {
 	? {
 			type: "message_update";
 			usage: Usage;
+			endTurn?: boolean;
 			assistantMessageEvent: WithoutPartial<TAssistantMessageEvent>;
 		}
 	: T;
@@ -24,7 +25,8 @@ type JsonMessageUpdateEvent = Extract<JsonAgentSessionEvent, { type: "message_up
  * Remove cumulative assistant snapshots from streaming wire events.
  * `message_start` provides the initial message, deltas build it, and
  * `message_end` provides the final authoritative message. Cumulative usage
- * remains available because its size is constant.
+ * and the provider's end-of-turn signal remain available because their size
+ * is constant.
  */
 export function toJsonEvent(event: MessageUpdateEvent): JsonMessageUpdateEvent;
 export function toJsonEvent(event: AgentSessionEvent): JsonAgentSessionEvent;
@@ -37,10 +39,22 @@ export function toJsonEvent(event: AgentSessionEvent): JsonAgentSessionEvent {
 	}
 
 	const assistantMessageEvent = event.assistantMessageEvent;
+	const usage = event.message.usage;
+	const endTurn = event.message.endTurn;
 	if (!("partial" in assistantMessageEvent)) {
-		return { type: "message_update", usage: event.message.usage, assistantMessageEvent };
+		return withEndTurn({ type: "message_update", usage, assistantMessageEvent }, endTurn);
 	}
 
 	const { partial: _partial, ...deltaEvent } = assistantMessageEvent;
-	return { type: "message_update", usage: event.message.usage, assistantMessageEvent: deltaEvent };
+	return withEndTurn({ type: "message_update", usage, assistantMessageEvent: deltaEvent }, endTurn);
+}
+
+/**
+ * Carry the provider's end-of-turn signal only when the provider reported one.
+ * A present-but-undefined key would make "the provider said nothing" look like
+ * a reported value, so an unreported signal leaves the key off the frame.
+ */
+function withEndTurn(update: JsonMessageUpdateEvent, endTurn: boolean | undefined): JsonMessageUpdateEvent {
+	if (endTurn === undefined) return update;
+	return { ...update, endTurn };
 }

--- a/packages/coding-agent/test/suite/regressions/end-turn-survives-json-and-rpc.test.ts
+++ b/packages/coding-agent/test/suite/regressions/end-turn-survives-json-and-rpc.test.ts
@@ -1,0 +1,99 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai/compat";
+import { afterEach, describe, expect, it } from "vitest";
+import { toJsonEvent } from "../../../src/modes/json-event.ts";
+import { serializeRpcOutputRecord } from "../../../src/modes/rpc/rpc-output-buffer.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+/**
+ * `AssistantMessage.endTurn` is the provider's explicit end-of-turn signal
+ * (OpenAI Codex `end_turn`). Atomic's two stdout protocols share one projection:
+ * print mode writes `JSON.stringify(toJsonEvent(event))` and the RPC session
+ * binding writes `serializeRpcOutputRecord(toJsonEvent(event))`, so both are
+ * exercised here against the same events.
+ */
+function jsonWire(event: unknown): Record<string, unknown> {
+	return JSON.parse(JSON.stringify(event)) as Record<string, unknown>;
+}
+
+function rpcWire(event: Parameters<typeof serializeRpcOutputRecord>[0]): Record<string, unknown> {
+	return JSON.parse(serializeRpcOutputRecord(event)) as Record<string, unknown>;
+}
+
+describe("regression end-turn-survives-json-and-rpc", () => {
+	let harness: Harness | undefined;
+
+	afterEach(() => {
+		harness?.cleanup();
+		harness = undefined;
+	});
+
+	it("carries a reported endTurn on streamed updates through both wires", async () => {
+		harness = await createHarness();
+		harness.setResponses([{ ...fauxAssistantMessage("hello"), endTurn: true }]);
+
+		await harness.session.prompt("respond");
+
+		// The delta-only projection strips `partial`, which is where a provider's
+		// end-of-turn signal lives during streaming — the same loss #7982 fixed for usage.
+		const updates = harness.eventsOfType("message_update").map((event) => toJsonEvent(event));
+		expect(updates.length).toBeGreaterThan(0);
+		for (const update of updates) {
+			expect(update.endTurn).toBe(true);
+			expect(jsonWire(update).endTurn).toBe(true);
+			expect(rpcWire(update).endTurn).toBe(true);
+		}
+	});
+
+	it("carries a reported endTurn on the final message through both wires", async () => {
+		harness = await createHarness();
+		harness.setResponses([{ ...fauxAssistantMessage("hello"), endTurn: true }]);
+
+		await harness.session.prompt("respond");
+
+		const end = harness
+			.eventsOfType("message_end")
+			.map((event) => toJsonEvent(event))
+			.find((event) => event.type === "message_end" && event.message.role === "assistant");
+		if (end?.type !== "message_end" || end.message.role !== "assistant") {
+			throw new Error("Expected an assistant message_end event");
+		}
+
+		expect(end.message.endTurn).toBe(true);
+		const jsonMessage = jsonWire(end).message as Record<string, unknown>;
+		const rpcMessage = rpcWire(end).message as Record<string, unknown>;
+		expect(jsonMessage.endTurn).toBe(true);
+		expect(rpcMessage.endTurn).toBe(true);
+	});
+
+	it("omits endTurn entirely when the provider reported none", async () => {
+		harness = await createHarness();
+		harness.setResponses([fauxAssistantMessage("hello")]);
+
+		await harness.session.prompt("respond");
+
+		// A present-but-undefined key would make silence indistinguishable from a
+		// provider that explicitly reported `endTurn: false`.
+		const updates = harness.eventsOfType("message_update").map((event) => toJsonEvent(event));
+		expect(updates.length).toBeGreaterThan(0);
+		for (const update of updates) {
+			expect(update).not.toHaveProperty("endTurn");
+			expect(jsonWire(update)).not.toHaveProperty("endTurn");
+			expect(rpcWire(update)).not.toHaveProperty("endTurn");
+		}
+	});
+
+	it("preserves a reported endTurn of false rather than dropping it as falsy", async () => {
+		harness = await createHarness();
+		harness.setResponses([{ ...fauxAssistantMessage("hello"), endTurn: false }]);
+
+		await harness.session.prompt("respond");
+
+		const updates = harness.eventsOfType("message_update").map((event) => toJsonEvent(event));
+		expect(updates.length).toBeGreaterThan(0);
+		for (const update of updates) {
+			expect(update.endTurn).toBe(false);
+			expect(jsonWire(update).endTurn).toBe(false);
+			expect(rpcWire(update).endTurn).toBe(false);
+		}
+	});
+});


### PR DESCRIPTION
pi-ai 0.84.2 adds `AssistantMessage.endTurn`, the provider's explicit
end-of-turn signal (OpenAI Codex `end_turn`). Atomic's shared JSON/RPC
projection strips `partial` from every `message_update`, so the signal
died there exactly as cumulative usage did before #7982: `message_end`
carried it, every streamed frame did not.

`toJsonEvent` now copies `endTurn` onto the update frame, and only when
the provider reported one — a present-but-undefined key would make
silence indistinguishable from a reported `false`.

Assistant-model: Claude Opus 5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789375730&installation_model_id=10562&pr_number=2419&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2419&signature=5a4bcf00a8aa28d67b88a958e1456351866c6028b0f10831b4ad3a899f6bc10a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change carries the provider-reported `endTurn` signal through JSON and RPC message-update output, preserving explicit `true` and `false` values while omitting the field when the provider does not report it.

One P2 test-convention issue remains in the new regression suite: its assertion and helper typing style does not follow the repository rule.

<h3>Confidence Score: 4/5</h3>

The functional change is covered by focused regression scenarios for streamed updates, final messages, omitted values, and explicit false values; merge is safe once the repository test-style requirement is addressed.

The final finding set contains one non-security P2 issue and no P0 or P1 findings, which maps to a score of 4.

**Files Needing Attention:** packages/coding-agent/test/suite/regressions/end-turn-survives-json-and-rpc.test.ts

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/test/suite/regressions/end-turn-survives-json-and-rpc.test.ts:2
**Follow repository test conventions**

This regression suite uses Vitest's `expect` assertions and ambiguous `unknown` helper types instead of the required `node:assert/strict` style and specific wire types, weakening type checking around the protocol shape under test.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(json-event): carry the provider end-..."](https://github.com/bastani-inc/atomic/commit/ce97052d7c719bf01c9e5647170a987a4efb0a22) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53723709)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->