### PR TITLE
pi 0.84.2/viewport gate

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -2713,6 +2713,8 @@ Custom component `handleInput` methods must return `true` when they consume an i
 
 Custom component `handleInput` methods must return `true` when they consume an input and `false` or `undefined` when they do not. In fullscreen mode, an unhandled viewport key continues to the transcript; remote components also fall through on a failed or timed-out reply. Return `true` for a handled key so it is not applied twice.
 
+A handler that returns a promise is judged when it settles: only a resolved `true` consumes the key, while `false`, `undefined`, and a rejection fall through to the viewport. A component with no `handleInput` declines everything, so viewport keys still scroll the transcript behind it.
+
 Pass `{ handlesCtrlC: true }` when the component binds Ctrl+C itself (cancel, skip, close). In isolated interactive sessions the host otherwise closes a component that owns input on the first Ctrl+C, so that a component which never resolves cannot trap the keyboard. See [Interactive callback isolation](#interactive-callback-isolation).
 
 See [TUI components](/tui) for the full component API.

--- a/packages/coding-agent/docs/tui.md
+++ b/packages/coding-agent/docs/tui.md
@@ -28,6 +28,8 @@ interface Component {
 
 The installed pi-tui type still permits handlers that return `void`; Atomic treats a missing or `undefined` result as unhandled only for a matching fullscreen viewport key or a mouse event deferred to a focused overlay. Components that mutate state for such an input must return `true` so the viewport does not apply it a second time.
 
+Omitting `handleInput` altogether is the same answer as declining: a focused overlay with no handler still lets fullscreen viewport keys and mouse wheel reports reach the transcript, so a notice or progress panel does not freeze scrolling behind it. An asynchronous handler is judged when it settles — only a promise that resolves `true` consumes the input, while `false`, `undefined`, and a rejection all fall through to the viewport. Input that moved focus while such a promise was pending is left to whatever holds focus when it settles.
+
 The TUI appends a full SGR reset and OSC 8 reset at the end of each rendered line. Styles do not carry across lines. If you emit multi-line text with styling, reapply styles per line or use `wrapTextWithAnsi()` so styles are preserved for each wrapped line.
 
 ## Focusable Interface (IME Support)

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-base.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-base.ts
@@ -120,9 +120,10 @@ export function isFullscreenViewportAction(data: string, keybindings: Keybinding
  * `app.thinking.toggle` is a documented, remappable host action, and it is
  * dispatched from `onOverlayUnhandledInput`, which only the gated route runs.
  * Exempting the find box first would send that key to pi-tui instead and drop
- * the toggle for as long as a search had focus. Routing it through the find box
- * costs nothing: pi-tui's `Input` rejects control sequences, so the query is
- * untouched and the declined key reaches the host action.
+ * the toggle for as long as a search had focus. The gated route answers it
+ * before the find box sees it (`interactive-tui.ts:routeViewportInput`),
+ * because the binding may be a bare letter (`docs/keybindings.md`) and pi-tui's
+ * `Input` types a printable character into the query rather than rejecting it.
  */
 export function shouldHandleFullscreenViewportInput(
 	focused: Component | null,

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-base.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-base.ts
@@ -96,6 +96,17 @@ export function isFullscreenViewportAction(data: string, keybindings: Keybinding
  * every action this list omits, so a user-bound `tui.altScreen.lineUp` still
  * reaches the focused component first.
  *
+ * **A focused overlay with no `handleInput` is still an overlay.** The handler
+ * is optional — `ExtensionCustomComponent` marks it `handleInput?` and
+ * `docs/tui.md` documents it as optional — and a component that cannot answer
+ * declines by definition. Answering "the viewport owns it" for that shape
+ * would hand the key to pi-tui, whose native deferral then drops it because an
+ * overlay holds focus, so the transcript would freeze behind a component that
+ * never asked for the key. A handler-less overlay therefore takes the same
+ * route as one that returns `false`: nothing to offer, then replay. Only a
+ * focused component that is *not* an overlay keeps the shortcut, because
+ * pi-tui defers nothing to it.
+ *
  * **Exemption: pi-tui's find box.** `focusedIsViewportSearch` reports whether
  * the focused overlay is the transcript-search box pi-tui mounts itself, which
  * is viewport chrome rather than an application overlay. It gets no first
@@ -122,7 +133,8 @@ export function shouldHandleFullscreenViewportInput(
 	keybindings: KeybindingsManager,
 	focusedIsViewportSearch = false,
 ): boolean {
-	if (focused === editor || !focused?.handleInput) return true;
+	if (focused === editor || !focused) return true;
+	if (!focused.handleInput && !focusedIsOverlay) return true;
 	// The find box is exempt from mouse deferral too: a wheel report over the
 	// transcript scrolls it rather than reaching the query.
 	if (isMouseInput) return focusedIsViewportSearch || !focusedIsOverlay;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-base.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-base.ts
@@ -84,6 +84,34 @@ export function isFullscreenViewportAction(data: string, keybindings: Keybinding
  * `AtomicTuiAltScreen`, so this policy does not duplicate terminal grammars.
  * Mouse deferral is limited to actual overlays so inline components do not
  * disable pi-tui's application-owned transcript selection path.
+ *
+ * **Who owns viewport keys while an overlay is focused.** pi-tui 0.84.2 added
+ * `shouldDeferViewportInputToOverlay()` (upstream #7894) and answers "the
+ * overlay". Atomic answers "the overlay first, the transcript with whatever it
+ * declines" (#2378 / PR #2381): the actions in `FULLSCREEN_VIEWPORT_ACTIONS`
+ * and wheel reports are offered to the focused overlay, and
+ * `AtomicTuiAltScreen` replays what it does not consume into pi-tui's viewport
+ * listener. Atomic's answer stands, because a mounted dialog that keeps its
+ * selection keys must not also freeze the transcript behind it. pi-tui keeps
+ * every action this list omits, so a user-bound `tui.altScreen.lineUp` still
+ * reaches the focused component first.
+ *
+ * **Exemption: pi-tui's find box.** `focusedIsViewportSearch` reports whether
+ * the focused overlay is the transcript-search box pi-tui mounts itself, which
+ * is viewport chrome rather than an application overlay. It gets no first
+ * offer: input goes straight to pi-tui, which exempts its own find box from
+ * native deferral, so the transcript keeps scrolling while a search is open and
+ * `home`/`end` scroll rather than move the query cursor — upstream's behavior
+ * exactly. Everything the viewport does not claim still falls through to the
+ * find box, so typing edits the query. Callers without a find box omit it.
+ *
+ * **Order matters: the host thinking toggle outranks the exemption.**
+ * `app.thinking.toggle` is a documented, remappable host action, and it is
+ * dispatched from `onOverlayUnhandledInput`, which only the gated route runs.
+ * Exempting the find box first would send that key to pi-tui instead and drop
+ * the toggle for as long as a search had focus. Routing it through the find box
+ * costs nothing: pi-tui's `Input` rejects control sequences, so the query is
+ * untouched and the declined key reaches the host action.
  */
 export function shouldHandleFullscreenViewportInput(
 	focused: Component | null,
@@ -92,10 +120,14 @@ export function shouldHandleFullscreenViewportInput(
 	isMouseInput: boolean,
 	focusedIsOverlay: boolean,
 	keybindings: KeybindingsManager,
+	focusedIsViewportSearch = false,
 ): boolean {
 	if (focused === editor || !focused?.handleInput) return true;
-	if (isMouseInput) return !focusedIsOverlay;
+	// The find box is exempt from mouse deferral too: a wheel report over the
+	// transcript scrolls it rather than reaching the query.
+	if (isMouseInput) return focusedIsViewportSearch || !focusedIsOverlay;
 	if (focusedIsOverlay && keybindings.matches(data, "app.thinking.toggle")) return false;
+	if (focusedIsViewportSearch) return true;
 	return !isFullscreenViewportAction(data, keybindings);
 }
 
@@ -149,6 +181,7 @@ export class InteractiveModeBase {
 		data: string,
 		isMouseInput: boolean,
 		focusedIsOverlay: boolean,
+		focusedIsViewportSearch: boolean,
 	): boolean => {
 		return shouldHandleFullscreenViewportInput(
 			this.renderer.getFocusedComponent(),
@@ -157,6 +190,7 @@ export class InteractiveModeBase {
 			isMouseInput,
 			focusedIsOverlay,
 			this.keybindings,
+			focusedIsViewportSearch,
 		);
 	};
 	private readonly onOverlayUnhandledInput = (data: string): boolean => this.handleOverlayUnhandledInput(data);

--- a/packages/coding-agent/src/modes/interactive/interactive-tui.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-tui.ts
@@ -49,6 +49,16 @@ interface TuiAltScreenViewportDeferral {
 	shouldDeferViewportInputToOverlay?(): boolean;
 }
 
+/**
+ * pi-tui 0.84.2 keeps its transcript-search state private
+ * (tui-alt-screen.d.ts:50). Only the focus question is read here: pi-tui's own
+ * `shouldDeferViewportInputToOverlay` asks it the same way
+ * (`dist/tui-alt-screen.js:379`), and a missing field reads as "no find box".
+ */
+interface TuiAltScreenSearchInternals {
+	activeSearch?: { overlay?: { isFocused(): boolean } };
+}
+
 export type InteractiveTui = TuiMainScreen | TuiAltScreen;
 
 export function isOverlayMounted(tui: TUI, component: Component): boolean {
@@ -88,8 +98,16 @@ export interface InteractiveTuiOptions {
 	 * Return false to let a focused overlay receive viewport input first.
 	 * Mouse input is deferred only while the focused component belongs to an
 	 * overlay; non-overlay focus keeps pi-tui's transcript selection path.
+	 * `focusedIsViewportSearch` marks the one overlay pi-tui mounts itself — its
+	 * find box — which is exempt so the transcript still scrolls while a search
+	 * is open.
 	 */
-	shouldHandleViewportInput?: (data: string, isMouseInput: boolean, focusedIsOverlay: boolean) => boolean;
+	shouldHandleViewportInput?: (
+		data: string,
+		isMouseInput: boolean,
+		focusedIsOverlay: boolean,
+		focusedIsViewportSearch: boolean,
+	) => boolean;
 	/** Handle an unconsumed overlay input before replaying it to the viewport. */
 	onOverlayUnhandledInput?: (data: string) => boolean;
 }
@@ -141,10 +159,14 @@ export function handleUrlActivation(url: string, handlers: UrlActivationHandlers
 
 const viewportInputListeners = new WeakSet<AtomicTuiAltScreen>();
 
-const viewportInputGates = new WeakMap<
-	AtomicTuiAltScreen,
-	(data: string, isMouseInput: boolean, focusedIsOverlay: boolean) => boolean
->();
+type ViewportInputGate = (
+	data: string,
+	isMouseInput: boolean,
+	focusedIsOverlay: boolean,
+	focusedIsViewportSearch: boolean,
+) => boolean;
+
+const viewportInputGates = new WeakMap<AtomicTuiAltScreen, ViewportInputGate>();
 const overlayUnhandledInputHandlers = new WeakMap<AtomicTuiAltScreen, (data: string) => boolean>();
 /** Instances currently replaying overlay-declined input into pi-tui's viewport listener. */
 const viewportInputReplays = new WeakSet<AtomicTuiAltScreen>();
@@ -216,7 +238,24 @@ function isLeftMouseSequence(data: string): boolean {
 	return parseMouseSequences(data)?.some((sequence) => isLeftMouseButton(sequence)) ?? false;
 }
 
-/** Replay a chunk one report at a time because pi-tui parses one report per call. */
+/**
+ * Replay a chunk one report at a time because pi-tui parses one report per
+ * call. Only a chunk whose every byte is a mouse report is split; anything else
+ * is replayed verbatim.
+ *
+ * **Probe, pi 0.84.2 (upstream `2a95ef70`, `06ed8716`):** neither the
+ * lone-ESC timeout scope nor the split-`Alt+Enter` reassembly is affected by
+ * this replay. Both land in `StdinBuffer`/`ProcessTerminal`
+ * (`dist/stdin-buffer.js:process`, `dist/terminal.js:48`), which assemble
+ * complete sequences before any listener runs; Atomic builds pi-tui's own
+ * `ProcessTerminal` in `createFullscreenTui`/`createInteractiveTui` below and
+ * overrides neither the buffer nor its escape timeout. A reassembled `\x1b` or
+ * `\x1b\r` reaches this function as one chunk, fails `parseMouseSequences`, and
+ * is handed on unsplit — so a viewport action bound to `escape` or `alt+enter`
+ * still matches after a decline.
+ * Outcome: no breakage, covered by the replay probes in
+ * `test/pi-0.84.2-overlay-viewport-deferral.test.ts`.
+ */
 function replayMouseInput(viewportListener: TuiInputListener, data: string): void {
 	const sequences = parseMouseSequences(data);
 	if (!sequences) {
@@ -239,7 +278,7 @@ class AtomicTuiAltScreen extends TuiAltScreen {
 		showHardwareCursor: boolean,
 		logDirectory: string,
 		options: ConstructorParameters<typeof TuiAltScreen>[3],
-		viewportInputGate?: (data: string, isMouseInput: boolean, focusedIsOverlay: boolean) => boolean,
+		viewportInputGate?: ViewportInputGate,
 		onOverlayUnhandledInput?: (data: string) => boolean,
 	) {
 		super(terminal, showHardwareCursor, logDirectory, options);
@@ -276,6 +315,17 @@ class AtomicTuiAltScreen extends TuiAltScreen {
 		return tui.overlayStack.some((entry) => entry.component === this.getFocusedComponent());
 	}
 
+	/**
+	 * Whether the focused overlay is pi-tui's own transcript find box. That
+	 * overlay is viewport chrome, so it is exempt from Atomic's gate: pi-tui
+	 * exempts it from native deferral too (`dist/tui-alt-screen.js:379`), which
+	 * is what keeps the transcript scrolling while a search is open.
+	 */
+	private isFocusedViewportSearch(): boolean {
+		const { activeSearch } = this as unknown as TuiAltScreenSearchInternals;
+		return activeSearch?.overlay?.isFocused() === true;
+	}
+
 	override addInputListener(listener: TuiInputListener): () => void {
 		if (!viewportInputListeners.has(this)) {
 			viewportInputListeners.add(this);
@@ -288,7 +338,8 @@ class AtomicTuiAltScreen extends TuiAltScreen {
 			subscription.viewportUnsubscribe = super.addInputListener((data) => {
 				const gate = viewportInputGates.get(this);
 				const isMouseInput = gate ? this.isPiTuiMouseSequence(data) : false;
-				if (gate && !gate(data, isMouseInput, this.isFocusedOverlay())) return undefined;
+				if (gate && !gate(data, isMouseInput, this.isFocusedOverlay(), this.isFocusedViewportSearch()))
+					return undefined;
 				return listener(data);
 			});
 			subscription.routeUnsubscribe = super.addInputListener(subscription.routeListener);
@@ -360,7 +411,7 @@ class AtomicTuiAltScreen extends TuiAltScreen {
 	private routeViewportInput(viewportListener: TuiInputListener, data: string): ReturnType<TuiInputListener> {
 		const gate = viewportInputGates.get(this);
 		const isMouseInput = gate ? this.isPiTuiMouseSequence(data) : false;
-		if (!gate || gate(data, isMouseInput, this.isFocusedOverlay())) return undefined;
+		if (!gate || gate(data, isMouseInput, this.isFocusedOverlay(), this.isFocusedViewportSearch())) return undefined;
 
 		// Returning `consume` below skips pi-tui's post-listener phase. Mirror its
 		// overlay-focus repair before reading the focused component so a resize

--- a/packages/coding-agent/src/modes/interactive/interactive-tui.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-tui.ts
@@ -408,6 +408,36 @@ class AtomicTuiAltScreen extends TuiAltScreen {
 			viewportInputReplays.delete(this);
 		}
 	}
+	/** Dispatch a declined chunk to the host action the gated route owns. */
+	private handleOverlayUnhandledInput(data: string, focused: Component | null): boolean {
+		if (this.getFocusedComponent() !== focused || !this.isFocusedOverlay()) return false;
+		return overlayUnhandledInputHandlers.get(this)?.(data) === true;
+	}
+
+	/**
+	 * Finish a chunk a focused overlay's asynchronous handler declined.
+	 *
+	 * Every settled result other than `true` is a decline. The component
+	 * contract is `boolean | undefined | Promise<boolean | undefined>`
+	 * (`ExtensionCustomComponent`), and both `docs/tui.md` and
+	 * `docs/extensions.md` document `false` *and* `undefined` as viewport
+	 * fallthrough, so a promise resolving `undefined` has to replay exactly like
+	 * one resolving `false` — matching only literal `false` consumed the key and
+	 * froze the transcript. A rejection is a decline for the same reason: the
+	 * overlay produced no answer.
+	 *
+	 * The focus guard stays: input that moved focus while the promise was
+	 * pending belongs to whatever holds focus now, not to the transcript.
+	 */
+	private declineAsyncViewportInput(viewportListener: TuiInputListener, data: string, focused: Component): void {
+		if (this.getFocusedComponent() !== focused) return;
+		if (this.handleOverlayUnhandledInput(data, focused)) {
+			(this as unknown as TuiOverlayInternals).requestImmediateRender();
+			return;
+		}
+		this.replayViewportInput(viewportListener, data);
+	}
+
 	private routeViewportInput(viewportListener: TuiInputListener, data: string): ReturnType<TuiInputListener> {
 		const gate = viewportInputGates.get(this);
 		const isMouseInput = gate ? this.isPiTuiMouseSequence(data) : false;
@@ -419,10 +449,6 @@ class AtomicTuiAltScreen extends TuiAltScreen {
 		this.repairOverlayFocus();
 		const focused = this.getFocusedComponent();
 		const tui = this as unknown as TuiOverlayInternals;
-		const handleOverlayUnhandledInput = (): boolean => {
-			if (this.getFocusedComponent() !== focused || !this.isFocusedOverlay()) return false;
-			return overlayUnhandledInputHandlers.get(this)?.(data) === true;
-		};
 		if (focused?.handleInput && (!isKeyRelease(data) || focused.wantsKeyRelease === true)) {
 			const handleInput = focused.handleInput as (
 				data: string,
@@ -434,17 +460,11 @@ class AtomicTuiAltScreen extends TuiAltScreen {
 						if (handled === true) {
 							this.forwardSelectionMouseInput(viewportListener, data, focused);
 							tui.requestImmediateRender();
-						} else if (handled === false && this.getFocusedComponent() === focused) {
-							if (handleOverlayUnhandledInput()) tui.requestImmediateRender();
-							else this.replayViewportInput(viewportListener, data);
+							return;
 						}
+						this.declineAsyncViewportInput(viewportListener, data, focused);
 					},
-					() => {
-						if (this.getFocusedComponent() === focused) {
-							if (handleOverlayUnhandledInput()) tui.requestImmediateRender();
-							else this.replayViewportInput(viewportListener, data);
-						}
-					},
+					() => this.declineAsyncViewportInput(viewportListener, data, focused),
 				);
 				return { consume: true };
 			}
@@ -455,7 +475,7 @@ class AtomicTuiAltScreen extends TuiAltScreen {
 			}
 		}
 
-		if (handleOverlayUnhandledInput()) {
+		if (this.handleOverlayUnhandledInput(data, focused)) {
 			tui.requestImmediateRender();
 			return { consume: true };
 		}

--- a/packages/coding-agent/src/modes/interactive/interactive-tui.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-tui.ts
@@ -253,7 +253,7 @@ function isLeftMouseSequence(data: string): boolean {
  * `\x1b\r` reaches this function as one chunk, fails `parseMouseSequences`, and
  * is handed on unsplit — so a viewport action bound to `escape` or `alt+enter`
  * still matches after a decline.
- * Outcome: no breakage, covered by the replay probes in
+ * Outcome: no breakage, no fix needed — covered by the replay probes in
  * `test/pi-0.84.2-overlay-viewport-deferral.test.ts`.
  */
 function replayMouseInput(viewportListener: TuiInputListener, data: string): void {
@@ -449,6 +449,19 @@ class AtomicTuiAltScreen extends TuiAltScreen {
 		this.repairOverlayFocus();
 		const focused = this.getFocusedComponent();
 		const tui = this as unknown as TuiOverlayInternals;
+		// pi-tui's find box is exempt from the gate for everything except a host
+		// action, so a chunk that reaches here while it holds focus is a host
+		// action by construction. Dispatch it before the query sees it: the
+		// binding is user-remappable to a bare letter (`docs/keybindings.md`),
+		// and pi-tui's `Input` inserts a printable character rather than
+		// rejecting it the way it rejects `ctrl+t` — so offering it first typed
+		// the key into the query and then ran the action. This is scoped to
+		// pi-tui's own chrome; an application overlay keeps first refusal on
+		// every key it is offered, host actions included.
+		if (this.isFocusedViewportSearch() && this.handleOverlayUnhandledInput(data, focused)) {
+			tui.requestImmediateRender();
+			return { consume: true };
+		}
 		if (focused?.handleInput && (!isKeyRelease(data) || focused.wantsKeyRelease === true)) {
 			const handleInput = focused.handleInput as (
 				data: string,

--- a/packages/coding-agent/test/helpers/interactive-fullscreen-layout.ts
+++ b/packages/coding-agent/test/helpers/interactive-fullscreen-layout.ts
@@ -146,7 +146,7 @@ export function createProductionFullscreenContext(
 		showHardwareCursor: false,
 		logDirectory: tmpdir(),
 		terminal,
-		shouldHandleViewportInput: (data, isMouseInput, focusedIsOverlay) =>
+		shouldHandleViewportInput: (data, isMouseInput, focusedIsOverlay, focusedIsViewportSearch) =>
 			shouldHandleFullscreenViewportInput(
 				tui.getFocusedComponent(),
 				editor,
@@ -154,6 +154,7 @@ export function createProductionFullscreenContext(
 				isMouseInput,
 				focusedIsOverlay,
 				keybindings,
+				focusedIsViewportSearch,
 			),
 	});
 	const headerContainer = new Container();

--- a/packages/coding-agent/test/pi-0.84.2-overlay-viewport-deferral.test.ts
+++ b/packages/coding-agent/test/pi-0.84.2-overlay-viewport-deferral.test.ts
@@ -2,8 +2,10 @@ import { tmpdir } from "node:os";
 import {
 	type Component,
 	getKeybindings,
+	isKeyRelease,
 	ScrollView,
 	setKeybindings,
+	setKittyProtocolActive,
 	Text,
 	TUI_KEYBINDINGS,
 	TuiAltScreen,
@@ -19,14 +21,27 @@ import { RecordingTerminal } from "./helpers/interactive-fullscreen-layout.ts";
 
 const PAGE_UP = "\x1b[5~";
 const PAGE_DOWN = "\x1b[6~";
+const HOME = "\x1b[H";
+const ESCAPE = "\x1b";
+/** Legacy `alt+enter`: ESC and CR reassembled into one sequence by `StdinBuffer`. */
+const ALT_ENTER = "\x1b\r";
 /** SGR wheel reports at row 2, column 10. */
 const WHEEL_UP = "\x1b[<64;10;2M";
 const CTRL_Y = "\x19";
+/** Default `app.thinking.toggle`. */
+const CTRL_T = "\x14";
+/** A remapped `app.thinking.toggle`, bound to nothing pi-tui's `Input` claims. */
+const ALT_T = "\x1bt";
 /** Kitty-protocol `ctrl+shift+f`, pi-tui 0.84.2's default `tui.altScreen.search` key. */
 const CTRL_SHIFT_F = "\x1b[102;6u";
 /** pi-tui's `PAGE_SCROLL_OVERLAP`: a page moves `viewportHeight` minus this. */
 const PAGE_SCROLL_OVERLAP = 4;
 const TRANSCRIPT_LINES = 120;
+/** Atomic ships the search actions unbound; a user binding is how the find box opens today. */
+const SEARCH_BINDING: KeybindingsConfig = { "tui.altScreen.search": "ctrl+shift+f" };
+const ANSI = /\x1b\[[0-9;]*[A-Za-z]/g;
+/** pi-tui's zero-width hardware-cursor marker (`dist/tui.js:21`). */
+const CURSOR_MARKER = "\x1b_pi:c\x07";
 
 const initialKeybindings = getKeybindings();
 
@@ -62,6 +77,8 @@ interface Fixture {
 	transcript: ScrollView;
 	overlay: RecordingOverlay;
 	editor: Text;
+	/** Input the gated route handed to the host thinking action, in order. */
+	thinkingToggles: string[];
 	stop: () => void;
 }
 
@@ -86,12 +103,13 @@ function createFixture(options: FixtureOptions = {}): Fixture {
 	terminal.rows = 40;
 
 	const editor = new Text("editor", 0, 0);
+	const thinkingToggles: string[] = [];
 	let tui!: TuiAltScreen;
 	tui = createFullscreenTui({
 		showHardwareCursor: false,
 		logDirectory: tmpdir(),
 		terminal,
-		shouldHandleViewportInput: (data, isMouseInput, focusedIsOverlay) =>
+		shouldHandleViewportInput: (data, isMouseInput, focusedIsOverlay, focusedIsViewportSearch) =>
 			shouldHandleFullscreenViewportInput(
 				tui.getFocusedComponent(),
 				editor,
@@ -99,7 +117,15 @@ function createFixture(options: FixtureOptions = {}): Fixture {
 				isMouseInput,
 				focusedIsOverlay,
 				keybindings,
+				focusedIsViewportSearch,
 			),
+		// Mirrors `InteractiveModeBase.handleOverlayUnhandledInput`: the host
+		// thinking action, dispatched only on the gated route.
+		onOverlayUnhandledInput: (data) => {
+			if (isKeyRelease(data) || !keybindings.matches(data, "app.thinking.toggle")) return false;
+			thinkingToggles.push(data);
+			return true;
+		},
 	});
 
 	const transcript = new ScrollView(
@@ -126,7 +152,7 @@ function createFixture(options: FixtureOptions = {}): Fixture {
 		expect(tui.getFocusedComponent()).toBe(editor);
 	}
 
-	return { tui, terminal, transcript, overlay, editor, stop: () => tui.stop() };
+	return { tui, terminal, transcript, overlay, editor, thinkingToggles, stop: () => tui.stop() };
 }
 
 /** Scroll to the bottom and report the resulting `scrollTop` plus a page's worth of rows. */
@@ -136,6 +162,57 @@ function anchorAtEnd(fixture: Fixture): { top: number; page: number } {
 	const page = Math.max(1, fixture.transcript.viewportHeight - PAGE_SCROLL_OVERLAP);
 	expect(page).toBeGreaterThan(1);
 	return { top: fixture.transcript.scrollTop, page };
+}
+
+/** pi-tui keeps its find box private (tui-alt-screen.d.ts:50, alt-screen-search.d.ts:12). */
+interface AltScreenSearchInternals {
+	activeSearch?: { component: Component; overlay?: { isFocused(): boolean } };
+}
+
+function activeSearch(fixture: Fixture): { component: Component; overlay?: { isFocused(): boolean } } | undefined {
+	return (fixture.tui as unknown as AltScreenSearchInternals).activeSearch;
+}
+
+/** Open pi-tui's find box the way a user with the action bound does, and confirm it took focus. */
+function openTranscriptSearch(fixture: Fixture): void {
+	fixture.terminal.input(CTRL_SHIFT_F);
+	fixture.tui.renderNow();
+	const search = activeSearch(fixture);
+	expect(search, "ctrl+shift+f opened no search").toBeDefined();
+	expect(search?.overlay?.isFocused()).toBe(true);
+	expect(fixture.tui.getFocusedComponent()).toBe(search?.component);
+}
+
+/** The find box's query, read off its own frame: the input field is private. */
+function searchQuery(fixture: Fixture): string {
+	const search = activeSearch(fixture);
+	if (!search) throw new Error("no active transcript search");
+	const rows = search.component.render(40);
+	const field = rows[rows.length - 1] ?? "";
+	return field.replaceAll(CURSOR_MARKER, "").replaceAll(ANSI, "").replace(/^> /, "").trimEnd();
+}
+
+function type(fixture: Fixture, text: string): void {
+	for (const character of text) fixture.terminal.input(character);
+	fixture.tui.renderNow();
+}
+
+/**
+ * Record what the find box is offered, without changing what it does.
+ * `AltScreenSearchComponent.handleInput` returns `void`, so a key it silently
+ * swallowed is invisible in the transcript's scroll position alone.
+ */
+function recordSearchInput(fixture: Fixture): string[] {
+	const search = activeSearch(fixture);
+	if (!search) throw new Error("no active transcript search");
+	const { component } = search;
+	const offered: string[] = [];
+	const handleInput = component.handleInput?.bind(component);
+	component.handleInput = (data: string): void => {
+		offered.push(data);
+		handleInput?.(data);
+	};
+	return offered;
 }
 
 /**
@@ -298,6 +375,235 @@ describe("pi-tui 0.84.2 transcript search defaults", () => {
 			fixture.terminal.input(CTRL_SHIFT_F);
 			fixture.tui.renderNow();
 			expect((fixture.tui as unknown as { activeSearch?: unknown }).activeSearch).toBeUndefined();
+		} finally {
+			fixture.stop();
+		}
+	});
+});
+
+/**
+ * The one overlay Atomic's gate does not own. pi-tui mounts its find box as an
+ * overlay and then exempts it from `shouldDeferViewportInputToOverlay()`
+ * (`dist/tui-alt-screen.js:379`) so the transcript keeps scrolling while a
+ * search is open. Atomic's gate had no such exemption: it offered every
+ * viewport action and every mouse report to the find box first, which let
+ * pi-tui's `Input` claim `home`/`end` as cursor motion — silently, since
+ * `AltScreenSearchComponent.handleInput` returns `void` — while the same key
+ * also scrolled the transcript through the replay.
+ *
+ * Atomic's own overlays keep Atomic's policy; this exemption is scoped to the
+ * find box while it holds focus.
+ */
+describe("focused transcript search keeps the viewport", () => {
+	test("transcript-scrolls-while-search-focused", () => {
+		const fixture = createFixture({ mountOverlay: false, userBindings: SEARCH_BINDING });
+		try {
+			const { top, page } = anchorAtEnd(fixture);
+			openTranscriptSearch(fixture);
+			const offered = recordSearchInput(fixture);
+
+			fixture.terminal.input(PAGE_UP);
+			fixture.tui.renderNow();
+			expect(top - fixture.transcript.scrollTop).toBe(page);
+
+			fixture.terminal.input(WHEEL_UP);
+			fixture.tui.renderNow();
+			expect(top - fixture.transcript.scrollTop).toBe(page + 1);
+
+			fixture.terminal.input(PAGE_DOWN);
+			fixture.tui.renderNow();
+			expect(top - fixture.transcript.scrollTop).toBe(1);
+
+			// The viewport owns these outright: the find box is never offered them,
+			// so it cannot swallow one silently.
+			expect(offered).toEqual([]);
+			// Scrolling never cost the find box its focus or its query.
+			expect(activeSearch(fixture)?.overlay?.isFocused()).toBe(true);
+			expect(searchQuery(fixture)).toBe("");
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	test("home scrolls the transcript instead of moving the query cursor", () => {
+		const fixture = createFixture({ mountOverlay: false, userBindings: SEARCH_BINDING });
+		try {
+			anchorAtEnd(fixture);
+			openTranscriptSearch(fixture);
+			type(fixture, "line");
+			expect(searchQuery(fixture)).toBe("line");
+
+			// `home` is `tui.altScreen.top` and `tui.editor.cursorLineStart` at once.
+			// Fullscreen gives it to the viewport, so the caret stays at the end.
+			fixture.terminal.input(HOME);
+			fixture.tui.renderNow();
+			expect(fixture.transcript.scrollTop).toBe(0);
+
+			type(fixture, "s");
+			expect(searchQuery(fixture)).toBe("lines");
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	test("the find box still receives every key the viewport does not claim", () => {
+		const fixture = createFixture({ mountOverlay: false, userBindings: SEARCH_BINDING });
+		try {
+			anchorAtEnd(fixture);
+			openTranscriptSearch(fixture);
+			const offered = recordSearchInput(fixture);
+
+			type(fixture, "line 7");
+			expect(offered).toEqual(["l", "i", "n", "e", " ", "7"]);
+			expect(searchQuery(fixture)).toBe("line 7");
+			// The query drives pi-tui's matcher, which is the point of typing at all.
+			expect(activeSearch(fixture)).toMatchObject({ query: "line 7" });
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	test("an Atomic overlay focused above an open search keeps Atomic's policy", () => {
+		const fixture = createFixture({ consumes: true, mountOverlay: false, userBindings: SEARCH_BINDING });
+		try {
+			const { top } = anchorAtEnd(fixture);
+			openTranscriptSearch(fixture);
+
+			fixture.tui.showOverlay(fixture.overlay, { anchor: "bottom-center", width: "100%" });
+			fixture.tui.renderNow();
+			expect(fixture.tui.getFocusedComponent()).toBe(fixture.overlay);
+			expect(activeSearch(fixture)?.overlay?.isFocused()).toBe(false);
+
+			fixture.terminal.input(PAGE_UP);
+			fixture.tui.renderNow();
+			expect(fixture.overlay.handledInputs).toEqual([PAGE_UP]);
+			expect(fixture.transcript.scrollTop).toBe(top);
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	/**
+	 * The exemption covers viewport keys, not host actions.
+	 * `app.thinking.toggle` is documented and remappable, and it is dispatched
+	 * from `onOverlayUnhandledInput`, which only the gated route runs — so an
+	 * exemption checked first would silently drop the toggle for as long as the
+	 * find box held focus.
+	 */
+	test("the default thinking toggle still runs while the find box has focus", () => {
+		const fixture = createFixture({ mountOverlay: false, userBindings: SEARCH_BINDING });
+		try {
+			anchorAtEnd(fixture);
+			openTranscriptSearch(fixture);
+			type(fixture, "line");
+			const scrollTop = fixture.transcript.scrollTop;
+			const offered = recordSearchInput(fixture);
+
+			fixture.terminal.input(CTRL_T);
+			fixture.tui.renderNow();
+
+			expect(fixture.thinkingToggles).toEqual([CTRL_T]);
+			// The find box is offered the key and declines it; that decline is what
+			// hands it to the host action.
+			expect(offered).toEqual([CTRL_T]);
+			// Routing it through the find box costs nothing: pi-tui's `Input`
+			// rejects control sequences, and the viewport never saw the key.
+			expect(searchQuery(fixture)).toBe("line");
+			expect(activeSearch(fixture)?.overlay?.isFocused()).toBe(true);
+			expect(fixture.transcript.scrollTop).toBe(scrollTop);
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	test("a remapped thinking toggle still runs while the find box has focus", () => {
+		const fixture = createFixture({
+			mountOverlay: false,
+			userBindings: { ...SEARCH_BINDING, "app.thinking.toggle": "alt+t" },
+		});
+		try {
+			anchorAtEnd(fixture);
+			openTranscriptSearch(fixture);
+			const offered = recordSearchInput(fixture);
+
+			// The default key binds nothing once the action moves.
+			fixture.terminal.input(CTRL_T);
+			fixture.tui.renderNow();
+			expect(fixture.thinkingToggles).toEqual([]);
+
+			fixture.terminal.input(ALT_T);
+			fixture.tui.renderNow();
+			expect(fixture.thinkingToggles).toEqual([ALT_T]);
+			expect(offered).toEqual([CTRL_T, ALT_T]);
+			expect(searchQuery(fixture)).toBe("");
+			expect(activeSearch(fixture)?.overlay?.isFocused()).toBe(true);
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	test("the find box still owns page and wheel scrolling with the toggle rule ahead of it", () => {
+		const fixture = createFixture({ mountOverlay: false, userBindings: SEARCH_BINDING });
+		try {
+			const { top, page } = anchorAtEnd(fixture);
+			openTranscriptSearch(fixture);
+			const offered = recordSearchInput(fixture);
+
+			fixture.terminal.input(PAGE_UP);
+			fixture.terminal.input(WHEEL_UP);
+			fixture.tui.renderNow();
+
+			expect(top - fixture.transcript.scrollTop).toBe(page + 1);
+			expect(offered).toEqual([]);
+			expect(fixture.thinkingToggles).toEqual([]);
+		} finally {
+			fixture.stop();
+		}
+	});
+});
+
+/**
+ * Probe for upstream `2a95ef70` (the `PI_TUI_ESC_TIMEOUT` window applies only
+ * to a lone ESC) and `06ed8716` (an `Alt+Enter` split by SSH latency must not
+ * read as Escape-then-Enter). Both fixes reassemble bytes inside
+ * `StdinBuffer`/`ProcessTerminal`, upstream of every input listener, so the
+ * open question for Atomic is the other direction: does the chunk-splitting
+ * replay in `routeViewportInput` take a reassembled sequence apart again?
+ *
+ * It does not. `replayMouseInput` splits only a chunk whose every byte is a
+ * mouse report; both sequences below survive a decline intact and still match
+ * the action they are bound to. **Outcome: no breakage, no fix needed.**
+ */
+describe("pi 0.84.2 ESC-timeout and split Alt+Enter probes", () => {
+	test("a lone ESC bound to a viewport action replays as one sequence", () => {
+		const fixture = createFixture({ userBindings: { "tui.altScreen.pageUp": "escape" } });
+		try {
+			const { top, page } = anchorAtEnd(fixture);
+
+			fixture.terminal.input(ESCAPE);
+			fixture.tui.renderNow();
+			expect(fixture.overlay.handledInputs).toEqual([ESCAPE]);
+			expect(top - fixture.transcript.scrollTop).toBe(page);
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	test("a reassembled alt+enter replays as one sequence", () => {
+		// `\x1b\r` is `alt+enter` only while the Kitty protocol is inactive, which
+		// is the transport `06ed8716` is about.
+		setKittyProtocolActive(false);
+		const fixture = createFixture({ userBindings: { "tui.altScreen.pageUp": "alt+enter" } });
+		try {
+			const { top, page } = anchorAtEnd(fixture);
+			expect(getKeybindings().matches(ALT_ENTER, "tui.altScreen.pageUp")).toBe(true);
+
+			fixture.terminal.input(ALT_ENTER);
+			fixture.tui.renderNow();
+			// One chunk to the overlay, and one chunk to pi-tui after the decline:
+			// a replay split into ESC and CR would match neither.
+			expect(fixture.overlay.handledInputs).toEqual([ALT_ENTER]);
+			expect(top - fixture.transcript.scrollTop).toBe(page);
 		} finally {
 			fixture.stop();
 		}

--- a/packages/coding-agent/test/pi-0.84.2-overlay-viewport-deferral.test.ts
+++ b/packages/coding-agent/test/pi-0.84.2-overlay-viewport-deferral.test.ts
@@ -32,6 +32,12 @@ const CTRL_Y = "\x19";
 const CTRL_T = "\x14";
 /** A remapped `app.thinking.toggle`, bound to nothing pi-tui's `Input` claims. */
 const ALT_T = "\x1bt";
+/**
+ * A printable `app.thinking.toggle` remap. `docs/keybindings.md` binds any
+ * action to a bare letter, and pi-tui's `Input` inserts this one into the find
+ * box query instead of rejecting it.
+ */
+const PLAIN_T = "t";
 /** Kitty-protocol `ctrl+shift+f`, pi-tui 0.84.2's default `tui.altScreen.search` key. */
 const CTRL_SHIFT_F = "\x1b[102;6u";
 /** pi-tui's `PAGE_SCROLL_OVERLAP`: a page moves `viewportHeight` minus this. */
@@ -371,6 +377,39 @@ describe("pi-tui 0.84.2 overlay viewport deferral", () => {
 			fixture.tui.renderNow();
 			expect(fixture.transcript.scrollTop).toBe(top - 1);
 			expect(fixture.overlay.handledInputs).toEqual([]);
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	/**
+	 * The find-box rule below dispatches a host action before the focused
+	 * component sees it. That rule is scoped to pi-tui's own chrome: an Atomic
+	 * overlay keeps first refusal on every key, host action included, so a
+	 * dialog can still bind a letter the host also binds.
+	 */
+	test("an application overlay keeps first refusal on a printable thinking toggle", () => {
+		const fixture = createFixture({ consumes: true, userBindings: { "app.thinking.toggle": "t" } });
+		try {
+			fixture.terminal.input(PLAIN_T);
+			fixture.tui.renderNow();
+			expect(fixture.overlay.handledInputs).toEqual([PLAIN_T]);
+			expect(fixture.thinkingToggles).toEqual([]);
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	test("an application overlay that declines a printable thinking toggle hands it to the host", () => {
+		const fixture = createFixture({ userBindings: { "app.thinking.toggle": "t" } });
+		try {
+			const { top } = anchorAtEnd(fixture);
+
+			fixture.terminal.input(PLAIN_T);
+			fixture.tui.renderNow();
+			expect(fixture.overlay.handledInputs).toEqual([PLAIN_T]);
+			expect(fixture.thinkingToggles).toEqual([PLAIN_T]);
+			expect(fixture.transcript.scrollTop).toBe(top);
 		} finally {
 			fixture.stop();
 		}
@@ -747,7 +786,8 @@ describe("focused transcript search keeps the viewport", () => {
 	 * `app.thinking.toggle` is documented and remappable, and it is dispatched
 	 * from `onOverlayUnhandledInput`, which only the gated route runs — so an
 	 * exemption checked first would silently drop the toggle for as long as the
-	 * find box held focus.
+	 * find box held focus. The gated route dispatches it before the find box
+	 * sees it, so the query cannot be edited by a key the host claims.
 	 */
 	test("the default thinking toggle still runs while the find box has focus", () => {
 		const fixture = createFixture({ mountOverlay: false, userBindings: SEARCH_BINDING });
@@ -762,11 +802,9 @@ describe("focused transcript search keeps the viewport", () => {
 			fixture.tui.renderNow();
 
 			expect(fixture.thinkingToggles).toEqual([CTRL_T]);
-			// The find box is offered the key and declines it; that decline is what
-			// hands it to the host action.
-			expect(offered).toEqual([CTRL_T]);
-			// Routing it through the find box costs nothing: pi-tui's `Input`
-			// rejects control sequences, and the viewport never saw the key.
+			// The host action runs before the find box sees the key, so the query
+			// cannot be edited by a chunk the host is about to claim.
+			expect(offered).toEqual([]);
 			expect(searchQuery(fixture)).toBe("line");
 			expect(activeSearch(fixture)?.overlay?.isFocused()).toBe(true);
 			expect(fixture.transcript.scrollTop).toBe(scrollTop);
@@ -793,9 +831,56 @@ describe("focused transcript search keeps the viewport", () => {
 			fixture.terminal.input(ALT_T);
 			fixture.tui.renderNow();
 			expect(fixture.thinkingToggles).toEqual([ALT_T]);
-			expect(offered).toEqual([CTRL_T, ALT_T]);
+			// `ctrl+t` binds nothing now, so it reaches the find box through pi-tui's
+			// own route; `alt+t` is claimed by the host before the query sees it.
+			expect(offered).toEqual([CTRL_T]);
 			expect(searchQuery(fixture)).toBe("");
 			expect(activeSearch(fixture)?.overlay?.isFocused()).toBe(true);
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	/**
+	 * The remap that made "offer it to the find box first" untenable.
+	 * `docs/keybindings.md` accepts a bare letter for any action, so
+	 * `"app.thinking.toggle": "t"` is a legal binding — and pi-tui's `Input`
+	 * does not reject a printable character the way it rejects `ctrl+t`. Offered
+	 * first, `t` was typed into the query and *then* toggled thinking: the key
+	 * did two things, one of them silent, because `AltScreenSearchComponent`
+	 * returns `void`.
+	 */
+	test("a printable thinking-toggle remap never reaches the find box query", () => {
+		const fixture = createFixture({
+			mountOverlay: false,
+			userBindings: { ...SEARCH_BINDING, "app.thinking.toggle": "t" },
+		});
+		try {
+			anchorAtEnd(fixture);
+			openTranscriptSearch(fixture);
+			type(fixture, "line");
+			// Typing drives pi-tui's matcher, which scrolls to a match; read the
+			// resulting position rather than the pre-search one.
+			const scrollTop = fixture.transcript.scrollTop;
+			const offered = recordSearchInput(fixture);
+
+			fixture.terminal.input(PLAIN_T);
+			fixture.tui.renderNow();
+
+			// The query first: it is the corruption this test exists for, and it
+			// reads `linet` when the find box is offered the key.
+			expect(searchQuery(fixture)).toBe("line");
+			expect(fixture.thinkingToggles).toEqual([PLAIN_T]);
+			expect(offered).toEqual([]);
+			expect(activeSearch(fixture)?.overlay?.isFocused()).toBe(true);
+			expect(fixture.transcript.scrollTop).toBe(scrollTop);
+
+			// Only the bound letter is claimed; every other printable key still
+			// edits the query, so the find box is not muted by the rule.
+			type(fixture, "s");
+			expect(offered).toEqual(["s"]);
+			expect(searchQuery(fixture)).toBe("lines");
+			expect(fixture.thinkingToggles).toEqual([PLAIN_T]);
 		} finally {
 			fixture.stop();
 		}

--- a/packages/coding-agent/test/pi-0.84.2-overlay-viewport-deferral.test.ts
+++ b/packages/coding-agent/test/pi-0.84.2-overlay-viewport-deferral.test.ts
@@ -71,6 +71,44 @@ class RecordingOverlay implements Component {
 	invalidate(): void {}
 }
 
+/**
+ * A focused overlay that only renders. `handleInput` is optional on a
+ * component — `ExtensionCustomComponent` declares `handleInput?` and
+ * `docs/tui.md` documents it as optional — so a notice, a spinner, or a
+ * progress panel is a supported shape rather than a malformed one. It declines
+ * every key by construction.
+ */
+class HandlerlessOverlay implements Component {
+	render(): string[] {
+		return ["notice"];
+	}
+
+	invalidate(): void {}
+}
+
+/** An overlay whose handler settles later, the way an async extension component does. */
+class AsyncOverlay implements Component {
+	readonly handledInputs: string[] = [];
+	/** What the returned promise settles to. `undefined` is a documented decline. */
+	settlesTo: boolean | undefined = undefined;
+	/** When set, the handler rejects instead of resolving. */
+	rejects = false;
+	/** Runs synchronously inside the handler, before the promise settles. */
+	onHandleInput?: () => void;
+
+	render(): string[] {
+		return ["async dialog"];
+	}
+
+	handleInput(data: string): Promise<boolean | undefined> {
+		this.handledInputs.push(data);
+		this.onHandleInput?.();
+		return this.rejects ? Promise.reject(new Error("handler failed")) : Promise.resolve(this.settlesTo);
+	}
+
+	invalidate(): void {}
+}
+
 interface Fixture {
 	tui: TuiAltScreen;
 	terminal: RecordingTerminal;
@@ -162,6 +200,20 @@ function anchorAtEnd(fixture: Fixture): { top: number; page: number } {
 	const page = Math.max(1, fixture.transcript.viewportHeight - PAGE_SCROLL_OVERLAP);
 	expect(page).toBeGreaterThan(1);
 	return { top: fixture.transcript.scrollTop, page };
+}
+
+/** Mount a component as a focused overlay, the way `createFixture` mounts its own. */
+function mountFocusedOverlay<T extends Component>(fixture: Fixture, component: T): T {
+	fixture.tui.showOverlay(component, { anchor: "bottom-center", width: "100%" });
+	fixture.tui.renderNow();
+	expect(fixture.tui.getFocusedComponent()).toBe(component);
+	return component;
+}
+
+/** Let a handler's promise settle, along with the replay its settlement schedules. */
+async function settle(fixture: Fixture): Promise<void> {
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	fixture.tui.renderNow();
 }
 
 /** pi-tui keeps its find box private (tui-alt-screen.d.ts:50, alt-screen-search.d.ts:12). */
@@ -319,6 +371,213 @@ describe("pi-tui 0.84.2 overlay viewport deferral", () => {
 			fixture.tui.renderNow();
 			expect(fixture.transcript.scrollTop).toBe(top - 1);
 			expect(fixture.overlay.handledInputs).toEqual([]);
+		} finally {
+			fixture.stop();
+		}
+	});
+});
+
+/**
+ * A focused overlay with no `handleInput` at all. pi-tui's
+ * `shouldDeferViewportInputToOverlay()` asks only whether an overlay holds
+ * focus (`dist/tui-alt-screen.js:378`), so answering "the viewport owns it" in
+ * Atomic's gate hands the key to pi-tui, which then drops it — the transcript
+ * freezes behind a component that never asked for the key, and Atomic's
+ * overlay-first / replay-on-decline policy is contradicted by the one overlay
+ * shape that cannot decline anything explicitly. Such an overlay takes the
+ * replay route instead.
+ */
+describe("a focused overlay with no input handler", () => {
+	test("a handler-less focused overlay still pages the transcript", () => {
+		const fixture = createFixture({ mountOverlay: false });
+		try {
+			mountFocusedOverlay(fixture, new HandlerlessOverlay());
+			const { top, page } = anchorAtEnd(fixture);
+
+			fixture.terminal.input(PAGE_UP);
+			fixture.tui.renderNow();
+			expect(top - fixture.transcript.scrollTop).toBe(page);
+
+			fixture.terminal.input(PAGE_DOWN);
+			fixture.tui.renderNow();
+			expect(fixture.transcript.scrollTop).toBe(top);
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	test("a handler-less focused overlay still scrolls the transcript on a wheel report", () => {
+		const fixture = createFixture({ mountOverlay: false });
+		try {
+			mountFocusedOverlay(fixture, new HandlerlessOverlay());
+			const { top } = anchorAtEnd(fixture);
+
+			fixture.terminal.input(WHEEL_UP);
+			fixture.tui.renderNow();
+			expect(fixture.transcript.scrollTop).toBe(top - 1);
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	test("the thinking toggle still runs under a handler-less focused overlay", () => {
+		const fixture = createFixture({ mountOverlay: false });
+		try {
+			mountFocusedOverlay(fixture, new HandlerlessOverlay());
+			const { top } = anchorAtEnd(fixture);
+
+			fixture.terminal.input(CTRL_T);
+			fixture.tui.renderNow();
+			expect(fixture.thinkingToggles).toEqual([CTRL_T]);
+			expect(fixture.transcript.scrollTop).toBe(top);
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	/**
+	 * The route is widened for overlays only. A focused *non*-overlay without a
+	 * handler keeps pi-tui's own routing, because pi-tui defers nothing to it and
+	 * the replay would skip its post-listener phase for no gain.
+	 */
+	test("only an overlay takes the replay route when it cannot handle input", () => {
+		const keybindings = new KeybindingsManager();
+		const editor = new Text("editor", 0, 0);
+		const handlerless = new HandlerlessOverlay();
+
+		expect(shouldHandleFullscreenViewportInput(handlerless, editor, PAGE_UP, false, true, keybindings)).toBe(false);
+		expect(shouldHandleFullscreenViewportInput(handlerless, editor, WHEEL_UP, true, true, keybindings)).toBe(false);
+		expect(shouldHandleFullscreenViewportInput(handlerless, editor, PAGE_UP, false, false, keybindings)).toBe(true);
+		expect(shouldHandleFullscreenViewportInput(handlerless, editor, WHEEL_UP, true, false, keybindings)).toBe(true);
+		// The find box is still exempt, handler or not, and the editor and an
+		// unfocused tree keep the shortcut.
+		expect(shouldHandleFullscreenViewportInput(handlerless, editor, PAGE_UP, false, true, keybindings, true)).toBe(
+			true,
+		);
+		expect(shouldHandleFullscreenViewportInput(editor, editor, PAGE_UP, false, false, keybindings)).toBe(true);
+		expect(shouldHandleFullscreenViewportInput(null, editor, PAGE_UP, false, false, keybindings)).toBe(true);
+	});
+});
+
+/**
+ * The component contract is `boolean | undefined | Promise<boolean |
+ * undefined>` (`src/core/extensions/ui-types.ts`), and `docs/tui.md` plus
+ * `docs/extensions.md` document `false` *and* `undefined` as viewport
+ * fallthrough. So every settled result other than `true` is a decline: a
+ * handler that resolved `undefined` — the value an `async` function returns
+ * when it just falls off the end — must replay exactly like one that resolved
+ * `false`, rather than consuming the key and freezing the transcript.
+ */
+describe("an asynchronous overlay handler", () => {
+	test("a handler resolving undefined still pages the transcript", async () => {
+		const fixture = createFixture({ mountOverlay: false });
+		try {
+			const overlay = mountFocusedOverlay(fixture, new AsyncOverlay());
+			const { top, page } = anchorAtEnd(fixture);
+
+			fixture.terminal.input(PAGE_UP);
+			await settle(fixture);
+
+			// Offered once and replayed once: the overlay is not asked twice.
+			expect(overlay.handledInputs).toEqual([PAGE_UP]);
+			expect(top - fixture.transcript.scrollTop).toBe(page);
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	test("a handler resolving undefined still scrolls the transcript on a wheel report", async () => {
+		const fixture = createFixture({ mountOverlay: false });
+		try {
+			const overlay = mountFocusedOverlay(fixture, new AsyncOverlay());
+			const { top } = anchorAtEnd(fixture);
+
+			fixture.terminal.input(WHEEL_UP);
+			await settle(fixture);
+
+			expect(overlay.handledInputs).toEqual([WHEEL_UP]);
+			expect(fixture.transcript.scrollTop).toBe(top - 1);
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	test("a handler resolving false still pages the transcript", async () => {
+		const fixture = createFixture({ mountOverlay: false });
+		try {
+			const overlay = mountFocusedOverlay(fixture, new AsyncOverlay());
+			overlay.settlesTo = false;
+			const { top, page } = anchorAtEnd(fixture);
+
+			fixture.terminal.input(PAGE_UP);
+			await settle(fixture);
+			expect(top - fixture.transcript.scrollTop).toBe(page);
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	test("a handler resolving true leaves the transcript alone", async () => {
+		const fixture = createFixture({ mountOverlay: false });
+		try {
+			const overlay = mountFocusedOverlay(fixture, new AsyncOverlay());
+			overlay.settlesTo = true;
+			const { top } = anchorAtEnd(fixture);
+
+			fixture.terminal.input(PAGE_UP);
+			await settle(fixture);
+			expect(overlay.handledInputs).toEqual([PAGE_UP]);
+			expect(fixture.transcript.scrollTop).toBe(top);
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	test("a rejected handler still pages the transcript", async () => {
+		const fixture = createFixture({ mountOverlay: false });
+		try {
+			const overlay = mountFocusedOverlay(fixture, new AsyncOverlay());
+			overlay.rejects = true;
+			const { top, page } = anchorAtEnd(fixture);
+
+			fixture.terminal.input(PAGE_UP);
+			await settle(fixture);
+			expect(top - fixture.transcript.scrollTop).toBe(page);
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	test("a handler resolving undefined still hands the thinking toggle to the host", async () => {
+		const fixture = createFixture({ mountOverlay: false });
+		try {
+			const overlay = mountFocusedOverlay(fixture, new AsyncOverlay());
+			const { top } = anchorAtEnd(fixture);
+
+			fixture.terminal.input(CTRL_T);
+			await settle(fixture);
+
+			expect(overlay.handledInputs).toEqual([CTRL_T]);
+			expect(fixture.thinkingToggles).toEqual([CTRL_T]);
+			expect(fixture.transcript.scrollTop).toBe(top);
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	/** The focus guard: a chunk that moved focus belongs to whoever holds it now. */
+	test("a handler that moves focus before it settles leaves the transcript alone", async () => {
+		const fixture = createFixture({ mountOverlay: false });
+		try {
+			const overlay = mountFocusedOverlay(fixture, new AsyncOverlay());
+			overlay.onHandleInput = () => fixture.tui.setFocus(fixture.editor);
+			const { top } = anchorAtEnd(fixture);
+
+			fixture.terminal.input(PAGE_UP);
+			await settle(fixture);
+
+			expect(overlay.handledInputs).toEqual([PAGE_UP]);
+			expect(fixture.transcript.scrollTop).toBe(top);
 		} finally {
 			fixture.stop();
 		}


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789384718&installation_model_id=10562&pr_number=2420&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2420&signature=eba2902bb7be0131b3bcba999a0b6c84664e2156bddf515acafb7fffed202041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change ensures a printable custom keybinding for the thinking toggle is handled before the focused transcript-search input can insert it into the query, while preserving normal printable search input and application-overlay first refusal.

The potential search-query corruption was disproved on the changed code: the focused checks passed for a printable thinking-toggle remap, an unbound printable search character, and both consuming and declining application overlays. The same regression check fails on the preceding revision, where the query changes from `line` to `linet`.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on focused runtime coverage of the affected fullscreen input paths.

The changed behavior was exercised against the real fullscreen fixture and compared with the preceding revision: the old behavior reproduces the accidental query edit, while the updated routing passes the corresponding host-action, search-editing, and overlay-precedence cases.

**Files Needing Attention:** No files require follow-up. The reviewed routing change is in `packages/coding-agent/src/modes/interactive/interactive-tui.ts`, with targeted coverage in `packages/coding-agent/test/pi-0.84.2-overlay-viewport-deferral.test.ts`.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Observed the pre-change failure where the printable thinking-toggle remap produced the wrong query.
- Ran the focused Vitest regression cases against the preceding revision and the changed revision using the fullscreen pi-tui fixture.
- After the change, the three focused cases passed: host action ran without query insertion, an unbound printable key edited the query, and application overlays retained first refusal.
- No product code was modified; only executable command and captured-output artifacts were created.

<a href="https://app.greptile.com/trex/runs/19084865/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(interactive): claim a host action be..."](https://github.com/bastani-inc/atomic/commit/0ec7c936f2f11113bf8537d383911d487ab59b1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53723715)</sub>

<!-- /greptile_comment -->