### PR TITLE
fix(interactive): end a selection on the generic SGR mouse release

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-tui.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-tui.ts
@@ -227,10 +227,18 @@ export function isMouseWheelInput(data: string): boolean {
 
 function isLeftMouseButton(sequence: ParsedMouseSequence): boolean {
 	const { button } = sequence;
-	// Shift, Meta/Option, and Ctrl are application-bypass gestures on press and
-	// motion. SGR releases can retain those bits and still need to close a
-	// selection. Legacy X10 release is button 3, which pi-tui cannot identify.
-	return (button & (3 | 64)) === 0 && (sequence.isRelease || (button & LEFT_MOUSE_MODIFIER_MASK) === 0);
+	if ((button & 64) !== 0) return false;
+	const held = button & 3;
+	// A release carries no button identity on the terminals upstream #7963
+	// describes: they report the generic SGR code 3 rather than 0. pi-tui 0.84.2
+	// ends a selection on `release && (button & 3) === 3`
+	// (`dist/tui-alt-screen.js:796`), so a release Atomic drops here leaves the
+	// press it already forwarded open — the selection never closes and the OSC 8
+	// link under the press never activates. Shift, Meta/Option, and Ctrl are
+	// application-bypass gestures on press and motion, but a release can retain
+	// those bits and still has to close a selection.
+	if (sequence.isRelease) return held === 0 || held === 3;
+	return held === 0 && (button & LEFT_MOUSE_MODIFIER_MASK) === 0;
 }
 
 /** Whether a mouse chunk contains a left-button selection gesture. */

--- a/packages/coding-agent/test/pi-0.84.2-generic-sgr-release.test.ts
+++ b/packages/coding-agent/test/pi-0.84.2-generic-sgr-release.test.ts
@@ -1,0 +1,235 @@
+import { tmpdir } from "node:os";
+import {
+	type Component,
+	getOsc8LinkAtColumn,
+	hyperlink,
+	Text,
+	type TuiAltScreen,
+	VStack,
+} from "@earendil-works/pi-tui";
+import { describe, expect, test } from "vitest";
+import { KeybindingsManager } from "../src/core/keybindings.ts";
+import { TRANSCRIPT_JUMP_TO_END_URL } from "../src/modes/interactive/components/transcript-follow-indicator.ts";
+import { shouldHandleFullscreenViewportInput } from "../src/modes/interactive/interactive-mode-base.ts";
+import { createFullscreenTui } from "../src/modes/interactive/interactive-tui.ts";
+import { RecordingTerminal } from "./helpers/interactive-fullscreen-layout.ts";
+
+/**
+ * Upstream #7963 (`83aed2ba`): terminals that report a release with the generic
+ * SGR button code 3 instead of 0. pi-tui 0.84.2 ends a selection — and
+ * activates the OSC 8 link under the press — on `release && (button & 3) === 3`.
+ *
+ * Atomic only hands pi-tui the reports a focused overlay consumed, through
+ * `forwardSelectionMouseInput`, so a generic release its own predicate rejects
+ * never reaches the fixed pi-tui code: the press stays open forever and the
+ * link never opens.
+ */
+const LINK_LABEL = "jump to end";
+const TRANSCRIPT_LINE = "alpha bravo charlie delta";
+
+/** Build an SGR mouse report. Terminal coordinates are 1-based; pi-tui's are not. */
+function sgr(button: number, column: number, row: number, release = false): string {
+	return `\x1b[<${button};${column + 1};${row + 1}${release ? "m" : "M"}`;
+}
+
+const PRESS = 0;
+const MOTION = 32;
+/** The generic release upstream #7963 describes: no button identity, code 3. */
+const GENERIC_RELEASE = 3;
+/** A wheel-up report; `64 | 3` is the same code carrying the wheel bit. */
+const WHEEL_UP = 64;
+
+/** An overlay that claims every input, the way a dialog claims its own clicks. */
+class ClaimingOverlay implements Component {
+	readonly handledInputs: string[] = [];
+
+	render(): string[] {
+		return ["dialog"];
+	}
+
+	handleInput(data: string): boolean {
+		this.handledInputs.push(data);
+		return true;
+	}
+
+	invalidate(): void {}
+}
+
+interface Fixture {
+	tui: TuiAltScreen;
+	terminal: RecordingTerminal;
+	overlay: ClaimingOverlay;
+	/** Internal-UI URLs `handleUrlActivation` routed, in order. */
+	internalUiActions: string[];
+	/** Text pi-tui copied through OSC 52, one entry per completed selection. */
+	copiedText: () => string[];
+	/** The rendered screen pi-tui itself reads for selection text and OSC 8 links. */
+	screen: () => string[];
+	stop: () => void;
+}
+
+function createFixture(): Fixture {
+	const keybindings = new KeybindingsManager({});
+	const terminal = new RecordingTerminal();
+	terminal.columns = 60;
+	terminal.rows = 12;
+
+	const editor = new Text("editor", 0, 0);
+	const internalUiActions: string[] = [];
+	let tui!: TuiAltScreen;
+	tui = createFullscreenTui({
+		showHardwareCursor: false,
+		logDirectory: tmpdir(),
+		terminal,
+		onInternalUiAction: (url) => {
+			internalUiActions.push(url);
+			return true;
+		},
+		shouldHandleViewportInput: (data, isMouseInput, focusedIsOverlay, focusedIsViewportSearch) =>
+			shouldHandleFullscreenViewportInput(
+				tui.getFocusedComponent(),
+				editor,
+				data,
+				isMouseInput,
+				focusedIsOverlay,
+				keybindings,
+				focusedIsViewportSearch,
+			),
+	});
+
+	const transcript = new Text(
+		[TRANSCRIPT_LINE, hyperlink(LINK_LABEL, TRANSCRIPT_JUMP_TO_END_URL), "epsilon zeta"].join("\n"),
+		0,
+		0,
+	);
+	tui.setLayoutRoot(
+		new VStack([
+			{ component: transcript, basis: 0, grow: 1, shrink: 1, minSize: 1 },
+			{ component: editor, basis: 1, shrink: 0 },
+		]),
+	);
+	tui.setFocus(editor);
+	tui.start();
+	tui.renderNow();
+
+	const overlay = new ClaimingOverlay();
+	tui.showOverlay(overlay, { anchor: "bottom-center", width: "100%" });
+	tui.renderNow();
+	expect(tui.getFocusedComponent()).toBe(overlay);
+
+	return {
+		tui,
+		terminal,
+		overlay,
+		internalUiActions,
+		copiedText: () =>
+			terminal.writes
+				.flatMap((write) => [...write.matchAll(/\x1b\]52;c;([A-Za-z0-9+/=]*)\x07/g)])
+				.map((match) => Buffer.from(match[1] ?? "", "base64").toString("utf8")),
+		// pi-tui reads its own `previousScreen` for both the copied text and the
+		// pressed OSC 8 link, so the test locates cells the same way.
+		screen: () => (Reflect.get(tui, "previousScreen") as string[] | undefined) ?? [],
+		stop: () => tui.stop(),
+	};
+}
+
+/** Locate the screen cell carrying an OSC 8 link to `url`. */
+function findLinkCell(screen: string[], url: string): { row: number; column: number } {
+	for (const [row, line] of screen.entries()) {
+		for (let column = 0; column < 60; column += 1) {
+			if (getOsc8LinkAtColumn(line, column) === url) return { row, column };
+		}
+	}
+	throw new Error(`no OSC 8 link to ${url} on screen`);
+}
+
+describe("generic SGR mouse release (upstream #7963)", () => {
+	test("generic-sgr-release-ends-selection", () => {
+		const fixture = createFixture();
+		try {
+			expect(fixture.screen()[0]).toContain("alpha");
+
+			fixture.terminal.input(sgr(PRESS, 0, 0));
+			fixture.terminal.input(sgr(MOTION, 5, 0));
+			fixture.terminal.input(sgr(GENERIC_RELEASE, 5, 0, true));
+
+			// The overlay claimed all three reports, so the only way pi-tui saw the
+			// release is Atomic forwarding it.
+			expect(fixture.overlay.handledInputs).toEqual([
+				sgr(PRESS, 0, 0),
+				sgr(MOTION, 5, 0),
+				sgr(GENERIC_RELEASE, 5, 0, true),
+			]);
+			expect(fixture.copiedText()).toEqual(["alpha"]);
+
+			// The press is closed: a further drag and release extends nothing and
+			// copies nothing, because pi-tui's press state was cleared.
+			fixture.terminal.input(sgr(MOTION, 20, 0));
+			fixture.terminal.input(sgr(GENERIC_RELEASE, 20, 0, true));
+			expect(fixture.copiedText()).toEqual(["alpha"]);
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	test("activates an OSC 8 link on a generic SGR release", () => {
+		const fixture = createFixture();
+		try {
+			const link = findLinkCell(fixture.screen(), TRANSCRIPT_JUMP_TO_END_URL);
+
+			fixture.terminal.input(sgr(PRESS, link.column, link.row));
+			fixture.terminal.input(sgr(GENERIC_RELEASE, link.column, link.row, true));
+
+			expect(fixture.internalUiActions).toEqual([TRANSCRIPT_JUMP_TO_END_URL]);
+			// A link click is an activation, not a selection.
+			expect(fixture.copiedText()).toEqual([]);
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	test("still ends a selection on a terminal that reports the left button on release", () => {
+		const fixture = createFixture();
+		try {
+			fixture.terminal.input(sgr(PRESS, 0, 0));
+			fixture.terminal.input(sgr(MOTION, 5, 0));
+			fixture.terminal.input(sgr(PRESS, 5, 0, true));
+
+			expect(fixture.copiedText()).toEqual(["alpha"]);
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	test("a release carrying modifier bits still closes the selection", () => {
+		const fixture = createFixture();
+		try {
+			// Shift is `4`; a terminal can report it alongside the generic code.
+			fixture.terminal.input(sgr(PRESS, 0, 0));
+			fixture.terminal.input(sgr(MOTION, 5, 0));
+			fixture.terminal.input(sgr(GENERIC_RELEASE | 4, 5, 0, true));
+
+			expect(fixture.copiedText()).toEqual(["alpha"]);
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	test("a wheel report is never forwarded as a selection gesture", () => {
+		const fixture = createFixture();
+		try {
+			fixture.terminal.input(sgr(PRESS, 0, 0));
+			fixture.terminal.input(sgr(MOTION, 5, 0));
+			// The wheel bit is set, so this is not a left-button release even
+			// though its low bits read as the generic code.
+			fixture.terminal.input(sgr(WHEEL_UP | GENERIC_RELEASE, 5, 0, true));
+			expect(fixture.copiedText()).toEqual([]);
+
+			// The real release still lands.
+			fixture.terminal.input(sgr(GENERIC_RELEASE, 5, 0, true));
+			expect(fixture.copiedText()).toEqual(["alpha"]);
+		} finally {
+			fixture.stop();
+		}
+	});
+});


### PR DESCRIPTION
Terminals in upstream #7963 report a mouse release with the generic SGR
button code 3 rather than 0. pi-tui 0.84.2 ends a selection on
`release && (button & 3) === 3` (`83aed2ba`), but Atomic's own
`isLeftMouseButton` required `(button & 3) === 0`, so the release was
dropped before `forwardSelectionMouseInput` could hand it to pi-tui.
A press a focused overlay claimed then stayed open forever: the drag
never closed, nothing was copied, and the OSC 8 link under the press —
including Atomic's internal `atomic-ui://transcript/jump-to-end` — never
activated.

Accept a release whose low bits read 0 or 3, keep the wheel bit
excluded so a wheel report is still not a selection gesture, and keep
press and motion unchanged. The comment claiming pi-tui cannot identify
a button-3 release is false at 0.84.2 and is gone.

Covered by `generic-sgr-release-ends-selection` plus OSC 8 activation,
modifier-carrying release, left-button release, and wheel-bit tests in
`packages/coding-agent/test/pi-0.84.2-generic-sgr-release.test.ts`. Four
of the five fail against the previous predicate.

Assistant-model: Claude Opus 5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789387374&installation_model_id=10562&pr_number=2421&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2421&signature=6183fe3125edb1a3f7bd82744a94a2c3a43d2ac1919cf772c1f8d0e02c9c151e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds fullscreen TUI coverage for generic SGR mouse releases, including selection completion, OSC 8 link activation, modifier-bearing releases, standard left-button releases, and wheel-report filtering.

The new test needs to follow the repository’s established assertion and TypeScript ESM import conventions before merge.

<h3>Confidence Score: 4/5</h3>

The interactive mouse-release behavior is covered by focused tests, but the new test file needs convention fixes.

There are two independent P2, non-security repository-rule findings and no P0 or P1 findings, which yields a score of 4.

**Files Needing Attention:** packages/coding-agent/test/pi-0.84.2-generic-sgr-release.test.ts

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/test/pi-0.84.2-generic-sgr-release.test.ts:14
**Vitest expect breaks assertion convention**

The new tests use Vitest's `expect` API throughout instead of the repository-required `node:assert/strict` style, introducing an inconsistent assertion pattern that makes future test maintenance less uniform.

### Issue 2
packages/coding-agent/test/pi-0.84.2-generic-sgr-release.test.ts:11-15
**Local imports use wrong suffixes**

These local imports use `.ts` suffixes instead of the repository-required TypeScript ESM `.js` suffixes, making the test depend on test-runner-specific module resolution and diverge from emitted-module conventions.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(interactive): end a selection on the..."](https://github.com/bastani-inc/atomic/commit/984e4d02f3b06306e527464ff56c8b5714cc857d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53723732)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->