### PR TITLE
feat(interactive): search the fullscreen transcript

### DIFF
--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -97,7 +97,7 @@ Fullscreen transcript bindings take precedence over editor bindings while the ma
 | `pageUp`, `pageDown` | Editor | Transcript |
 | `ctrl+pageUp`, `ctrl+pageDown` | Editor | Editor |
 
-This routing remains configurable through the ordinary action bindings. For example, `"tui.altScreen.pageUp": "ctrl+pageUp"` makes `pageUp` control the editor and `ctrl+pageUp` control the transcript in fullscreen mode. Bind `tui.altScreen.halfPageUp` and `tui.altScreen.halfPageDown` for smaller transcript steps while keeping the full-page bindings. Setting `"tui.altScreen.pageUp": []` disables that transcript shortcut entirely. User bindings replace the defaults for that action.
+This routing remains configurable through the ordinary action bindings. For example, `"tui.altScreen.pageUp": "ctrl+pageUp"` makes `pageUp` control the editor and `ctrl+pageUp` control the transcript in fullscreen mode. Bind `tui.altScreen.halfPageUp` and `tui.altScreen.halfPageDown` for half-page steps, or `tui.altScreen.lineUp` and `tui.altScreen.lineDown` for single-line steps, while keeping the full-page bindings. Setting `"tui.altScreen.pageUp": []` disables that transcript shortcut entirely. User bindings replace the defaults for that action.
 When a fullscreen overlay or inline custom component owns focus, it receives matching `pageUp`, `pageDown`, `home`, `end`, and custom `tui.altScreen.*` bindings before transcript scrolling. Its handler returns `true` when it consumes the key; an unhandled result lets transcript scrolling proceed. Remote components receive a correlated reply and have a bounded fallback if the engine stalls. Mouse-wheel and click sequences follow the same focused-component route, so workflow graphs and stage chats can consume them before unhandled events fall through to the fullscreen viewport.
 The blocking `ask_user_question` dialog is pinned to the bottom of the screen as an overlay rather than measured into the layout, so opening it does not shrink the transcript viewport or the page step: `pageUp`, `pageDown`, `home`, `end`, and the wheel move by the same amount and reach every line of the scrollback, including the newest ones, in the strip that stays visible above the dialog. Those transcript actions still work while the Notes editor is open. Notes keeps ordinary text and edit actions, including the default `ctrl+home` and `ctrl+end`; a key moves the transcript instead only when configured for a `tui.altScreen.*` action. The dialog is bounded so the visible strip survives on a short terminal, and the active questionnaire row stays visible inside the bound as you move through single-select choices, multi-select choices, Next, Submit, Cancel, and inline inputs. It keeps its own arrow, `enter`, `tab`, `space`, `esc`, click, and selection input.
 
@@ -107,10 +107,20 @@ The blocking `ask_user_question` dialog is pinned to the bottom of the screen as
 | `tui.altScreen.pageDown` | `pageDown` | Scroll the transcript down by one page |
 | `tui.altScreen.halfPageUp` | *(none)* | Scroll the transcript up by half a page |
 | `tui.altScreen.halfPageDown` | *(none)* | Scroll the transcript down by half a page |
+| `tui.altScreen.lineUp` | *(none)* | Scroll the transcript up by one line |
+| `tui.altScreen.lineDown` | *(none)* | Scroll the transcript down by one line |
 | `tui.altScreen.previousPrompt` | `ctrl+shift+up` | Jump to the previous marked message |
 | `tui.altScreen.nextPrompt` | `ctrl+shift+down` | Jump to the next marked message |
+| `tui.altScreen.search` | `ctrl+shift+f` | Search the rendered transcript |
+| `tui.altScreen.searchNext` | `enter`, `ctrl+g` | Select the next search match while searching |
+| `tui.altScreen.searchPrevious` | `shift+enter`, `ctrl+shift+g` | Select the previous search match while searching |
+| `tui.altScreen.searchClose` | `escape` | Close transcript search |
 | `tui.altScreen.top` | `home` | Scroll to the beginning of the transcript |
 | `tui.altScreen.bottom` | `end` | Scroll to the transcript end and follow new output |
+
+`ctrl+shift+f` opens a find box over the transcript. Typing filters as you go, `enter` and `ctrl+g` move to the next match, `shift+enter` and `ctrl+shift+g` move to the previous one, and `escape` closes the box. While the find box has focus it keeps `escape`, `enter`, and `ctrl+g`, so those keys navigate the search rather than interrupting the turn, submitting the editor, or opening the external editor. Scrolling still works while a search is open: `pageUp`, `pageDown`, `home`, `end`, and the wheel move the transcript instead of the query cursor. Matches use the `searchMatchText` on `searchMatchBg` theme colors with an underline; the current match swaps that pair and adds bold. Both colors are optional in a theme file and fall back to `text` and `selectedBg`, so a theme written before they existed keeps working. See [Themes](/themes).
+
+A focused fullscreen overlay or inline custom component is offered `ctrl+shift+f` before the transcript is, on the same route as the scroll bindings above, so a component that owns a transcript of its own can search that one instead.
 
 On Windows, pressing the secondary mouse button in fullscreen pastes text from the system clipboard into the focused component.
 

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -62,19 +62,13 @@ declare module "@earendil-works/pi-tui" {
 
 export const KEYBINDINGS = {
 	...TUI_KEYBINDINGS,
-	// pi-tui 0.84.2 ships transcript search bound by default (`ctrl+shift+f`,
-	// plus `enter`/`shift+enter`/`escape` while its find box is focused).
-	// Atomic routes fullscreen viewport actions through an explicit allowlist
-	// (`FULLSCREEN_VIEWPORT_ACTIONS`, `modes/interactive/interactive-mode-base.ts`)
-	// that does not list them, and pi-tui matches `tui.altScreen.search` *before*
-	// it defers input to a focused overlay — so the inherited default opens an
-	// unthemed search over the main transcript from inside a focused overlay and
-	// takes its focus. Ship the actions unbound until the layer that routes,
-	// themes, and scopes them lands.
-	"tui.altScreen.search": { ...TUI_KEYBINDINGS["tui.altScreen.search"], defaultKeys: [] },
-	"tui.altScreen.searchNext": { ...TUI_KEYBINDINGS["tui.altScreen.searchNext"], defaultKeys: [] },
-	"tui.altScreen.searchPrevious": { ...TUI_KEYBINDINGS["tui.altScreen.searchPrevious"], defaultKeys: [] },
-	"tui.altScreen.searchClose": { ...TUI_KEYBINDINGS["tui.altScreen.searchClose"], defaultKeys: [] },
+	// pi-tui 0.84.2's transcript-search defaults (`ctrl+shift+f`, plus
+	// `enter`/`shift+enter`/`ctrl+g`/`ctrl+shift+g`/`escape` while its find box
+	// is focused) are inherited as they ship. Atomic routes every
+	// `tui.altScreen.*` action through `FULLSCREEN_VIEWPORT_ACTIONS`
+	// (`modes/interactive/interactive-mode-base.ts`), so a focused overlay is
+	// offered `ctrl+shift+f` before the viewport opens a search behind it, and
+	// the matches are themed through `searchMatchBg`/`searchMatchText`.
 	"app.interrupt": { defaultKeys: "escape", description: "Cancel or abort" },
 	"app.clear": { defaultKeys: "ctrl+c", description: "Clear editor" },
 	"app.exit": { defaultKeys: "ctrl+d", description: "Exit when editor is empty" },

--- a/packages/coding-agent/src/modes/interactive/interactive-extension-custom-ui.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-extension-custom-ui.ts
@@ -5,7 +5,7 @@ import {
 	transcriptOverlayIntersection,
 	type WrappedOverlayComponent,
 } from "./components/reserved-bottom-overlay.ts";
-import { InteractiveModeBase, isFullscreenViewportAction } from "./interactive-mode-base.ts";
+import { InteractiveModeBase, isFullscreenTranscriptScrollAction } from "./interactive-mode-base.ts";
 import {
 	type Component,
 	type KeybindingsManager,
@@ -224,7 +224,7 @@ InteractiveModeBase.prototype.showExtensionCustom = async function <T>(
 							() => this.ui.terminal.rows,
 							resolvedOverlayOptions?.margin,
 							resolvedOverlayOptions?.maxHeight,
-							(data) => isFullscreenViewportAction(data, this.keybindings) || isMouseWheelInput(data),
+							(data) => isFullscreenTranscriptScrollAction(data, this.keybindings) || isMouseWheelInput(data),
 							() => this.ui.requestRender(),
 						);
 						mountedComponent = bounded;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-base.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-base.ts
@@ -63,19 +63,49 @@ import {
 	type InternalUiActionResult,
 } from "./interactive-tui.ts";
 
-const FULLSCREEN_VIEWPORT_ACTIONS = [
+/** Move the transcript and nothing else: what a reserving overlay may release. */
+const FULLSCREEN_TRANSCRIPT_SCROLL_ACTIONS = [
 	"tui.altScreen.pageUp",
 	"tui.altScreen.pageDown",
 	"tui.altScreen.halfPageUp",
 	"tui.altScreen.halfPageDown",
+	"tui.altScreen.lineUp",
+	"tui.altScreen.lineDown",
 	"tui.altScreen.previousPrompt",
 	"tui.altScreen.nextPrompt",
 	"tui.altScreen.top",
 	"tui.altScreen.bottom",
 ] as const;
 
+/** Open and drive pi-tui's find box over the transcript. */
+const FULLSCREEN_SEARCH_ACTIONS = [
+	"tui.altScreen.search",
+	"tui.altScreen.searchNext",
+	"tui.altScreen.searchPrevious",
+	"tui.altScreen.searchClose",
+] as const;
+
+const FULLSCREEN_VIEWPORT_ACTIONS = [...FULLSCREEN_TRANSCRIPT_SCROLL_ACTIONS, ...FULLSCREEN_SEARCH_ACTIONS] as const;
+
 export function isFullscreenViewportAction(data: string, keybindings: KeybindingsManager): boolean {
 	return FULLSCREEN_VIEWPORT_ACTIONS.some((action) => keybindings.matches(data, action));
+}
+
+/**
+ * Whether a key scrolls the transcript, as opposed to driving a search over it.
+ * A reserving overlay — the `ask_user_question` dialog, an extension component
+ * with `reserveTranscriptRows` — declines these so the strip above it still
+ * pages and jumps (#2378), and keeps everything else.
+ *
+ * The search actions are deliberately excluded. Their default keys include
+ * `enter`, `shift+enter`, `escape`, and `ctrl+g`, which such a dialog owns for
+ * submit, cancel, and its own editing; and pi-tui acts on `searchNext`,
+ * `searchPrevious`, and `searchClose` only while its find box holds focus,
+ * which cannot be true while the dialog does. Releasing them would drop those
+ * keys into a viewport that ignores them.
+ */
+export function isFullscreenTranscriptScrollAction(data: string, keybindings: KeybindingsManager): boolean {
+	return FULLSCREEN_TRANSCRIPT_SCROLL_ACTIONS.some((action) => keybindings.matches(data, action));
 }
 
 /**
@@ -92,9 +122,14 @@ export function isFullscreenViewportAction(data: string, keybindings: Keybinding
  * and wheel reports are offered to the focused overlay, and
  * `AtomicTuiAltScreen` replays what it does not consume into pi-tui's viewport
  * listener. Atomic's answer stands, because a mounted dialog that keeps its
- * selection keys must not also freeze the transcript behind it. pi-tui keeps
- * every action this list omits, so a user-bound `tui.altScreen.lineUp` still
- * reaches the focused component first.
+ * selection keys must not also freeze the transcript behind it.
+ *
+ * **The list covers every `tui.altScreen.*` action pi-tui defines**, transcript
+ * search included. A focused overlay therefore gets first refusal on
+ * `ctrl+shift+f` as well as on the scroll keys, which is what keeps a search
+ * scoped to the surface the reader is looking at instead of opening a find box
+ * over the main transcript hidden behind it. An action a focused overlay
+ * declines still reaches the transcript, so the shortcut is never simply lost.
  *
  * **A focused overlay with no `handleInput` is still an overlay.** The handler
  * is optional — `ExtensionCustomComponent` marks it `handleInput?` and

--- a/packages/coding-agent/src/modes/interactive/interactive-tui.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-tui.ts
@@ -10,6 +10,7 @@ import {
 } from "@earendil-works/pi-tui";
 import { openBrowser } from "../../utils/open-browser.ts";
 import { TRANSCRIPT_JUMP_TO_END_URL } from "./components/transcript-follow-indicator.ts";
+import { theme } from "./theme/theme.ts";
 
 interface TuiOverlayEntry {
 	component: Component;
@@ -298,10 +299,9 @@ class AtomicTuiAltScreen extends TuiAltScreen {
 		// replays only what the overlay declined (#2378 / PR #2381); pi-tui then
 		// defers the replay a second time and the transcript freezes behind an
 		// open dialog. Suppress the native answer for the replay alone. Input the
-		// gate never routed through the overlay — every action outside
-		// `FULLSCREEN_VIEWPORT_ACTIONS`, including a user-bound
-		// `tui.altScreen.lineUp` — keeps pi-tui's own routing and still reaches
-		// the focused component first.
+		// gate never routed through the overlay — anything the gate admits to the
+		// viewport, including every key while pi-tui's own find box holds focus —
+		// keeps pi-tui's routing and its own deferral.
 		const deferral = this as unknown as TuiAltScreenViewportDeferral;
 		const deferToOverlay = deferral.shouldDeferViewportInputToOverlay?.bind(this);
 		deferral.shouldDeferViewportInputToOverlay = () => !viewportInputReplays.has(this) && deferToOverlay?.() === true;
@@ -526,6 +526,15 @@ function shouldUseFullscreenTui(usesInjectedTerminal: boolean): boolean {
 }
 
 /**
+ * Style a transcript search match. Read the theme at render time rather than at
+ * construction: the renderer is built before `initTheme` on some startup paths,
+ * and `/theme` swaps the instance under a running session.
+ */
+function styleSearchMatch(text: string): string {
+	return theme.bg("searchMatchBg", theme.fg("searchMatchText", text));
+}
+
+/**
  * Build Atomic's fullscreen renderer, `viewportInputGate` included, without
  * consulting the environment. `createInteractiveTui` calls this whenever
  * fullscreen applies; fixtures that assert fullscreen behavior call it
@@ -539,6 +548,8 @@ export function createFullscreenTui(options: InteractiveTuiOptions): TuiAltScree
 		options.showHardwareCursor,
 		options.logDirectory,
 		{
+			searchMatchStyle: (text) => theme.underline(styleSearchMatch(text)),
+			searchCurrentMatchStyle: (text) => theme.bold(theme.inverse(styleSearchMatch(text))),
 			openUrl: (url) =>
 				handleUrlActivation(url, {
 					onOverlayInternalUiAction: options.onOverlayInternalUiAction,

--- a/packages/coding-agent/src/modes/interactive/theme/dark.json
+++ b/packages/coding-agent/src/modes/interactive/theme/dark.json
@@ -33,6 +33,8 @@
 
 		"selectedBg": "selectedBg",
 		"scrollbarThumb": "selectedBg",
+		"searchMatchBg": "selectedBg",
+		"searchMatchText": "",
 		"userMessageBg": "userMsgBg",
 		"userMessageText": "",
 		"customMessageBg": "customMsgBg",

--- a/packages/coding-agent/src/modes/interactive/theme/light.json
+++ b/packages/coding-agent/src/modes/interactive/theme/light.json
@@ -32,6 +32,8 @@
 
 		"selectedBg": "selectedBg",
 		"scrollbarThumb": "selectedBg",
+		"searchMatchBg": "selectedBg",
+		"searchMatchText": "",
 		"userMessageBg": "userMsgBg",
 		"userMessageText": "",
 		"customMessageBg": "customMsgBg",

--- a/packages/coding-agent/src/modes/interactive/theme/theme-class.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme-class.ts
@@ -14,6 +14,7 @@ export type ThemeColor =
 	| "dim"
 	| "text"
 	| "thinkingText"
+	| "searchMatchText"
 	| "userMessageText"
 	| "customMessageText"
 	| "customMessageLabel"
@@ -52,11 +53,21 @@ export type ThemeColor =
 export type ThemeBg =
 	| "selectedBg"
 	| "scrollbarThumb"
+	| "searchMatchBg"
 	| "userMessageBg"
 	| "customMessageBg"
 	| "toolPendingBg"
 	| "toolSuccessBg"
 	| "toolErrorBg";
+
+/**
+ * Colors a theme may omit. Each one resolves from a color every theme already
+ * defines, so a theme written before the token existed keeps validating and
+ * keeps rendering: `searchMatchText` falls back to `text` and `searchMatchBg`
+ * to `selectedBg`.
+ */
+type OptionalThemeColor = "searchMatchText";
+type OptionalThemeBg = "scrollbarThumb" | "searchMatchBg";
 
 export type WorkingIndicatorTone = "dark" | "lift" | "muted" | "accent" | "bright" | "peak";
 
@@ -70,9 +81,10 @@ export class Theme {
 	private workingIndicatorColors: Map<WorkingIndicatorTone, string>;
 
 	constructor(
-		fgColors: Record<ThemeColor, string | number>,
-		bgColors: Record<Exclude<ThemeBg, "scrollbarThumb">, string | number> &
-			Partial<Record<"scrollbarThumb", string | number>>,
+		fgColors: Record<Exclude<ThemeColor, OptionalThemeColor>, string | number> &
+			Partial<Record<OptionalThemeColor, string | number>>,
+		bgColors: Record<Exclude<ThemeBg, OptionalThemeBg>, string | number> &
+			Partial<Record<OptionalThemeBg, string | number>>,
 		mode: ColorMode,
 		options: {
 			name?: string;
@@ -86,13 +98,18 @@ export class Theme {
 		this.sourceInfo = options.sourceInfo;
 		this.mode = mode;
 		this.fgColors = new Map();
-		for (const [key, value] of Object.entries(fgColors) as [ThemeColor, string | number][]) {
+		const foregrounds = {
+			...fgColors,
+			searchMatchText: fgColors.searchMatchText ?? fgColors.text,
+		};
+		for (const [key, value] of Object.entries(foregrounds) as [ThemeColor, string | number][]) {
 			this.fgColors.set(key, fgAnsi(value, mode));
 		}
 		this.bgColors = new Map();
 		const backgrounds = {
 			...bgColors,
 			scrollbarThumb: bgColors.scrollbarThumb ?? bgColors.selectedBg,
+			searchMatchBg: bgColors.searchMatchBg ?? bgColors.selectedBg,
 		};
 		for (const [key, value] of Object.entries(backgrounds) as [ThemeBg, string | number][]) {
 			this.bgColors.set(key, bgAnsi(value, mode));

--- a/packages/coding-agent/src/modes/interactive/theme/theme-loading.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme-loading.ts
@@ -120,6 +120,7 @@ function createTheme(themeJson: ThemeJson, mode?: ColorMode, sourcePath?: string
 	const bgColorKeys: Set<string> = new Set([
 		"selectedBg",
 		"scrollbarThumb",
+		"searchMatchBg",
 		"userMessageBg",
 		"customMessageBg",
 		"toolPendingBg",

--- a/packages/coding-agent/src/modes/interactive/theme/theme-schema.json
+++ b/packages/coding-agent/src/modes/interactive/theme/theme-schema.json
@@ -34,7 +34,7 @@
 		},
 		"colors": {
 			"type": "object",
-			"description": "Theme color definitions (scrollbarThumb is optional and falls back to selectedBg)",
+			"description": "Theme color definitions (scrollbarThumb and the search highlight colors are optional and fall back to compatible colors)",
 			"required": [
 				"accent",
 				"border",
@@ -140,6 +140,14 @@
 				"scrollbarThumb": {
 					"$ref": "#/$defs/colorValue",
 					"description": "Fullscreen scrollbar thumb background (falls back to selectedBg when omitted)"
+				},
+				"searchMatchBg": {
+					"$ref": "#/$defs/colorValue",
+					"description": "Transcript search match background and current-match text (falls back to selectedBg when omitted)"
+				},
+				"searchMatchText": {
+					"$ref": "#/$defs/colorValue",
+					"description": "Transcript search match text and current-match background (falls back to text when omitted)"
 				},
 				"userMessageBg": {
 					"$ref": "#/$defs/colorValue",

--- a/packages/coding-agent/src/modes/interactive/theme/theme-schema.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme-schema.ts
@@ -25,9 +25,11 @@ export const ThemeJsonSchema = Type.Object({
 		dim: ColorValueSchema,
 		text: ColorValueSchema,
 		thinkingText: ColorValueSchema,
-		// Backgrounds & Content Text (11 required, 1 optional)
+		// Backgrounds & Content Text (11 required, 3 optional)
 		selectedBg: ColorValueSchema,
 		scrollbarThumb: Type.Optional(ColorValueSchema),
+		searchMatchBg: Type.Optional(ColorValueSchema),
+		searchMatchText: Type.Optional(ColorValueSchema),
 		userMessageBg: ColorValueSchema,
 		userMessageText: ColorValueSchema,
 		customMessageBg: ColorValueSchema,

--- a/packages/coding-agent/test/ask-user-question-transcript-scroll.test.ts
+++ b/packages/coding-agent/test/ask-user-question-transcript-scroll.test.ts
@@ -31,6 +31,7 @@ import {
 	transcriptOverlayIntersection,
 } from "../src/modes/interactive/components/reserved-bottom-overlay.ts";
 import {
+	isFullscreenTranscriptScrollAction,
 	isFullscreenViewportAction,
 	shouldHandleFullscreenViewportInput,
 } from "../src/modes/interactive/interactive-mode-base.ts";
@@ -1473,7 +1474,7 @@ describe("ask_user_question transcript scrolling (#2378)", () => {
 			() => 24,
 			undefined,
 			undefined,
-			(data) => isFullscreenViewportAction(data, keybindings) || isMouseWheelInput(data),
+			(data) => isFullscreenTranscriptScrollAction(data, keybindings) || isMouseWheelInput(data),
 		);
 
 		for (const data of [PAGE_UP, PAGE_DOWN, HOME, END, WHEEL_UP, WHEEL_DOWN]) {
@@ -1546,7 +1547,7 @@ describe("ask_user_question transcript scrolling (#2378)", () => {
 				() => terminal.rows,
 				undefined,
 				undefined,
-				(data) => isFullscreenViewportAction(data, keybindings) || isMouseWheelInput(data),
+				(data) => isFullscreenTranscriptScrollAction(data, keybindings) || isMouseWheelInput(data),
 			);
 			tui.showOverlay(bounded, QUESTIONNAIRE_OVERLAY_OPTIONS);
 			tui.renderNow();

--- a/packages/coding-agent/test/pi-0.84.2-fullscreen-search.test.ts
+++ b/packages/coding-agent/test/pi-0.84.2-fullscreen-search.test.ts
@@ -1,0 +1,430 @@
+import { readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	type Component,
+	getKeybindings,
+	isKeyRelease,
+	ScrollView,
+	setKeybindings,
+	Text,
+	type TuiAltScreen,
+	VStack,
+} from "@earendil-works/pi-tui";
+import Ajv from "ajv";
+import { afterEach, beforeAll, describe, expect, test } from "vitest";
+import { getThemesDir } from "../src/config.ts";
+import { type KeybindingsConfig, KeybindingsManager } from "../src/core/keybindings.ts";
+import {
+	isFullscreenTranscriptScrollAction,
+	isFullscreenViewportAction,
+	shouldHandleFullscreenViewportInput,
+} from "../src/modes/interactive/interactive-mode-base.ts";
+import { createFullscreenTui } from "../src/modes/interactive/interactive-tui.ts";
+import { initTheme, loadThemeFromContent, theme } from "../src/modes/interactive/theme/theme.ts";
+import { validateThemeJson } from "../src/modes/interactive/theme/theme-schema.ts";
+import { RecordingTerminal } from "./helpers/interactive-fullscreen-layout.ts";
+
+/** Kitty-protocol `ctrl+shift+f`: pi-tui's default `tui.altScreen.search`. */
+const CTRL_SHIFT_F = "\x1b[102;6u";
+/** `tui.altScreen.searchNext`, one of its two defaults. */
+const CTRL_G = "\x07";
+/** `tui.altScreen.searchPrevious`, in kitty form. */
+const CTRL_SHIFT_G = "\x1b[103;6u";
+/** `tui.altScreen.searchClose`, and `app.interrupt` outside a search. */
+const ESCAPE = "\x1b";
+/** Bound below to `tui.altScreen.lineUp`; pi-tui ships that action unbound. */
+const CTRL_Y = "\x19";
+/** Bound below to `tui.altScreen.lineDown`. */
+const CTRL_U = "\x15";
+const TRANSCRIPT_LINES = 120;
+/** The two single-line actions have no default key, so the fixture supplies one. */
+const LINE_BINDINGS: KeybindingsConfig = {
+	"tui.altScreen.lineUp": "ctrl+y",
+	"tui.altScreen.lineDown": "ctrl+u",
+};
+/** Every `tui.altScreen.*` action this layer added to Atomic's gate. */
+const NEW_VIEWPORT_ACTIONS = [
+	"tui.altScreen.lineUp",
+	"tui.altScreen.lineDown",
+	"tui.altScreen.search",
+	"tui.altScreen.searchNext",
+	"tui.altScreen.searchPrevious",
+	"tui.altScreen.searchClose",
+] as const;
+
+const initialKeybindings = getKeybindings();
+
+beforeAll(() => {
+	initTheme("dark");
+});
+
+afterEach(() => {
+	setKeybindings(initialKeybindings);
+	initTheme("dark");
+});
+
+/** A focused overlay that declines everything, the way a notice or progress panel does. */
+class DecliningOverlay implements Component {
+	readonly handledInputs: string[] = [];
+
+	render(): string[] {
+		return ["dialog"];
+	}
+
+	handleInput(data: string): boolean {
+		this.handledInputs.push(data);
+		return false;
+	}
+
+	invalidate(): void {}
+}
+
+/** pi-tui keeps its find box and its match styles private (tui-alt-screen.d.ts:50,55). */
+interface AltScreenSearchInternals {
+	activeSearch?: {
+		query: string;
+		selectedIndex: number;
+		matches: unknown[];
+		overlay?: { isFocused(): boolean };
+	};
+	searchMatchStyle: (text: string) => string;
+	searchCurrentMatchStyle: (text: string) => string;
+}
+
+interface Fixture {
+	tui: TuiAltScreen;
+	terminal: RecordingTerminal;
+	transcript: ScrollView;
+	editor: Text;
+	overlay: DecliningOverlay;
+	stop: () => void;
+}
+
+function internals(fixture: Fixture): AltScreenSearchInternals {
+	return fixture.tui as unknown as AltScreenSearchInternals;
+}
+
+function activeSearch(fixture: Fixture): AltScreenSearchInternals["activeSearch"] {
+	return internals(fixture).activeSearch;
+}
+
+/**
+ * Build the fullscreen renderer with Atomic's real gate, the way
+ * `InteractiveModeBase` wires it. `mountOverlay` focuses a declining overlay,
+ * which is the route that proves the gate rather than pi-tui's own routing:
+ * with the editor focused every key reaches the viewport regardless of the
+ * allowlist.
+ */
+function createFixture(options: { mountOverlay?: boolean; userBindings?: KeybindingsConfig } = {}): Fixture {
+	const userBindings = options.userBindings ?? LINE_BINDINGS;
+	setKeybindings(new KeybindingsManager(userBindings));
+	const keybindings = new KeybindingsManager(userBindings);
+	const terminal = new RecordingTerminal();
+	terminal.columns = 100;
+	terminal.rows = 40;
+
+	const editor = new Text("editor", 0, 0);
+	let tui!: TuiAltScreen;
+	tui = createFullscreenTui({
+		showHardwareCursor: false,
+		logDirectory: tmpdir(),
+		terminal,
+		shouldHandleViewportInput: (data, isMouseInput, focusedIsOverlay, focusedIsViewportSearch) =>
+			shouldHandleFullscreenViewportInput(
+				tui.getFocusedComponent(),
+				editor,
+				data,
+				isMouseInput,
+				focusedIsOverlay,
+				keybindings,
+				focusedIsViewportSearch,
+			),
+		onOverlayUnhandledInput: (data) => {
+			if (isKeyRelease(data)) return false;
+			return keybindings.matches(data, "app.thinking.toggle");
+		},
+	});
+
+	const transcript = new ScrollView(
+		new Text(Array.from({ length: TRANSCRIPT_LINES }, (_, index) => `transcript line ${index + 1}`).join("\n"), 0, 0),
+		{ follow: "end", primary: true },
+	);
+	tui.setLayoutRoot(
+		new VStack([
+			{ component: transcript, basis: 0, grow: 1, shrink: 1, minSize: 1 },
+			{ component: editor, basis: 1, shrink: 0 },
+		]),
+	);
+	tui.setFocus(editor);
+	tui.start();
+	tui.renderNow();
+
+	const overlay = new DecliningOverlay();
+	if (options.mountOverlay !== false) {
+		tui.showOverlay(overlay, { anchor: "bottom-center", width: "100%" });
+		tui.renderNow();
+		expect(tui.getFocusedComponent()).toBe(overlay);
+	}
+
+	return { tui, terminal, transcript, editor, overlay, stop: () => tui.stop() };
+}
+
+function type(fixture: Fixture, text: string): void {
+	for (const character of text) fixture.terminal.input(character);
+	fixture.tui.renderNow();
+}
+
+function loadDarkThemeJson(): { name: string; colors: Record<string, string | number> } {
+	return JSON.parse(readFileSync(join(getThemesDir(), "dark.json"), "utf8")) as {
+		name: string;
+		colors: Record<string, string | number>;
+	};
+}
+
+/**
+ * The six `tui.altScreen.*` actions pi 0.84.2 added to Atomic's surface: the two
+ * single-line scroll steps from upstream `1279952d` and the four transcript
+ * search actions from `00121ed9`. Upstream has no action allowlist, so there is
+ * no hunk to copy — without these entries in `FULLSCREEN_VIEWPORT_ACTIONS` the
+ * bindings never reach the viewport through Atomic's gate, and the feature
+ * looks ported while doing nothing.
+ */
+describe("fullscreen transcript search routing", () => {
+	test("7913-fullscreen-search-actions-routed", () => {
+		const fixture = createFixture();
+		try {
+			fixture.transcript.scrollToEnd();
+			fixture.tui.renderNow();
+			const anchored = fixture.transcript.scrollTop;
+
+			// 1 & 2 — the single-line steps reach the viewport after the focused
+			// overlay declines them.
+			fixture.terminal.input(CTRL_Y);
+			fixture.tui.renderNow();
+			expect(fixture.transcript.scrollTop).toBe(anchored - 1);
+			fixture.terminal.input(CTRL_U);
+			fixture.tui.renderNow();
+			expect(fixture.transcript.scrollTop).toBe(anchored);
+			expect(fixture.overlay.handledInputs).toEqual([CTRL_Y, CTRL_U]);
+
+			// 3 — `search` opens pi-tui's find box over the transcript.
+			fixture.terminal.input(CTRL_SHIFT_F);
+			fixture.tui.renderNow();
+			expect(activeSearch(fixture), "ctrl+shift+f opened no search").toBeDefined();
+			expect(activeSearch(fixture)?.overlay?.isFocused()).toBe(true);
+
+			type(fixture, "line 1");
+			const matches = activeSearch(fixture)?.matches.length ?? 0;
+			expect(matches).toBeGreaterThan(1);
+			const first = activeSearch(fixture)?.selectedIndex ?? -1;
+			expect(first).toBeGreaterThanOrEqual(0);
+
+			// 4 — `searchNext` advances the selected match.
+			fixture.terminal.input(CTRL_G);
+			fixture.tui.renderNow();
+			const next = activeSearch(fixture)?.selectedIndex ?? -1;
+			expect(next).toBe((first + 1) % matches);
+
+			// 5 — `searchPrevious` walks back to it.
+			fixture.terminal.input(CTRL_SHIFT_G);
+			fixture.tui.renderNow();
+			expect(activeSearch(fixture)?.selectedIndex).toBe(first);
+
+			// 6 — `searchClose` dismisses the find box.
+			fixture.terminal.input(ESCAPE);
+			fixture.tui.renderNow();
+			expect(activeSearch(fixture)).toBeUndefined();
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	test("every new action is gated, so a focused overlay is offered it first", () => {
+		const keybindings = new KeybindingsManager(LINE_BINDINGS);
+		const editor = new Text("editor", 0, 0);
+		const overlay = new DecliningOverlay();
+		const keys: Record<(typeof NEW_VIEWPORT_ACTIONS)[number], string> = {
+			"tui.altScreen.lineUp": CTRL_Y,
+			"tui.altScreen.lineDown": CTRL_U,
+			"tui.altScreen.search": CTRL_SHIFT_F,
+			"tui.altScreen.searchNext": CTRL_G,
+			"tui.altScreen.searchPrevious": CTRL_SHIFT_G,
+			"tui.altScreen.searchClose": ESCAPE,
+		};
+
+		for (const action of NEW_VIEWPORT_ACTIONS) {
+			const data = keys[action];
+			expect(keybindings.matches(data, action), `${action} does not match its key`).toBe(true);
+			expect(isFullscreenViewportAction(data, keybindings), `${action} is outside the gate`).toBe(true);
+			// A focused overlay gets first refusal, which is what keeps a stage
+			// chat's own search from opening over the main transcript behind it.
+			expect(
+				shouldHandleFullscreenViewportInput(overlay, editor, data, false, true, keybindings),
+				`${action} skips the focused overlay`,
+			).toBe(false);
+			// The main editor keeps the shortcut.
+			expect(shouldHandleFullscreenViewportInput(editor, editor, data, false, false, keybindings)).toBe(true);
+		}
+	});
+
+	/**
+	 * A reserving overlay — the `ask_user_question` dialog, or an extension
+	 * component with `reserveTranscriptRows` — declines transcript scrolling so
+	 * the strip above it still pages (#2378). The search actions must stay out of
+	 * that release set: `enter`, `shift+enter`, `escape`, and `ctrl+g` are the
+	 * dialog's own submit, cancel, and edit keys, and pi-tui drops all three
+	 * navigation actions unless its find box has focus, which it cannot have
+	 * while the dialog does.
+	 */
+	test("a reserving overlay releases scrolling but keeps the search keys", () => {
+		const keybindings = new KeybindingsManager(LINE_BINDINGS);
+
+		for (const data of [CTRL_Y, CTRL_U]) {
+			expect(isFullscreenTranscriptScrollAction(data, keybindings)).toBe(true);
+			expect(isFullscreenViewportAction(data, keybindings)).toBe(true);
+		}
+		for (const data of [CTRL_SHIFT_F, CTRL_G, CTRL_SHIFT_G, ESCAPE, "\r"]) {
+			expect(isFullscreenTranscriptScrollAction(data, keybindings), `${JSON.stringify(data)} is released`).toBe(
+				false,
+			);
+		}
+		// The gate still owns them, which is the whole point of the split.
+		for (const data of [CTRL_SHIFT_F, CTRL_G, CTRL_SHIFT_G, ESCAPE]) {
+			expect(isFullscreenViewportAction(data, keybindings)).toBe(true);
+		}
+	});
+
+	test("the transcript still scrolls while the find box has focus", () => {
+		const fixture = createFixture({ mountOverlay: false });
+		try {
+			fixture.transcript.scrollToEnd();
+			fixture.tui.renderNow();
+			const anchored = fixture.transcript.scrollTop;
+
+			fixture.terminal.input(CTRL_SHIFT_F);
+			fixture.tui.renderNow();
+			expect(activeSearch(fixture)?.overlay?.isFocused()).toBe(true);
+
+			fixture.terminal.input(CTRL_Y);
+			fixture.tui.renderNow();
+			expect(fixture.transcript.scrollTop).toBe(anchored - 1);
+			expect(activeSearch(fixture)?.query).toBe("");
+		} finally {
+			fixture.stop();
+		}
+	});
+});
+
+/**
+ * The match styles the renderer hands pi-tui. They read the global theme on
+ * every call rather than capturing colors at construction, so `/theme` repaints
+ * an open search instead of leaving it in the previous palette.
+ */
+describe("fullscreen search match styling", () => {
+	test("the renderer styles matches with the theme's search colors", () => {
+		const fixture = createFixture({ mountOverlay: false });
+		try {
+			const { searchMatchStyle, searchCurrentMatchStyle } = internals(fixture);
+			const painted = theme.bg("searchMatchBg", theme.fg("searchMatchText", "hit"));
+
+			expect(searchMatchStyle("hit")).toBe(theme.underline(painted));
+			expect(searchCurrentMatchStyle("hit")).toBe(theme.bold(theme.inverse(painted)));
+			expect(searchMatchStyle("hit")).toContain(theme.getBgAnsi("searchMatchBg"));
+			expect(searchMatchStyle("hit")).toContain(theme.getFgAnsi("searchMatchText"));
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	test("a theme change repaints later matches", () => {
+		const fixture = createFixture({ mountOverlay: false });
+		try {
+			const { searchMatchStyle } = internals(fixture);
+			const dark = searchMatchStyle("hit");
+
+			initTheme("light");
+			expect(searchMatchStyle("hit")).toBe(
+				theme.underline(theme.bg("searchMatchBg", theme.fg("searchMatchText", "hit"))),
+			);
+			expect(searchMatchStyle("hit")).toContain(theme.getBgAnsi("searchMatchBg"));
+			expect(searchMatchStyle("hit")).not.toBe(dark);
+		} finally {
+			fixture.stop();
+		}
+	});
+
+	test("a rendered match carries the search background", () => {
+		const fixture = createFixture({ mountOverlay: false });
+		try {
+			fixture.terminal.input(CTRL_SHIFT_F);
+			fixture.tui.renderNow();
+			fixture.terminal.writes.length = 0;
+			type(fixture, "line 42");
+
+			expect(activeSearch(fixture)?.matches.length).toBeGreaterThan(0);
+			expect(fixture.terminal.writes.join("")).toContain(theme.getBgAnsi("searchMatchBg"));
+		} finally {
+			fixture.stop();
+		}
+	});
+});
+
+/**
+ * `searchMatchBg` and `searchMatchText` are optional. Every Atomic theme written
+ * before they existed — including a user's own file — must keep validating and
+ * keep rendering, which is what the fallbacks to `selectedBg` and `text` buy.
+ */
+describe("search match theme colors", () => {
+	test("a theme omitting both colors still resolves them", () => {
+		const themeJson = loadDarkThemeJson();
+		themeJson.name = "legacy-search-theme";
+		delete themeJson.colors.searchMatchBg;
+		delete themeJson.colors.searchMatchText;
+
+		expect(validateThemeJson.Check(themeJson)).toBe(true);
+		const loaded = loadThemeFromContent("legacy-search-theme.json", JSON.stringify(themeJson), "truecolor");
+		expect(loaded.getBgAnsi("searchMatchBg")).toBe(loaded.getBgAnsi("selectedBg"));
+		expect(loaded.getFgAnsi("searchMatchText")).toBe(loaded.getFgAnsi("text"));
+	});
+
+	test("a theme defining both colors keeps them", () => {
+		const themeJson = loadDarkThemeJson();
+		themeJson.name = "custom-search-theme";
+		themeJson.colors.searchMatchBg = "#112233";
+		themeJson.colors.searchMatchText = "#223344";
+
+		const loaded = loadThemeFromContent("custom-search-theme.json", JSON.stringify(themeJson), "truecolor");
+		expect(loaded.getBgAnsi("searchMatchBg")).toBe("\x1b[48;2;17;34;51m");
+		expect(loaded.getFgAnsi("searchMatchText")).toBe("\x1b[38;2;34;51;68m");
+	});
+
+	test("both schema forms accept a theme with and without the colors", () => {
+		const schema = JSON.parse(readFileSync(join(getThemesDir(), "theme-schema.json"), "utf8")) as object;
+		const validateJsonSchema = new Ajv({ allErrors: true }).compile(schema);
+
+		const withColors = loadDarkThemeJson();
+		withColors.name = "schema-search-theme";
+		withColors.colors.searchMatchBg = "#112233";
+		withColors.colors.searchMatchText = "#223344";
+		expect(validateJsonSchema(withColors), JSON.stringify(validateJsonSchema.errors)).toBe(true);
+		expect(validateThemeJson.Check(withColors)).toBe(true);
+
+		const without = loadDarkThemeJson();
+		without.name = "schema-legacy-search-theme";
+		delete without.colors.searchMatchBg;
+		delete without.colors.searchMatchText;
+		expect(validateJsonSchema(without), JSON.stringify(validateJsonSchema.errors)).toBe(true);
+		expect(validateThemeJson.Check(without)).toBe(true);
+	});
+
+	test("the bundled themes define both colors", () => {
+		for (const name of ["dark", "light"] as const) {
+			const themeJson = JSON.parse(readFileSync(join(getThemesDir(), `${name}.json`), "utf8")) as {
+				colors: Record<string, string | number>;
+			};
+			expect(themeJson.colors.searchMatchBg, `${name} omits searchMatchBg`).toBeDefined();
+			expect(themeJson.colors.searchMatchText, `${name} omits searchMatchText`).toBeDefined();
+		}
+	});
+});

--- a/packages/coding-agent/test/pi-0.84.2-overlay-viewport-deferral.test.ts
+++ b/packages/coding-agent/test/pi-0.84.2-overlay-viewport-deferral.test.ts
@@ -43,7 +43,7 @@ const CTRL_SHIFT_F = "\x1b[102;6u";
 /** pi-tui's `PAGE_SCROLL_OVERLAP`: a page moves `viewportHeight` minus this. */
 const PAGE_SCROLL_OVERLAP = 4;
 const TRANSCRIPT_LINES = 120;
-/** Atomic ships the search actions unbound; a user binding is how the find box opens today. */
+/** Pinned explicitly so these fixtures do not silently follow a change in pi-tui's default. */
 const SEARCH_BINDING: KeybindingsConfig = { "tui.altScreen.search": "ctrl+shift+f" };
 const ANSI = /\x1b\[[0-9;]*[A-Za-z]/g;
 /** pi-tui's zero-width hardware-cursor marker (`dist/tui.js:21`). */
@@ -348,13 +348,12 @@ describe("pi-tui 0.84.2 overlay viewport deferral", () => {
 	});
 
 	/**
-	 * `tui.altScreen.lineUp` is deliberately absent from
-	 * `FULLSCREEN_VIEWPORT_ACTIONS`, so Atomic's gate never offers it to the
-	 * overlay and never replays it. pi-tui's native deferral therefore decides,
-	 * and a focused component sees the key first — what `docs/keybindings.md`
-	 * documents for a custom `tui.altScreen.*` binding.
+	 * `tui.altScreen.lineUp` is listed in `FULLSCREEN_VIEWPORT_ACTIONS` like
+	 * every other `tui.altScreen.*` action, so the focused overlay is offered it
+	 * first — what `docs/keybindings.md` documents for a custom
+	 * `tui.altScreen.*` binding — and a consuming overlay keeps it.
 	 */
-	test("a viewport action outside Atomic's gate reaches a consuming focused overlay", () => {
+	test("a single-line scroll binding reaches a consuming focused overlay", () => {
 		const fixture = createFixture({ consumes: true, userBindings: { "tui.altScreen.lineUp": "ctrl+y" } });
 		try {
 			const { top } = anchorAtEnd(fixture);
@@ -625,29 +624,29 @@ describe("an asynchronous overlay handler", () => {
 
 /**
  * pi-tui 0.84.2 binds transcript search by default and matches
- * `tui.altScreen.search` *before* it defers input to a focused overlay. Atomic's
- * gate does not list the search actions and nothing themes or scopes them yet,
- * so an inherited default would open an unthemed search over the main transcript
- * from inside a focused overlay and take its focus.
+ * `tui.altScreen.search` *before* it defers input to a focused overlay. Atomic
+ * inherits those defaults now that the actions are themed and listed in
+ * `FULLSCREEN_VIEWPORT_ACTIONS`: the gate offers `ctrl+shift+f` to a focused
+ * overlay first, so a search opens over the transcript the reader is actually
+ * looking at rather than the one hidden behind an open dialog.
  */
 describe("pi-tui 0.84.2 transcript search defaults", () => {
-	test("Atomic ships the four transcript-search actions unbound", () => {
+	test("Atomic inherits the four transcript-search bindings", () => {
 		for (const action of [
 			"tui.altScreen.search",
 			"tui.altScreen.searchNext",
 			"tui.altScreen.searchPrevious",
 			"tui.altScreen.searchClose",
 		] as const) {
-			expect(TUI_KEYBINDINGS[action].defaultKeys, `pi-tui still binds ${action}`).not.toEqual([]);
-			expect(KEYBINDINGS[action].defaultKeys, `${action} is bound by default`).toEqual([]);
+			expect(TUI_KEYBINDINGS[action].defaultKeys, `pi-tui no longer binds ${action}`).not.toEqual([]);
+			expect(KEYBINDINGS[action].defaultKeys, `${action} diverges from pi-tui`).toEqual(
+				TUI_KEYBINDINGS[action].defaultKeys,
+			);
 			expect(KEYBINDINGS[action].description).toBe(TUI_KEYBINDINGS[action].description);
 		}
 
-		// The same byte sequence matches under pi-tui's defaults, which is what
-		// proves the assertion above is about Atomic's suppression rather than an
-		// unrecognized key.
 		expect(new TuiKeybindingsManager(TUI_KEYBINDINGS, {}).matches(CTRL_SHIFT_F, "tui.altScreen.search")).toBe(true);
-		expect(new KeybindingsManager().matches(CTRL_SHIFT_F, "tui.altScreen.search")).toBe(false);
+		expect(new KeybindingsManager().matches(CTRL_SHIFT_F, "tui.altScreen.search")).toBe(true);
 	});
 
 	test("ctrl+shift+f reaches the focused overlay instead of opening a transcript search", () => {
@@ -667,12 +666,12 @@ describe("pi-tui 0.84.2 transcript search defaults", () => {
 		}
 	});
 
-	test("ctrl+shift+f opens no search over the main transcript either", () => {
+	test("ctrl+shift+f opens a search over the main transcript from the editor", () => {
 		const fixture = createFixture({ mountOverlay: false });
 		try {
 			fixture.terminal.input(CTRL_SHIFT_F);
 			fixture.tui.renderNow();
-			expect((fixture.tui as unknown as { activeSearch?: unknown }).activeSearch).toBeUndefined();
+			expect((fixture.tui as unknown as { activeSearch?: unknown }).activeSearch).toBeDefined();
 		} finally {
 			fixture.stop();
 		}


### PR DESCRIPTION
pi-tui 0.84.2 ships the transcript search engine (upstream `00121ed9`) and two
single-line scroll actions (`1279952d`). Atomic owns the surface, and L6 shipped
the four search actions unbound until a layer routed, themed, and scoped them.
This is that layer.

`FULLSCREEN_VIEWPORT_ACTIONS` now lists all fourteen `tui.altScreen.*` actions:
`lineUp`, `lineDown`, `search`, `searchNext`, `searchPrevious`, and
`searchClose` join the eight already there. Upstream has no allowlist, so there
is no hunk to copy — without these entries the bindings never reach the viewport
through Atomic's gate and the feature is inert. Listing the search actions is
also what gives a focused overlay first refusal on `ctrl+shift+f`, so a search
opens over the surface the reader is looking at rather than the main transcript
hidden behind it.

The gate's list and the set a reserving overlay releases are no longer the same
list. `ReservedBottomOverlay` declines transcript scrolling so the strip above
the `ask_user_question` dialog still pages (#2378); releasing the search actions
too would have handed it `enter`, `shift+enter`, `escape`, and `ctrl+g` — its
submit, cancel, and edit keys — to a viewport that ignores all three navigation
actions unless pi-tui's find box holds focus, which it cannot while the dialog
does. `isFullscreenTranscriptScrollAction` is the narrower predicate; the two
#2378 regression tests fail against the wide one.

`searchMatchBg` and `searchMatchText` are optional theme colors falling back to
`selectedBg` and `text`, in the typebox schema, the JSON schema, and the `Theme`
constructor, so every user-authored theme keeps validating and keeps rendering.
`createFullscreenTui` passes `searchMatchStyle`/`searchCurrentMatchStyle`, read
from the global theme per call so `/theme` repaints an open search.

The `Theme` constructor signature widens to accept the optional colors — a
public API change, noted here because `CHANGELOG.md` belongs to L21.

Covered by `7913-fullscreen-search-actions-routed`, which drives all six actions
through a real fullscreen renderer, plus gate, predicate-split, styling, and
theme-fallback tests in `test/pi-0.84.2-fullscreen-search.test.ts`. Six of the
eleven fail against the previous behavior.

Assistant-model: Claude Opus 5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789392041&installation_model_id=10562&pr_number=2422&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2422&signature=9b5d4a714cfe2eda6eb6df1815df536fed0e5711fa6caf9f7e1d87fa853b8c8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change enables fullscreen transcript search, adds themed search-match rendering with compatibility fallbacks for existing themes, and preserves focused overlay ownership of search shortcuts. Fullscreen search opening, query navigation, close behavior, viewport scrolling while searching, focused and reserving-overlay routing, and legacy theme fallback behavior were exercised successfully. No defects were found.

<h3>Confidence Score: 5/5</h3>

The fullscreen search behavior and its interaction with overlays and existing custom themes are safe to merge based on the exercised runtime paths.

Focused runtime coverage passed for search shortcut handling, match navigation, search styling, overlay-first input routing, reserving-overlay behavior, and fallback rendering for themes without the new color tokens. Type checks and whitespace validation also completed successfully.

**Files Needing Attention:** No additional files need attention. The key behavior was exercised across interactive-mode-base.ts, interactive-tui.ts, interactive-extension-custom-ui.ts, and the interactive theme loading and class code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before the change, the pre-capture run showed the parent revision failing the routed-input assertion and throwing an Unknown theme background color: searchMatchBg for an omitted-token legacy theme.
- Compared the focused fullscreen-search assertions with the parent revision, noting that routed input did not scroll and that a legacy theme without searchMatchBg threw an error.
- After applying the change, the focused fullscreen-search and overlay viewport-deferral suites passed all 45 tests.
- Mounted a real reserving overlay and verified that Ctrl+Shift+F remained with the overlay instead of opening a main-transcript search.
- Whitespace validation and TypeScript checks completed successfully.

<a href="https://app.greptile.com/trex/runs/19084884/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(interactive): search the fullscreen..."](https://github.com/bastani-inc/atomic/commit/ea4001619e58c104a9255686b77e3dcd8e6f8d74) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53723740)</sub>

<!-- /greptile_comment -->