### PR TITLE
feat(interactive): fullscreen clipboard, exit output, managed-tool status

### DIFF
--- a/packages/coding-agent/src/core/settings-manager-ui-accessors.ts
+++ b/packages/coding-agent/src/core/settings-manager-ui-accessors.ts
@@ -2,7 +2,7 @@ import type { ScrollViewScrollbar } from "@earendil-works/pi-tui";
 import { ENV_CLEAR_ON_SHRINK, ENV_HARDWARE_CURSOR, getEnvValue } from "../config.ts";
 import { SettingsManager } from "./settings-manager-core.ts";
 import { settingsInternals } from "./settings-manager-internals.ts";
-import type { MermaidRenderingMode, WarningSettings } from "./settings-types.ts";
+import type { FullscreenExitOutput, MermaidRenderingMode, WarningSettings } from "./settings-types.ts";
 
 interface SettingsManagerUiAccessors {
 	getShowImages(): boolean;
@@ -42,6 +42,8 @@ interface SettingsManagerUiAccessors {
 	setCodexFastModeSettings(settings: Partial<{ chat: boolean; workflow: boolean }>): void;
 	getFullscreenScrollbar(): ScrollViewScrollbar;
 	setFullscreenScrollbar(mode: ScrollViewScrollbar): void;
+	getFullscreenExitOutput(): FullscreenExitOutput;
+	setFullscreenExitOutput(output: FullscreenExitOutput): void;
 }
 
 declare module "./settings-manager-core.ts" {
@@ -197,6 +199,17 @@ const uiAccessors: SettingsManagerUiAccessors = {
 		const state = settingsInternals(this);
 		state.globalSettings.fullscreenScrollbar = mode;
 		state.markModified("fullscreenScrollbar");
+		state.save();
+	},
+
+	getFullscreenExitOutput() {
+		return settingsInternals(this).settings.fullscreenExitOutput === "resume-hint" ? "resume-hint" : "transcript";
+	},
+
+	setFullscreenExitOutput(output) {
+		const state = settingsInternals(this);
+		state.globalSettings.fullscreenExitOutput = output;
+		state.markModified("fullscreenExitOutput");
 		state.save();
 	},
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -11,6 +11,7 @@ export type {
 	CodexFastModeSettings,
 	CompactionSettings,
 	DefaultProjectTrust,
+	FullscreenExitOutput,
 	ImageSettings,
 	MarkdownSettings,
 	MermaidRenderingMode,

--- a/packages/coding-agent/src/core/settings-types.ts
+++ b/packages/coding-agent/src/core/settings-types.ts
@@ -75,6 +75,9 @@ export type DefaultProjectTrust = "ask" | "always" | "never";
 
 export type TransportSetting = Transport;
 
+/** What the terminal keeps when Atomic's fullscreen session exits. */
+export type FullscreenExitOutput = "transcript" | "resume-hint";
+
 /**
  * Package source for npm/git packages.
  * - String form: load all resources from the package
@@ -145,6 +148,7 @@ export interface Settings {
 	autocompleteMaxVisible?: number; // Max visible items in autocomplete dropdown (default: 5)
 	showHardwareCursor?: boolean; // Show terminal cursor while still positioning it for IME
 	fullscreenScrollbar?: ScrollViewScrollbar; // default: "auto"
+	fullscreenExitOutput?: FullscreenExitOutput; // default: "transcript"
 	markdown?: MarkdownSettings;
 	warnings?: WarningSettings;
 	codexFastMode?: CodexFastModeSettings; // OpenAI priority service tier toggles for chat/workflow

--- a/packages/coding-agent/src/core/tools/find.ts
+++ b/packages/coding-agent/src/core/tools/find.ts
@@ -642,7 +642,7 @@ export function createFindToolDefinition(
 							);
 							return;
 						}
-						const fdPath = await ensureTool("fd", true);
+						const fdPath = await ensureTool("fd");
 						if (signal?.aborted) {
 							settle(() => reject(new Error("Operation aborted")));
 							return;

--- a/packages/coding-agent/src/core/tools/grep.ts
+++ b/packages/coding-agent/src/core/tools/grep.ts
@@ -335,7 +335,7 @@ export function createGrepToolDefinition(
 							return lines;
 						};
 
-						const rgPath = await ensureTool("rg", true);
+						const rgPath = await ensureTool("rg");
 						if (!rgPath) {
 							settle(() => reject(new Error("ripgrep (rg) is not available and could not be downloaded")));
 							return;

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector-handlers.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector-handlers.ts
@@ -1,7 +1,7 @@
 import type { Transport } from "@earendil-works/pi-ai/compat";
 import type { ScrollViewScrollbar } from "@earendil-works/pi-tui";
 import { DEFAULT_HTTP_IDLE_TIMEOUT_MS, HTTP_IDLE_TIMEOUT_CHOICES } from "../../../core/http-dispatcher.ts";
-import type { MermaidRenderingMode } from "../../../core/settings-manager.ts";
+import type { FullscreenExitOutput, MermaidRenderingMode } from "../../../core/settings-manager.ts";
 import { DEFAULT_PROJECT_TRUST_BY_LABEL } from "./settings-selector-options.ts";
 import type {
 	DoubleEscapeAction,
@@ -84,6 +84,9 @@ export function createSettingsChangeHandler(callbacks: SettingsCallbacks): (id: 
 				break;
 			case "fullscreen-scrollbar":
 				callbacks.onFullscreenScrollbarChange(newValue as ScrollViewScrollbar);
+				break;
+			case "fullscreen-exit-output":
+				callbacks.onFullscreenExitOutputChange(newValue as FullscreenExitOutput);
 				break;
 			case "editor-padding":
 				callbacks.onEditorPaddingXChange(parseInt(newValue, 10));

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector-items.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector-items.ts
@@ -68,6 +68,13 @@ function insertUiToggles(items: SettingItem[], config: SettingsConfig): void {
 		values: ["auto", "always", "hidden"],
 	});
 	insertAfter(items, "fullscreen-scrollbar", {
+		id: "fullscreen-exit-output",
+		label: "Fullscreen exit output",
+		description: "Print the transcript or only a session resume hint when exiting",
+		currentValue: config.fullscreenExitOutput,
+		values: ["transcript", "resume-hint"],
+	});
+	insertAfter(items, "fullscreen-exit-output", {
 		id: "editor-padding",
 		label: "Editor padding",
 		description: "Horizontal padding for input editor (0-3)",

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector-types.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector-types.ts
@@ -1,7 +1,12 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Transport } from "@earendil-works/pi-ai/compat";
 import type { ScrollViewScrollbar } from "@earendil-works/pi-tui";
-import type { DefaultProjectTrust, MermaidRenderingMode, WarningSettings } from "../../../core/settings-manager.ts";
+import type {
+	DefaultProjectTrust,
+	FullscreenExitOutput,
+	MermaidRenderingMode,
+	WarningSettings,
+} from "../../../core/settings-manager.ts";
 import type { TerminalTheme } from "../theme/theme.ts";
 
 export type QueueDeliveryMode = "all" | "one-at-a-time";
@@ -34,6 +39,7 @@ export interface SettingsConfig {
 	treeFilterMode: TreeFilterMode;
 	showHardwareCursor: boolean;
 	fullscreenScrollbar: ScrollViewScrollbar;
+	fullscreenExitOutput: FullscreenExitOutput;
 	editorPaddingX: number;
 	outputPad: 0 | 1;
 	showCacheMissNotices: boolean;
@@ -69,6 +75,7 @@ export interface SettingsCallbacks {
 	onTreeFilterModeChange: (mode: TreeFilterMode) => void;
 	onShowHardwareCursorChange: (enabled: boolean) => void;
 	onFullscreenScrollbarChange: (mode: ScrollViewScrollbar) => void;
+	onFullscreenExitOutputChange: (output: FullscreenExitOutput) => void;
 	onEditorPaddingXChange: (padding: number) => void;
 	onOutputPadChange: (padding: 0 | 1) => void;
 	onShowCacheMissNoticesChange: (enabled: boolean) => void;

--- a/packages/coding-agent/src/modes/interactive/interactive-bash-compact.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-bash-compact.ts
@@ -1,3 +1,4 @@
+import type { FullscreenExitOutput } from "../../core/settings-manager.ts";
 import { InteractiveModeBase } from "./interactive-mode-base.ts";
 import { BashExecutionComponent, type TruncationResult } from "./interactive-mode-deps.ts";
 import { isEngineSendFailure } from "./interactive-prompt-restore.ts";
@@ -147,7 +148,10 @@ InteractiveModeBase.prototype.handleCompactCommand = async function (this: Inter
 	}
 };
 
-InteractiveModeBase.prototype.stop = function (this: InteractiveModeBase): void {
+InteractiveModeBase.prototype.stop = function (
+	this: InteractiveModeBase,
+	fullscreenExitOutput: FullscreenExitOutput = this.settingsManager.getFullscreenExitOutput(),
+): void {
 	this.disposeActiveSelector();
 	this.disposeInteractiveEngineHost();
 	this.disposeInteractiveEngineHost = () => {};
@@ -166,7 +170,7 @@ InteractiveModeBase.prototype.stop = function (this: InteractiveModeBase): void 
 		this.unsubscribe();
 	}
 	if (this.isInitialized) {
-		this.stopInteractiveTui();
+		this.stopInteractiveTui(fullscreenExitOutput);
 		this.isInitialized = false;
 	}
 	this.unregisterSignalHandlers();

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-base.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-base.ts
@@ -6,7 +6,7 @@ import { isKeyRelease, isViewportTUI, type ScrollView, type TuiInputListener } f
 
 import type { AgentSessionQueuePauseControl } from "../../core/agent-session-methods.ts";
 import type { MarkdownTransformer } from "../../core/extensions/types.ts";
-import type { MermaidRenderingMode } from "../../core/settings-manager.ts";
+import type { FullscreenExitOutput, MermaidRenderingMode } from "../../core/settings-manager.ts";
 import type { EarlyInputSnapshot } from "../../main-early-input.ts";
 import { readClipboardText } from "../../utils/clipboard.ts";
 import { renderEngineDiagnostic } from "../interactive-engine/engine-diagnostic-view.ts";
@@ -363,6 +363,9 @@ export class InteractiveModeBase {
 
 	lastStatusText: Text | undefined = undefined;
 
+	/** Leading spacer added once for the managed-tool startup status block. */
+	managedToolStatusStarted = false;
+
 	// Streaming message tracking
 	streamingComponent: AssistantMessageComponent | undefined = undefined;
 
@@ -566,9 +569,22 @@ export class InteractiveModeBase {
 		}
 	}
 
-	stopInteractiveTui(): void {
-		while (this.renderer.hasOverlayEntries) this.renderer.hideOverlay();
-		this.ui.stop();
+	stopInteractiveTui(fullscreenExitOutput: FullscreenExitOutput): void {
+		const isFullscreen = this.renderer.mode === "fullscreen";
+		if (isFullscreen && fullscreenExitOutput === "transcript") {
+			// Atomic has no regular renderer to switch into, so pi-tui's own
+			// exit paint is the only painter: its stop renders the layout root
+			// at natural height onto the main screen. The docked fullscreen
+			// layout squeezes its scroll view to `basis` (one row) at natural
+			// height, so hand it the document container directly — the exit
+			// paint then carries the whole transcript. Drop overlays first so
+			// what gets painted is the transcript, not the focused dialog.
+			while (this.renderer.hasOverlayEntries) this.renderer.hideOverlay();
+			if (isViewportTUI(this.renderer)) this.renderer.setLayoutRoot(this.documentContainer);
+		}
+		// `resume-hint` keeps whatever the alternate screen held: the prior
+		// shell contents reappear and shutdown prints only the resume line.
+		this.ui.stop({ preserveScreen: isFullscreen && fullscreenExitOutput === "resume-hint" });
 	}
 
 	declare options: InteractiveModeOptions;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-surface.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-surface.ts
@@ -2,6 +2,8 @@
 
 import type { MarkdownTransformer } from "../../core/extensions/types.ts";
 import type { CustomEntry, SessionEntry } from "../../core/session-manager.ts";
+import type { FullscreenExitOutput } from "../../core/settings-manager.ts";
+import type { ToolStatus } from "../../utils/tools-manager.ts";
 import type { JsonAgentSessionEvent } from "../json-event.ts";
 import type { AtomicWorkingLoader } from "./components/atomic-working-status.ts";
 import type {
@@ -242,6 +244,10 @@ declare module "./interactive-mode-base.ts" {
 		handleEvent(event: AgentSessionEvent | JsonAgentSessionEvent): Promise<void>;
 		getUserMessageText(message: Message): string;
 		showStatus(message: string): void;
+		/** Report a managed-tool (fd/rg) readiness update inside the transcript. */
+		showManagedToolStatus(status: ToolStatus): void;
+		/** Bring fd/rg to readiness after first paint; progress lands in the transcript. */
+		ensureManagedToolsReady(): Promise<void>;
 		chatMessageRenderOptions(): ChatMessageRenderOptions;
 		addRenderedChatEntry(entry: ChatMessageEntry): Component;
 		addCompactionBoundaryToChat(result: VerbatimCompactionResult): void;
@@ -375,6 +381,6 @@ declare module "./interactive-mode-base.ts" {
 		checkDaxnutsEasterEgg(model: { provider: string; id: string }): void;
 		handleBashCommand(command: string, excludeFromContext?: boolean): Promise<void>;
 		handleCompactCommand(): Promise<void>;
-		stop(): void;
+		stop(fullscreenExitOutput?: FullscreenExitOutput): void;
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/interactive-selectors.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-selectors.ts
@@ -107,6 +107,7 @@ InteractiveModeBase.prototype.showSettingsSelector = function (this: Interactive
 				treeFilterMode: this.settingsManager.getTreeFilterMode(),
 				showHardwareCursor: this.settingsManager.getShowHardwareCursor(),
 				fullscreenScrollbar: this.settingsManager.getFullscreenScrollbar(),
+				fullscreenExitOutput: this.settingsManager.getFullscreenExitOutput(),
 				editorPaddingX: this.settingsManager.getEditorPaddingX(),
 				outputPad: this.settingsManager.getOutputPad(),
 				showCacheMissNotices: this.settingsManager.getShowCacheMissNotices(),
@@ -221,6 +222,9 @@ InteractiveModeBase.prototype.showSettingsSelector = function (this: Interactive
 					this.settingsManager.setFullscreenScrollbar(mode);
 					this.transcriptScrollView?.setScrollbar(mode);
 					this.ui.requestRender();
+				},
+				onFullscreenExitOutputChange: (output) => {
+					this.settingsManager.setFullscreenExitOutput(output);
 				},
 				onEditorPaddingXChange: (padding) => {
 					this.settingsManager.setEditorPaddingX(padding);

--- a/packages/coding-agent/src/modes/interactive/interactive-session-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-session-runtime.ts
@@ -140,7 +140,9 @@ InteractiveModeBase.prototype.handleFatalRuntimeError = async function (
 	const message = error instanceof Error ? error.message : String(error);
 	this.showError(`${prefix}: ${message}`);
 	stopThemeWatcher();
-	this.stop();
+	// A fatal exit keeps the transcript visible: the error the user just saw
+	// must remain on screen after the process dies, whatever the setting says.
+	this.stop("transcript");
 	process.exit(1);
 };
 

--- a/packages/coding-agent/src/modes/interactive/interactive-startup.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-startup.ts
@@ -1,6 +1,7 @@
 import { ScrollView, VStack } from "@earendil-works/pi-tui";
 import { isOfflineModeEnabled } from "../../core/package-manager-env.ts";
 import { createChildProcessEnvironment } from "../../utils/child-process.ts";
+import type { ToolStatus } from "../../utils/tools-manager.ts";
 import {
 	onInteractiveEngineRemoteCommandsChanged,
 	waitForInteractiveEngineBound,
@@ -126,6 +127,36 @@ InteractiveModeBase.prototype.showStartupNoticesIfNeeded = function (
 	this.ui.requestRender();
 };
 
+/** Bring fd and rg to readiness, reporting progress into the transcript. */
+InteractiveModeBase.prototype.ensureManagedToolsReady = function (this: InteractiveModeBase): Promise<void> {
+	return Promise.all([
+		ensureTool("fd", (status) => this.showManagedToolStatus(status)),
+		ensureTool("rg", (status) => this.showManagedToolStatus(status)),
+	])
+		.then(([fdPath]) => {
+			this.fdPath = fdPath;
+			this.setupAutocompleteProvider();
+		})
+		.catch((error) => {
+			const message = error instanceof Error ? error.message : String(error);
+			this.showManagedToolStatus({ type: "warning", message: `Tool readiness check failed: ${message}` });
+		});
+};
+
+/** Show a managed-tool status update in the chat, never on the console. */
+InteractiveModeBase.prototype.showManagedToolStatus = function (this: InteractiveModeBase, status: ToolStatus): void {
+	if (!this.managedToolStatusStarted) {
+		this.chatContainer.addChild(new Spacer(1));
+		this.managedToolStatusStarted = true;
+	}
+	const message = status.type === "warning" ? `Warning: ${status.message}` : status.message;
+	const color = status.type === "warning" ? "warning" : "dim";
+	this.chatContainer.addChild(new Text(theme.fg(color, message), 1, 0));
+	this.lastStatusSpacer = undefined;
+	this.lastStatusText = undefined;
+	this.ui.requestRender();
+};
+
 InteractiveModeBase.prototype.init = async function (this: InteractiveModeBase): Promise<void> {
 	if (this.isInitialized) return;
 
@@ -223,15 +254,10 @@ InteractiveModeBase.prototype.init = async function (this: InteractiveModeBase):
 	}
 	this.ui.requestRender();
 
-	void Promise.all([ensureTool("fd"), ensureTool("rg")])
-		.then(([fdPath]) => {
-			this.fdPath = fdPath;
-			this.setupAutocompleteProvider();
-		})
-		.catch((error) => {
-			const message = error instanceof Error ? error.message : String(error);
-			console.error(`Tool readiness check failed: ${message}`);
-		});
+	// fd/rg readiness runs after first paint so slow downloads never make
+	// startup appear frozen. Progress reports land in the transcript: a console
+	// write here lands in the alternate screen and corrupts the frame.
+	void this.ensureManagedToolsReady();
 
 	// When startup resources are deferred, keep the already-painted editor responsive.
 	// Extension UI bindings are installed at the deferred reload boundary, not here,

--- a/packages/coding-agent/src/modes/interactive/interactive-tui.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-tui.ts
@@ -8,6 +8,7 @@ import {
 	type TuiInputListener,
 	TuiMainScreen,
 } from "@earendil-works/pi-tui";
+import { copyToClipboard } from "../../utils/clipboard.ts";
 import { openBrowser } from "../../utils/open-browser.ts";
 import { TRANSCRIPT_JUMP_TO_END_URL } from "./components/transcript-follow-indicator.ts";
 import { theme } from "./theme/theme.ts";
@@ -111,6 +112,24 @@ export interface InteractiveTuiOptions {
 	) => boolean;
 	/** Handle an unconsumed overlay input before replaying it to the viewport. */
 	onOverlayUnhandledInput?: (data: string) => boolean;
+	/**
+	 * Copy selected text to the system clipboard; resolve false when the host
+	 * clipboard never received it. Defaults to Atomic's `copyToClipboard` with
+	 * its platform fallbacks, so pi-tui flashes "Copy failed" on a terminal
+	 * whose clipboard stayed untouched (upstream #8110) instead of the old
+	 * unconditional "Copied!". Injectable so hosts and tests observe the write.
+	 */
+	copySelection?: (text: string) => Promise<boolean>;
+}
+
+/** The default selection-copy route: Atomic's host clipboard write. */
+async function copySelectionToHostClipboard(text: string): Promise<boolean> {
+	try {
+		await copyToClipboard(text);
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 export interface UrlActivationHandlers {
@@ -557,6 +576,7 @@ export function createFullscreenTui(options: InteractiveTuiOptions): TuiAltScree
 					openUrl: openBrowser,
 				}),
 			onRightClickPaste: options.onRightClickPaste,
+			copySelection: options.copySelection ?? copySelectionToHostClipboard,
 		},
 		options.shouldHandleViewportInput,
 		options.onOverlayUnhandledInput,

--- a/packages/coding-agent/src/utils/tools-manager.ts
+++ b/packages/coding-agent/src/utils/tools-manager.ts
@@ -1,4 +1,3 @@
-import chalk from "chalk";
 import { type SpawnSyncReturns, spawnSync } from "child_process";
 import { chmodSync, existsSync, mkdirSync, readdirSync, renameSync, rmSync } from "fs";
 import { writeFile } from "fs/promises";
@@ -319,9 +318,26 @@ const TERMUX_PACKAGES: Record<string, string> = {
 	rg: "ripgrep",
 };
 
-// Ensure a tool is available, downloading if necessary
-// Returns the path to the tool, or null if unavailable
-export async function ensureTool(tool: "fd" | "rg", silent: boolean = false): Promise<string | undefined> {
+/** A managed-tool readiness update, reported to the caller that asked. */
+export interface ToolStatus {
+	type: "info" | "warning";
+	message: string;
+}
+
+/**
+ * Ensure a tool is available, downloading if necessary.
+ *
+ * Progress and problems are reported through `onStatus`; the function never
+ * writes to the console itself, because in a fullscreen session a console
+ * write lands in the alternate screen and corrupts the frame. Callers without
+ * a status sink stay silent.
+ *
+ * Returns the tool path, or undefined if unavailable.
+ */
+export async function ensureTool(
+	tool: "fd" | "rg",
+	onStatus?: (status: ToolStatus) => void,
+): Promise<string | undefined> {
 	const existingPath = getToolPath(tool);
 	if (existingPath) {
 		return existingPath;
@@ -331,9 +347,7 @@ export async function ensureTool(tool: "fd" | "rg", silent: boolean = false): Pr
 	if (!config) return undefined;
 
 	if (isOfflineModeEnabled()) {
-		if (!silent) {
-			console.log(chalk.yellow(`${config.name} not found. Offline mode enabled, skipping download.`));
-		}
+		onStatus?.({ type: "warning", message: `${config.name} not found. Offline mode enabled, skipping download.` });
 		return undefined;
 	}
 
@@ -341,27 +355,22 @@ export async function ensureTool(tool: "fd" | "rg", silent: boolean = false): Pr
 	// Users must install via pkg.
 	if (platform() === "android") {
 		const pkgName = TERMUX_PACKAGES[tool] ?? tool;
-		if (!silent) {
-			console.log(chalk.yellow(`${config.name} not found. Install with: pkg install ${pkgName}`));
-		}
+		onStatus?.({ type: "warning", message: `${config.name} not found. Install with: pkg install ${pkgName}` });
 		return undefined;
 	}
 
 	// Tool not found - download it
-	if (!silent) {
-		console.log(chalk.dim(`${config.name} not found. Downloading...`));
-	}
+	onStatus?.({ type: "info", message: `${config.name} not found. Downloading...` });
 
 	try {
 		const path = await downloadTool(tool);
-		if (!silent) {
-			console.log(chalk.dim(`${config.name} installed to ${path}`));
-		}
+		onStatus?.({ type: "info", message: `${config.name} installed to ${path}` });
 		return path;
 	} catch (e) {
-		if (!silent) {
-			console.log(chalk.yellow(`Failed to download ${config.name}: ${e instanceof Error ? e.message : e}`));
-		}
+		onStatus?.({
+			type: "warning",
+			message: `Failed to download ${config.name}: ${e instanceof Error ? e.message : e}`,
+		});
 		return undefined;
 	}
 }

--- a/packages/coding-agent/test/interactive-managed-tool-status.test.ts
+++ b/packages/coding-agent/test/interactive-managed-tool-status.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import type { ToolStatus } from "../src/utils/tools-manager.ts";
+
+const toolMocks = vi.hoisted(() => ({
+	ensureTool: vi.fn<(tool: "fd" | "rg", onStatus?: (status: ToolStatus) => void) => Promise<string | undefined>>(),
+}));
+
+vi.mock("../src/utils/tools-manager.ts", () => ({ ensureTool: toolMocks.ensureTool }));
+
+/**
+ * Upstream `6f707eb3`, the Atomic half: `ensureTool(tool, onStatus)` reports
+ * through a callback, and interactive startup routes those reports into the
+ * transcript. A console write during deferred startup lands in the alternate
+ * screen and corrupts the frame, which is exactly what the old
+ * `console.error` in the readiness catch produced.
+ */
+
+type ManagedToolsThis = {
+	fdPath: string | undefined;
+	managedToolStatusStarted: boolean;
+	lastStatusSpacer: unknown;
+	lastStatusText: unknown;
+	chatContainer: { children: unknown[]; addChild: (child: unknown) => void };
+	ui: { requestRender: ReturnType<typeof vi.fn> };
+	setupAutocompleteProvider: ReturnType<typeof vi.fn>;
+	showManagedToolStatus: (status: ToolStatus) => void;
+};
+
+const prototype = InteractiveMode.prototype as unknown as {
+	ensureManagedToolsReady(this: ManagedToolsThis): Promise<void>;
+	showManagedToolStatus(this: ManagedToolsThis, status: ToolStatus): void;
+};
+
+function createMode(): ManagedToolsThis {
+	const mode: ManagedToolsThis = {
+		fdPath: undefined,
+		managedToolStatusStarted: false,
+		lastStatusSpacer: undefined,
+		lastStatusText: undefined,
+		chatContainer: {
+			children: [],
+			addChild(child: unknown) {
+				this.children.push(child);
+			},
+		},
+		ui: { requestRender: vi.fn() },
+		setupAutocompleteProvider: vi.fn(),
+		showManagedToolStatus: undefined as never,
+	};
+	mode.showManagedToolStatus = (status) => prototype.showManagedToolStatus.call(mode, status);
+	return mode;
+}
+
+function transcriptText(mode: ManagedToolsThis): string {
+	return mode.chatContainer.children
+		.flatMap((child) => (child as { render?: (width: number) => string[] }).render?.(80) ?? [])
+		.join("\n");
+}
+
+beforeEach(() => {
+	initTheme("dark");
+	toolMocks.ensureTool.mockReset();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+test("managed-tool warnings land in the transcript, never on the console", async () => {
+	const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+	const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+	const mode = createMode();
+	toolMocks.ensureTool.mockImplementation(async (tool, onStatus) => {
+		onStatus?.({
+			type: "warning",
+			message: `${tool === "fd" ? "fd" : "ripgrep"} not found. Offline mode enabled, skipping download.`,
+		});
+		return undefined;
+	});
+
+	await prototype.ensureManagedToolsReady.call(mode);
+
+	expect(consoleLog).not.toHaveBeenCalled();
+	expect(consoleError).not.toHaveBeenCalled();
+	expect(transcriptText(mode)).toContain("Warning: fd not found. Offline mode enabled, skipping download.");
+	expect(transcriptText(mode)).toContain("Warning: ripgrep not found. Offline mode enabled, skipping download.");
+	expect(mode.ui.requestRender).toHaveBeenCalled();
+	expect(mode.setupAutocompleteProvider).toHaveBeenCalled();
+	expect(mode.fdPath).toBeUndefined();
+});
+
+test("info statuses render dim without the Warning prefix and share one spacer", async () => {
+	const mode = createMode();
+	toolMocks.ensureTool.mockImplementation(async (tool, onStatus) => {
+		if (tool === "rg") return "/tools/rg";
+		onStatus?.({ type: "info", message: "fd not found. Downloading..." });
+		onStatus?.({ type: "info", message: "fd installed to /tools/fd" });
+		return "/tools/fd";
+	});
+
+	await prototype.ensureManagedToolsReady.call(mode);
+
+	expect(transcriptText(mode)).toContain("fd not found. Downloading...");
+	expect(transcriptText(mode)).toContain("fd installed to /tools/fd");
+	expect(transcriptText(mode)).not.toContain("Warning:");
+	// One spacer for the whole block: the first status opens it and the second
+	// reuses it rather than stacking blank rows between updates.
+	expect(mode.chatContainer.children).toHaveLength(3);
+	expect(mode.fdPath).toBe("/tools/fd");
+});
+
+test("a rejected readiness check reports into the transcript instead of console.error", async () => {
+	const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+	const mode = createMode();
+	toolMocks.ensureTool.mockImplementation((tool) =>
+		tool === "fd" ? Promise.reject(new Error("spawn failed")) : Promise.resolve("/tools/rg"),
+	);
+
+	await expect(prototype.ensureManagedToolsReady.call(mode)).resolves.toBeUndefined();
+
+	expect(consoleError).not.toHaveBeenCalled();
+	expect(transcriptText(mode)).toContain("Warning: Tool readiness check failed: spawn failed");
+});

--- a/packages/coding-agent/test/pi-0.84.2-fullscreen-exit-output.test.ts
+++ b/packages/coding-agent/test/pi-0.84.2-fullscreen-exit-output.test.ts
@@ -1,0 +1,244 @@
+import { tmpdir } from "node:os";
+import { Container, ScrollView, Text, type TuiAltScreen, VStack } from "@earendil-works/pi-tui";
+import { expect, test, vi } from "vitest";
+import { type FullscreenExitOutput, SettingsManager } from "../src/core/settings-manager.ts";
+import { createSettingsChangeHandler } from "../src/modes/interactive/components/settings-selector-handlers.ts";
+import { buildSettingsItems } from "../src/modes/interactive/components/settings-selector-items.ts";
+import type { SettingsCallbacks, SettingsConfig } from "../src/modes/interactive/components/settings-selector-types.ts";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+import { createFullscreenTui } from "../src/modes/interactive/interactive-tui.ts";
+import { RecordingTerminal } from "./helpers/interactive-fullscreen-layout.ts";
+
+/**
+ * Upstream `ac4ac9ea`, adapted: Atomic has no regular renderer to switch into,
+ * so the exit setting chooses between pi-tui painting the transcript onto the
+ * main screen (`transcript`) and preserving whatever the alternate screen held
+ * so only the resume hint prints (`resume-hint`).
+ */
+
+const EXIT_ALT_SCREEN = "\x1b[?1049l";
+
+function createSettingsConfig(): SettingsConfig {
+	return {
+		autoCompact: true,
+		showImages: true,
+		imageWidthCells: 60,
+		autoResizeImages: true,
+		blockImages: false,
+		enableSkillCommands: true,
+		steeringMode: "one-at-a-time",
+		followUpMode: "one-at-a-time",
+		transport: "auto",
+		httpIdleTimeoutMs: 300_000,
+		bashInterceptorEnabled: false,
+		thinkingLevel: "off",
+		availableThinkingLevels: ["off"],
+		currentTheme: "dark",
+		terminalTheme: "dark",
+		availableThemes: ["dark"],
+		hideThinkingBlock: false,
+		collapseChangelog: false,
+		enableInstallTelemetry: true,
+		doubleEscapeAction: "tree",
+		mermaidRenderingMode: "streaming",
+		latexRenderingEnabled: true,
+		treeFilterMode: "default",
+		showHardwareCursor: false,
+		fullscreenScrollbar: "auto",
+		fullscreenExitOutput: "transcript",
+		editorPaddingX: 0,
+		outputPad: 1,
+		showCacheMissNotices: false,
+		autocompleteMaxVisible: 5,
+		quietStartup: false,
+		defaultProjectTrust: "ask",
+		clearOnShrink: false,
+		showTerminalProgress: false,
+		warnings: {},
+	};
+}
+
+test("fullscreen exit output setting defaults to transcript and round-trips", () => {
+	const settingsManager = SettingsManager.inMemory({});
+	expect(settingsManager.getFullscreenExitOutput()).toBe("transcript");
+
+	settingsManager.setFullscreenExitOutput("resume-hint");
+	expect(settingsManager.getFullscreenExitOutput()).toBe("resume-hint");
+	expect(settingsManager.getGlobalSettings().fullscreenExitOutput).toBe("resume-hint");
+
+	settingsManager.setFullscreenExitOutput("transcript");
+	expect(settingsManager.getFullscreenExitOutput()).toBe("transcript");
+	expect(settingsManager.getGlobalSettings().fullscreenExitOutput).toBe("transcript");
+});
+
+test("an invalid stored exit output value reads as transcript", () => {
+	const settingsManager = SettingsManager.inMemory({ fullscreenExitOutput: "nonsense" as FullscreenExitOutput });
+	expect(settingsManager.getFullscreenExitOutput()).toBe("transcript");
+});
+
+test("/settings offers the exit output row beside the fullscreen scrollbar", () => {
+	const items = buildSettingsItems(createSettingsConfig(), {} as SettingsCallbacks);
+	const scrollbarIndex = items.findIndex(({ id }) => id === "fullscreen-scrollbar");
+	const item = items.find(({ id }) => id === "fullscreen-exit-output");
+
+	expect(scrollbarIndex).toBeGreaterThan(-1);
+	expect(item).toMatchObject({
+		label: "Fullscreen exit output",
+		description: "Print the transcript or only a session resume hint when exiting",
+		currentValue: "transcript",
+		values: ["transcript", "resume-hint"],
+	});
+	expect(items.indexOf(item!)).toBe(scrollbarIndex + 1);
+});
+
+test("the exit output selector dispatches both values", () => {
+	const onFullscreenExitOutputChange = vi.fn();
+	const callbacks = { onFullscreenExitOutputChange } as unknown as SettingsCallbacks;
+
+	createSettingsChangeHandler(callbacks)("fullscreen-exit-output", "resume-hint");
+	createSettingsChangeHandler(callbacks)("fullscreen-exit-output", "transcript");
+
+	expect(onFullscreenExitOutputChange.mock.calls.flat()).toEqual(["resume-hint", "transcript"]);
+});
+
+type StopInteractiveTuiThis = {
+	renderer: TuiAltScreen;
+	ui: TuiAltScreen;
+	documentContainer: Container;
+};
+type StopMode = {
+	stopInteractiveTui(this: StopInteractiveTuiThis, fullscreenExitOutput: FullscreenExitOutput): void;
+};
+
+const stopInteractiveTui = InteractiveMode.prototype.stopInteractiveTui as unknown as StopMode["stopInteractiveTui"];
+
+function createExitFixture(): { fixture: StopInteractiveTuiThis; exitWrites: () => string } {
+	const terminal = new RecordingTerminal();
+	terminal.columns = 50;
+	terminal.rows = 8;
+	const renderer = createFullscreenTui({ showHardwareCursor: false, logDirectory: tmpdir(), terminal });
+	// Production shape: the transcript lives in a scroll view with `basis: 0`
+	// inside the docked layout root, while the document container itself holds
+	// every chat line without a height constraint.
+	const documentContainer = new Container();
+	documentContainer.addChild(new Text(["transcript line one", "transcript line two", "line three"].join("\n"), 0, 0));
+	const transcriptScrollView = new ScrollView(documentContainer, { follow: "end", primary: true });
+	const dock = new VStack([{ component: new Text("editor", 0, 0), basis: "auto", minSize: 1 }]);
+	renderer.setLayoutRoot(
+		new VStack([
+			{ component: transcriptScrollView, basis: 0, grow: 1, shrink: 1, minSize: 1 },
+			{ component: dock, basis: "auto", shrink: 1, minSize: 1 },
+		]),
+	);
+	renderer.start();
+	renderer.renderNow();
+	const writesBeforeExit = terminal.writes.length;
+	return {
+		fixture: { renderer, ui: renderer, documentContainer },
+		exitWrites: () => terminal.writes.slice(writesBeforeExit).join(""),
+	};
+}
+
+test('exiting with "transcript" paints the whole transcript onto the main screen', () => {
+	const { fixture, exitWrites } = createExitFixture();
+
+	stopInteractiveTui.call(fixture, "transcript");
+
+	const writes = exitWrites();
+	expect(writes).toContain(EXIT_ALT_SCREEN);
+	// The docked layout would squeeze the scroll view to its one-row basis;
+	// the exit must paint every chat line, not the final frame's slice.
+	expect(writes).toContain("transcript line one");
+	expect(writes).toContain("transcript line two");
+	expect(writes).toContain("line three");
+	expect(writes).toContain("\x1b[2K");
+});
+
+test('exiting with "resume-hint" preserves the prior screen instead of painting', () => {
+	const { fixture, exitWrites } = createExitFixture();
+
+	stopInteractiveTui.call(fixture, "resume-hint");
+
+	const writes = exitWrites();
+	expect(writes).toContain(EXIT_ALT_SCREEN);
+	// Nothing of the session is repainted: shutdown prints only the resume hint.
+	expect(writes).not.toContain("transcript line");
+	expect(writes).not.toContain("\x1b[2K");
+});
+
+type StopThis = {
+	disposeActiveSelector: () => void;
+	disposeInteractiveEngineHost: () => void;
+	settingsManager: { getShowTerminalProgress: () => boolean; getFullscreenExitOutput: () => FullscreenExitOutput };
+	loadingAnimation: undefined;
+	themeController: { disableAutoSync: () => void };
+	clearExtensionTerminalInputListeners: () => void;
+	footer: { dispose: () => void };
+	footerDataProvider: { dispose: () => void };
+	unsubscribe: undefined;
+	isInitialized: boolean;
+	stopInteractiveTui: ReturnType<typeof vi.fn>;
+	unregisterSignalHandlers: () => void;
+};
+
+function createStopThis(exitOutput: FullscreenExitOutput): StopThis {
+	return {
+		disposeActiveSelector: () => {},
+		disposeInteractiveEngineHost: () => {},
+		settingsManager: {
+			getShowTerminalProgress: () => false,
+			getFullscreenExitOutput: () => exitOutput,
+		},
+		loadingAnimation: undefined,
+		themeController: { disableAutoSync: () => {} },
+		clearExtensionTerminalInputListeners: () => {},
+		footer: { dispose: () => {} },
+		footerDataProvider: { dispose: () => {} },
+		unsubscribe: undefined,
+		isInitialized: true,
+		stopInteractiveTui: vi.fn(),
+		unregisterSignalHandlers: () => {},
+	};
+}
+
+const stop = InteractiveMode.prototype.stop as unknown as (
+	this: StopThis,
+	fullscreenExitOutput?: FullscreenExitOutput,
+) => void;
+
+test("stop() forwards the configured exit output and accepts an explicit one", () => {
+	const defaultMode = createStopThis("resume-hint");
+	stop.call(defaultMode);
+	expect(defaultMode.stopInteractiveTui).toHaveBeenCalledWith("resume-hint");
+
+	const explicitMode = createStopThis("resume-hint");
+	stop.call(explicitMode, "transcript");
+	expect(explicitMode.stopInteractiveTui).toHaveBeenCalledWith("transcript");
+});
+
+test("a fatal runtime error always exits through the transcript, whatever the setting says", async () => {
+	const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+		throw new Error("process.exit called");
+	}) as never);
+	const mode = {
+		...createStopThis("resume-hint"),
+		showError: vi.fn(),
+		stop,
+	};
+
+	const handleFatalRuntimeError = InteractiveMode.prototype as unknown as {
+		handleFatalRuntimeError(
+			this: { showError: (message: string) => void; stop: typeof stop },
+			prefix: string,
+			error: unknown,
+		): Promise<never>;
+	};
+
+	await expect(
+		handleFatalRuntimeError.handleFatalRuntimeError.call(mode, "Failed to resume session", new Error("boom")),
+	).rejects.toThrow("process.exit called");
+
+	expect(mode.showError).toHaveBeenCalledWith("Failed to resume session: boom");
+	expect(mode.stopInteractiveTui).toHaveBeenCalledWith("transcript");
+	expect(exitSpy).toHaveBeenCalledWith(1);
+});

--- a/packages/coding-agent/test/pi-0.84.2-generic-sgr-release.test.ts
+++ b/packages/coding-agent/test/pi-0.84.2-generic-sgr-release.test.ts
@@ -7,12 +7,19 @@ import {
 	type TuiAltScreen,
 	VStack,
 } from "@earendil-works/pi-tui";
-import { describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { KeybindingsManager } from "../src/core/keybindings.ts";
 import { TRANSCRIPT_JUMP_TO_END_URL } from "../src/modes/interactive/components/transcript-follow-indicator.ts";
 import { shouldHandleFullscreenViewportInput } from "../src/modes/interactive/interactive-mode-base.ts";
 import { createFullscreenTui } from "../src/modes/interactive/interactive-tui.ts";
 import { RecordingTerminal } from "./helpers/interactive-fullscreen-layout.ts";
+
+const clipboardMocks = vi.hoisted(() => ({
+	copyToClipboard: vi.fn<(text: string) => Promise<void>>(),
+	readClipboardText: vi.fn<() => Promise<string | null>>(),
+}));
+
+vi.mock("../src/utils/clipboard.ts", () => clipboardMocks);
 
 /**
  * Upstream #7963 (`83aed2ba`): terminals that report a release with the generic
@@ -61,12 +68,21 @@ interface Fixture {
 	overlay: ClaimingOverlay;
 	/** Internal-UI URLs `handleUrlActivation` routed, in order. */
 	internalUiActions: string[];
-	/** Text pi-tui copied through OSC 52, one entry per completed selection. */
+	/**
+	 * Text handed to the host clipboard, one entry per completed selection.
+	 * Selection copy is routed through `copyToClipboard` (upstream #8110), so
+	 * this is the channel a completed — or refused — copy is observed on.
+	 */
 	copiedText: () => string[];
 	/** The rendered screen pi-tui itself reads for selection text and OSC 8 links. */
 	screen: () => string[];
 	stop: () => void;
 }
+
+beforeEach(() => {
+	clipboardMocks.copyToClipboard.mockReset();
+	clipboardMocks.readClipboardText.mockReset();
+});
 
 function createFixture(): Fixture {
 	const keybindings = new KeybindingsManager({});
@@ -122,10 +138,7 @@ function createFixture(): Fixture {
 		terminal,
 		overlay,
 		internalUiActions,
-		copiedText: () =>
-			terminal.writes
-				.flatMap((write) => [...write.matchAll(/\x1b\]52;c;([A-Za-z0-9+/=]*)\x07/g)])
-				.map((match) => Buffer.from(match[1] ?? "", "base64").toString("utf8")),
+		copiedText: () => clipboardMocks.copyToClipboard.mock.calls.map(([text]) => text),
 		// pi-tui reads its own `previousScreen` for both the copied text and the
 		// pressed OSC 8 link, so the test locates cells the same way.
 		screen: () => (Reflect.get(tui, "previousScreen") as string[] | undefined) ?? [],

--- a/packages/coding-agent/test/pi-0.84.2-selection-copy.test.ts
+++ b/packages/coding-agent/test/pi-0.84.2-selection-copy.test.ts
@@ -1,0 +1,111 @@
+import { tmpdir } from "node:os";
+import { Text, type TuiAltScreen, VStack } from "@earendil-works/pi-tui";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { createFullscreenTui } from "../src/modes/interactive/interactive-tui.ts";
+import { RecordingTerminal } from "./helpers/interactive-fullscreen-layout.ts";
+
+const clipboardMocks = vi.hoisted(() => ({
+	copyToClipboard: vi.fn<(text: string) => Promise<void>>(),
+	readClipboardText: vi.fn<() => Promise<string | null>>(),
+}));
+
+vi.mock("../src/utils/clipboard.ts", () => clipboardMocks);
+
+/**
+ * Upstream #8110 (`4caa3c44`): selection copy must go through the host
+ * clipboard and report the honest outcome. The old bare-OSC-52 path flashed
+ * "Copied!" unconditionally even on terminals whose clipboard never received
+ * the text, so Atomic injects `copySelection` into pi-tui's fullscreen
+ * renderer and returns false whenever `copyToClipboard` rejects.
+ */
+const TRANSCRIPT_LINE = "alpha bravo charlie";
+
+/** Build an SGR mouse report. Terminal coordinates are 1-based; pi-tui's are not. */
+function sgr(button: number, column: number, row: number, release = false): string {
+	return `\x1b[<${button};${column + 1};${row + 1}${release ? "m" : "M"}`;
+}
+
+const PRESS = 0;
+const MOTION = 32;
+
+function createFixture(): { tui: TuiAltScreen; terminal: RecordingTerminal } {
+	const terminal = new RecordingTerminal();
+	terminal.columns = 60;
+	terminal.rows = 12;
+	const tui = createFullscreenTui({
+		showHardwareCursor: false,
+		logDirectory: tmpdir(),
+		terminal,
+	});
+	tui.setLayoutRoot(
+		new VStack([
+			{ component: new Text(TRANSCRIPT_LINE, 0, 0), basis: 0, grow: 1, shrink: 1, minSize: 1 },
+			{ component: new Text("editor", 0, 0), basis: 1, shrink: 0 },
+		]),
+	);
+	tui.start();
+	tui.renderNow();
+	return { tui, terminal };
+}
+
+function dragSelect(fixture: { terminal: RecordingTerminal }): void {
+	fixture.terminal.input(sgr(PRESS, 0, 0));
+	fixture.terminal.input(sgr(MOTION, 5, 0));
+	fixture.terminal.input(sgr(PRESS, 5, 0, true));
+}
+
+/** Flush the microtasks between pi-tui's async copy and its flash. */
+async function flushCopy(): Promise<void> {
+	await new Promise<void>((resolve) => {
+		setTimeout(resolve, 0);
+	});
+}
+
+function renderedScreen(tui: TuiAltScreen): string {
+	return ((Reflect.get(tui, "previousScreen") as string[] | undefined) ?? []).join("\n");
+}
+
+beforeEach(() => {
+	clipboardMocks.copyToClipboard.mockReset();
+	clipboardMocks.readClipboardText.mockReset();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+test("8110-selection-copy-reports-failure", async () => {
+	clipboardMocks.copyToClipboard.mockRejectedValue(new Error("no clipboard available"));
+	const fixture = createFixture();
+	try {
+		dragSelect(fixture);
+		await flushCopy();
+		fixture.tui.renderNow();
+
+		expect(clipboardMocks.copyToClipboard).toHaveBeenCalledWith("alpha");
+		const screen = renderedScreen(fixture.tui);
+		expect(screen).toContain("Copy failed");
+		expect(screen).not.toContain("Copied!");
+		// The host path owns the write: no bare OSC 52 fallback may flash a
+		// false success next to the honest failure message.
+		expect(fixture.terminal.writes.join("")).not.toMatch(/\x1b\]52;c;/);
+	} finally {
+		fixture.tui.stop();
+	}
+});
+
+test("a successful host copy flashes Copied without writing OSC 52", async () => {
+	clipboardMocks.copyToClipboard.mockResolvedValue(undefined);
+	const fixture = createFixture();
+	try {
+		dragSelect(fixture);
+		await flushCopy();
+		fixture.tui.renderNow();
+
+		expect(clipboardMocks.copyToClipboard).toHaveBeenCalledWith("alpha");
+		expect(renderedScreen(fixture.tui)).toContain("Copied!");
+		expect(fixture.terminal.writes.join("")).not.toMatch(/\x1b\]52;c;/);
+	} finally {
+		fixture.tui.stop();
+	}
+});

--- a/packages/coding-agent/test/settings-selector-tui-mode.test.ts
+++ b/packages/coding-agent/test/settings-selector-tui-mode.test.ts
@@ -31,6 +31,7 @@ function createSettingsConfig(): SettingsConfig {
 		treeFilterMode: "default",
 		showHardwareCursor: false,
 		fullscreenScrollbar: "auto",
+		fullscreenExitOutput: "transcript",
 		editorPaddingX: 0,
 		outputPad: 1,
 		showCacheMissNotices: false,

--- a/packages/coding-agent/test/suite/regressions/6817-find-windows-path-glob.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6817-find-windows-path-glob.test.ts
@@ -7,7 +7,7 @@ import { spawn } from "child_process";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-	ensureTool: vi.fn<(tool: "fd" | "rg", silent?: boolean) => Promise<string | undefined>>(),
+	ensureTool: vi.fn<(tool: "fd" | "rg", onStatus?: (status: ToolStatus) => void) => Promise<string | undefined>>(),
 	loadNativeSearchBinding: vi.fn(),
 	spawn: vi.fn(),
 }));
@@ -26,6 +26,7 @@ vi.mock("../../../src/utils/tools-manager.ts", () => ({
 }));
 
 import { createFindToolDefinition } from "../../../src/core/tools/find.ts";
+import type { ToolStatus } from "../../../src/utils/tools-manager.ts";
 
 const mockedSpawn = vi.mocked(spawn);
 
@@ -65,7 +66,7 @@ describe("issue #6817: Windows find path globs", () => {
 		}
 
 		const args = mockedSpawn.mock.calls[0]?.[1];
-		expect(mocks.ensureTool).toHaveBeenCalledWith("fd", true);
+		expect(mocks.ensureTool).toHaveBeenCalledWith("fd");
 		expect(args).toContain("--full-path");
 		expect(args?.at((args?.indexOf("--") ?? -1) + 1)).toBe(String.raw`**[/\\]lib[/\\]*.spec.ts`);
 	});

--- a/packages/coding-agent/test/tools-manager.test.ts
+++ b/packages/coding-agent/test/tools-manager.test.ts
@@ -46,7 +46,7 @@ describe("managed tool downloads", () => {
 			return new Response("download unavailable", { status: 404 });
 		});
 
-		await expect(ensureTool("fd", true)).resolves.toBeUndefined();
+		await expect(ensureTool("fd")).resolves.toBeUndefined();
 
 		expect(releaseAttempts).toBe(3);
 		expect(fetchMock.mock.calls.filter(([input]) => String(input) === releaseUrl)).toHaveLength(3);
@@ -65,11 +65,31 @@ describe("managed tool downloads", () => {
 			}
 			return new Response("unexpected request", { status: 404 });
 		});
-
-		await expect(ensureTool("fd", true)).resolves.toBeUndefined();
+		await expect(ensureTool("fd")).resolves.toBeUndefined();
 
 		expect(archiveAttempts).toBe(3);
 		expect(fetchMock.mock.calls.filter(([input]) => String(input) === releaseUrl)).toHaveLength(1);
 		expect(fetchMock.mock.calls.filter(([input]) => String(input).startsWith(archiveUrlPrefix))).toHaveLength(3);
+	});
+
+	it("reports an offline skip through onStatus and never writes to the console", async () => {
+		vi.stubEnv(ENV_OFFLINE, "1");
+		const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		const statuses: import("../src/utils/tools-manager.ts").ToolStatus[] = [];
+
+		await expect(ensureTool("fd", (status) => statuses.push(status))).resolves.toBeUndefined();
+
+		expect(statuses).toEqual([
+			{ type: "warning", message: "fd not found. Offline mode enabled, skipping download." },
+		]);
+		expect(consoleLog).not.toHaveBeenCalled();
+		expect(consoleError).not.toHaveBeenCalled();
+	});
+
+	it("no longer contains any console write, silent flag or not", () => {
+		// The fullscreen alternate screen makes any console write here a frame
+		// corruption; guard the whole function against reintroduction.
+		expect(ensureTool.toString()).not.toContain("console.");
 	});
 });

--- a/test/unit/interactive-engine-remote-input.test.ts
+++ b/test/unit/interactive-engine-remote-input.test.ts
@@ -68,6 +68,8 @@ type HostComponent = Omit<Component, "handleInput"> & {
 interface Bridge {
 	readonly child: EngineCustomUiService;
 	readonly childCommands: InteractiveEngineCommand[];
+	/** Text each completed selection handed to the host clipboard, in order. */
+	readonly selectionCopies: string[];
 	readonly tui?: TuiAltScreen;
 	readonly terminal?: RecordingTerminal;
 	hostComponent: HostComponent | undefined;
@@ -92,6 +94,10 @@ function makeBridge(options: BridgeOptions = {}): Bridge {
 	const childCommands: InteractiveEngineCommand[] = [];
 	const mainEditor: Component = { render: () => [], invalidate: () => {} };
 	const keybindings = options.keybindings ?? new KeybindingsManager();
+	// Selection copies are recorded rather than observed through the clipboard
+	// module: the renderer routes its default through `copyToClipboard`
+	// (upstream #8110), and an injected `copySelection` is the same door.
+	const selectionCopies: string[] = [];
 	const terminal = options.fullscreen ? new RecordingTerminal() : undefined;
 	if (terminal) {
 		terminal.columns = 40;
@@ -103,6 +109,10 @@ function makeBridge(options: BridgeOptions = {}): Bridge {
 			showHardwareCursor: false,
 			logDirectory: "/tmp",
 			terminal,
+			copySelection: async (text) => {
+				selectionCopies.push(text);
+				return true;
+			},
 			shouldHandleViewportInput: (data, isMouseInput, focusedIsOverlay): boolean =>
 				shouldHandleFullscreenViewportInput(
 					tui?.getFocusedComponent() ?? null,
@@ -117,7 +127,7 @@ function makeBridge(options: BridgeOptions = {}): Bridge {
 			onInternalUiAction: options.onInternalUiAction,
 		}) as TuiAltScreen;
 	}
-	const bridge = { hostComponent: undefined, childCommands, terminal, tui } as unknown as Bridge;
+	const bridge = { hostComponent: undefined, childCommands, terminal, tui, selectionCopies } as unknown as Bridge;
 
 	const child = new EngineCustomUiService((line) => {
 		const message = parseInteractiveEngineMessage(line);
@@ -392,7 +402,7 @@ test("fullscreen forwards workflow node click press and release through the remo
 });
 
 test("fullscreen keeps pi-tui selection active while a workflow overlay owns focus", async () => {
-	const { host, overlay, tui, terminal } = await makeFullscreenGraphFixture();
+	const { host, overlay, tui, terminal, bridge } = await makeFullscreenGraphFixture();
 	try {
 		const lines = host.render(terminal.columns).map((line) => stripTerminalSequences(line));
 		const targetRow = lines.findIndex((line) => line.includes("stage-0"));
@@ -410,17 +420,17 @@ test("fullscreen keeps pi-tui selection active while a workflow overlay owns foc
 		assert.equal(Reflect.get(tui, "selectionPressActive"), false, "overlay drag selection did not complete");
 		assert.equal(Reflect.get(tui, "selectionDragged"), true, "overlay consumed the drag selection");
 		assert.ok(
-			terminal.writes.some((write) => write.includes("\x1b]52;c;")),
+			bridge.selectionCopies.some((text) => text.includes("stage")),
 			"pi-tui did not copy a selection made over the workflow overlay",
 		);
 
-		const writesBeforeMultiClick = terminal.writes.length;
+		const copiesBeforeMultiClick = bridge.selectionCopies.length;
 		for (const final of ["M", "m", "M", "m"] as const) {
 			terminal.input(sgrMouse(0, targetCol, targetRow, final));
 			await flush();
 		}
 		assert.ok(
-			terminal.writes.slice(writesBeforeMultiClick).some((write) => write.includes("\x1b]52;c;")),
+			bridge.selectionCopies.length > copiesBeforeMultiClick,
 			"pi-tui did not copy a multi-click selection over the overlay",
 		);
 	} finally {
@@ -577,10 +587,7 @@ test("fullscreen keeps transcript mouse selection with a focused non-overlay com
 		terminal.input(sgrMouse(0, 5, 2, "m"));
 		assert.equal(Reflect.get(tui, "selectionPressActive"), false, "transcript selection did not complete");
 		assert.equal(Reflect.get(tui, "selectionDragged"), true, "focused inline input stole selection drag events");
-		assert.ok(
-			terminal.writes.some((write) => write.includes("\x1b]52;c;")),
-			"transcript did not copy the dragged selection",
-		);
+		assert.ok(bridge.selectionCopies.length > 0, "transcript did not copy the dragged selection");
 	} finally {
 		tui.stop();
 	}

--- a/test/unit/pi-parity-group-5.test.ts
+++ b/test/unit/pi-parity-group-5.test.ts
@@ -171,6 +171,7 @@ describe("Group 5 parity", () => {
 				treeFilterMode: "default",
 				showHardwareCursor: false,
 				fullscreenScrollbar: "auto",
+				fullscreenExitOutput: "transcript",
 				editorPaddingX: 0,
 				outputPad: 1,
 				showCacheMissNotices: false,


### PR DESCRIPTION
Port the pi 0.84.2 fullscreen shell commits to Atomic's fullscreen-only
renderer (migration layer L10):

- 4caa3c44: selection copy routes through Atomic's copyToClipboard via
  a new copySelection option on InteractiveTuiOptions. The copy reports
  the honest outcome: pi-tui flashes "Copy failed" when the host
  clipboard never received the text, so the old bare-OSC-52 path can no
  longer show a false "Copied!" (upstream #8110). Regression test:
  8110-selection-copy-reports-failure.

- ac4ac9ea, adapted: new fullscreenExitOutput setting ("transcript" |
  "resume-hint", default "transcript") with accessors and a /settings
  selector row beside fullscreenScrollbar. Atomic has no regular
  renderer to switch into: the transcript exit hands the document
  container to pi-tui's exit paint (the docked layout's basis-0 scroll
  view would squeeze it to one row), while the resume-hint exit stops
  with preserveScreen and lets shutdown print only the resume hint.
  The fatal-error path passes "transcript" explicitly.

- 6f707eb3, partial: ensureTool(tool, onStatus) replaces the silent
  flag and no longer writes to the console; find/grep call sites drop
  the flag. Interactive startup routes fd/rg readiness reports into the
  transcript through showManagedToolStatus, so no console write lands
  in the alternate screen during deferred startup. The handleStartupSubmit
  gating is deliberately rejected: Atomic already accepts input during
  deferred startup.

Assisted-by: Atomic
Assistant-model: Claude Opus 5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789419554&installation_model_id=10562&pr_number=2429&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2429&signature=ff18c8434a6b716959077444792b01603c0bf42ac0a985090dce6db8d2437baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change moves fullscreen clipboard and managed-tool feedback into the interactive transcript, adds configurable fullscreen exit output, and persists the related setting. A delayed `fd` or `rg` readiness callback can write startup status into a newly resumed or switched chat after its transcript is rebuilt. The reproduced session-switch flow shows old startup output appearing alongside the replacement session’s content.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until managed-tool readiness callbacks are scoped or cancelled when the active session changes.

The session-switch failure was reproduced with a focused test using the production readiness callback and transcript rebuild behavior. The fixture-type rule violation is directly visible in the changed test code.

**Files Needing Attention:** packages/coding-agent/src/modes/interactive/interactive-startup.ts needs lifecycle protection for readiness status callbacks; the affected interactive test fixtures should use concrete pi-tui component types.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding and attached the focused regression source and its passing test output to support the claim.
- T-Rex published a second P1 finding proof to cover additional validation.
- T-Rex validated the managed-tool-session-race contract by running Vitest, capturing the exact command, working directory, and startup-state changes with exit code 0.

<a href="https://app.greptile.com/trex/runs/19084893/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Stale managed-tool startup status is appended to a replacement session**

   - **Bug**
     - If fd/rg readiness remains pending while the chat transcript is rebuilt for a session switch or resume, a delayed callback appends its old startup status to the current session transcript.
   - **Cause**
     - `ensureManagedToolsReady()` captures only the mode instance at `interactive-startup.ts:133-134`; `showManagedToolStatus()` at `:147-157` writes to mutable `this.chatContainer` without checking a startup/session generation, captured target container, or cancellation signal.
   - **Fix**
     - Capture a startup/session generation or the initial target container when readiness starts, and discard callbacks after a session replacement/rebuild; alternatively cancel/supersede the readiness operation on session lifecycle changes.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/src/modes/interactive/interactive-startup.ts:133-134
**Stale managed-tool status callbacks**

When a user switches or resumes sessions while `fd` or `rg` readiness is still running, these callbacks append status from the original startup to the rebuilt shared `chatContainer`, causing progress or failure messages to appear in the wrong session transcript.

### Issue 2
packages/coding-agent/test/interactive-managed-tool-status.test.ts:23-25
**Ambiguous component fixture types**

These new fixtures model component fields, child storage, and `addChild` inputs as `unknown`, discarding compile-time validation of the production shapes they exercise and making interface drift harder to detect. Use the concrete pi-tui component types instead; the same pattern also appears in the new fullscreen-exit tests.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(interactive): fullscreen clipboard,..."](https://github.com/bastani-inc/atomic/commit/2336974e39a0d1cc2a201f9194979dd41a5eab0e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53723755)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/bastani-inc/atomic/blob/main/CLAUDE.md))

<!-- /greptile_comment -->