### PR TITLE
pi 0.84.2/default tools

### DIFF
--- a/packages/coding-agent/src/core/sdk-types.ts
+++ b/packages/coding-agent/src/core/sdk-types.ts
@@ -49,11 +49,12 @@ export interface CreateAgentSessionOptions {
 	/**
 	 * Optional allowlist of tool names.
 	 *
-	 * When omitted, pi enables the default built-in tools (read, bash, edit, write,
-	 * find, search, ask_user_question, todo) and leaves extension/custom tools enabled unless
-	 * `noTools` changes that default.
-	 * When provided, only the listed tool names are enabled, minus any names in
-	 * `excludedTools`.
+	 * When omitted, Atomic uses the `defaultTools` setting for the initial
+	 * built-in selection when configured. Otherwise it enables the default
+	 * built-in tools (read, bash, edit, write, find, search, ask_user_question,
+	 * todo). Extension/custom tools remain enabled unless `noTools` changes
+	 * that default. When provided, only the listed tool names are enabled,
+	 * minus any names in `excludedTools`.
 	 */
 	tools?: string[];
 	/**

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -181,12 +181,17 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		thinkingLevel = clampThinkingLevel(model, thinkingLevel) as ThinkingLevel;
 	}
 
+	// `defaultTools` narrows only the initial BUILT-IN selection. It must not
+	// narrow `allowedToolNames`: a narrow allowlist would drop every extension
+	// and SDK custom tool (workflow, subagent, intercom, mcp, web_search, ...)
+	// for any user who configures it (upstream 4d9aa837 + companion fix 541045ae).
+	const configuredDefaultToolNames = settingsManager.getDefaultTools();
 	const allowedToolNames = options.tools ?? (options.noTools === "all" ? [] : undefined);
 	const initialActiveToolNames: string[] = options.tools
 		? [...options.tools]
 		: options.noTools
 			? []
-			: [...defaultToolNames];
+			: [...(configuredDefaultToolNames ?? defaultToolNames)];
 
 	let agent: Agent;
 

--- a/packages/coding-agent/src/core/settings-manager-basic-accessors.ts
+++ b/packages/coding-agent/src/core/settings-manager-basic-accessors.ts
@@ -32,6 +32,7 @@ interface SettingsManagerBasicAccessors {
 	setShowCacheMissNotices(enabled: boolean): void;
 	getDefaultThinkingLevel(): "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | undefined;
 	setDefaultThinkingLevel(level: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max"): void;
+	getDefaultTools(): string[] | undefined;
 	getFallbackModels(): string[];
 	getTransport(): TransportSetting;
 	setTransport(transport: TransportSetting): void;
@@ -215,6 +216,11 @@ const basicAccessors: SettingsManagerBasicAccessors = {
 		state.globalSettings.defaultThinkingLevel = level;
 		state.markModified("defaultThinkingLevel");
 		state.save();
+	},
+
+	getDefaultTools() {
+		const tools = settingsInternals(this).settings.defaultTools;
+		return tools ? [...tools] : undefined;
 	},
 
 	getFallbackModels() {

--- a/packages/coding-agent/src/core/settings-manager-basic-accessors.ts
+++ b/packages/coding-agent/src/core/settings-manager-basic-accessors.ts
@@ -219,8 +219,12 @@ const basicAccessors: SettingsManagerBasicAccessors = {
 	},
 
 	getDefaultTools() {
+		// Settings load unvalidated from disk, so guard the shape here the same
+		// way getFallbackModels() does: a non-array (or null) reads as unset,
+		// and non-string entries are dropped rather than passed through to the
+		// initial tool selection.
 		const tools = settingsInternals(this).settings.defaultTools;
-		return tools ? [...tools] : undefined;
+		return Array.isArray(tools) ? tools.filter((tool): tool is string => typeof tool === "string") : undefined;
 	},
 
 	getFallbackModels() {

--- a/packages/coding-agent/src/core/settings-types.ts
+++ b/packages/coding-agent/src/core/settings-types.ts
@@ -140,6 +140,7 @@ export interface Settings {
 	terminal?: TerminalSettings;
 	images?: ImageSettings;
 	enabledModels?: string[]; // Model patterns for cycling (same format as --models CLI flag)
+	defaultTools?: string[]; // Initial built-in tool selection; extension and SDK custom tools stay enabled
 	doubleEscapeAction?: "fork" | "tree" | "none"; // Action for double-escape with empty editor (default: "tree")
 	treeFilterMode?: "default" | "no-tools" | "user-only" | "labeled-only" | "all"; // Default filter when opening /tree
 	thinkingBudgets?: ThinkingBudgetsSettings; // Custom token budgets for thinking levels

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -454,14 +454,32 @@ describe("SettingsManager", () => {
 
 			expect(SettingsManager.create(projectDir, agentDir).getDefaultTools()).toEqual(["read", "bash"]);
 
-			writeFileSync(join(projectDir, ".pi", "settings.json"), JSON.stringify({ defaultTools: ["grep"] }));
+			writeFileSync(join(projectDir, ".pi", "settings.json"), JSON.stringify({ defaultTools: ["find"] }));
 
-			expect(SettingsManager.create(projectDir, agentDir).getDefaultTools()).toEqual(["grep"]);
+			expect(SettingsManager.create(projectDir, agentDir).getDefaultTools()).toEqual(["find"]);
 		});
 
 		it("preserves an empty tool list", () => {
 			expect(SettingsManager.inMemory({ defaultTools: [] }).getDefaultTools()).toEqual([]);
 			expect(SettingsManager.inMemory().getDefaultTools()).toBeUndefined();
+		});
+
+		it("reads a non-array value as unset instead of throwing or splitting it", () => {
+			// Settings load unvalidated from disk; a malformed value must read as
+			// unset rather than spread a string into characters or throw.
+			for (const raw of ['"read"', "42", '{"read":true}', "null"]) {
+				writeFileSync(join(agentDir, "settings.json"), `{"defaultTools": ${raw}}`);
+				expect(SettingsManager.create(projectDir, agentDir).getDefaultTools()).toBeUndefined();
+			}
+		});
+
+		it("drops non-string entries from the list", () => {
+			writeFileSync(
+				join(agentDir, "settings.json"),
+				JSON.stringify({ defaultTools: ["read", 42, null, { name: "bash" }] }),
+			);
+
+			expect(SettingsManager.create(projectDir, agentDir).getDefaultTools()).toEqual(["read"]);
 		});
 
 		it("returns a copy, not the stored array", () => {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -448,6 +448,37 @@ describe("SettingsManager", () => {
 			expect(savedSettings.theme).toBe("light");
 		});
 	});
+	describe("defaultTools", () => {
+		it("loads global defaults and lets project settings replace them", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ defaultTools: ["read", "bash"] }));
+
+			expect(SettingsManager.create(projectDir, agentDir).getDefaultTools()).toEqual(["read", "bash"]);
+
+			writeFileSync(join(projectDir, ".pi", "settings.json"), JSON.stringify({ defaultTools: ["grep"] }));
+
+			expect(SettingsManager.create(projectDir, agentDir).getDefaultTools()).toEqual(["grep"]);
+		});
+
+		it("preserves an empty tool list", () => {
+			expect(SettingsManager.inMemory({ defaultTools: [] }).getDefaultTools()).toEqual([]);
+			expect(SettingsManager.inMemory().getDefaultTools()).toBeUndefined();
+		});
+
+		it("returns a copy, not the stored array", () => {
+			const manager = SettingsManager.inMemory({ defaultTools: ["read", "bash"] });
+
+			const first = manager.getDefaultTools();
+			const second = manager.getDefaultTools();
+			expect(first).not.toBe(second);
+			expect(first).toEqual(["read", "bash"]);
+
+			first.push("write");
+			first.length = 0;
+
+			expect(manager.getDefaultTools()).toEqual(["read", "bash"]);
+		});
+	});
+
 	describe("getSessionDir", () => {
 		it("should return undefined when not set", () => {
 			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ theme: "dark" }));

--- a/test/unit/default-tools-setting.test.ts
+++ b/test/unit/default-tools-setting.test.ts
@@ -1,0 +1,279 @@
+/// <reference path="../../packages/coding-agent/src/utils/highlight-js-lib-index.d.ts" />
+
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getModel } from "@earendil-works/pi-ai/compat";
+import { Type } from "typebox";
+import { afterEach, describe, test } from "vitest";
+import { getBuiltinPackagePaths } from "../../packages/coding-agent/src/core/builtin-packages.js";
+import { DefaultResourceLoader } from "../../packages/coding-agent/src/core/resource-loader.js";
+import {
+	type CreateAgentSessionOptions,
+	createAgentSession,
+	type InlineExtension,
+} from "../../packages/coding-agent/src/core/sdk.js";
+import { SessionManager } from "../../packages/coding-agent/src/core/session-manager.js";
+import { SettingsManager } from "../../packages/coding-agent/src/core/settings-manager.js";
+import { allToolNames, defaultToolNames } from "../../packages/coding-agent/src/core/tools/index.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+function tempDir(prefix: string): string {
+	const dir = mkdtempSync(join(tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+function sessionRoots(prefix: string): { cwd: string; agentDir: string } {
+	const cwd = tempDir(prefix);
+	const agentDir = join(cwd, "agent");
+	mkdirSync(agentDir, { recursive: true });
+	return { cwd, agentDir };
+}
+
+/**
+ * Structural cost, not a slow test: the case performs a full builtin-package
+ * loader reload (workflows, subagents, mcp, web-access, i-have-adhd, intercom)
+ * and creates a real agent session from the result. Do not reuse this budget
+ * for a test that merely inspects data.
+ */
+const BUILTIN_PACKAGE_SESSION_TIMEOUT_MS = 120_000;
+
+/** Every tool contributed by Atomic's builtin extension packages. */
+const BUILTIN_EXTENSION_TOOLS = ["workflow", "subagent", "intercom", "mcp", "web_search"] as const;
+
+type ToolOptions = Pick<CreateAgentSessionOptions, "tools" | "excludedTools" | "noTools" | "customTools">;
+
+async function createSession(
+	// undefined leaves the setting unset; [] requests zero initial built-ins.
+	defaultTools: string[] | undefined,
+	options: ToolOptions = {},
+	extensionFactories: InlineExtension[] = [],
+	builtinPackagePaths: string[] = [],
+) {
+	const { cwd, agentDir } = sessionRoots("atomic-default-tools-");
+	const settingsManager = SettingsManager.inMemory(
+		defaultTools === undefined ? {} : { defaultTools: [...defaultTools] },
+	);
+	const resourceLoader = new DefaultResourceLoader({
+		cwd,
+		agentDir,
+		settingsManager,
+		builtinPackagePaths,
+		extensionFactories,
+	});
+	await resourceLoader.reload();
+
+	const { session } = await createAgentSession({
+		cwd,
+		agentDir,
+		model: getModel("anthropic", "claude-sonnet-4-5")!,
+		settingsManager,
+		sessionManager: SessionManager.inMemory(cwd),
+		resourceLoader,
+		...options,
+	});
+	return session;
+}
+
+function staticExtensionTool(name: string): InlineExtension {
+	return (pi) => {
+		pi.registerTool({
+			name,
+			label: name,
+			description: "Statically registered extension tool",
+			parameters: Type.Object({}),
+			execute: async () => ({ content: [{ type: "text", text: "ok" }], details: {} }),
+		});
+	};
+}
+
+describe("defaultTools setting", () => {
+	test(
+		'keeps every builtin extension tool registered and active under defaultTools: ["read"]',
+		async () => {
+			const session = await createSession(["read"], {}, [], getBuiltinPackagePaths());
+			try {
+				await session.bindExtensions({});
+
+				const registered = session.getAllTools().map((tool) => tool.name);
+				const active = session.getActiveToolNames();
+
+				// The companion fix (upstream 541045ae): a narrow defaultTools must
+				// narrow only the initial built-in selection. allowedToolNames stays
+				// undefined, so every builtin extension tool survives both
+				// registration and the active set — including `mcp`, which only
+				// registers during session_start.
+				for (const bundled of BUILTIN_EXTENSION_TOOLS) {
+					assert.ok(
+						registered.includes(bundled),
+						`expected the bundled '${bundled}' tool to stay registered, got: ${registered.join(", ")}`,
+					);
+					assert.ok(
+						active.includes(bundled),
+						`expected the bundled '${bundled}' tool to stay active, got: ${active.join(", ")}`,
+					);
+				}
+
+				// "read" is the only initially active built-in; the others stay
+				// registered (reachable via /tools) but inactive.
+				assert.ok(active.includes("read"));
+				for (const builtin of allToolNames) {
+					assert.ok(registered.includes(builtin), `expected built-in '${builtin}' to stay registered`);
+					if (builtin !== "read") {
+						assert.equal(
+							active.includes(builtin),
+							false,
+							`expected built-in '${builtin}' to start inactive under defaultTools: ["read"]`,
+						);
+					}
+				}
+
+				// The system prompt advertises active tools only.
+				assert.ok(session.systemPrompt.includes("- read:"), "expected the active read tool in the system prompt");
+				assert.equal(
+					session.systemPrompt.includes("- bash:"),
+					false,
+					"expected inactive built-ins to leave the system prompt",
+				);
+			} finally {
+				session.dispose();
+			}
+		},
+		BUILTIN_PACKAGE_SESSION_TIMEOUT_MS,
+	);
+
+	test("keeps extension and SDK custom tools enabled alongside a narrow selection", async () => {
+		const session = await createSession(
+			["read"],
+			{
+				customTools: [
+					{
+						name: "sdk_tool",
+						label: "SDK Tool",
+						description: "SDK custom tool",
+						parameters: Type.Object({}),
+						execute: async () => ({ content: [{ type: "text", text: "ok" }], details: {} }),
+					},
+				],
+			},
+			[
+				staticExtensionTool("static_tool"),
+				(pi) => {
+					pi.on("session_start", () => {
+						pi.registerTool({
+							name: "dynamic_tool",
+							label: "Dynamic Tool",
+							description: "Dynamically registered extension tool",
+							parameters: Type.Object({}),
+							execute: async () => ({ content: [{ type: "text", text: "ok" }], details: {} }),
+						});
+					});
+				},
+			],
+		);
+		try {
+			await session.bindExtensions({});
+
+			assert.deepEqual([...session.getActiveToolNames()].sort(), [
+				"dynamic_tool",
+				"read",
+				"sdk_tool",
+				"static_tool",
+			]);
+			const registered = session
+				.getAllTools()
+				.map((tool) => tool.name)
+				.sort();
+			assert.deepEqual(registered, [
+				"ask_user_question",
+				"bash",
+				"dynamic_tool",
+				"edit",
+				"find",
+				"ls",
+				"read",
+				"sdk_tool",
+				"search",
+				"static_tool",
+				"todo",
+				"write",
+			]);
+		} finally {
+			session.dispose();
+		}
+	});
+
+	test("preserves explicit tool option precedence over the setting", async () => {
+		const allowlistedSession = await createSession(["read", "find"], { tools: ["read"] });
+		try {
+			assert.deepEqual(allowlistedSession.getActiveToolNames(), ["read"]);
+		} finally {
+			allowlistedSession.dispose();
+		}
+
+		const excludedSession = await createSession(["read", "find"], { excludedTools: ["read"] });
+		try {
+			assert.deepEqual(excludedSession.getActiveToolNames(), ["find"]);
+		} finally {
+			excludedSession.dispose();
+		}
+
+		const toolLessSession = await createSession(["read"], { noTools: "all" });
+		try {
+			assert.deepEqual(toolLessSession.getAllTools(), []);
+			assert.deepEqual(toolLessSession.getActiveToolNames(), []);
+		} finally {
+			toolLessSession.dispose();
+		}
+	});
+
+	test('noTools: "builtin" ignores the configured defaults but keeps extension tools', async () => {
+		const session = await createSession(["read"], { noTools: "builtin" }, [staticExtensionTool("static_tool")]);
+		try {
+			assert.deepEqual(session.getActiveToolNames(), ["static_tool"]);
+			assert.ok(
+				session
+					.getAllTools()
+					.map((tool) => tool.name)
+					.includes("read"),
+				'expected built-ins to stay registered under noTools: "builtin"',
+			);
+		} finally {
+			session.dispose();
+		}
+	});
+
+	test("an unset setting keeps the standard built-in defaults; an empty list keeps none", async () => {
+		const unsetSession = await createSession(undefined);
+		try {
+			assert.deepEqual(unsetSession.getActiveToolNames(), [...defaultToolNames]);
+		} finally {
+			unsetSession.dispose();
+		}
+
+		const emptySession = await createSession([], {}, [staticExtensionTool("static_tool")]);
+		try {
+			assert.deepEqual(emptySession.getActiveToolNames(), ["static_tool"]);
+			for (const builtin of allToolNames) {
+				assert.ok(
+					emptySession
+						.getAllTools()
+						.map((tool) => tool.name)
+						.includes(builtin),
+					`expected built-in '${builtin}' to stay registered under defaultTools: []`,
+				);
+			}
+		} finally {
+			emptySession.dispose();
+		}
+	});
+});

--- a/test/unit/default-tools-setting.test.ts
+++ b/test/unit/default-tools-setting.test.ts
@@ -1,7 +1,7 @@
 /// <reference path="../../packages/coding-agent/src/utils/highlight-js-lib-index.d.ts" />
 
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getModel } from "@earendil-works/pi-ai/compat";
@@ -52,17 +52,14 @@ const BUILTIN_EXTENSION_TOOLS = ["workflow", "subagent", "intercom", "mcp", "web
 
 type ToolOptions = Pick<CreateAgentSessionOptions, "tools" | "excludedTools" | "noTools" | "customTools">;
 
-async function createSession(
-	// undefined leaves the setting unset; [] requests zero initial built-ins.
-	defaultTools: string[] | undefined,
+async function createSessionFromManager(
+	settingsManager: SettingsManager,
+	cwd: string,
+	agentDir: string,
 	options: ToolOptions = {},
 	extensionFactories: InlineExtension[] = [],
 	builtinPackagePaths: string[] = [],
 ) {
-	const { cwd, agentDir } = sessionRoots("atomic-default-tools-");
-	const settingsManager = SettingsManager.inMemory(
-		defaultTools === undefined ? {} : { defaultTools: [...defaultTools] },
-	);
 	const resourceLoader = new DefaultResourceLoader({
 		cwd,
 		agentDir,
@@ -82,6 +79,20 @@ async function createSession(
 		...options,
 	});
 	return session;
+}
+
+async function createSession(
+	// undefined leaves the setting unset; [] requests zero initial built-ins.
+	defaultTools: string[] | undefined,
+	options: ToolOptions = {},
+	extensionFactories: InlineExtension[] = [],
+	builtinPackagePaths: string[] = [],
+) {
+	const { cwd, agentDir } = sessionRoots("atomic-default-tools-");
+	const settingsManager = SettingsManager.inMemory(
+		defaultTools === undefined ? {} : { defaultTools: [...defaultTools] },
+	);
+	return createSessionFromManager(settingsManager, cwd, agentDir, options, extensionFactories, builtinPackagePaths);
 }
 
 function staticExtensionTool(name: string): InlineExtension {
@@ -274,6 +285,30 @@ describe("defaultTools setting", () => {
 			}
 		} finally {
 			emptySession.dispose();
+		}
+	});
+
+	test("an unreadable setting value falls back to the standard built-in defaults", async () => {
+		// Settings load unvalidated from disk. Before the accessor guarded the
+		// stored shape, a string value spread into single characters and silently
+		// produced a zero-tool session, while a number threw out of
+		// createAgentSession itself (the hazard upstream 541045ae exists to
+		// prevent, reached through a malformed input shape).
+		for (const raw of ['"read"', "42", '{"read":true}']) {
+			const { cwd, agentDir } = sessionRoots("atomic-default-tools-invalid-");
+			writeFileSync(join(agentDir, "settings.json"), `{"defaultTools": ${raw}}`);
+			const settingsManager = SettingsManager.create(cwd, agentDir);
+
+			const session = await createSessionFromManager(settingsManager, cwd, agentDir);
+			try {
+				assert.deepEqual(
+					session.getActiveToolNames(),
+					[...defaultToolNames],
+					`expected malformed defaultTools ${raw} to fall back to the standard defaults`,
+				);
+			} finally {
+				session.dispose();
+			}
 		}
 	});
 });


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789423263&installation_model_id=10562&pr_number=2430&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2430&signature=aab3f699cf3c81eefaf48dc18cebe4446f69cda658a6856832d56f4eac5d791b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds a `defaultTools` setting so new coding-agent sessions can start with selected built-in tools while retaining extension and SDK custom tools. One repository-convention P2 remains: complete the setting’s documentation and changelog coverage, and use the portable root-test filesystem helper.

<h3>Confidence Score: 4/5</h3>

The functional setting behavior is covered by the updated settings and session tests; merge after addressing the repository-convention follow-up.

There is one independent non-security P2 finding. Under the scoring policy, a nonempty finding set containing only P2 findings receives a score of 4.

**Files Needing Attention:** Add `defaultTools` to the relevant settings documentation and changelog, and update the root default-tools test to use `test/helpers/runtime.ts` rather than direct `node:fs` access.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/src/core/settings-types.ts:143
**Complete defaultTools integration updates**

The new user-facing `defaultTools` setting is absent from the settings documentation and changelog, while its root-level test directly uses `node:fs` instead of the required `test/helpers/runtime.ts` abstraction. This leaves the shipped setting undiscoverable in project guidance and bypasses the repository's portable test-runtime convention.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(core): guard defaultTools accessor a..."](https://github.com/bastani-inc/atomic/commit/d550e5a72ee699e60d30abb00b2e307cd7cc15af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53723761)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->