### PR TITLE
perf(interactive): prove concurrent theme-probe startup at its call sites

### DIFF
--- a/packages/coding-agent/src/cli/startup-ui.ts
+++ b/packages/coding-agent/src/cli/startup-ui.ts
@@ -30,7 +30,13 @@ async function clearStartupTui(ui: TUI): Promise<void> {
 	await new Promise((resolve) => setTimeout(resolve, 25));
 }
 
-async function detectStartupTheme(ui: TUI): Promise<TerminalTheme> {
+/**
+ * Detect the terminal theme for first-run setup. The colour-scheme (DSR 996)
+ * and background (OSC 11) probes start concurrently through
+ * `detectTerminalThemeForAuto`, so a terminal that answers neither costs one
+ * timeout window instead of two. Exported for probe-concurrency coverage.
+ */
+export async function detectStartupTheme(ui: TUI): Promise<TerminalTheme> {
 	return detectTerminalThemeForAuto({ ui, timeoutMs: 100 });
 }
 

--- a/packages/coding-agent/test/theme-probe-concurrency.test.ts
+++ b/packages/coding-agent/test/theme-probe-concurrency.test.ts
@@ -1,0 +1,110 @@
+import type { RgbColor, TUI } from "@earendil-works/pi-tui";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { detectStartupTheme } from "../src/cli/startup-ui.ts";
+import { SettingsManager } from "../src/core/settings-manager.ts";
+import { initTheme, type TerminalTheme, theme } from "../src/modes/interactive/theme/theme.ts";
+import { InteractiveThemeController } from "../src/modes/interactive/theme/theme-controller.ts";
+
+/**
+ * A TUI double whose colour-scheme and background probes stay unsettled until
+ * the test releases them, so a test can observe which probes have started
+ * while neither has answered yet.
+ */
+function createProbeUi() {
+	let releaseColorScheme: ((terminalTheme: TerminalTheme | undefined) => void) | undefined;
+	let releaseBackground: ((rgb: RgbColor | undefined) => void) | undefined;
+	let colorSchemeCalls = 0;
+	let backgroundCalls = 0;
+	const setTerminalColorSchemeNotifications = vi.fn();
+	const ui = {
+		invalidate: vi.fn(),
+		requestRender: vi.fn(),
+		setTerminalColorSchemeNotifications,
+		onTerminalColorSchemeChange: vi.fn(() => vi.fn()),
+		queryTerminalColorScheme: vi.fn(
+			() =>
+				new Promise<TerminalTheme | undefined>((resolve) => {
+					colorSchemeCalls += 1;
+					releaseColorScheme = resolve;
+				}),
+		),
+		queryTerminalBackgroundColor: vi.fn(
+			() =>
+				new Promise<RgbColor | undefined>((resolve) => {
+					backgroundCalls += 1;
+					releaseBackground = resolve;
+				}),
+		),
+	} as unknown as TUI;
+	return {
+		ui,
+		setTerminalColorSchemeNotifications,
+		colorSchemeCallCount: () => colorSchemeCalls,
+		backgroundCallCount: () => backgroundCalls,
+		/** Settle the still-pending colour-scheme probe; the background probe keeps waiting. */
+		settleColorScheme(terminalTheme: TerminalTheme): void {
+			expect(releaseColorScheme).toBeTypeOf("function");
+			releaseColorScheme?.(terminalTheme);
+		},
+		/** Settle the still-pending background probe. */
+		settleBackground(rgb: RgbColor | undefined): void {
+			expect(releaseBackground).toBeTypeOf("function");
+			releaseBackground?.(rgb);
+		},
+	};
+}
+
+afterEach(() => {
+	initTheme("dark");
+});
+
+describe("InteractiveThemeController theme probes", () => {
+	it("starts the colour-scheme and background probes together for an automatic theme", async () => {
+		const probes = createProbeUi();
+		const manager = SettingsManager.inMemory({ theme: "light/dark" });
+		const controller = new InteractiveThemeController(probes.ui, manager, vi.fn(), vi.fn());
+
+		const applied = controller.applyFromSettings();
+		// Both probes must be in flight before either settles: each resolver is
+		// still held by the test.
+		expect(probes.colorSchemeCallCount()).toBe(1);
+		expect(probes.backgroundCallCount()).toBe(1);
+
+		// Answering the colour-scheme probe alone completes automatic theming;
+		// the still-pending background probe must not hold it back.
+		probes.settleColorScheme("light");
+		await applied;
+
+		expect(theme.name).toBe("light");
+		expect(probes.setTerminalColorSchemeNotifications).toHaveBeenCalledWith(true);
+	});
+
+	it("queries only the background probe when no theme is configured", async () => {
+		const probes = createProbeUi();
+		const manager = SettingsManager.inMemory({});
+		const controller = new InteractiveThemeController(probes.ui, manager, vi.fn(), vi.fn());
+
+		const applied = controller.applyFromSettings();
+		expect(probes.backgroundCallCount()).toBe(1);
+		expect(probes.colorSchemeCallCount()).toBe(0);
+
+		probes.settleBackground({ r: 250, g: 250, b: 250 });
+		await applied;
+
+		// High-confidence background detection wins and is applied directly.
+		expect(theme.name).toBe("light");
+	});
+});
+
+describe("startup theme probe", () => {
+	it("starts the colour-scheme and background probes together before first-run setup", async () => {
+		const probes = createProbeUi();
+
+		const detection = detectStartupTheme(probes.ui);
+		expect(probes.colorSchemeCallCount()).toBe(1);
+		expect(probes.backgroundCallCount()).toBe(1);
+
+		probes.settleColorScheme("light");
+		await expect(detection).resolves.toBe("light");
+	});
+});


### PR DESCRIPTION
Upstream 7cb2a51 starts the colour-scheme (DSR 996) and background
(OSC 11) probes concurrently inside detectTerminalThemeForAuto, halving
the worst-case automatic-theme detection delay from 200 ms to 100 ms.
Atomic's terminal-detection.ts already carries that shape and its
function-level regression test; the two surfaces that pay the cost on
every automatic-theme startup had no such coverage.

Export cli/startup-ui.ts's detectStartupTheme and add
theme-probe-concurrency.test.ts, which drives InteractiveThemeController
.applyFromSettings and the first-run setup probe with deferred probe
promises and asserts both probes start before either settles, that a
colour-scheme answer alone completes automatic theming, and that the
unset-setting path queries only the background probe. Reverting
detectTerminalThemeForAuto to its serial pre-7cb2a51 shape fails all
three concurrency assertions.

Assistant-model: Claude Opus 5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789425625&installation_model_id=10562&pr_number=2432&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2432&signature=017b4268b8921d234c1dbada985a21d15501600633f39978fe5ee6121cc49ee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change exports the existing first-run theme-detection helper so its behavior can be covered directly, and adds regression coverage for concurrent terminal probes. A focused executable check disproved a potential startup-detection regression: both probes began together, a colour-scheme response completed detection while the background probe remained pending, a late background rejection was handled, and no-response behavior retained the dark fallback. No defects were found.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised startup theme-detection paths and the absence of review findings.

The focused executable check covered concurrent probe startup, early colour-scheme completion, late background-probe rejection, and the no-response fallback. The helper's detection call is unchanged apart from being exported.

**Files Needing Attention:** No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Captured the parent revision’s startup helper and confirmed that detectTerminalThemeForAuto({ ui, timeoutMs: 100 }) was called before the export.
- Ran a focused Vitest validation that started both probes, completed the color-scheme probe while the background probe remained pending, rejected the late background probe, and exercised the no-response fallback, with the run completing successfully.
- Validated the changed code paths in startup-ui.ts and terminal-detection.ts, showing that the before-capture kept the detectTerminalThemeForAuto behavior private and that two focused executable assertions passed in 8 ms with exit code 0.

<a href="https://app.greptile.com/trex/runs/19084897/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["perf(interactive): prove concurrent them..."](https://github.com/bastani-inc/atomic/commit/33285a41f41e0dcf4a69fc6c8d49eef59d61ccb0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53723765)</sub>

<!-- /greptile_comment -->