### PR TITLE
feat(cli): add --use-theme for per-run interactive theme selection

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -50,6 +50,7 @@ export interface Args {
 	promptTemplates?: string[];
 	noPromptTemplates?: boolean;
 	themes?: string[];
+	useTheme?: string;
 	noThemes?: boolean;
 	noContextFiles?: boolean;
 	listModels?: string | true;
@@ -187,6 +188,14 @@ export function parseArgs(args: string[]): Args {
 		} else if (arg === "--theme" && i + 1 < args.length) {
 			result.themes = result.themes ?? [];
 			result.themes.push(args[++i]);
+		} else if (arg === "--use-theme") {
+			const themeName = args[i + 1];
+			if (themeName === undefined || themeName.startsWith("-")) {
+				result.diagnostics.push({ type: "error", message: "--use-theme requires a theme name" });
+			} else {
+				result.useTheme = themeName;
+				i++;
+			}
 		} else if (arg === "--no-skills" || arg === "-ns") {
 			result.noSkills = true;
 		} else if (arg === "--no-prompt-templates" || arg === "-np") {
@@ -294,6 +303,7 @@ ${chalk.bold("Options:")}
   --prompt-template <path>       Load a prompt template file or directory (can be used multiple times)
   --no-prompt-templates, -np     Disable prompt template discovery and loading
   --theme <path>                 Load a theme file or directory (can be used multiple times)
+  --use-theme <name[/name]>      Set the interactive theme for this run without saving it
   --no-themes                    Disable theme discovery and loading
   --no-context-files, -nc        Disable context-file discovery and loading
   --export <file>                Export session file to HTML and exit

--- a/packages/coding-agent/src/core/agent-session-export.ts
+++ b/packages/coding-agent/src/core/agent-session-export.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import type { AssistantMessage } from "@earendil-works/pi-ai/compat";
-import { theme } from "../modes/interactive/theme/theme.ts";
+import { getThemeByName, theme } from "../modes/interactive/theme/theme.ts";
 import { resolvePath } from "../utils/paths.ts";
 import type { AgentSessionInternalSurface as AgentSession } from "./agent-session-methods.ts";
 import type { SessionStats } from "./agent-session-types.ts";
@@ -106,11 +106,20 @@ export function getContextUsage(this: AgentSession): ContextUsage | undefined {
 /**
  * Export session to HTML.
  * @param outputPath Optional output path (defaults to session directory)
+ * @param options Optional export presentation settings; `themeName` overrides the
+ * saved theme setting (e.g. with this run's --use-theme selection) when it names a
+ * registered theme.
  * @returns Path to exported file
  */
 
-export async function exportToHtml(this: AgentSession, outputPath?: string): Promise<string> {
-	const themeName = this.settingsManager.getTheme();
+export async function exportToHtml(
+	this: AgentSession,
+	outputPath?: string,
+	options: { themeName?: string } = {},
+): Promise<string> {
+	const themeName = [options.themeName, this.settingsManager.getTheme()].find(
+		(candidate) => candidate !== undefined && getThemeByName(candidate) !== undefined,
+	);
 	const [{ exportSessionToHtml }, { createToolHtmlRenderer }] = await Promise.all([
 		import("./export-html/index.ts"),
 		import("./export-html/tool-renderer.ts"),

--- a/packages/coding-agent/src/core/agent-session-methods.ts
+++ b/packages/coding-agent/src/core/agent-session-methods.ts
@@ -302,7 +302,7 @@ export interface AgentSessionMethodSurface extends AgentSessionQueuePauseControl
 
 	getSessionStats(): SessionStats;
 	getContextUsage(): ContextUsage | undefined;
-	exportToHtml(outputPath?: string): Promise<string>;
+	exportToHtml(outputPath?: string, options?: { themeName?: string }): Promise<string>;
 	exportToJsonl(outputPath?: string): string;
 	getLastAssistantText(): string | undefined;
 	createReplacedSessionContext(): ReplacedSessionContext;

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -398,6 +398,14 @@ export async function main(argv: string[], options?: MainOptions) {
 	const startupSettingsManager = SettingsManager.create(cwd, agentDir, { projectTrusted: startupProjectTrusted });
 	reportDiagnostics(collectSettingsDiagnostics(startupSettingsManager, "startup session lookup"));
 
+	// --use-theme steers this run only: the override lives in the startup
+	// manager's effective settings and never reaches its global settings file.
+	// The interactive controller applies the same value through
+	// initialThemeSetting, so nothing here persists the selection.
+	if (appMode === "interactive" && parsed.useTheme !== undefined) {
+		startupSettingsManager.applyOverrides({ theme: parsed.useTheme });
+	}
+
 	// Decide the final runtime cwd before creating cwd-bound runtime services.
 	// --session and --resume may select a session from another project, so project-local
 	// settings, resources, provider registrations, and models must be resolved only after
@@ -736,6 +744,7 @@ export async function main(argv: string[], options?: MainOptions) {
 			initialImages,
 			initialMessages: parsed.messages,
 			verbose: parsed.verbose,
+			initialThemeSetting: parsed.useTheme,
 			deferredExtensionLoad,
 			startupInputCapture: startupEarlyInputCapture,
 			deferredModelScopePatterns: deferredExtensionLoad

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-base.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-base.ts
@@ -599,6 +599,9 @@ export class InteractiveModeBase {
 		});
 		this.runtimeHost.setRebindSession(async () => {
 			await this.rebindCurrentSession();
+			// A rebound session can carry a different settings manager; re-apply
+			// the theme so the live selection tracks the session that is current.
+			await this.themeController.applyFromSettings();
 		});
 		this.version = VERSION;
 		this.renderer = createInteractiveTui({
@@ -658,12 +661,12 @@ export class InteractiveModeBase {
 
 		// Register themes from resource loader and initialize
 		setRegisteredThemes(this.session.resourceLoader.getThemes().themes);
-		this.themeController = new InteractiveThemeController(
-			this.ui,
-			this.settingsManager,
-			(message) => this.showError(message),
-			() => this.updateEditorBorderColor(),
-		);
+		this.themeController = new InteractiveThemeController(this.ui, {
+			getSettingsManager: () => this.settingsManager,
+			showError: (message) => this.showError(message),
+			onChanged: () => this.updateEditorBorderColor(),
+			initialThemeSetting: options.initialThemeSetting,
+		});
 		this.disposeInteractiveEngineHost = attachInteractiveEngineHost(
 			runtimeHost,
 			this.createExtensionUIContext(),

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-types.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-types.ts
@@ -30,6 +30,8 @@ export interface InteractiveModeOptions {
 	initialMessages?: string[];
 	/** Force verbose startup (overrides quietStartup setting) */
 	verbose?: boolean;
+	/** Initial interactive theme setting for this invocation (from --use-theme; never persisted). */
+	initialThemeSetting?: string;
 	/** Runtime was created without extension code; finish loading in the background after first paint. */
 	deferredExtensionLoad?: boolean;
 	/** Model scope patterns resolved again after deferred extension load registers providers. */

--- a/packages/coding-agent/src/modes/interactive/interactive-selectors.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-selectors.ts
@@ -95,7 +95,7 @@ InteractiveModeBase.prototype.showSettingsSelector = function (this: Interactive
 				bashInterceptorEnabled: this.settingsManager.getBashInterceptorEnabled(),
 				thinkingLevel: this.session.thinkingLevel,
 				availableThinkingLevels: this.session.getAvailableThinkingLevels(),
-				currentTheme: this.settingsManager.getThemeSetting() || "dark",
+				currentTheme: this.themeController.getThemeSelection() || "dark",
 				terminalTheme: this.themeController.getTerminalTheme(),
 				availableThemes: getAvailableThemes(),
 				hideThinkingBlock: this.hideThinkingBlock,
@@ -173,7 +173,7 @@ InteractiveModeBase.prototype.showSettingsSelector = function (this: Interactive
 				},
 				onThemeChange: (themeSetting) => {
 					this.settingsManager.setTheme(themeSetting);
-					void this.themeController.applyFromSettings();
+					void this.themeController.setThemeSetting(themeSetting);
 				},
 				onThemePreview: (themeName) => this.themeController.preview(themeName),
 				onHideThinkingBlockChange: (hidden) => {

--- a/packages/coding-agent/src/modes/interactive/interactive-slash-commands.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-slash-commands.ts
@@ -119,7 +119,7 @@ InteractiveModeBase.prototype.handleExportCommand = async function (
 			const filePath = this.session.exportToJsonl(outputPath);
 			this.showStatus(`Session exported to: ${filePath}`);
 		} else {
-			const filePath = await this.session.exportToHtml(outputPath);
+			const filePath = await this.session.exportToHtml(outputPath, { themeName: theme.name });
 			this.showStatus(`Session exported to: ${filePath}`);
 		}
 	} catch (error: unknown) {
@@ -238,7 +238,7 @@ InteractiveModeBase.prototype.handleShareCommand = async function (this: Interac
 	// Export to a temp file
 	const tmpFile = path.join(os.tmpdir(), "session.html");
 	try {
-		await this.session.exportToHtml(tmpFile);
+		await this.session.exportToHtml(tmpFile, { themeName: theme.name });
 	} catch (error: unknown) {
 		this.showError(`Failed to export session: ${error instanceof Error ? error.message : "Unknown error"}`);
 		return;

--- a/packages/coding-agent/src/modes/interactive/theme/theme-controller.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme-controller.ts
@@ -17,26 +17,40 @@ type ThemeResult = { success: boolean; error?: string };
 
 export class InteractiveThemeController {
 	private readonly ui: TUI;
-	private readonly settingsManager: SettingsManager;
+	private readonly getSettingsManager: () => SettingsManager;
 	private readonly showError: (message: string) => void;
 	private readonly onChanged: () => void;
+	private currentThemeSetting: string | undefined;
 	private terminalTheme: TerminalTheme = detectTerminalBackgroundFromEnv().theme;
 	private activeThemeName: string | undefined;
 	private autoSyncEnabled = false;
 	private terminalColorSchemeUnsubscribe: (() => void) | undefined;
 
-	constructor(ui: TUI, settingsManager: SettingsManager, showError: (message: string) => void, onChanged: () => void) {
+	constructor(
+		ui: TUI,
+		options: {
+			getSettingsManager: () => SettingsManager;
+			showError: (message: string) => void;
+			onChanged: () => void;
+			initialThemeSetting?: string;
+		},
+	) {
 		this.ui = ui;
-		this.settingsManager = settingsManager;
-		this.showError = showError;
-		this.onChanged = onChanged;
-		this.activeThemeName = resolveThemeSetting(this.settingsManager.getThemeSetting(), this.terminalTheme);
+		this.getSettingsManager = options.getSettingsManager;
+		this.showError = options.showError;
+		this.onChanged = options.onChanged;
+		this.currentThemeSetting = options.initialThemeSetting;
+		this.activeThemeName = resolveThemeSetting(
+			this.currentThemeSetting ?? this.getSettingsManager().getThemeSetting(),
+			this.terminalTheme,
+		);
 		initTheme(this.activeThemeName, true);
 		this.bindTerminalColorSchemeListener();
 	}
 
 	async applyFromSettings(): Promise<void> {
-		const themeSetting = this.settingsManager.getThemeSetting();
+		const settingsManager = this.getSettingsManager();
+		const themeSetting = this.currentThemeSetting ?? settingsManager.getThemeSetting();
 		const autoTheme = parseAutoThemeSetting(themeSetting);
 		if (autoTheme) {
 			this.terminalTheme = await detectTerminalThemeForAuto({ ui: this.ui, timeoutMs: 100 });
@@ -55,14 +69,27 @@ export class InteractiveThemeController {
 		this.terminalTheme = detection.theme;
 		if (!this.applyThemeName(detection.theme).success) return;
 		if (detection.confidence === "high") {
-			this.settingsManager.setTheme(detection.theme);
-			await this.settingsManager.flush();
+			settingsManager.setTheme(detection.theme);
+			await settingsManager.flush();
 		}
+	}
+
+	getThemeSelection(): string | undefined {
+		return this.currentThemeSetting ?? this.getSettingsManager().getThemeSetting() ?? this.activeThemeName;
 	}
 
 	setThemeName(themeName: string, showError = false): ThemeResult {
 		this.setAutoSync(false);
-		return this.applyThemeName(themeName, showError);
+		const result = this.applyThemeName(themeName, showError);
+		if (result.success) {
+			this.currentThemeSetting = themeName;
+		}
+		return result;
+	}
+
+	async setThemeSetting(themeSetting: string): Promise<void> {
+		this.currentThemeSetting = themeSetting;
+		await this.applyFromSettings();
 	}
 
 	setThemeInstance(themeInstance: Theme): ThemeResult {
@@ -126,7 +153,7 @@ export class InteractiveThemeController {
 	private applyTerminalTheme(terminalTheme: TerminalTheme): void {
 		if (!this.autoSyncEnabled) return;
 		this.terminalTheme = terminalTheme;
-		const autoTheme = parseAutoThemeSetting(this.settingsManager.getThemeSetting());
+		const autoTheme = parseAutoThemeSetting(this.currentThemeSetting ?? this.getSettingsManager().getThemeSetting());
 		if (!autoTheme) {
 			this.setAutoSync(false);
 			return;

--- a/packages/coding-agent/test/args.test.ts
+++ b/packages/coding-agent/test/args.test.ts
@@ -265,6 +265,40 @@ describe("parseArgs", () => {
 		});
 	});
 
+	describe("--use-theme flag", () => {
+		test("parses --use-theme", () => {
+			const result = parseArgs(["--use-theme", "light"]);
+			expect(result.useTheme).toBe("light");
+			expect(result.diagnostics).toEqual([]);
+		});
+
+		test("parses a light/dark theme pair", () => {
+			const result = parseArgs(["--use-theme", "catppuccin-latte/dark"]);
+			expect(result.useTheme).toBe("catppuccin-latte/dark");
+			expect(result.diagnostics).toEqual([]);
+		});
+
+		test("reports when the theme name value is missing", () => {
+			const result = parseArgs(["--use-theme", "--print"]);
+			expect(result.useTheme).toBeUndefined();
+			expect(result.print).toBe(true);
+			expect(result.diagnostics).toEqual([{ type: "error", message: "--use-theme requires a theme name" }]);
+		});
+
+		test("reports a value missing at the end of the arguments", () => {
+			const result = parseArgs(["--use-theme"]);
+			expect(result.useTheme).toBeUndefined();
+			expect(result.diagnostics).toEqual([{ type: "error", message: "--use-theme requires a theme name" }]);
+		});
+
+		test("treats any dash-prefixed value as a flag rather than a theme name", () => {
+			const result = parseArgs(["--use-theme", "-p"]);
+			expect(result.useTheme).toBeUndefined();
+			expect(result.print).toBe(true);
+			expect(result.diagnostics).toEqual([{ type: "error", message: "--use-theme requires a theme name" }]);
+		});
+	});
+
 	describe("--no-skills flag", () => {
 		test("parses --no-skills flag", () => {
 			const result = parseArgs(["--no-skills"]);

--- a/packages/coding-agent/test/interactive-selectors-tui-mode.test.ts
+++ b/packages/coding-agent/test/interactive-selectors-tui-mode.test.ts
@@ -62,7 +62,11 @@ function openSettingsSelector() {
 		renderer,
 		ui: undefined as unknown as TUI,
 		fullscreenLayoutRoot: { render: () => [], invalidate: () => {} },
-		themeController: { getTerminalTheme: () => "dark", rebindTui: () => {} },
+		themeController: {
+			getTerminalTheme: () => "dark",
+			getThemeSelection: () => undefined,
+			rebindTui: () => {},
+		},
 		tuiInputSubscriptions: new Set(),
 		tuiRendererChangeListeners: new Set(),
 		showSelector(create: (done: () => void) => { component: Component; focus: Component }): void {

--- a/packages/coding-agent/test/theme-controller.test.ts
+++ b/packages/coding-agent/test/theme-controller.test.ts
@@ -1,0 +1,125 @@
+import type { TUI } from "@earendil-works/pi-tui";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SettingsManager } from "../src/core/settings-manager.ts";
+import { initTheme, type TerminalTheme, theme } from "../src/modes/interactive/theme/theme.ts";
+import { InteractiveThemeController } from "../src/modes/interactive/theme/theme-controller.ts";
+
+function createUi() {
+	const queryTerminalBackgroundColor = vi.fn();
+	const queryTerminalColorScheme = vi.fn();
+	const setTerminalColorSchemeNotifications = vi.fn();
+	let terminalColorSchemeListener: ((terminalTheme: TerminalTheme) => void) | undefined;
+	const ui = {
+		invalidate: vi.fn(),
+		requestRender: vi.fn(),
+		setTerminalColorSchemeNotifications,
+		onTerminalColorSchemeChange: vi.fn((listener: (terminalTheme: TerminalTheme) => void) => {
+			terminalColorSchemeListener = listener;
+			return vi.fn();
+		}),
+		queryTerminalBackgroundColor,
+		queryTerminalColorScheme,
+	} as unknown as TUI;
+	return {
+		ui,
+		queryTerminalBackgroundColor,
+		queryTerminalColorScheme,
+		setTerminalColorSchemeNotifications,
+		emitTerminalColorScheme: (terminalTheme: TerminalTheme) => terminalColorSchemeListener?.(terminalTheme),
+	};
+}
+
+function createController(ui: TUI, getSettingsManager: () => SettingsManager, initialThemeSetting?: string) {
+	return new InteractiveThemeController(ui, {
+		getSettingsManager,
+		showError: vi.fn(),
+		onChanged: vi.fn(),
+		initialThemeSetting,
+	});
+}
+
+afterEach(() => {
+	initTheme("dark");
+	vi.unstubAllEnvs();
+});
+
+describe("InteractiveThemeController", () => {
+	it("uses the initial theme without persisting it", async () => {
+		const { ui, queryTerminalBackgroundColor } = createUi();
+		const manager = SettingsManager.inMemory({ theme: "dark" });
+		const setTheme = vi.spyOn(manager, "setTheme");
+		const flush = vi.spyOn(manager, "flush");
+		const controller = createController(ui, () => manager, "light");
+
+		expect(theme.name).toBe("light");
+		expect(controller.getThemeSelection()).toBe("light");
+		await controller.applyFromSettings();
+
+		expect(queryTerminalBackgroundColor).not.toHaveBeenCalled();
+		expect(setTheme).not.toHaveBeenCalled();
+		expect(flush).not.toHaveBeenCalled();
+	});
+
+	it("resolves a theme pair and follows terminal appearance changes", async () => {
+		vi.stubEnv("COLORFGBG", "15;0");
+		const { ui, queryTerminalColorScheme, setTerminalColorSchemeNotifications, emitTerminalColorScheme } = createUi();
+		queryTerminalColorScheme.mockResolvedValue("light");
+		const manager = SettingsManager.inMemory({ theme: "dark" });
+		const controller = createController(ui, () => manager, "light/dark");
+
+		expect(theme.name).toBe("dark");
+		await controller.applyFromSettings();
+		expect(theme.name).toBe("light");
+		expect(setTerminalColorSchemeNotifications).toHaveBeenCalledWith(true);
+
+		emitTerminalColorScheme("dark");
+		expect(theme.name).toBe("dark");
+	});
+
+	it("detects the current terminal appearance when selecting a theme pair", async () => {
+		vi.stubEnv("COLORFGBG", "");
+		const { ui, queryTerminalColorScheme } = createUi();
+		queryTerminalColorScheme.mockResolvedValue("light");
+		const manager = SettingsManager.inMemory({ theme: "dark" });
+		const controller = createController(ui, () => manager);
+
+		expect(theme.name).toBe("dark");
+		await controller.setThemeSetting("light/dark");
+		expect(theme.name).toBe("light");
+		expect(queryTerminalColorScheme).toHaveBeenCalledOnce();
+	});
+
+	it("lets an explicit selection replace the initial theme", async () => {
+		const { ui } = createUi();
+		const firstManager = SettingsManager.inMemory({ theme: "dark" });
+		const secondManager = SettingsManager.inMemory({ theme: "light" });
+		let manager = firstManager;
+		const controller = createController(ui, () => manager, "light");
+		await controller.applyFromSettings();
+
+		expect(controller.setThemeName("dark")).toEqual({ success: true });
+		manager = secondManager;
+		await controller.applyFromSettings();
+
+		expect(controller.getThemeSelection()).toBe("dark");
+		expect(theme.name).toBe("dark");
+	});
+
+	it("reloads theme settings when no initial theme was supplied", async () => {
+		const { ui } = createUi();
+		const firstManager = SettingsManager.inMemory({ theme: "dark" });
+		const secondManager = SettingsManager.inMemory({ theme: "light" });
+		let manager = firstManager;
+		const controller = createController(ui, () => manager);
+		await controller.applyFromSettings();
+
+		firstManager.applyOverrides({ theme: "light" });
+		await controller.applyFromSettings();
+		expect(theme.name).toBe("light");
+
+		secondManager.applyOverrides({ theme: "dark" });
+		manager = secondManager;
+		await controller.applyFromSettings();
+		expect(theme.name).toBe("dark");
+	});
+});

--- a/packages/coding-agent/test/theme-probe-concurrency.test.ts
+++ b/packages/coding-agent/test/theme-probe-concurrency.test.ts
@@ -62,7 +62,11 @@ describe("InteractiveThemeController theme probes", () => {
 	it("starts the colour-scheme and background probes together for an automatic theme", async () => {
 		const probes = createProbeUi();
 		const manager = SettingsManager.inMemory({ theme: "light/dark" });
-		const controller = new InteractiveThemeController(probes.ui, manager, vi.fn(), vi.fn());
+		const controller = new InteractiveThemeController(probes.ui, {
+			getSettingsManager: () => manager,
+			showError: vi.fn(),
+			onChanged: vi.fn(),
+		});
 
 		const applied = controller.applyFromSettings();
 		// Both probes must be in flight before either settles: each resolver is
@@ -82,8 +86,11 @@ describe("InteractiveThemeController theme probes", () => {
 	it("queries only the background probe when no theme is configured", async () => {
 		const probes = createProbeUi();
 		const manager = SettingsManager.inMemory({});
-		const controller = new InteractiveThemeController(probes.ui, manager, vi.fn(), vi.fn());
-
+		const controller = new InteractiveThemeController(probes.ui, {
+			getSettingsManager: () => manager,
+			showError: vi.fn(),
+			onChanged: vi.fn(),
+		});
 		const applied = controller.applyFromSettings();
 		expect(probes.backgroundCallCount()).toBe(1);
 		expect(probes.colorSchemeCallCount()).toBe(0);

--- a/packages/coding-agent/test/use-theme-run.test.ts
+++ b/packages/coding-agent/test/use-theme-run.test.ts
@@ -1,0 +1,110 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { TUI } from "@earendil-works/pi-tui";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parseArgs } from "../src/cli/args.ts";
+import { SettingsManager } from "../src/core/settings-manager.ts";
+import { initTheme, type TerminalTheme, theme } from "../src/modes/interactive/theme/theme.ts";
+import { InteractiveThemeController } from "../src/modes/interactive/theme/theme-controller.ts";
+
+function createUi() {
+	let terminalColorSchemeListener: ((terminalTheme: TerminalTheme) => void) | undefined;
+	const ui = {
+		invalidate: vi.fn(),
+		requestRender: vi.fn(),
+		setTerminalColorSchemeNotifications: vi.fn(),
+		onTerminalColorSchemeChange: vi.fn((listener: (terminalTheme: TerminalTheme) => void) => {
+			terminalColorSchemeListener = listener;
+			return vi.fn();
+		}),
+		queryTerminalBackgroundColor: vi.fn(),
+		queryTerminalColorScheme: vi.fn(),
+	} as unknown as TUI;
+	return {
+		ui,
+		emitTerminalColorScheme: (terminalTheme: TerminalTheme) => terminalColorSchemeListener?.(terminalTheme),
+	};
+}
+
+function readSettingsFile(agentDir: string): string | undefined {
+	const path = join(agentDir, "settings.json");
+	return existsSync(path) ? readFileSync(path, "utf-8") : undefined;
+}
+
+/**
+ * --use-theme selects the interactive theme for one run and must never write
+ * settings, while an in-session selection must. The test drives the real CLI
+ * parser, a real file-backed SettingsManager, and the real controller — the
+ * same surfaces main.ts wires together — and asserts against the bytes on
+ * disk rather than in-memory spies.
+ */
+describe("--use-theme run flag persistence", () => {
+	let tempDir: string;
+	let agentDir: string;
+	let cwd: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `atomic-use-theme-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		agentDir = join(tempDir, "agent");
+		cwd = join(tempDir, "project");
+		mkdirSync(agentDir, { recursive: true });
+		mkdirSync(cwd, { recursive: true });
+		writeFileSync(join(agentDir, "settings.json"), `${JSON.stringify({ theme: "dark" }, null, 2)}\n`, "utf-8");
+	});
+
+	afterEach(() => {
+		if (tempDir && existsSync(tempDir)) {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+		initTheme("dark");
+	});
+
+	it("applies the run theme without writing settings while an in-session selection writes them", async () => {
+		const parsed = parseArgs(["--use-theme", "light"]);
+		expect(parsed.useTheme).toBe("light");
+		expect(parsed.diagnostics).toEqual([]);
+
+		const { ui } = createUi();
+		const manager = SettingsManager.create(cwd, agentDir);
+		const controller = new InteractiveThemeController(ui, {
+			getSettingsManager: () => manager,
+			showError: vi.fn(),
+			onChanged: vi.fn(),
+			initialThemeSetting: parsed.useTheme,
+		});
+
+		// The run theme is active from construction and survives applyFromSettings.
+		expect(theme.name).toBe("light");
+		await controller.applyFromSettings();
+		expect(theme.name).toBe("light");
+		expect(controller.getThemeSelection()).toBe("light");
+
+		// The saved theme is untouched: same bytes, same effective setting.
+		await manager.flush();
+		expect(readSettingsFile(agentDir)).toBe(`${JSON.stringify({ theme: "dark" }, null, 2)}\n`);
+		expect(manager.getThemeSetting()).toBe("dark");
+
+		// An in-session selection uses the settings selector's exact sequence:
+		// persist first, then apply through the controller.
+		manager.setTheme("light");
+		await controller.setThemeSetting("light");
+		await manager.flush();
+
+		expect(theme.name).toBe("light");
+		const saved = JSON.parse(readSettingsFile(agentDir) ?? "{}") as { theme?: string };
+		expect(saved.theme).toBe("light");
+	});
+
+	it("keeps the startup settings override out of the settings file", async () => {
+		const manager = SettingsManager.create(cwd, agentDir);
+		manager.applyOverrides({ theme: "light" });
+
+		// The override steers this manager's reads for the run...
+		expect(manager.getThemeSetting()).toBe("light");
+
+		// ...and never reaches the file the next run would load.
+		await manager.flush();
+		expect(readSettingsFile(agentDir)).toBe(`${JSON.stringify({ theme: "dark" }, null, 2)}\n`);
+	});
+});


### PR DESCRIPTION
Port upstream 9795d602 (#7722). `--use-theme <name[/name]>` selects the
interactive theme for this run without writing settings. main.ts applies
a non-persistent override to the startup settings manager and threads
the same value into InteractiveThemeController through the new
initialThemeSetting option, so there is still exactly one path that
persists a theme: an explicit in-session selection.

InteractiveThemeController's constructor moves to the options object
with getSettingsManager and initialThemeSetting. The getter indirection
keeps the controller on the session's current settings manager across
rebinds (the rebind hook now re-applies the theme), and a
currentThemeSetting field holds the run's selection until an explicit
change replaces it. The settings selector reads the live selection via
getThemeSelection() and applies changes through setThemeSetting() after
persisting. /export and /share pass the active theme name to
exportToHtml, whose new themeName option prefers the run theme when it
names a registered theme.

A missing or flag-shaped value reports the named diagnostic
"--use-theme requires a theme name"; an unknown theme name surfaces
through the existing theme error path.

Tests: parseArgs diagnostics for missing and flag-shaped values plus
pair parsing; controller unit coverage ported from upstream (initial
theme applied without persistence, pair resolution with terminal
appearance following, explicit selection replacing the initial theme,
settings reload when no initial theme was supplied);
use-theme-run.test.ts drives the real parser, a file-backed
SettingsManager, and the controller to assert --use-theme leaves
settings.json byte-identical while the settings selector's
persist-then-apply sequence writes it, and that the startup override
never reaches the file. theme-probe-concurrency.test.ts and the
selectors TUI stub move to the new constructor surface.

Assistant-model: Claude Opus 5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789428625&installation_model_id=10562&pr_number=2433&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2433&signature=fd1cc10823319923ce250f3d8e4f2a15a7b1d92a85de44cbf691b4998f79ae05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds a non-persistent `--use-theme` CLI option and propagates the selected theme through interactive sessions and HTML export. The new option is shown in CLI help, but it is not yet recorded in the durable package documentation or changelog.

<h3>Confidence Score: 4/5</h3>

Merge is safe after documenting the newly shipped CLI behavior.

One non-security P2 documentation finding remains; under the scoring policy, P2-only findings result in a score of 4.

**Files Needing Attention:** packages/coding-agent/docs/usage.md or the relevant theme documentation, plus packages/coding-agent/CHANGELOG.md.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/src/cli/args.ts:303
**Document the new CLI option**

`--use-theme` adds shipped, user-facing behavior without a corresponding update under `packages/coding-agent/docs` or the package changelog, leaving the option absent from the durable CLI documentation and release history.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(cli): add --use-theme for per-run i..."](https://github.com/bastani-inc/atomic/commit/67e2e34e70cefca6d9514a53682015a3590118d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53723768)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->