### PR TITLE
feat(core): expandPromptTemplates on sendUserMessage and experimental strict tool sampling

### DIFF
--- a/packages/coding-agent/src/core/agent-session-methods.ts
+++ b/packages/coding-agent/src/core/agent-session-methods.ts
@@ -174,7 +174,7 @@ export interface AgentSessionMethodSurface extends AgentSessionQueuePauseControl
 	followUp(text: string, images?: ImageContent[]): Promise<void>;
 	sendUserMessage(
 		content: string | (TextContent | ImageContent)[],
-		options?: { deliverAs?: "steer" | "followUp" },
+		options?: { deliverAs?: "steer" | "followUp"; expandPromptTemplates?: boolean },
 	): Promise<void>;
 
 	_queueSteer(text: string, images?: ImageContent[]): Promise<void>;

--- a/packages/coding-agent/src/core/agent-session-prompt.ts
+++ b/packages/coding-agent/src/core/agent-session-prompt.ts
@@ -483,14 +483,24 @@ export async function followUp(this: AgentSession, text: string, images?: ImageC
 }
 
 /**
- * Internal: Queue a steering message (already expanded, no extension command check).
+ * Send a user message and trigger a turn.
+ *
+ * By default the text is delivered literally: extension commands are not
+ * dispatched and skill commands / prompt templates are not expanded. Set
+ * `expandPromptTemplates: true` to dispatch a registered extension or skill
+ * command (or expand a prompt template) instead of sending the raw text —
+ * with that option the message may DISPATCH a command rather than be sent.
+ *
+ * @param content User message content (string or content array)
+ * @param options.deliverAs Delivery mode when streaming: "steer" or "followUp"
+ * @param options.expandPromptTemplates Whether to dispatch extension commands and expand skill commands and prompt templates. Default: false.
  */
-
 export async function sendUserMessage(
 	this: AgentSession,
 	content: string | (TextContent | ImageContent)[],
 	options?: {
 		deliverAs?: "steer" | "followUp";
+		expandPromptTemplates?: boolean;
 		__workflowDelivery?: PromptOptionsWithWorkflowDelivery["__workflowDelivery"];
 	},
 ): Promise<void> {
@@ -514,11 +524,12 @@ export async function sendUserMessage(
 		if (images.length === 0) images = undefined;
 	}
 
-	// Use prompt() with expandPromptTemplates: false to skip command handling and template expansion.
-	// The private delivery hook lets workflow routing report and gate the branch
-	// selected after asynchronous input/compaction extension preflight.
+	// prompt() owns command dispatch and template expansion; the default (false)
+	// keeps every pre-existing caller sending literally. The private delivery hook
+	// lets workflow routing report and gate the branch selected after asynchronous
+	// input/compaction extension preflight.
 	await this.prompt(text, {
-		expandPromptTemplates: false,
+		expandPromptTemplates: options?.expandPromptTemplates ?? false,
 		streamingBehavior: options?.deliverAs,
 		images,
 		source: "extension",

--- a/packages/coding-agent/src/core/agent-session-types.ts
+++ b/packages/coding-agent/src/core/agent-session-types.ts
@@ -178,6 +178,7 @@ export interface AgentSessionReloadOptions {
 }
 
 export interface PromptOptions {
+	/** Whether to dispatch extension commands and expand skill commands and prompt templates (default: true) */
 	expandPromptTemplates?: boolean;
 	images?: ImageContent[];
 	streamingBehavior?: "steer" | "followUp";

--- a/packages/coding-agent/src/core/experimental.ts
+++ b/packages/coding-agent/src/core/experimental.ts
@@ -1,3 +1,4 @@
+import type { ConstrainedSamplingConfig } from "@earendil-works/pi-ai/compat";
 import { APP_NAME, LEGACY_ENV_PREFIX } from "../config.ts";
 
 export function areExperimentalFeaturesEnabled(): boolean {
@@ -5,4 +6,33 @@ export function areExperimentalFeaturesEnabled(): boolean {
 		process.env[`${APP_NAME.toUpperCase()}_EXPERIMENTAL`] === "1" ||
 		process.env[`${LEGACY_ENV_PREFIX}_EXPERIMENTAL`] === "1"
 	);
+}
+
+const PREFER_STRICT_TOOL_SAMPLING = { type: "json_schema", strict: "prefer" } as const;
+
+/**
+ * Experimental strict JSON-schema constrained sampling for built-in tool definitions.
+ *
+ * Returns a `prefer` (not `require`) constraint so providers without strict
+ * support keep working, and `undefined` unless experimental features are enabled
+ * (`ATOMIC_EXPERIMENTAL=1` or the legacy `PI_EXPERIMENTAL=1`), leaving tool
+ * definitions unconstrained by default.
+ */
+export function getExperimentalToolSampling(): ConstrainedSamplingConfig | undefined {
+	return areExperimentalFeaturesEnabled() ? PREFER_STRICT_TOOL_SAMPLING : undefined;
+}
+
+/**
+ * Tool-definition spread fragment for the experimental strict sampling above.
+ *
+ * Sets `constrainedSampling` only when the experimental gate is on. Key presence
+ * is semantic through the tool plumbing (`Object.hasOwn` guards in
+ * tool-definition-wrapper, agent-session-state, and loader-runtime), so an
+ * unconstrained definition must keep the property absent rather than own it
+ * with `undefined`.
+ */
+export function experimentalToolSamplingProperty():
+	| { constrainedSampling: { type: "json_schema"; strict: "prefer" } }
+	| Record<string, never> {
+	return areExperimentalFeaturesEnabled() ? { constrainedSampling: PREFER_STRICT_TOOL_SAMPLING } : {};
 }

--- a/packages/coding-agent/src/core/extensions/api-types.ts
+++ b/packages/coding-agent/src/core/extensions/api-types.ts
@@ -210,10 +210,15 @@ export interface ExtensionAPI {
 	/**
 	 * Send a user message to the agent. Always triggers a turn.
 	 * When the agent is streaming, use deliverAs to specify how to queue the message.
+	 *
+	 * By default the text is sent literally. Set expandPromptTemplates to true to
+	 * dispatch a registered extension or skill command (or expand a prompt
+	 * template) — with that option the message may DISPATCH a command rather
+	 * than being sent. Default: false.
 	 */
 	sendUserMessage(
 		content: string | (TextContent | ImageContent)[],
-		options?: { deliverAs?: "steer" | "followUp" },
+		options?: { deliverAs?: "steer" | "followUp"; expandPromptTemplates?: boolean },
 	): void;
 
 	/** Append a custom entry to the session for state persistence (not sent to LLM). */

--- a/packages/coding-agent/src/core/extensions/context-types.ts
+++ b/packages/coding-agent/src/core/extensions/context-types.ts
@@ -216,6 +216,6 @@ export interface ReplacedSessionContext extends ExtensionCommandContext {
 
 	sendUserMessage(
 		content: string | (TextContent | ImageContent)[],
-		options?: { deliverAs?: "steer" | "followUp" },
+		options?: { deliverAs?: "steer" | "followUp"; expandPromptTemplates?: boolean },
 	): Promise<void>;
 }

--- a/packages/coding-agent/src/core/extensions/runtime-types.ts
+++ b/packages/coding-agent/src/core/extensions/runtime-types.ts
@@ -55,7 +55,7 @@ export type SendMessagesHandler = <T = unknown>(
 
 export type SendUserMessageHandler = (
 	content: string | (TextContent | ImageContent)[],
-	options?: { deliverAs?: "steer" | "followUp" },
+	options?: { deliverAs?: "steer" | "followUp"; expandPromptTemplates?: boolean },
 ) => void;
 
 export type AppendEntryHandler = <T = unknown>(customType: string, data?: T) => void;

--- a/packages/coding-agent/src/core/tools/ask-user-question/ask-user-question.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/ask-user-question.ts
@@ -1,4 +1,5 @@
 import type { OverlayOptions } from "@earendil-works/pi-tui";
+import { experimentalToolSamplingProperty } from "../../experimental.ts";
 import type { ToolDefinition } from "../../extensions/types.ts";
 import { loadConfig, validateGuidanceFields } from "./config.ts";
 import { QuestionnaireSession } from "./state/questionnaire-session.ts";
@@ -89,6 +90,7 @@ Use the optional \`preview\` field on options when presenting concrete artifacts
 Preview content is rendered as markdown in a monospace box. Multi-line text with newlines is supported. When any option has a preview, the UI switches to a side-by-side layout with a vertical option list on the left and preview on the right. Do not use previews for simple preference questions where labels and descriptions suffice. Note: previews are only supported for single-select questions (not multiSelect).`,
 		promptSnippet: guidance.promptSnippet ?? DEFAULT_PROMPT_SNIPPET,
 		promptGuidelines: guidance.promptGuidelines ?? DEFAULT_PROMPT_GUIDELINES,
+		...experimentalToolSamplingProperty(),
 		parameters: QuestionParamsSchema,
 
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {

--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -18,6 +18,7 @@ import {
 	untrackDetachedChildPid,
 } from "../../utils/shell.ts";
 import type { BashResult } from "../bash-executor.ts";
+import { experimentalToolSamplingProperty } from "../experimental.ts";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.ts";
 import {
 	type BashInterceptorRule,
@@ -359,6 +360,7 @@ export function createBashToolDefinition(
 		label: "bash",
 		description: "Execute a shell command in the session workspace, with optional PTY handling.",
 		promptSnippet: bashToolSystemPromptContribution.snippet,
+		...experimentalToolSamplingProperty(),
 		promptGuidelines: exposeSessionEnvironment ? [...bashToolSystemPromptContribution.guidelines] : undefined,
 		parameters: bashSchema,
 		maxResultSizeChars: Infinity,

--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -5,6 +5,7 @@ import { access as fsAccess, readFile as fsReadFile, writeFile as fsWriteFile } 
 import { type Static, Type } from "typebox";
 import { renderDiff } from "../../modes/interactive/components/diff.ts";
 import type { Theme } from "../../modes/interactive/theme/theme.ts";
+import { experimentalToolSamplingProperty } from "../experimental.ts";
 import type { ToolDefinition } from "../extensions/types.ts";
 import { nativeBlockResolver } from "./block-resolver.ts";
 import { generateDiffString, generateUnifiedPatch, normalizeToLF, stripBom } from "./edit-diff.ts";
@@ -220,6 +221,7 @@ export function createEditToolDefinition(
 			"Edit existing files with the hashline patch language: each section starts with [PATH#TAG] (TAG is the 4-hex snapshot tag from your latest read/search), then hunk headers (replace N..M:, replace block N:, delete N..M, delete block N, insert before|after N:, insert after block N:, insert head:, insert tail:) followed by +TEXT body rows. Numbers refer to the original file. Use the write tool to create new files.",
 		promptSnippet: editToolSystemPromptContribution.snippet,
 		promptGuidelines: [...editToolSystemPromptContribution.guidelines],
+		...experimentalToolSamplingProperty(),
 		parameters: editSchema,
 		async execute(_toolCallId, input: EditToolInput, signal?: AbortSignal) {
 			if (typeof input.input !== "string" || input.input.trim() === "")

--- a/packages/coding-agent/src/core/tools/find.ts
+++ b/packages/coding-agent/src/core/tools/find.ts
@@ -9,6 +9,7 @@ import { type Static, Type } from "typebox";
 import { parenthesizedKeyHint } from "../../modes/interactive/components/keybinding-hints.ts";
 import { createChildProcessEnvironment } from "../../utils/child-process.ts";
 import { ensureTool } from "../../utils/tools-manager.ts";
+import { experimentalToolSamplingProperty } from "../experimental.ts";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.ts";
 import { normalizePathLikeInput, splitPathLikeGlob } from "./glob-path-utils.ts";
 import { pathExists, resolveToCwd } from "./path-utils.ts";
@@ -387,6 +388,7 @@ export function createFindToolDefinition(
 		label: "find",
 		description: "Find filesystem paths by glob; use search when you need content matches instead of path matches.",
 		promptSnippet: findToolSystemPromptContribution.snippet,
+		...experimentalToolSamplingProperty(),
 		parameters: findSchema,
 		async execute(_toolCallId, params: FindToolInput, signal?: AbortSignal, _onUpdate?, _ctx?) {
 			return new Promise((resolve, reject) => {

--- a/packages/coding-agent/src/core/tools/ls.ts
+++ b/packages/coding-agent/src/core/tools/ls.ts
@@ -4,6 +4,7 @@ import { Text } from "@earendil-works/pi-tui";
 import nodePath from "path";
 import { type Static, Type } from "typebox";
 import { parenthesizedKeyHint } from "../../modes/interactive/components/keybinding-hints.ts";
+import { experimentalToolSamplingProperty } from "../experimental.ts";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.ts";
 import { pathExists, resolveToCwd } from "./path-utils.ts";
 import { getTextOutput, invalidArgText, shortenPath, str } from "./render-utils.ts";
@@ -111,6 +112,7 @@ export function createLsToolDefinition(
 		label: "ls",
 		description: `List directory contents. Returns entries sorted alphabetically, with '/' suffix for directories. Includes dotfiles. Output is truncated to ${DEFAULT_LIMIT} entries or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first).`,
 		promptSnippet: lsToolSystemPromptContribution.snippet,
+		...experimentalToolSamplingProperty(),
 		parameters: lsSchema,
 		async execute(
 			_toolCallId,

--- a/packages/coding-agent/src/core/tools/read.ts
+++ b/packages/coding-agent/src/core/tools/read.ts
@@ -11,6 +11,7 @@ import { getLanguageFromPath, highlightCode, type Theme } from "../../modes/inte
 import { processImage } from "../../utils/image-process.ts";
 import { detectSupportedImageMimeTypeFromFile } from "../../utils/mime.ts";
 import { formatPathRelativeToCwdOrAbsolute } from "../../utils/paths.ts";
+import { experimentalToolSamplingProperty } from "../experimental.ts";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.ts";
 import { parseConflictBlocks, registerConflictBlocks } from "./conflict-registry.ts";
 import {
@@ -316,6 +317,7 @@ export function createReadToolDefinition(
 			"Read files, directories, archives, SQLite databases, internal resources, images, documents, and URLs through one path string.",
 		promptSnippet: readToolSystemPromptContribution.snippet,
 		promptGuidelines: [...readToolSystemPromptContribution.guidelines],
+		...experimentalToolSamplingProperty(),
 		parameters: readSchema,
 		maxResultSizeChars: Infinity,
 		async execute(_toolCallId, { path }: ReadToolInput, signal?: AbortSignal, _onUpdate?, ctx?) {

--- a/packages/coding-agent/src/core/tools/search.ts
+++ b/packages/coding-agent/src/core/tools/search.ts
@@ -4,6 +4,7 @@ import { dirname, join, resolve as resolvePath } from "node:path";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { Text } from "@earendil-works/pi-tui";
 import { type Static, Type } from "typebox";
+import { experimentalToolSamplingProperty } from "../experimental.ts";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.ts";
 import { normalizePathLikeInput, splitPathLikeGlob } from "./glob-path-utils.ts";
 import { createGrepToolDefinition, type GrepToolOptions } from "./grep.ts";
@@ -506,6 +507,7 @@ export function createSearchToolDefinition(
 		label: "search",
 		description: "Search file contents with a regex across files, directories, globs, and internal URLs.",
 		promptSnippet: searchToolSystemPromptContribution.snippet,
+		...experimentalToolSamplingProperty(),
 		parameters: searchSchema,
 		async execute(toolCallId, params, signal, onUpdate, ctx) {
 			const resourceCtx = ctx as InternalResourceContext | undefined;

--- a/packages/coding-agent/src/core/tools/todos.ts
+++ b/packages/coding-agent/src/core/tools/todos.ts
@@ -9,6 +9,7 @@
  *   { id, title, tags, status, created_at, assigned_to_session }
  * - After the JSON block comes optional markdown body text separated by a blank line.
  */
+import { experimentalToolSamplingProperty } from "../experimental.ts";
 import type { ToolDefinition } from "../extensions/types.ts";
 import { executeTodoToolAction } from "./todos-execute.ts";
 import { getTodosDirLabel } from "./todos-paths.ts";
@@ -32,6 +33,7 @@ export function createTodoToolDefinition(
 			"Title is the short summary; body is long-form markdown notes (update replaces, append adds). " +
 			"Todo ids are shown as TODO-<hex>; id parameters accept TODO-<hex> or the raw hex filename. " +
 			"Claim tasks before working on them to avoid conflicts, and close them when complete.",
+		...experimentalToolSamplingProperty(),
 		parameters: TodoParams,
 		promptGuidelines: DEFAULT_PROMPT_GUIDANCE,
 		execute: (_toolCallId, params, _signal, _onUpdate, ctx) => executeTodoToolAction(params, ctx),

--- a/packages/coding-agent/src/core/tools/write.ts
+++ b/packages/coding-agent/src/core/tools/write.ts
@@ -12,6 +12,7 @@ import { dirname, join } from "path";
 import { type Static, Type } from "typebox";
 import { parenthesizedKeyHint } from "../../modes/interactive/components/keybinding-hints.ts";
 import { getLanguageFromPath, highlightCode } from "../../modes/interactive/theme/theme.ts";
+import { experimentalToolSamplingProperty } from "../experimental.ts";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.ts";
 import { type ConflictBlock, getRegisteredConflictBlocks, parseConflictBlocks } from "./conflict-registry.ts";
 import { withFileMutationQueue } from "./file-mutation-queue.ts";
@@ -323,6 +324,7 @@ export function createWriteToolDefinition(
 			"Create or overwrite a file, writable internal resource, archive entry, SQLite row, or merge-conflict resolution.",
 		promptSnippet: writeToolSystemPromptContribution.snippet,
 		promptGuidelines: [...writeToolSystemPromptContribution.guidelines],
+		...experimentalToolSamplingProperty(),
 		parameters: writeSchema,
 		async execute(
 			_toolCallId,

--- a/packages/coding-agent/src/server/create-harness.ts
+++ b/packages/coding-agent/src/server/create-harness.ts
@@ -10,6 +10,7 @@ import {
 } from "@earendil-works/pi-agent-core";
 import { minimatch } from "minimatch";
 import type { Static, TSchema } from "typebox";
+import { getExperimentalToolSampling } from "../core/experimental.ts";
 import type { ExtensionContext, ToolDefinition } from "../core/extensions/types.ts";
 import type { ReadonlySessionManager } from "../core/session-manager.ts";
 import { type BuildSystemPromptOptions, buildSystemPrompt } from "../core/system-prompt.ts";
@@ -31,10 +32,19 @@ function createCodingAgentHarnessTool<TParameters extends TSchema, TDetails>(
 	options: CodingAgentToolDefinition<TParameters, TDetails>,
 ): CodingAgentHarnessTool {
 	const { definition, getContext } = options;
+	const experimentalSampling = getExperimentalToolSampling();
 	return {
 		...definition,
 		promptSnippet: definition.promptSnippet,
 		promptGuidelines: definition.promptGuidelines ? [...definition.promptGuidelines] : undefined,
+		// Compose rather than double-wrap: a definition that already constrains its
+		// own sampling (including an explicit `false` opt-out, e.g. a structured-output
+		// tool constraining its caller-supplied schema) keeps that constraint; only
+		// unconstrained definitions pick up the experimental strict default. When
+		// neither applies the key stays absent — key presence is semantic downstream.
+		...(definition.constrainedSampling === undefined && experimentalSampling === undefined
+			? {}
+			: { constrainedSampling: definition.constrainedSampling ?? experimentalSampling }),
 		execute: async (toolCallId, params, signal, onUpdate) =>
 			definition.execute(toolCallId, params as Static<TParameters>, signal, onUpdate, await getContext()),
 	};

--- a/packages/coding-agent/test/experimental-tool-strict-mode.test.ts
+++ b/packages/coding-agent/test/experimental-tool-strict-mode.test.ts
@@ -1,0 +1,150 @@
+import { Type } from "typebox";
+import { Value } from "typebox/value";
+import { afterEach, describe, expect, it } from "vitest";
+import { createAskUserQuestionToolDefinition } from "../src/core/tools/ask-user-question/index.ts";
+import { QuestionParamsSchema } from "../src/core/tools/ask-user-question/tool/types.ts";
+import { allToolNames, createToolDefinition, type ToolDef } from "../src/core/tools/index.ts";
+import { createStructuredOutputTool } from "../src/core/tools/structured-output.ts";
+import { wrapToolDefinition } from "../src/core/tools/tool-definition-wrapper.ts";
+
+function createBuiltInToolDefinitions(): ToolDef[] {
+	return [...allToolNames].map((name) => createToolDefinition(name, process.cwd()));
+}
+
+/**
+ * A questionnaire shaped exactly like a model-authored call: three questions,
+ * each with a valid 2-4 option array, one single-select with previews, one
+ * multiSelect. `ask_user_question`'s option arrays are the arrays strict-mode
+ * sampling has to reproduce, so this is the payload that must keep validating.
+ */
+const VALID_QUESTIONNAIRE = {
+	questions: [
+		{
+			question: "Which library should we use for date formatting?",
+			header: "Library",
+			options: [
+				{ label: "date-fns", description: "Functional, tree-shakeable." },
+				{ label: "Day.js", description: "Small and immutable." },
+			],
+		},
+		{
+			question: "Which features do you want to enable?",
+			header: "Features",
+			multiSelect: true,
+			options: [
+				{ label: "Search", description: "Transcript search." },
+				{ label: "Clipboard", description: "Selection copy." },
+				{ label: "Exit output", description: "Configurable exit print." },
+				{ label: "Tool status", description: "Managed-tool warnings." },
+			],
+		},
+		{
+			question: "Which layout should the selector use?",
+			header: "Layout",
+			options: [
+				{ label: "Vertical list", description: "One option per row.", preview: "one\ntwo" },
+				{ label: "Side by side", description: "Options left, preview right.", preview: "left | right" },
+			],
+		},
+	],
+};
+
+describe("experimental strict built-in tools", () => {
+	const originalAtomicExperimental = process.env.ATOMIC_EXPERIMENTAL;
+	const originalPiExperimental = process.env.PI_EXPERIMENTAL;
+
+	afterEach(() => {
+		if (originalAtomicExperimental === undefined) delete process.env.ATOMIC_EXPERIMENTAL;
+		else process.env.ATOMIC_EXPERIMENTAL = originalAtomicExperimental;
+		if (originalPiExperimental === undefined) delete process.env.PI_EXPERIMENTAL;
+		else process.env.PI_EXPERIMENTAL = originalPiExperimental;
+	});
+
+	it("only enables strict-prefer sampling in experimental mode", () => {
+		delete process.env.ATOMIC_EXPERIMENTAL;
+		delete process.env.PI_EXPERIMENTAL;
+		const normalTools = createBuiltInToolDefinitions();
+
+		process.env.PI_EXPERIMENTAL = "1";
+		const experimentalTools = createBuiltInToolDefinitions();
+
+		expect(experimentalTools.map((tool) => tool.name)).toEqual(normalTools.map((tool) => tool.name));
+		for (const [index, tool] of experimentalTools.entries()) {
+			expect(tool.constrainedSampling).toEqual({ type: "json_schema", strict: "prefer" });
+			// Strict mode is a sampling hint, never a schema rewrite: parameters
+			// stay identical to the unconstrained definitions, and the key stays
+			// absent rather than owned-with-undefined when the gate is off.
+			expect(tool.parameters).toEqual(normalTools[index]?.parameters);
+			expect(normalTools[index]?.constrainedSampling).toBeUndefined();
+			expect(Object.hasOwn(normalTools[index]!, "constrainedSampling")).toBe(false);
+			expect(Object.hasOwn(tool, "constrainedSampling")).toBe(true);
+		}
+	});
+
+	it("honors ATOMIC_EXPERIMENTAL as well as the legacy PI_EXPERIMENTAL", () => {
+		delete process.env.PI_EXPERIMENTAL;
+		process.env.ATOMIC_EXPERIMENTAL = "1";
+		for (const tool of createBuiltInToolDefinitions()) {
+			expect(tool.constrainedSampling).toEqual({ type: "json_schema", strict: "prefer" });
+		}
+	});
+
+	it("covers every built-in tool name", () => {
+		process.env.ATOMIC_EXPERIMENTAL = "1";
+		const names = createBuiltInToolDefinitions()
+			.map((tool) => tool.name)
+			.sort();
+		expect(names).toEqual([...allToolNames].sort());
+	});
+
+	it("ask_user_question option arrays still validate under strict mode", () => {
+		process.env.PI_EXPERIMENTAL = "1";
+		const tool = createAskUserQuestionToolDefinition();
+
+		expect(tool.constrainedSampling).toEqual({ type: "json_schema", strict: "prefer" });
+		// The schema itself is unchanged, so valid option arrays (2-4 options,
+		// previews, multiSelect) keep passing validation with strict mode on.
+		expect(tool.parameters).toBe(QuestionParamsSchema);
+		expect(Value.Check(QuestionParamsSchema, VALID_QUESTIONNAIRE)).toBe(true);
+		expect(Value.Check(QuestionParamsSchema, { questions: [] })).toBe(false);
+		expect(
+			Value.Check(QuestionParamsSchema, {
+				questions: [
+					{
+						question: "Too few options?",
+						header: "Options",
+						options: [{ label: "Only", description: "A single option." }],
+					},
+				],
+			}),
+		).toBe(false);
+	});
+
+	it("composes structured-output's own schema constraint with strict mode rather than double-wrapping", () => {
+		delete process.env.ATOMIC_EXPERIMENTAL;
+		const schema = Type.Object({ verdict: Type.String() });
+		const normalTool = createStructuredOutputTool({ schema });
+
+		process.env.PI_EXPERIMENTAL = "1";
+		const experimentalTool = createStructuredOutputTool({ schema });
+
+		// Layer 1 — structured-output constrains its output with the caller's
+		// schema itself. That constraint is shared, never re-wrapped: the same
+		// schema object, with strict mode on or off.
+		expect(experimentalTool.parameters).toBe(schema);
+		expect(normalTool.parameters).toBe(schema);
+
+		// Layer 2 — experimental strict sampling applies to the built-in tools
+		// only; it does not bolt a second constraint onto a tool whose
+		// constraint already lives in its parameters.
+		expect(experimentalTool.constrainedSampling).toBeUndefined();
+		expect(normalTool.constrainedSampling).toBeUndefined();
+
+		// Crossing into the agent runtime preserves both facts: one schema,
+		// zero added wrappers, even with the experimental flag set.
+		const wrapped = wrapToolDefinition(experimentalTool);
+		expect(wrapped.parameters).toBe(schema);
+		expect(wrapped.constrainedSampling).toBeUndefined();
+		expect(Object.hasOwn(wrapped, "constrainedSampling")).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/server/create-harness.test.ts
+++ b/packages/coding-agent/test/server/create-harness.test.ts
@@ -17,6 +17,8 @@ import { createModels } from "@earendil-works/pi-ai";
 import { getModel } from "@earendil-works/pi-ai/compat";
 import { Type } from "typebox";
 import { describe, expect, test, vi } from "vitest";
+import { createStructuredOutputTool } from "../../src/core/tools/structured-output.ts";
+import { wrapToolDefinition } from "../../src/core/tools/tool-definition-wrapper.ts";
 import {
 	buildCodingAgentHarnessSystemPrompt,
 	type CodingAgentHarnessTool,
@@ -781,6 +783,77 @@ describe("coding-agent Harness construction", () => {
 			throw error;
 		} finally {
 			await created.harness.close();
+			await env.cleanup();
+		}
+	});
+
+	test("applies experimental strict sampling to default harness tools without rewriting schemas", async () => {
+		const originalPiExperimental = process.env.PI_EXPERIMENTAL;
+		delete process.env.PI_EXPERIMENTAL;
+		const session = createSession("strict-sampling-session");
+		const env = new NodeExecutionEnv({ cwd: "/workspace" });
+		let created: Awaited<ReturnType<typeof createCodingAgentHarness>> | undefined;
+		try {
+			created = await createCodingAgentHarness({
+				session,
+				models: createModels(),
+				model: getModel("google", "gemini-2.5-flash"),
+				env,
+			});
+			const normalTools = await created.harness.getTools();
+			for (const tool of normalTools) {
+				expect(tool.constrainedSampling).toBeUndefined();
+			}
+
+			process.env.PI_EXPERIMENTAL = "1";
+			created = await createCodingAgentHarness({
+				session: createSession("strict-sampling-experimental-session"),
+				models: createModels(),
+				model: getModel("google", "gemini-2.5-flash"),
+				env,
+			});
+			const experimentalTools = await created.harness.getTools();
+			expect(experimentalTools.map((tool) => tool.name)).toEqual(normalTools.map((tool) => tool.name));
+			for (const [index, tool] of experimentalTools.entries()) {
+				expect(tool.constrainedSampling).toEqual({ type: "json_schema", strict: "prefer" });
+				// One flat sampling hint, never a schema rewrite.
+				expect(tool.parameters).toEqual(normalTools[index]?.parameters);
+			}
+		} finally {
+			if (originalPiExperimental === undefined) delete process.env.PI_EXPERIMENTAL;
+			else process.env.PI_EXPERIMENTAL = originalPiExperimental;
+			await created?.harness.close();
+			await env.cleanup();
+		}
+	});
+
+	test("keeps a structured-output tool's own constraint instead of double-wrapping under strict mode", async () => {
+		const originalPiExperimental = process.env.PI_EXPERIMENTAL;
+		process.env.PI_EXPERIMENTAL = "1";
+		const session = createSession("structured-compose-session");
+		const env = new NodeExecutionEnv({ cwd: "/workspace" });
+		const schema = Type.Object({ verdict: Type.String() });
+		const structured = wrapToolDefinition(createStructuredOutputTool({ schema }));
+		let created: Awaited<ReturnType<typeof createCodingAgentHarness>> | undefined;
+		try {
+			created = await createCodingAgentHarness({
+				session,
+				models: createModels(),
+				model: getModel("google", "gemini-2.5-flash"),
+				env,
+				tools: [structured],
+				activeToolNames: [structured.name],
+			});
+			const tools = await created.harness.getTools();
+			expect(tools.map((tool) => tool.name)).toEqual([structured.name]);
+			// The caller-supplied schema constraint arrives untouched — the same
+			// schema object, no second wrapper from experimental strict mode.
+			expect(tools[0]?.parameters).toBe(schema);
+			expect(tools[0]?.constrainedSampling).toBeUndefined();
+		} finally {
+			if (originalPiExperimental === undefined) delete process.env.PI_EXPERIMENTAL;
+			else process.env.PI_EXPERIMENTAL = originalPiExperimental;
+			await created?.harness.close();
 			await env.cleanup();
 		}
 	});

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -260,6 +260,90 @@ describe("AgentSession prompt characterization", () => {
 		expect(getMessageText(harness.session.messages[0]!)).toBe("from extension");
 	});
 
+	it("sendUserMessage sends a registered command literally by default", async () => {
+		const commandRuns: string[] = [];
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.registerCommand("testcmd", {
+						description: "Test command",
+						handler: async (args) => {
+							commandRuns.push(args);
+						},
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("ok")]);
+
+		await harness.session.sendUserMessage("/testcmd hello world");
+
+		// Absent the option, every pre-existing caller keeps today's meaning:
+		// no dispatch, the raw text is sent to the model.
+		expect(commandRuns).toEqual([]);
+		expect(getMessageText(harness.session.messages[0])).toBe("/testcmd hello world");
+	});
+
+	it("sendUserMessage dispatches extension commands with expandPromptTemplates", async () => {
+		const commandRuns: string[] = [];
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.registerCommand("testcmd", {
+						description: "Test command",
+						handler: async (args) => {
+							commandRuns.push(args);
+						},
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("should stay queued")]);
+
+		await harness.session.sendUserMessage("/testcmd hello world", { expandPromptTemplates: true });
+
+		expect(commandRuns).toEqual(["hello world"]);
+		expect(harness.session.messages).toEqual([]);
+		expect(harness.getPendingResponseCount()).toBe(1);
+	});
+
+	it("sendUserMessage with expandPromptTemplates falls through to a literal send for unknown commands", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("ok")]);
+
+		await harness.session.sendUserMessage("/nosuchcommand keep literal", { expandPromptTemplates: true });
+
+		expect(getMessageText(harness.session.messages[0])).toBe("/nosuchcommand keep literal");
+		expect(harness.session.messages.map((message) => message.role)).toEqual(["user", "assistant"]);
+	});
+
+	it("sendUserMessage expands prompt templates with expandPromptTemplates", async () => {
+		const template: PromptTemplate = {
+			name: "review",
+			description: "Review template",
+			content: "Review this code: $1",
+			filePath: "/virtual/review.md",
+			sourceInfo: createSyntheticSourceInfo("/virtual/review.md", {
+				source: "local",
+				scope: "temporary",
+				origin: "top-level",
+			}),
+		};
+		const resourceLoader = {
+			...createTestResourceLoader(),
+			getPrompts: () => ({ prompts: [template], diagnostics: [] }),
+		};
+		const harness = await createHarness({ resourceLoader });
+		harnesses.push(harness);
+
+		await harness.session.sendUserMessage("/review src/index.ts", { expandPromptTemplates: true });
+
+		expect(getMessageText(harness.session.messages[0])).toBe("Review this code: src/index.ts");
+	});
+
 	it("does not report streamingBehavior to input handlers while idle", async () => {
 		const inputEvents: InputEvent[] = [];
 		const harness = await createHarness({


### PR DESCRIPTION
Port b987ead3 and 7915cdac from pi v0.84.2 as the L14 agent-api layer.

sendUserMessage now accepts expandPromptTemplates (default false, so every
existing caller keeps its literal-send meaning). With true, the message may
dispatch a registered extension or skill command, or expand a prompt template,
instead of being sent as-is; unknown commands still fall through to a literal
send. The option threads through the AgentSession surface, ExtensionAPI,
ReplacedSessionContext, and SendUserMessageHandler; loader-api picks it up
through the ExtensionAPI contextual type. Doc comments state the dispatch
consequence at both the session and extension API surfaces.

Strict JSON-schema constrained sampling ({ type: "json_schema", strict:
"prefer" }) now applies to read, bash, edit, write, find, search, ls,
ask_user_question, todo, and the create-harness tool wrapper, gated by the
existing experimental flag (ATOMIC_EXPERIMENTAL=1 or legacy PI_EXPERIMENTAL=1).
Definitions only own the constrainedSampling key when the gate is on: key
presence is semantic through the Object.hasOwn guards in the tool plumbing, so
unconstrained definitions keep the property absent. The harness wrapper composes
rather than double-wraps: a definition carrying its own constraint (including an
explicit false opt-out) keeps it, and structured-output's caller-supplied schema
constraint is never re-wrapped by the experimental default.

Tests: sendUserMessage literal-by-default, dispatch-on-true, unknown-command
fallthrough, and template expansion; strict-mode gating across all nine tools
via both env flags with parameters unchanged between modes; harness default
tools strict under the flag; structured-output compose; ask_user_question
option arrays still validating under strict mode.

Assistant-model: Claude Opus 5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2434"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789431759&installation_model_id=10562&pr_number=2434&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2434&signature=e0007b86a633afec07be2fc5efe3612226d965a5ead5f77c3dddaea3b92e0e3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds opt-in prompt-template expansion and experimental constrained sampling for coding-agent tools. The harness test does not fully isolate its normal-mode environment: when `ATOMIC_EXPERIMENTAL=1` is inherited and `PI_EXPERIMENTAL` is unset, the test enables strict sampling before its normal-mode assertion and fails. The test should clear and restore both supported experiment flags.

<h3>Confidence Score: 4/5</h3>

Not ready to merge until the harness test isolates both experiment environment variables.

The focused test passed with both experiment flags disabled and failed at the expected normal-mode assertion with only `ATOMIC_EXPERIMENTAL=1`, directly confirming the environment-isolation failure.

**Files Needing Attention:** packages/coding-agent/test/server/create-harness.test.ts needs to save, clear, and restore `ATOMIC_EXPERIMENTAL` together with `PI_EXPERIMENTAL`.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Produced a proof for the posted P1 finding and captured focused harness tests under two configurations, including the environment setup source.
- Produced an additional finding-comment-proof for the same P1 finding.
- Validated contract behavior by running the baseline tests, which passed, and documented the gating logic that treats ATOMIC\_EXPERIMENTAL or PI\_EXPERIMENTAL as enabled; observed a different outcome when ATOMIC\_EXPERIMENTAL=1 and PI\_EXPERIMENTAL unset.

<a href="https://app.greptile.com/trex/runs/19084901/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Harness strict-sampling test does not isolate ATOMIC_EXPERIMENTAL**

   - **Bug**
     - The normal-mode phase of `packages/coding-agent/test/server/create-harness.test.ts` deletes `PI_EXPERIMENTAL` but leaves `ATOMIC_EXPERIMENTAL` inherited from the process. With `ATOMIC_EXPERIMENTAL=1` and `PI_EXPERIMENTAL` unset, the focused test fails its baseline assertion because normal harness tools already receive constrained sampling.
   - **Cause**
     - The test saves, clears, and restores only `process.env.PI_EXPERIMENTAL` at lines 791–792 and 823–824, while the experimental gate accepts either environment variable.
   - **Fix**
     - Save, clear, and restore `ATOMIC_EXPERIMENTAL` alongside `PI_EXPERIMENTAL` for this test's normal-mode setup and cleanup.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/test/server/create-harness.test.ts:791-792
**Normal-mode baseline leaves experiments enabled**

The test clears only `PI_EXPERIMENTAL`, but the shared experiment gate also enables strict sampling when `ATOMIC_EXPERIMENTAL=1`. A process that sets `ATOMIC_EXPERIMENTAL` therefore reaches the normal-mode assertion with constrained sampling already enabled and fails before exercising the legacy-flag branch. Save, clear, and restore `ATOMIC_EXPERIMENTAL` alongside `PI_EXPERIMENTAL` so this baseline is independent of inherited environment state.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(core): expandPromptTemplates on sen..."](https://github.com/bastani-inc/atomic/commit/a62d4481fc8167efe7f2077bc28af98f40a75c77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53723774)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->