### PR TITLE
refactor(core): hoist tool prompt text into module-level contribution constants

### DIFF
--- a/packages/coding-agent/src/core/tools/ask-user-question/ask-user-question.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/ask-user-question.ts
@@ -56,13 +56,15 @@ export function buildItemsForQuestion(question: QuestionData): WrappingSelectIte
 	return items;
 }
 
-export const DEFAULT_PROMPT_SNIPPET = `Ask the user up to ${MAX_QUESTIONS} structured questions (${MIN_OPTIONS}-${MAX_OPTIONS} options each) when requirements are ambiguous`;
-export const DEFAULT_PROMPT_GUIDELINES: string[] = [
-	`Use ask_user_question whenever the user's request is underspecified and you cannot proceed without concrete decisions — you can ask up to ${MAX_QUESTIONS} questions per invocation.`,
-	`Each question MUST have ${MIN_OPTIONS}-${MAX_OPTIONS} options. Every option requires a concise label (1-5 words) and a description explaining what the choice means or its trade-offs. The user can additionally type a custom answer ("Type something." row is appended automatically to single-select questions) or pick "Chat about this" to abandon the questionnaire.`,
-	`Set multiSelect: true when multiple answers are valid; this suppresses the "Type something." row. Provide an options[].preview markdown string when an option benefits from richer side-by-side context (mockups, code snippets, diagrams, configs) — single-select only. NOTE: any non-empty preview on a single-select question ALSO suppresses the "Type something." row (no room in the side-by-side layout); "Chat about this" remains the escape hatch. If you recommend a specific option, make it the first option and append "(Recommended)" to its label.`,
-	"Do not stack multiple ask_user_question calls back-to-back — group all clarifying questions into one invocation.",
-];
+export const askUserQuestionToolSystemPromptContribution = Object.freeze({
+	snippet: `Ask the user up to ${MAX_QUESTIONS} structured questions (${MIN_OPTIONS}-${MAX_OPTIONS} options each) when requirements are ambiguous`,
+	guidelines: Object.freeze([
+		`Use ask_user_question whenever the user's request is underspecified and you cannot proceed without concrete decisions — you can ask up to ${MAX_QUESTIONS} questions per invocation.`,
+		`Each question MUST have ${MIN_OPTIONS}-${MAX_OPTIONS} options. Every option requires a concise label (1-5 words) and a description explaining what the choice means or its trade-offs. The user can additionally type a custom answer ("Type something." row is appended automatically to single-select questions) or pick "Chat about this" to abandon the questionnaire.`,
+		`Set multiSelect: true when multiple answers are valid; this suppresses the "Type something." row. Provide an options[].preview markdown string when an option benefits from richer side-by-side context (mockups, code snippets, diagrams, configs) — single-select only. NOTE: any non-empty preview on a single-select question ALSO suppresses the "Type something." row (no room in the side-by-side layout); "Chat about this" remains the escape hatch. If you recommend a specific option, make it the first option and append "(Recommended)" to its label.`,
+		"Do not stack multiple ask_user_question calls back-to-back — group all clarifying questions into one invocation.",
+	] as const),
+} as const);
 
 export function createAskUserQuestionToolDefinition(): ToolDefinition<typeof QuestionParamsSchema, unknown> {
 	const guidance = validateGuidanceFields(loadConfig().guidance);
@@ -88,8 +90,8 @@ Use the optional \`preview\` field on options when presenting concrete artifacts
 - Configuration examples
 
 Preview content is rendered as markdown in a monospace box. Multi-line text with newlines is supported. When any option has a preview, the UI switches to a side-by-side layout with a vertical option list on the left and preview on the right. Do not use previews for simple preference questions where labels and descriptions suffice. Note: previews are only supported for single-select questions (not multiSelect).`,
-		promptSnippet: guidance.promptSnippet ?? DEFAULT_PROMPT_SNIPPET,
-		promptGuidelines: guidance.promptGuidelines ?? DEFAULT_PROMPT_GUIDELINES,
+		promptSnippet: guidance.promptSnippet ?? askUserQuestionToolSystemPromptContribution.snippet,
+		promptGuidelines: guidance.promptGuidelines ?? [...askUserQuestionToolSystemPromptContribution.guidelines],
 		...experimentalToolSamplingProperty(),
 		parameters: QuestionParamsSchema,
 

--- a/packages/coding-agent/src/core/tools/todos.ts
+++ b/packages/coding-agent/src/core/tools/todos.ts
@@ -16,9 +16,11 @@ import { getTodosDirLabel } from "./todos-paths.ts";
 import { renderTodoCall, renderTodoResult } from "./todos-render.ts";
 import { TodoParams, type TodoToolDetails } from "./todos-types.ts";
 
-export const DEFAULT_PROMPT_GUIDANCE: string[] = [
-	"**To-do management**: If the user has a complex task that can be broken down into actionable steps, use the `todo` tool to create a task list before proceeding. This ensures clarity and alignment with the user's goals and that you have a way to track your work and ensure you are meeting the user's expectations.",
-];
+export const todoToolSystemPromptContribution = Object.freeze({
+	guidelines: Object.freeze([
+		"**To-do management**: If the user has a complex task that can be broken down into actionable steps, use the `todo` tool to create a task list before proceeding. This ensures clarity and alignment with the user's goals and that you have a way to track your work and ensure you are meeting the user's expectations.",
+	] as const),
+} as const);
 
 export function createTodoToolDefinition(
 	cwd: string = process.cwd(),
@@ -35,7 +37,7 @@ export function createTodoToolDefinition(
 			"Claim tasks before working on them to avoid conflicts, and close them when complete.",
 		...experimentalToolSamplingProperty(),
 		parameters: TodoParams,
-		promptGuidelines: DEFAULT_PROMPT_GUIDANCE,
+		promptGuidelines: [...todoToolSystemPromptContribution.guidelines],
 		execute: (_toolCallId, params, _signal, _onUpdate, ctx) => executeTodoToolAction(params, ctx),
 		renderCall: renderTodoCall,
 		renderResult: renderTodoResult,

--- a/packages/coding-agent/test/tool-system-prompt-contributions.test.ts
+++ b/packages/coding-agent/test/tool-system-prompt-contributions.test.ts
@@ -1,28 +1,69 @@
-import { describe, expect, test } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { buildSystemPrompt } from "../src/core/system-prompt.ts";
+import {
+	askUserQuestionToolSystemPromptContribution,
+	createAskUserQuestionToolDefinition,
+} from "../src/core/tools/ask-user-question/ask-user-question.ts";
 import { bashToolSystemPromptContribution, createBashToolDefinition } from "../src/core/tools/bash.ts";
 import { createEditToolDefinition, editToolSystemPromptContribution } from "../src/core/tools/edit.ts";
 import { createFindToolDefinition, findToolSystemPromptContribution } from "../src/core/tools/find.ts";
 import { createLsToolDefinition, lsToolSystemPromptContribution } from "../src/core/tools/ls.ts";
 import { createReadToolDefinition, readToolSystemPromptContribution } from "../src/core/tools/read.ts";
 import { createSearchToolDefinition, searchToolSystemPromptContribution } from "../src/core/tools/search.ts";
+import { createTodoToolDefinition, todoToolSystemPromptContribution } from "../src/core/tools/todos.ts";
 import { createWriteToolDefinition, writeToolSystemPromptContribution } from "../src/core/tools/write.ts";
 
-const cases = [
-	["read", readToolSystemPromptContribution, createReadToolDefinition],
-	["bash", bashToolSystemPromptContribution, createBashToolDefinition],
-	["edit", editToolSystemPromptContribution, createEditToolDefinition],
-	["write", writeToolSystemPromptContribution, createWriteToolDefinition],
-	["search", searchToolSystemPromptContribution, createSearchToolDefinition],
-	["find", findToolSystemPromptContribution, createFindToolDefinition],
-	["ls", lsToolSystemPromptContribution, createLsToolDefinition],
-] as const;
+// The ask_user_question definition reads machine-local guidance overrides from
+// ~/.config/rpiv-ask-user-question/config.json. Pin loadConfig to an empty
+// config so the alignment assertions below observe the module constant rather
+// than whatever happens to live on the host running the suite.
+const askUserQuestionConfig = vi.hoisted(
+	(): { guidance?: { promptSnippet?: string; promptGuidelines?: string[] } } => ({}),
+);
+
+vi.mock("../src/core/tools/ask-user-question/config.ts", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../src/core/tools/ask-user-question/config.ts")>();
+	return { ...actual, loadConfig: () => askUserQuestionConfig };
+});
+
+/** Prompt-contribution surface shared by all nine built-in tool modules. */
+interface ToolPromptContribution {
+	readonly snippet?: string;
+	readonly guidelines: readonly string[];
+}
+
+interface DefinitionWithPromptText {
+	name: string;
+	promptSnippet?: string;
+	promptGuidelines?: string[];
+}
+
+type DefinitionFactory = () => DefinitionWithPromptText;
+
+const cases: ReadonlyArray<readonly [string, ToolPromptContribution, DefinitionFactory]> = [
+	["read", readToolSystemPromptContribution, () => createReadToolDefinition("/workspace")],
+	["bash", bashToolSystemPromptContribution, () => createBashToolDefinition("/workspace")],
+	["edit", editToolSystemPromptContribution, () => createEditToolDefinition("/workspace")],
+	["write", writeToolSystemPromptContribution, () => createWriteToolDefinition("/workspace")],
+	["find", findToolSystemPromptContribution, () => createFindToolDefinition("/workspace")],
+	["search", searchToolSystemPromptContribution, () => createSearchToolDefinition("/workspace")],
+	["ls", lsToolSystemPromptContribution, () => createLsToolDefinition("/workspace")],
+	["ask_user_question", askUserQuestionToolSystemPromptContribution, () => createAskUserQuestionToolDefinition()],
+	["todo", todoToolSystemPromptContribution, () => createTodoToolDefinition("/workspace")],
+];
+
+afterEach(() => {
+	askUserQuestionConfig.guidance = undefined;
+});
 
 describe("built-in tool system prompt contributions", () => {
 	test.each(cases)(
 		"keeps the %s tool definition aligned with its immutable contribution",
 		(_name, contribution, createDefinition) => {
-			const definition = createDefinition("/workspace");
+			const definition = createDefinition();
 
 			expect(definition.promptSnippet).toBe(contribution.snippet);
 			expect(definition.promptGuidelines ?? []).toEqual(contribution.guidelines);
@@ -39,17 +80,19 @@ describe("built-in tool system prompt contributions", () => {
 	test.each(cases)(
 		"adds the %s contribution exactly once to the system prompt",
 		(_name, contribution, createDefinition) => {
-			const definition = createDefinition("/workspace");
+			const definition = createDefinition();
 			const prompt = buildSystemPrompt({
 				selectedTools: [definition.name],
-				toolSnippets: { [definition.name]: definition.promptSnippet! },
+				toolSnippets: definition.promptSnippet ? { [definition.name]: definition.promptSnippet } : {},
 				promptGuidelines: definition.promptGuidelines,
 				contextFiles: [],
 				skills: [],
 				cwd: "/workspace",
 			});
 
-			expect(prompt.split(contribution.snippet)).toHaveLength(2);
+			if (contribution.snippet !== undefined) {
+				expect(prompt.split(contribution.snippet)).toHaveLength(2);
+			}
 			for (const guideline of contribution.guidelines) expect(prompt.split(guideline)).toHaveLength(2);
 		},
 	);
@@ -58,5 +101,32 @@ describe("built-in tool system prompt contributions", () => {
 		const definition = createBashToolDefinition("/workspace", { exposeSessionEnvironment: false });
 
 		expect(definition.promptGuidelines).toBeUndefined();
+	});
+
+	test("keeps ask_user_question machine-config guidance overriding the contribution", () => {
+		askUserQuestionConfig.guidance = {
+			promptSnippet: "Custom ask_user_question snippet from machine config",
+			promptGuidelines: ["Custom ask_user_question guideline from machine config"],
+		};
+
+		const definition = createAskUserQuestionToolDefinition();
+
+		expect(definition.promptSnippet).toBe("Custom ask_user_question snippet from machine config");
+		expect(definition.promptGuidelines).toEqual(["Custom ask_user_question guideline from machine config"]);
+	});
+
+	test("keeps the ask_user_question and todo contributions out of the public surface", () => {
+		const srcDir = join(dirname(fileURLToPath(import.meta.url)), "..", "src");
+
+		for (const entry of ["index.ts", "index-extensions.ts"]) {
+			const source = readFileSync(join(srcDir, entry), "utf8");
+			expect(source, entry).not.toContain("askUserQuestionToolSystemPromptContribution");
+			expect(source, entry).not.toContain("todoToolSystemPromptContribution");
+		}
+
+		// Sanity check that the entries are actually read: the seven upstream-facing
+		// contributions predate this change and stay exported from src/index.ts.
+		const indexSource = readFileSync(join(srcDir, "index.ts"), "utf8");
+		expect(indexSource).toContain("bashToolSystemPromptContribution");
 	});
 });


### PR DESCRIPTION
Close spec §5.6 gap 5 (upstream 9ab91fb): every built-in tool's
promptSnippet/promptGuidelines now lives in a frozen module-level
contribution const that its definition reads, so the two cannot drift.

The seven tools with an upstream counterpart already followed this shape.
This adds askUserQuestionToolSystemPromptContribution and
todoToolSystemPromptContribution for the two Atomic-only tools, replacing
the loose DEFAULT_PROMPT_* module constants. ask_user_question keeps its
machine-config guidance override; todo's definition now receives a copy of
its frozen guidelines instead of a mutable shared array.

Matching upstream, the new constants stay module-level: they are not
re-exported from src/index.ts or src/index-extensions.ts, so no new export
appears in the public surface. The contribution test now covers all nine
tools, pins the config-override precedence, and asserts the public entries
never re-export the new names.

Assistant-model: Claude Opus 5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789433742&installation_model_id=10562&pr_number=2435&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2435&signature=5dd11cc5b8c7afb60e2bcedda0e73eac183e69faef5df92af3622b2031cae5dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change centralizes Atomic-specific prompt contributions for the ask-user-question and todo tools, preserves machine-config overrides, and expands coverage for prompt alignment, immutability, override precedence, and package-surface boundaries.

One P2 repository-rule issue remains in the new test: it reads the filesystem through `node:fs` instead of the required runtime abstraction.

<h3>Confidence Score: 4/5</h3>

The functional prompt-contribution changes are covered, but the test should be brought back behind the repository runtime abstraction before merge.

There is one non-security P2 finding, so the required scoring table assigns a score of 4.

**Files Needing Attention:** packages/coding-agent/test/tool-system-prompt-contributions.test.ts

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/test/tool-system-prompt-contributions.test.ts:1
**Direct filesystem access in test**

The new test imports `readFileSync` from `node:fs`, bypassing the required runtime abstraction in `test/helpers/runtime.ts` and allowing runtime-specific behavior to produce inconsistent test results.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(core): hoist tool prompt text i..."](https://github.com/bastani-inc/atomic/commit/81a59e0ae3856d304b199dc8135f5dbc5e0eeaa7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53723780)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->