### PR TITLE
pi 0.84.2/subagents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9422,7 +9422,8 @@
       "license": "MIT",
       "dependencies": {
         "jiti": "^2.7.0",
-        "typebox": "^1.3.7"
+        "typebox": "^1.3.7",
+        "yaml": "2.9.0"
       },
       "engines": {
         "bun": ">=1.3.14"

--- a/packages/subagents/README.md
+++ b/packages/subagents/README.md
@@ -413,7 +413,7 @@ Important fields:
 | `package` | Optional package identifier. A file with `name: api-auditor` and `package: code-analysis` registers as `code-analysis.api-auditor`; serialization keeps `name` and `package` separate. |
 | `tools` | Builtin tool allowlist, comma-separated (`tools: read, bash`) or YAML array-form (`tools: [read, bash]`, or a `tools:` block list) — both spellings produce the same tool set. `mcp:` entries select direct MCP tools when `pi-mcp-adapter` is installed. |
 | `extensions` | Omitted means normal extensions; empty means no extensions; comma-separated values allowlist specific extensions. |
-| `model` | Default model. Bare ids prefer the current provider when possible, then unique registry matches. When omitted — and no per-call model override is given — the subagent inherits the dispatching session's active model and thinking level; a declared `thinking` still takes precedence over the inherited level. |
+| `model` | Default model. Bare ids prefer the current provider when possible, then unique registry matches. When omitted — with no `fallbackModels` and no per-call model override — the subagent inherits the dispatching session's active model and thinking level; a declared `thinking` still takes precedence over the inherited level. |
 | `fallbackModels` | Ordered backup models for provider/model failures such as quota, auth, timeout, or unavailable model. The current user-selected model is automatically appended as the last fallback and de-duplicated. Ordinary task failures do not trigger fallback. |
 | `thinking` | Appended as a `:level` suffix at runtime unless a suffix is already present. |
 | `systemPromptMode` | `replace` by default; `append` keeps Pi’s base prompt. |

--- a/packages/subagents/README.md
+++ b/packages/subagents/README.md
@@ -406,6 +406,8 @@ maxSubagentDepth: 1
 Your system prompt goes here.
 ```
 
+Frontmatter is parsed with a real YAML parser, so it must be valid YAML: a file whose frontmatter does not parse (for example a colon-space inside an unquoted scalar like `description: Deploy: fast`, duplicate keys, or tab-indented block lists) is skipped during discovery. `subagent({ action: "doctor" })` lists every skipped file with the parser's message, so a bad file never disappears silently.
+
 Important fields:
 
 | Field | Notes |

--- a/packages/subagents/README.md
+++ b/packages/subagents/README.md
@@ -411,9 +411,9 @@ Important fields:
 | Field | Notes |
 |-------|-------|
 | `package` | Optional package identifier. A file with `name: api-auditor` and `package: code-analysis` registers as `code-analysis.api-auditor`; serialization keeps `name` and `package` separate. |
-| `tools` | Builtin tool allowlist. `mcp:` entries select direct MCP tools when `pi-mcp-adapter` is installed. |
+| `tools` | Builtin tool allowlist, comma-separated (`tools: read, bash`) or YAML array-form (`tools: [read, bash]`, or a `tools:` block list) — both spellings produce the same tool set. `mcp:` entries select direct MCP tools when `pi-mcp-adapter` is installed. |
 | `extensions` | Omitted means normal extensions; empty means no extensions; comma-separated values allowlist specific extensions. |
-| `model` | Default model. Bare ids prefer the current provider when possible, then unique registry matches. |
+| `model` | Default model. Bare ids prefer the current provider when possible, then unique registry matches. When omitted — and no per-call model override is given — the subagent inherits the dispatching session's active model and thinking level; a declared `thinking` still takes precedence over the inherited level. |
 | `fallbackModels` | Ordered backup models for provider/model failures such as quota, auth, timeout, or unavailable model. The current user-selected model is automatically appended as the last fallback and de-duplicated. Ordinary task failures do not trigger fallback. |
 | `thinking` | Appended as a `:level` suffix at runtime unless a suffix is already present. |
 | `systemPromptMode` | `replace` by default; `append` keeps Pi’s base prompt. |

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "jiti": "^2.7.0",
-    "typebox": "^1.3.7"
+    "typebox": "^1.3.7",
+    "yaml": "2.9.0"
   }
 }

--- a/packages/subagents/src/agents/agent-discovery.ts
+++ b/packages/subagents/src/agents/agent-discovery.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { getEnvValue } from "@bastani/atomic";
-import { loadAgentsFromDir } from "./agent-loaders.ts";
+import { type AgentLoadDiagnostic, loadAgentsFromDir, loadAgentsFromDirWithDiagnostics } from "./agent-loaders.ts";
 import { applyBuiltinOverrides, readMergedSubagentSettings } from "./agent-overrides.ts";
 import {
 	BUILTIN_AGENTS_DIR,
@@ -60,6 +60,7 @@ export function discoverAgentsAll(cwd: string): {
 	projectDir: string | null;
 	userSettingsPath: string;
 	projectSettingsPath: string | null;
+	diagnostics: AgentLoadDiagnostic[];
 } {
 	const userDirOld = getUserAgentDirs();
 	const userDirNew = path.join(os.homedir(), ".agents");
@@ -71,20 +72,24 @@ export function discoverAgentsAll(cwd: string): {
 	const userSettings = userSettingsLoad.settings;
 	const projectSettings = projectSettingsLoad.settings;
 
+	const diagnostics: AgentLoadDiagnostic[] = [];
+	const loadDir = (dir: string, source: "builtin" | "user" | "project"): AgentConfig[] => {
+		const result = loadAgentsFromDirWithDiagnostics(dir, source);
+		diagnostics.push(...result.diagnostics);
+		return result.agents;
+	};
+
 	const builtin = applyBuiltinOverrides(
-		loadAgentsFromDir(BUILTIN_AGENTS_DIR, "builtin"),
+		loadDir(BUILTIN_AGENTS_DIR, "builtin"),
 		userSettings,
 		projectSettings,
 		userSettingsPath,
 		projectSettingsPath,
 	);
-	const user = [
-		...userDirOld.flatMap((dir) => loadAgentsFromDir(dir, "user")),
-		...loadAgentsFromDir(userDirNew, "user"),
-	];
+	const user = [...userDirOld.flatMap((dir) => loadDir(dir, "user")), ...loadDir(userDirNew, "user")];
 	const projectMap = new Map<string, AgentConfig>();
 	for (const dir of projectDirs) {
-		for (const agent of loadAgentsFromDir(dir, "project")) {
+		for (const agent of loadDir(dir, "project")) {
 			projectMap.set(agent.name, agent);
 		}
 	}
@@ -106,5 +111,6 @@ export function discoverAgentsAll(cwd: string): {
 		projectDir,
 		userSettingsPath,
 		projectSettingsPath,
+		diagnostics,
 	};
 }

--- a/packages/subagents/src/agents/agent-loaders.ts
+++ b/packages/subagents/src/agents/agent-loaders.ts
@@ -91,8 +91,28 @@ function parseToolList(value: FrontmatterValue | undefined): string[] | undefine
 	return tools.length > 0 ? tools : undefined;
 }
 
-export function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
+export interface AgentLoadDiagnostic {
+	/** Absolute path of the skipped file. */
+	path: string;
+	/** Why the file was skipped, from the YAML parser when it threw. */
+	message: string;
+}
+
+export interface AgentDirLoadResult {
+	agents: AgentConfig[];
+	diagnostics: AgentLoadDiagnostic[];
+}
+
+/**
+ * Load every agent file in a directory, collecting a diagnostic per file
+ * skipped for invalid YAML frontmatter. The real YAML parser is stricter
+ * than the line reader it replaced (`description: Deploy: fast` is a
+ * nested-mapping error, not a description), so without this record those
+ * files would vanish from discovery with no signal.
+ */
+export function loadAgentsFromDirWithDiagnostics(dir: string, source: AgentSource): AgentDirLoadResult {
 	const agents: AgentConfig[] = [];
+	const diagnostics: AgentLoadDiagnostic[] = [];
 
 	for (const filePath of listFilesRecursive(dir, (fileName) => fileName.endsWith(".md"))) {
 		let content: string;
@@ -102,7 +122,11 @@ export function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig
 			continue;
 		}
 
-		const { frontmatter, body } = parseFrontmatter(content);
+		const { frontmatter, body, parseError } = parseFrontmatter(content);
+		if (parseError !== undefined) {
+			diagnostics.push({ path: filePath, message: parseError });
+			continue;
+		}
 
 		// Sequences are legal frontmatter but not valid `name`/`description`
 		// spellings; a file whose identity fields are not plain strings is
@@ -188,5 +212,9 @@ export function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig
 		});
 	}
 
-	return agents;
+	return { agents, diagnostics };
+}
+
+export function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
+	return loadAgentsFromDirWithDiagnostics(dir, source).agents;
 }

--- a/packages/subagents/src/agents/agent-loaders.ts
+++ b/packages/subagents/src/agents/agent-loaders.ts
@@ -55,6 +55,19 @@ function frontmatterString(value: FrontmatterValue | undefined): string | undefi
 }
 
 /**
+ * Narrow a frontmatter value to a boolean. The real YAML parser yields true
+ * booleans for the unquoted spellings `serializeAgent` itself writes
+ * (`interactive: true`); quoted or hand-written `"true"`/`"false"` strings
+ * from the legacy line-reader era stay accepted.
+ */
+function frontmatterBoolean(value: FrontmatterValue | undefined): boolean | undefined {
+	if (typeof value === "boolean") return value;
+	if (value === "true") return true;
+	if (value === "false") return false;
+	return undefined;
+}
+
+/**
  * Normalize a frontmatter `tools` value to a list of tool names.
  *
  * Both spellings are valid YAML and both are in use (upstream pi #7598):
@@ -107,38 +120,30 @@ export function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig
 
 		const rawTools = parseToolList(frontmatter.tools);
 		const parsedTools = splitToolList(rawTools);
+		const inheritProjectContextRaw = frontmatterBoolean(frontmatter.inheritProjectContext);
+		const inheritSkillsRaw = frontmatterBoolean(frontmatter.inheritSkills);
+		const defaultContextRaw = frontmatterString(frontmatter.defaultContext);
+		const extensionsRaw = frontmatterString(frontmatter.extensions);
+		const systemPromptModeRaw = frontmatterString(frontmatter.systemPromptMode);
 		const defaultReads = parseCommaSeparatedList(frontmatterString(frontmatter.defaultReads));
 		const skillStr = frontmatterString(frontmatter.skill) || frontmatterString(frontmatter.skills) || undefined;
 		const skills = parseCommaSeparatedList(skillStr);
 		const fallbackModels = parseCommaSeparatedList(frontmatterString(frontmatter.fallbackModels));
 		const fallbackThinkingLevels = parseCommaSeparatedList(frontmatterString(frontmatter.fallbackThinkingLevels));
-		const systemPromptModeRaw = frontmatterString(frontmatter.systemPromptMode);
-		const inheritProjectContextRaw = frontmatterString(frontmatter.inheritProjectContext);
-		const inheritSkillsRaw = frontmatterString(frontmatter.inheritSkills);
-		const defaultContextRaw = frontmatterString(frontmatter.defaultContext);
-		const extensionsRaw = frontmatterString(frontmatter.extensions);
-		const maxSubagentDepthRaw = frontmatterString(frontmatter.maxSubagentDepth);
+		const inheritProjectContext = inheritProjectContextRaw ?? defaultInheritProjectContext(localName);
+		const inheritSkills = inheritSkillsRaw ?? defaultInheritSkills();
 		const systemPromptMode =
 			systemPromptModeRaw === "replace"
 				? "replace"
 				: systemPromptModeRaw === "append"
 					? "append"
 					: defaultSystemPromptMode(localName);
-		const inheritProjectContext =
-			inheritProjectContextRaw === "true"
-				? true
-				: inheritProjectContextRaw === "false"
-					? false
-					: defaultInheritProjectContext(localName);
-		const inheritSkills =
-			inheritSkillsRaw === "true" ? true : inheritSkillsRaw === "false" ? false : defaultInheritSkills();
 		const defaultContext =
 			defaultContextRaw === "fork"
 				? ("fork" as const)
 				: defaultContextRaw === "fresh"
 					? ("fresh" as const)
 					: undefined;
-
 		let extensions: string[] | undefined;
 		if (extensionsRaw !== undefined) {
 			extensions = extensionsRaw
@@ -147,12 +152,12 @@ export function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig
 				.filter(Boolean);
 		}
 
-		const extraFields: Record<string, string> = {};
+		const extraFields: Record<string, FrontmatterValue> = {};
 		for (const [key, value] of Object.entries(frontmatter)) {
-			if (shouldPreserveAgentExtraField(key) && typeof value === "string") extraFields[key] = value;
+			if (shouldPreserveAgentExtraField(key)) extraFields[key] = value;
 		}
 
-		const parsedMaxSubagentDepth = normalizeMaxSubagentDepth(maxSubagentDepthRaw);
+		const parsedMaxSubagentDepth = normalizeMaxSubagentDepth(frontmatter.maxSubagentDepth);
 
 		agents.push({
 			name: runtimeName,
@@ -176,8 +181,8 @@ export function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig
 			extensions,
 			output: frontmatterString(frontmatter.output),
 			defaultReads,
-			defaultProgress: frontmatterString(frontmatter.defaultProgress) === "true",
-			interactive: frontmatterString(frontmatter.interactive) === "true",
+			defaultProgress: frontmatterBoolean(frontmatter.defaultProgress) === true,
+			interactive: frontmatterBoolean(frontmatter.interactive) === true,
 			maxSubagentDepth: parsedMaxSubagentDepth,
 			extraFields: Object.keys(extraFields).length > 0 ? extraFields : undefined,
 		});

--- a/packages/subagents/src/agents/agent-loaders.ts
+++ b/packages/subagents/src/agents/agent-loaders.ts
@@ -10,7 +10,7 @@ import {
 	defaultInheritSkills,
 	defaultSystemPromptMode,
 } from "./agent-types.ts";
-import { parseFrontmatter } from "./frontmatter.ts";
+import { type FrontmatterValue, parseFrontmatter } from "./frontmatter.ts";
 import { buildRuntimeName, parsePackageName } from "./identity.ts";
 
 function listFilesRecursive(dir: string, predicate: (fileName: string) => boolean): string[] {
@@ -45,6 +45,39 @@ function parseCommaSeparatedList(value: string | undefined): string[] | undefine
 	return parsed && parsed.length > 0 ? parsed : undefined;
 }
 
+/**
+ * Narrow a frontmatter value to its scalar spelling. A YAML sequence where a
+ * scalar belongs (`model: [anthropic, x]`) reads as undefined rather than a
+ * stringified list, matching upstream's `typeof` narrowing.
+ */
+function frontmatterString(value: FrontmatterValue | undefined): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Normalize a frontmatter `tools` value to a list of tool names.
+ *
+ * Both spellings are valid YAML and both are in use (upstream pi #7598):
+ *
+ *     tools: read, bash        # string, comma-separated
+ *     tools: [read, bash]      # flow sequence
+ *     tools:                   # block sequence
+ *       - read
+ *       - bash
+ *
+ * so accept either. Anything else yields no tools rather than throwing: this
+ * runs inside agent discovery, where a single bad file must not take down
+ * every other agent in the same directory.
+ */
+function parseToolList(value: FrontmatterValue | undefined): string[] | undefined {
+	const raw = Array.isArray(value) ? value : typeof value === "string" ? value.split(",") : [];
+	const tools = raw
+		.filter((tool): tool is string => typeof tool === "string")
+		.map((tool) => tool.trim())
+		.filter(Boolean);
+	return tools.length > 0 ? tools : undefined;
+}
+
 export function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 	const agents: AgentConfig[] = [];
 
@@ -58,51 +91,57 @@ export function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig
 
 		const { frontmatter, body } = parseFrontmatter(content);
 
-		if (!frontmatter.name || !frontmatter.description) {
+		// Sequences are legal frontmatter but not valid `name`/`description`
+		// spellings; a file whose identity fields are not plain strings is
+		// skipped whole, exactly as upstream's loader does.
+		const localName = frontmatterString(frontmatter.name);
+		const description = frontmatterString(frontmatter.description);
+		if (!localName || !description) {
 			continue;
 		}
 
-		const localName = frontmatter.name;
-		const parsedPackage = parsePackageName(frontmatter.package, `Agent '${localName}' package`);
+		const parsedPackage = parsePackageName(frontmatterString(frontmatter.package), `Agent '${localName}' package`);
 		if (parsedPackage.error) continue;
 		const packageName = parsedPackage.packageName;
 		const runtimeName = buildRuntimeName(localName, packageName);
 
-		const rawTools = parseCommaSeparatedList(frontmatter.tools);
+		const rawTools = parseToolList(frontmatter.tools);
 		const parsedTools = splitToolList(rawTools);
-		const defaultReads = parseCommaSeparatedList(frontmatter.defaultReads);
-		const skillStr = frontmatter.skill || frontmatter.skills;
+		const defaultReads = parseCommaSeparatedList(frontmatterString(frontmatter.defaultReads));
+		const skillStr = frontmatterString(frontmatter.skill) || frontmatterString(frontmatter.skills) || undefined;
 		const skills = parseCommaSeparatedList(skillStr);
-		const fallbackModels = parseCommaSeparatedList(frontmatter.fallbackModels);
-		const fallbackThinkingLevels = parseCommaSeparatedList(frontmatter.fallbackThinkingLevels);
+		const fallbackModels = parseCommaSeparatedList(frontmatterString(frontmatter.fallbackModels));
+		const fallbackThinkingLevels = parseCommaSeparatedList(frontmatterString(frontmatter.fallbackThinkingLevels));
+		const systemPromptModeRaw = frontmatterString(frontmatter.systemPromptMode);
+		const inheritProjectContextRaw = frontmatterString(frontmatter.inheritProjectContext);
+		const inheritSkillsRaw = frontmatterString(frontmatter.inheritSkills);
+		const defaultContextRaw = frontmatterString(frontmatter.defaultContext);
+		const extensionsRaw = frontmatterString(frontmatter.extensions);
+		const maxSubagentDepthRaw = frontmatterString(frontmatter.maxSubagentDepth);
 		const systemPromptMode =
-			frontmatter.systemPromptMode === "replace"
+			systemPromptModeRaw === "replace"
 				? "replace"
-				: frontmatter.systemPromptMode === "append"
+				: systemPromptModeRaw === "append"
 					? "append"
 					: defaultSystemPromptMode(localName);
 		const inheritProjectContext =
-			frontmatter.inheritProjectContext === "true"
+			inheritProjectContextRaw === "true"
 				? true
-				: frontmatter.inheritProjectContext === "false"
+				: inheritProjectContextRaw === "false"
 					? false
 					: defaultInheritProjectContext(localName);
 		const inheritSkills =
-			frontmatter.inheritSkills === "true"
-				? true
-				: frontmatter.inheritSkills === "false"
-					? false
-					: defaultInheritSkills();
+			inheritSkillsRaw === "true" ? true : inheritSkillsRaw === "false" ? false : defaultInheritSkills();
 		const defaultContext =
-			frontmatter.defaultContext === "fork"
+			defaultContextRaw === "fork"
 				? ("fork" as const)
-				: frontmatter.defaultContext === "fresh"
+				: defaultContextRaw === "fresh"
 					? ("fresh" as const)
 					: undefined;
 
 		let extensions: string[] | undefined;
-		if (frontmatter.extensions !== undefined) {
-			extensions = frontmatter.extensions
+		if (extensionsRaw !== undefined) {
+			extensions = extensionsRaw
 				.split(",")
 				.map((extension) => extension.trim())
 				.filter(Boolean);
@@ -110,22 +149,22 @@ export function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig
 
 		const extraFields: Record<string, string> = {};
 		for (const [key, value] of Object.entries(frontmatter)) {
-			if (shouldPreserveAgentExtraField(key)) extraFields[key] = value;
+			if (shouldPreserveAgentExtraField(key) && typeof value === "string") extraFields[key] = value;
 		}
 
-		const parsedMaxSubagentDepth = normalizeMaxSubagentDepth(frontmatter.maxSubagentDepth);
+		const parsedMaxSubagentDepth = normalizeMaxSubagentDepth(maxSubagentDepthRaw);
 
 		agents.push({
 			name: runtimeName,
 			localName,
 			packageName,
-			description: frontmatter.description,
+			description,
 			tools: parsedTools.tools,
 			mcpDirectTools: parsedTools.mcpDirectTools,
-			model: frontmatter.model,
+			model: frontmatterString(frontmatter.model),
 			fallbackModels,
 			fallbackThinkingLevels,
-			thinking: frontmatter.thinking,
+			thinking: frontmatterString(frontmatter.thinking),
 			systemPromptMode,
 			inheritProjectContext,
 			inheritSkills,
@@ -135,10 +174,10 @@ export function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig
 			filePath,
 			skills,
 			extensions,
-			output: frontmatter.output,
+			output: frontmatterString(frontmatter.output),
 			defaultReads,
-			defaultProgress: frontmatter.defaultProgress === "true",
-			interactive: frontmatter.interactive === "true",
+			defaultProgress: frontmatterString(frontmatter.defaultProgress) === "true",
+			interactive: frontmatterString(frontmatter.interactive) === "true",
 			maxSubagentDepth: parsedMaxSubagentDepth,
 			extraFields: Object.keys(extraFields).length > 0 ? extraFields : undefined,
 		});

--- a/packages/subagents/src/agents/agent-serializer.ts
+++ b/packages/subagents/src/agents/agent-serializer.ts
@@ -1,3 +1,4 @@
+import { stringify } from "yaml";
 import type { AgentConfig } from "./agents.ts";
 import type { FrontmatterValue } from "./frontmatter.ts";
 import { frontmatterNameForConfig } from "./identity.ts";
@@ -37,15 +38,22 @@ function joinComma(values: string[] | undefined): string | undefined {
 }
 
 /**
- * Render an extra frontmatter field back to its YAML spelling so an unknown
- * custom field survives an agent update: sequences return as flow sequences,
- * booleans/numbers/null as their own scalars, strings verbatim. Each shape
- * re-parses to itself, so load → serialize → load is stable.
+ * Render one extra frontmatter field through the real YAML emitter so an
+ * unknown custom field survives an agent update without changing meaning.
+ * The yaml package quotes scalars a hand-joined spelling corrupts: `a #b`
+ * would open a comment mid-flow-sequence and leave the file unparseable,
+ * `a, b` would split into two items, `a: b` would start a nested mapping,
+ * and an unquoted `""` or `"true"` would change type on re-parse. Keys are
+ * emitted by the same call, so a custom key that needs quoting gets it.
+ * Sequences render as block collections and may span several lines; nested
+ * maps are dropped at parse (they have no agent-frontmatter spelling) and
+ * so never reach this path. Every emitted shape re-parses to itself, so
+ * load → serialize → load is stable.
  */
-function serializeExtraFieldValue(value: FrontmatterValue): string {
-	if (Array.isArray(value)) return `[${value.join(", ")}]`;
-	if (value === null) return "null";
-	return String(value);
+function serializeExtraFieldEntry(key: string, value: FrontmatterValue): string[] {
+	return stringify({ [key]: value }, { lineWidth: 0 })
+		.trimEnd()
+		.split("\n");
 }
 
 export function serializeAgent(config: AgentConfig): string {
@@ -93,7 +101,7 @@ export function serializeAgent(config: AgentConfig): string {
 	if (config.extraFields) {
 		for (const [key, value] of Object.entries(config.extraFields)) {
 			if (!shouldPreserveAgentExtraField(key)) continue;
-			lines.push(`${key}: ${serializeExtraFieldValue(value)}`);
+			lines.push(...serializeExtraFieldEntry(key, value));
 		}
 	}
 

--- a/packages/subagents/src/agents/agent-serializer.ts
+++ b/packages/subagents/src/agents/agent-serializer.ts
@@ -1,4 +1,5 @@
 import type { AgentConfig } from "./agents.ts";
+import type { FrontmatterValue } from "./frontmatter.ts";
 import { frontmatterNameForConfig } from "./identity.ts";
 
 export const KNOWN_FIELDS = new Set([
@@ -33,6 +34,18 @@ export function shouldPreserveAgentExtraField(key: string): boolean {
 function joinComma(values: string[] | undefined): string | undefined {
 	if (!values || values.length === 0) return undefined;
 	return values.join(", ");
+}
+
+/**
+ * Render an extra frontmatter field back to its YAML spelling so an unknown
+ * custom field survives an agent update: sequences return as flow sequences,
+ * booleans/numbers/null as their own scalars, strings verbatim. Each shape
+ * re-parses to itself, so load → serialize → load is stable.
+ */
+function serializeExtraFieldValue(value: FrontmatterValue): string {
+	if (Array.isArray(value)) return `[${value.join(", ")}]`;
+	if (value === null) return "null";
+	return String(value);
 }
 
 export function serializeAgent(config: AgentConfig): string {
@@ -80,7 +93,7 @@ export function serializeAgent(config: AgentConfig): string {
 	if (config.extraFields) {
 		for (const [key, value] of Object.entries(config.extraFields)) {
 			if (!shouldPreserveAgentExtraField(key)) continue;
-			lines.push(`${key}: ${value}`);
+			lines.push(`${key}: ${serializeExtraFieldValue(value)}`);
 		}
 	}
 

--- a/packages/subagents/src/agents/agent-types.ts
+++ b/packages/subagents/src/agents/agent-types.ts
@@ -1,3 +1,5 @@
+import type { FrontmatterValue } from "./frontmatter.ts";
+
 export type AgentScope = "user" | "project" | "both";
 
 export type AgentSource = "builtin" | "user" | "project";
@@ -79,7 +81,7 @@ export interface AgentConfig {
 	interactive?: boolean;
 	maxSubagentDepth?: number;
 	disabled?: boolean;
-	extraFields?: Record<string, string>;
+	extraFields?: Record<string, FrontmatterValue>;
 	override?: BuiltinAgentOverrideInfo;
 }
 

--- a/packages/subagents/src/agents/agents.ts
+++ b/packages/subagents/src/agents/agents.ts
@@ -3,6 +3,8 @@
  */
 
 export { discoverAgents, discoverAgentsAll } from "./agent-discovery.ts";
+export type { AgentDirLoadResult, AgentLoadDiagnostic } from "./agent-loaders.ts";
+export { loadAgentsFromDir, loadAgentsFromDirWithDiagnostics } from "./agent-loaders.ts";
 export {
 	buildBuiltinOverrideConfig,
 	removeBuiltinAgentOverride,

--- a/packages/subagents/src/agents/frontmatter.ts
+++ b/packages/subagents/src/agents/frontmatter.ts
@@ -23,20 +23,36 @@ function toFrontmatterValue(value: unknown): FrontmatterValue | undefined {
 	return undefined;
 }
 
+export interface ParsedAgentFrontmatter {
+	frontmatter: Frontmatter;
+	body: string;
+	/**
+	 * The YAML parser's error message when the document does not parse.
+	 * The switch from a line reader to the real parser made previously
+	 * loadable files (a colon-space inside a plain scalar, duplicate keys,
+	 * tab-indented block lists) read as frontmatter-less; carrying the
+	 * error lets the loader report the skipped file instead of letting it
+	 * vanish silently.
+	 */
+	parseError?: string;
+}
+
 /**
  * Parse a markdown file's frontmatter with the real YAML parser exported by
  * `@bastani/atomic`. This function never throws: agent discovery loads every
  * `.md` file in a directory, and one file with invalid YAML (an unclosed flow
  * sequence, a colon-space inside a plain scalar) must not take down every
  * other agent there. An unparseable document reads as no frontmatter, which
- * makes the loader skip that file for lacking `name`/`description`.
+ * makes the loader skip that file for lacking `name`/`description`, and the
+ * parse error is returned so discovery can surface a diagnostic.
  */
-export function parseFrontmatter(content: string): { frontmatter: Frontmatter; body: string } {
+export function parseFrontmatter(content: string): ParsedAgentFrontmatter {
 	let parsed: { frontmatter: unknown; body: string };
 	try {
 		parsed = parseYamlFrontmatter(content);
-	} catch {
-		return { frontmatter: {}, body: content };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		return { frontmatter: {}, body: content, parseError: message };
 	}
 	const frontmatter: Frontmatter = {};
 	const raw = parsed.frontmatter;

--- a/packages/subagents/src/agents/frontmatter.ts
+++ b/packages/subagents/src/agents/frontmatter.ts
@@ -1,77 +1,49 @@
+import { parseFrontmatter as parseYamlFrontmatter } from "@bastani/atomic";
+
 /**
- * A frontmatter value. Scalars stay strings; YAML sequence values — flow
- * (`tools: [read, bash]`) and block (`tools:` followed by `- read` lines) —
- * parse to arrays so list fields accept the same spellings a real YAML
- * parser produces (upstream pi #7598). Callers narrow per field: a sequence
- * where a scalar belongs is ignored, never stringified.
+ * A frontmatter value as a real YAML parser produces it (upstream pi #7598
+ * parses agent frontmatter with the yaml library, not a line reader): scalars
+ * parse to strings, booleans, numbers, or null; sequences — flow
+ * (`tools: [read, bash]`, single- or multi-line) and block (`tools:` followed
+ * by `- read` lines at any indentation) — parse to arrays of their string
+ * items. Nested maps have no agent-frontmatter spelling and are dropped at
+ * parse, so every consumer narrows over a finite union instead of
+ * re-deriving YAML semantics per field.
  */
-export type FrontmatterValue = string | string[];
+export type FrontmatterValue = string | string[] | boolean | number | null;
 export type Frontmatter = Record<string, FrontmatterValue>;
 
-function stripSurroundingQuotes(value: string): string {
-	if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
-		return value.slice(1, -1);
+function toFrontmatterValue(value: unknown): FrontmatterValue | undefined {
+	if (value === null || typeof value === "string" || typeof value === "boolean" || typeof value === "number") {
+		return value;
 	}
-	return value;
+	if (Array.isArray(value)) {
+		return value.filter((item): item is string => typeof item === "string");
+	}
+	return undefined;
 }
 
 /**
- * Split the inside of a YAML flow sequence (`[a, b]`) into trimmed items.
- * Items keep no surrounding quotes, matching scalar handling.
+ * Parse a markdown file's frontmatter with the real YAML parser exported by
+ * `@bastani/atomic`. This function never throws: agent discovery loads every
+ * `.md` file in a directory, and one file with invalid YAML (an unclosed flow
+ * sequence, a colon-space inside a plain scalar) must not take down every
+ * other agent there. An unparseable document reads as no frontmatter, which
+ * makes the loader skip that file for lacking `name`/`description`.
  */
-function parseFlowSequenceItems(inner: string): string[] {
-	return inner
-		.split(",")
-		.map((item) => stripSurroundingQuotes(item.trim()))
-		.filter(Boolean);
-}
-
 export function parseFrontmatter(content: string): { frontmatter: Frontmatter; body: string } {
+	let parsed: { frontmatter: unknown; body: string };
+	try {
+		parsed = parseYamlFrontmatter(content);
+	} catch {
+		return { frontmatter: {}, body: content };
+	}
 	const frontmatter: Frontmatter = {};
-	const normalized = content.replace(/\r\n/g, "\n");
-
-	if (!normalized.startsWith("---")) {
-		return { frontmatter, body: normalized };
+	const raw = parsed.frontmatter;
+	if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return { frontmatter, body: parsed.body };
+	for (const [key, value] of Object.entries(raw)) {
+		const narrowed = toFrontmatterValue(value);
+		if (narrowed !== undefined) frontmatter[key] = narrowed;
 	}
-
-	const endIndex = normalized.indexOf("\n---", 3);
-	if (endIndex === -1) {
-		return { frontmatter, body: normalized };
-	}
-
-	const frontmatterBlock = normalized.slice(4, endIndex);
-	const body = normalized.slice(endIndex + 4).trim();
-	const lines = frontmatterBlock.split("\n");
-
-	for (let index = 0; index < lines.length; index++) {
-		const match = lines[index]!.match(/^([\w-]+):\s*(.*)$/);
-		if (!match) continue;
-		const key = match[1]!;
-		const value = match[2]!.trim();
-
-		// YAML flow sequence: `key: [a, b]`. `[]` parses to an empty list.
-		if (value.startsWith("[") && value.endsWith("]")) {
-			frontmatter[key] = parseFlowSequenceItems(value.slice(1, -1));
-			continue;
-		}
-
-		// YAML block sequence: `key:` alone, followed by indented `- item` lines.
-		if (value === "") {
-			const items: string[] = [];
-			while (index + 1 < lines.length) {
-				const itemMatch = lines[index + 1]!.match(/^\s+-\s+(.*)$/);
-				if (!itemMatch) break;
-				items.push(stripSurroundingQuotes(itemMatch[1]!.trim()));
-				index++;
-			}
-			if (items.length > 0) {
-				frontmatter[key] = items;
-				continue;
-			}
-		}
-
-		frontmatter[key] = stripSurroundingQuotes(value);
-	}
-
-	return { frontmatter, body };
+	return { frontmatter, body: parsed.body };
 }

--- a/packages/subagents/src/agents/frontmatter.ts
+++ b/packages/subagents/src/agents/frontmatter.ts
@@ -1,5 +1,33 @@
-export function parseFrontmatter(content: string): { frontmatter: Record<string, string>; body: string } {
-	const frontmatter: Record<string, string> = {};
+/**
+ * A frontmatter value. Scalars stay strings; YAML sequence values — flow
+ * (`tools: [read, bash]`) and block (`tools:` followed by `- read` lines) —
+ * parse to arrays so list fields accept the same spellings a real YAML
+ * parser produces (upstream pi #7598). Callers narrow per field: a sequence
+ * where a scalar belongs is ignored, never stringified.
+ */
+export type FrontmatterValue = string | string[];
+export type Frontmatter = Record<string, FrontmatterValue>;
+
+function stripSurroundingQuotes(value: string): string {
+	if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+		return value.slice(1, -1);
+	}
+	return value;
+}
+
+/**
+ * Split the inside of a YAML flow sequence (`[a, b]`) into trimmed items.
+ * Items keep no surrounding quotes, matching scalar handling.
+ */
+function parseFlowSequenceItems(inner: string): string[] {
+	return inner
+		.split(",")
+		.map((item) => stripSurroundingQuotes(item.trim()))
+		.filter(Boolean);
+}
+
+export function parseFrontmatter(content: string): { frontmatter: Frontmatter; body: string } {
+	const frontmatter: Frontmatter = {};
 	const normalized = content.replace(/\r\n/g, "\n");
 
 	if (!normalized.startsWith("---")) {
@@ -13,16 +41,36 @@ export function parseFrontmatter(content: string): { frontmatter: Record<string,
 
 	const frontmatterBlock = normalized.slice(4, endIndex);
 	const body = normalized.slice(endIndex + 4).trim();
+	const lines = frontmatterBlock.split("\n");
 
-	for (const line of frontmatterBlock.split("\n")) {
-		const match = line.match(/^([\w-]+):\s*(.*)$/);
-		if (match) {
-			let value = match[2].trim();
-			if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
-				value = value.slice(1, -1);
-			}
-			frontmatter[match[1]] = value;
+	for (let index = 0; index < lines.length; index++) {
+		const match = lines[index]!.match(/^([\w-]+):\s*(.*)$/);
+		if (!match) continue;
+		const key = match[1]!;
+		const value = match[2]!.trim();
+
+		// YAML flow sequence: `key: [a, b]`. `[]` parses to an empty list.
+		if (value.startsWith("[") && value.endsWith("]")) {
+			frontmatter[key] = parseFlowSequenceItems(value.slice(1, -1));
+			continue;
 		}
+
+		// YAML block sequence: `key:` alone, followed by indented `- item` lines.
+		if (value === "") {
+			const items: string[] = [];
+			while (index + 1 < lines.length) {
+				const itemMatch = lines[index + 1]!.match(/^\s+-\s+(.*)$/);
+				if (!itemMatch) break;
+				items.push(stripSurroundingQuotes(itemMatch[1]!.trim()));
+				index++;
+			}
+			if (items.length > 0) {
+				frontmatter[key] = items;
+				continue;
+			}
+		}
+
+		frontmatter[key] = stripSurroundingQuotes(value);
 	}
 
 	return { frontmatter, body };

--- a/packages/subagents/src/extension/doctor.ts
+++ b/packages/subagents/src/extension/doctor.ts
@@ -115,7 +115,17 @@ function formatDiscovery(input: DoctorReportInput, deps: DoctorDeps): string[] {
 				user: discovered.user.length,
 				project: discovered.project.length,
 			};
-			return `- agents: total ${agentCounts.builtin + agentCounts.user + agentCounts.project} (${formatSourceCounts(agentCounts)})`;
+			const lines = [
+				`- agents: total ${agentCounts.builtin + agentCounts.user + agentCounts.project} (${formatSourceCounts(agentCounts)})`,
+			];
+			// A file whose frontmatter is invalid YAML is skipped by discovery;
+			// without these lines it would vanish with no signal at all.
+			for (const diagnostic of discovered.diagnostics) {
+				lines.push(
+					`- agents: warning — ${diagnostic.path}: invalid YAML frontmatter (${diagnostic.message}); file skipped`,
+				);
+			}
+			return lines.join("\n");
 		}),
 		lineFromCheck("skills", () => {
 			const skills = deps.discoverAvailableSkills(input.cwd);

--- a/packages/subagents/src/runs/foreground/inprocess-run-sync.ts
+++ b/packages/subagents/src/runs/foreground/inprocess-run-sync.ts
@@ -199,6 +199,13 @@ export async function runSingleInProcess(
 		return noSpawnableCandidatesResult(agent, task, filteredCandidates.skippedAttempts);
 	const candidate = filteredCandidates.candidates[0];
 	const fallbackCandidates = filteredCandidates.candidates.slice(1);
+	// Upstream pi #7897: a subagent that pins no model of its own inherits the
+	// dispatching session's model AND thinking level. Atomic resolves the
+	// parent's model as the trailing candidate, so the same condition governs
+	// the parent's thinking level: only when neither the agent's frontmatter
+	// nor the caller named a model. An agent's own `thinking` still wins over
+	// the inherited level, and a candidate `:level` suffix wins over both.
+	const inheritsDispatchConfig = agent.model === undefined && options.modelOverride === undefined;
 	// The candidate is only a string. `createAgentSession` selects a model from a
 	// `Model<Api>` object and otherwise restores the model persisted in the
 	// session file — which, for a fork-context child, is the parent's model.
@@ -254,7 +261,9 @@ export async function runSingleInProcess(
 		mcpDirectTools: agent.mcpDirectTools,
 		skills: options.skills ?? agent.skills,
 		model: resolvedCandidate?.model,
-		thinkingLevel: (resolvedCandidate?.thinkingLevel ?? agent.thinking) as ChildSpec["thinkingLevel"],
+		thinkingLevel: (resolvedCandidate?.thinkingLevel ??
+			agent.thinking ??
+			(inheritsDispatchConfig ? options.currentThinkingLevel : undefined)) as ChildSpec["thinkingLevel"],
 		parent,
 		intercom: options.orchestratorIntercomTarget
 			? {

--- a/packages/subagents/src/runs/foreground/inprocess-run-sync.ts
+++ b/packages/subagents/src/runs/foreground/inprocess-run-sync.ts
@@ -201,11 +201,16 @@ export async function runSingleInProcess(
 	const fallbackCandidates = filteredCandidates.candidates.slice(1);
 	// Upstream pi #7897: a subagent that pins no model of its own inherits the
 	// dispatching session's model AND thinking level. Atomic resolves the
-	// parent's model as the trailing candidate, so the same condition governs
-	// the parent's thinking level: only when neither the agent's frontmatter
-	// nor the caller named a model. An agent's own `thinking` still wins over
-	// the inherited level, and a candidate `:level` suffix wins over both.
-	const inheritsDispatchConfig = agent.model === undefined && options.modelOverride === undefined;
+	// parent's model as the trailing candidate, so the parent's thinking level
+	// applies only when nothing the agent configured can outrank it: no
+	// frontmatter `model`, no `fallbackModels` (an agent whose fallback chain
+	// selects its own first candidate runs on that model, not the parent's),
+	// and no per-call override. An agent's own `thinking` still wins over the
+	// inherited level, and a candidate `:level` suffix wins over both.
+	const inheritsDispatchConfig =
+		agent.model === undefined &&
+		(agent.fallbackModels === undefined || agent.fallbackModels.length === 0) &&
+		options.modelOverride === undefined;
 	// The candidate is only a string. `createAgentSession` selects a model from a
 	// `Model<Api>` object and otherwise restores the model persisted in the
 	// session file — which, for a fork-context child, is the parent's model.

--- a/packages/subagents/src/runs/foreground/subagent-executor-parallel-task.ts
+++ b/packages/subagents/src/runs/foreground/subagent-executor-parallel-task.ts
@@ -149,6 +149,7 @@ export async function runForegroundParallelTasks(input: ForegroundParallelRunInp
 				resolveCandidateModel: input.resolveCandidateModel,
 				preferredModelProvider: input.ctx.model?.provider,
 				currentModel: currentModelFullId(input.ctx.model),
+				currentThinkingLevel: input.ctx.thinkingLevel,
 				skills: effectiveSkills === false ? [] : effectiveSkills,
 				onUpdate: input.onUpdate
 					? (progressUpdate) => {

--- a/packages/subagents/src/runs/foreground/subagent-executor-single.ts
+++ b/packages/subagents/src/runs/foreground/subagent-executor-single.ts
@@ -229,6 +229,7 @@ export async function runSinglePath(
 			resolveCandidateModel: createCandidateModelResolver(ctx.modelRegistry, currentProvider),
 			preferredModelProvider: currentProvider,
 			currentModel: currentModelFullId(ctx.model),
+			currentThinkingLevel: ctx.thinkingLevel,
 			skills: effectiveSkills,
 		});
 	} catch (error) {

--- a/packages/subagents/src/runs/foreground/subagent-executor.ts
+++ b/packages/subagents/src/runs/foreground/subagent-executor.ts
@@ -154,6 +154,7 @@ async function resumeRetainedForegroundChild(
 			resolveCandidateModel: createCandidateModelResolver(ctx.modelRegistry, ctx.model?.provider),
 			preferredModelProvider: ctx.model?.provider,
 			currentModel: currentModelFullId(ctx.model),
+			currentThinkingLevel: ctx.thinkingLevel,
 			onUpdate: forwardSingleUpdate,
 			onDetachedExit: (detachedResult) => {
 				cleanupProgress();

--- a/packages/subagents/src/shared/types-config.ts
+++ b/packages/subagents/src/shared/types-config.ts
@@ -111,6 +111,13 @@ export interface RunSyncOptions {
 	preferredModelProvider?: string;
 	/** Current parent-session model to try after configured fallback models */
 	currentModel?: string;
+	/**
+	 * Current parent-session thinking level. Inherited by a child that pins no
+	 * model of its own — neither frontmatter `model` nor a per-call override —
+	 * matching upstream pi #7897: a subagent dispatched without a model runs on
+	 * the dispatching session's model and thinking level.
+	 */
+	currentThinkingLevel?: string;
 	/** Skills to inject (overrides agent default if provided) */
 	skills?: string[];
 	/** Test-only in-process session stub configuration; production runs create a real AgentSession. */

--- a/packages/subagents/src/shared/types-config.ts
+++ b/packages/subagents/src/shared/types-config.ts
@@ -113,9 +113,12 @@ export interface RunSyncOptions {
 	currentModel?: string;
 	/**
 	 * Current parent-session thinking level. Inherited by a child that pins no
-	 * model of its own — neither frontmatter `model` nor a per-call override —
-	 * matching upstream pi #7897: a subagent dispatched without a model runs on
-	 * the dispatching session's model and thinking level.
+	 * model of its own — no frontmatter `model`, no `fallbackModels`, and no
+	 * per-call override — matching upstream pi #7897: a subagent dispatched
+	 * without a model runs on the dispatching session's model and thinking
+	 * level. An agent whose fallback chain selects its own first candidate
+	 * runs on that model, not the parent's, and keeps its own thinking
+	 * configuration.
 	 */
 	currentThinkingLevel?: string;
 	/** Skills to inject (overrides agent default if provided) */

--- a/test/unit/subagents-extra-field-round-trip.test.ts
+++ b/test/unit/subagents-extra-field-round-trip.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Review repair for the L16 serializer: `serializeExtraFieldValue` used to
+ * hand-join sequence values into unquoted flow sequences, which corrupts
+ * any item the YAML grammar cannot hold bare. The destructive case:
+ * `custom: ["a #b", c]` serialized to `custom: [a #b, c]`, where `#` opens
+ * a comment and leaves an unterminated flow sequence — the rewritten agent
+ * file then fails YAML parse, so the agent silently disappears from every
+ * later scan. Other shapes were lossy rather than destructive: `["a, b"]`
+ * split into two items, `["[x]"]` and `["a: b"]` collapsed, `""` became
+ * null, and the string `"true"` became a boolean.
+ *
+ * serializeAgent now renders extra fields through the yaml package's
+ * `stringify`, which quotes exactly the scalars that need it. These tests
+ * round-trip every probed shape through real files on disk — load, rewrite
+ * the way agent-management does, then re-scan — and require the values to
+ * come back identical and the agent to still be discoverable.
+ */
+
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, test } from "vitest";
+import { loadAgentsFromDir } from "../../packages/subagents/src/agents/agent-loaders.ts";
+import { serializeAgent } from "../../packages/subagents/src/agents/agent-serializer.ts";
+import { type FrontmatterValue, parseFrontmatter } from "../../packages/subagents/src/agents/frontmatter.ts";
+
+const roots: string[] = [];
+
+function writeAgents(files: Record<string, string>): string {
+	const dir = mkdtempSync(join(tmpdir(), "subagent-extra-fields-"));
+	roots.push(dir);
+	for (const [fileName, content] of Object.entries(files)) {
+		writeFileSync(join(dir, fileName), content, "utf-8");
+	}
+	return dir;
+}
+
+afterAll(() => {
+	for (const root of roots) rmSync(root, { recursive: true, force: true });
+});
+
+function agentFile(customYaml: string): string {
+	return `---\nname: probe\ndescription: probe agent\ntools: read\n${customYaml}---\n\nDo the thing.\n`;
+}
+
+const PROBED_SHAPES: Array<{ label: string; yaml: string; expected: FrontmatterValue }> = [
+	// Destructive under the old emitter: the bare `#` opened a comment,
+	// leaving an unterminated flow sequence that killed the whole file.
+	{ label: "items containing a comment character", yaml: 'custom: ["a #b", c]\n', expected: ["a #b", "c"] },
+	// Lossy under the old emitter: the comma split one item into two.
+	{ label: "an item containing a comma", yaml: 'custom: ["a, b", c]\n', expected: ["a, b", "c"] },
+	// Lossy: a bare `[x]` item parsed as a nested flow sequence and was
+	// dropped by the string-only narrowing, collapsing the list to [].
+	{ label: "an item that looks like a flow opener", yaml: 'custom: ["[x]"]\n', expected: ["[x]"] },
+	// Lossy: a bare `a: b` item parsed as a nested mapping and was dropped.
+	{ label: "an item containing a colon-space", yaml: 'custom: ["a: b"]\n', expected: ["a: b"] },
+	// Type-changing: bare spellings re-parse as null / boolean, not strings.
+	{ label: "the empty string", yaml: 'custom: ""\n', expected: "" },
+	{ label: "the string true", yaml: 'custom: "true"\n', expected: "true" },
+	// Typed scalars must keep their types, not stringify.
+	{ label: "a number", yaml: "custom: 3\n", expected: 3 },
+	{ label: "a boolean", yaml: "custom: true\n", expected: true },
+	{ label: "a null", yaml: "custom: null\n", expected: null },
+	// The empty sequence round-trips as itself.
+	{ label: "an empty sequence", yaml: "custom: []\n", expected: [] },
+];
+
+describe("extra-field YAML round-trip safety", () => {
+	for (const { label, yaml, expected } of PROBED_SHAPES) {
+		test(`${label} survives load → serializeAgent → load with identical values`, () => {
+			const dir = writeAgents({ "probe.md": agentFile(yaml) });
+
+			const [loaded] = loadAgentsFromDir(dir, "user");
+			assert.ok(loaded, "agent must load before the round-trip");
+			assert.deepEqual(loaded.extraFields?.custom, expected);
+
+			// agent-management overwrites the file in place with exactly
+			// this call; the output must be parseable YAML, or the agent
+			// vanishes from every later scan of the directory.
+			const rewritten = serializeAgent(loaded);
+			assert.equal(parseFrontmatter(rewritten).parseError, undefined);
+
+			const roundTripDir = writeAgents({ "probe.md": rewritten });
+			const [reloaded] = loadAgentsFromDir(roundTripDir, "user");
+			assert.ok(reloaded, "agent must still be discoverable after the rewrite");
+			assert.equal(reloaded.name, "probe");
+			assert.deepEqual(reloaded.extraFields?.custom, expected);
+		});
+	}
+
+	test("the comment-character shape rewrites to quoted YAML, not an unterminated flow sequence", () => {
+		const dir = writeAgents({ "probe.md": agentFile('custom: ["a #b", c]\n') });
+		const [loaded] = loadAgentsFromDir(dir, "user");
+
+		const rewritten = serializeAgent(loaded!);
+		// The old emitter produced `custom: [a #b, c]` here. Every item the
+		// grammar cannot hold bare must arrive quoted.
+		assert.doesNotMatch(rewritten, /^custom: \[a #b, c\]$/m);
+		assert.match(rewritten, /"a #b"/);
+	});
+});

--- a/test/unit/subagents-frontmatter-array-tools.test.ts
+++ b/test/unit/subagents-frontmatter-array-tools.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Pi 0.84.2 parity audit (upstream d268454e, "accept array-form `tools` in
+ * the subagent example", #7598): agent frontmatter must accept YAML
+ * array-form `tools` — flow (`tools: [read, bash]`) and block sequences —
+ * as well as the comma-separated string, and both spellings must produce
+ * the same tool set.
+ *
+ * Atomic's `@bastani/subagents` parses frontmatter with a line-based reader
+ * rather than a YAML library, so before this fix a flow form arrived as the
+ * literal string `"[read, bash]"` and comma-split into garbage tool names
+ * (`["[read", "bash]"]`) that reached the child as a bogus allowlist. The
+ * parser now yields sequences as arrays and the loader normalizes either
+ * spelling; scalar fields narrow to strings, so a sequence where a scalar
+ * belongs is ignored rather than stringified (upstream's own `typeof`
+ * narrowing).
+ *
+ * These tests run the real `loadAgentsFromDir` against agent files on disk.
+ */
+
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, test } from "vitest";
+import { loadAgentsFromDir } from "../../packages/subagents/src/agents/agent-loaders.ts";
+import { parseFrontmatter } from "../../packages/subagents/src/agents/frontmatter.ts";
+
+const roots: string[] = [];
+
+function writeAgents(files: Record<string, string>): string {
+	const dir = mkdtempSync(join(tmpdir(), "subagent-frontmatter-"));
+	roots.push(dir);
+	for (const [fileName, content] of Object.entries(files)) {
+		writeFileSync(join(dir, fileName), content, "utf-8");
+	}
+	return dir;
+}
+
+afterAll(() => {
+	for (const root of roots) rmSync(root, { recursive: true, force: true });
+});
+
+function agentFile(frontmatterTools: string, extra = ""): string {
+	return `---\nname: probe\ndescription: probe agent\n${frontmatterTools}${extra}---\n\nDo the thing.\n`;
+}
+
+describe("array-form tools frontmatter parity", () => {
+	test("flow, block, and comma-separated tools produce the same tool set", () => {
+		const dir = writeAgents({
+			"comma.md": agentFile("tools: read, bash\n"),
+			"flow.md": agentFile("tools: [read, bash]\n"),
+			"block.md": agentFile("tools:\n  - read\n  - bash\n"),
+		});
+
+		const agents = loadAgentsFromDir(dir, "user");
+		assert.equal(agents.length, 3);
+
+		const toolSets = agents.map((agent) => agent.tools);
+		for (const tools of toolSets) {
+			assert.deepEqual(tools, ["read", "bash"]);
+		}
+		// No spelling splits out MCP direct tools when none are declared.
+		assert.deepEqual(
+			agents.map((agent) => agent.mcpDirectTools),
+			[undefined, undefined, undefined],
+		);
+	});
+
+	test("array-form tools split mcp: entries exactly like the comma form", () => {
+		const dir = writeAgents({
+			"comma.md": agentFile("tools: read, mcp:chrome-devtools\n"),
+			"flow.md": agentFile("tools: [read, mcp:chrome-devtools]\n"),
+			"block.md": agentFile("tools:\n  - read\n  - mcp:chrome-devtools\n"),
+		});
+
+		for (const agent of loadAgentsFromDir(dir, "user")) {
+			assert.deepEqual(agent.tools, ["read"]);
+			assert.deepEqual(agent.mcpDirectTools, ["chrome-devtools"]);
+		}
+	});
+
+	test("an empty flow sequence means no tool narrowing, like an omitted or empty list", () => {
+		const dir = writeAgents({
+			"empty-flow.md": agentFile("tools: []\n"),
+			"empty-comma.md": agentFile("tools:\n"),
+		});
+
+		for (const agent of loadAgentsFromDir(dir, "user")) {
+			assert.equal(agent.tools, undefined);
+			assert.equal(agent.mcpDirectTools, undefined);
+		}
+	});
+
+	test("quoted flow items lose their quotes like quoted scalars do", () => {
+		const dir = writeAgents({
+			"quoted.md": agentFile("tools: [\"read\", 'bash']\n"),
+		});
+
+		const [agent] = loadAgentsFromDir(dir, "user");
+		assert.deepEqual(agent?.tools, ["read", "bash"]);
+	});
+
+	test("a sequence where a scalar belongs is ignored, never stringified", () => {
+		const dir = writeAgents({
+			"array-model.md": agentFile("", "model: [anthropic/claude-fable-5]\n"),
+		});
+
+		const [agent] = loadAgentsFromDir(dir, "user");
+		assert.equal(agent?.model, undefined);
+	});
+
+	test("a file whose name is a sequence is skipped whole", () => {
+		const dir = writeAgents({
+			"bad-name.md": agentFile("", "").replace("name: probe\n", "name:\n  - probe\n"),
+			"good.md": agentFile("tools: read\n"),
+		});
+
+		const agents = loadAgentsFromDir(dir, "user");
+		assert.deepEqual(
+			agents.map((agent) => agent.name),
+			["probe"],
+		);
+	});
+
+	test("parseFrontmatter keeps scalar fields as strings alongside sequences", () => {
+		const { frontmatter, body } = parseFrontmatter(
+			["---", "name: custom", "tools: [read, bash]", "model: provider:with-colon/model:off", "---", "body"].join(
+				"\n",
+			),
+		);
+
+		assert.equal(frontmatter.name, "custom");
+		assert.deepEqual(frontmatter.tools, ["read", "bash"]);
+		// A scalar keeps every later colon; only the first splits key from value.
+		assert.equal(frontmatter.model, "provider:with-colon/model:off");
+		assert.equal(body, "body");
+	});
+});

--- a/test/unit/subagents-frontmatter-array-tools.test.ts
+++ b/test/unit/subagents-frontmatter-array-tools.test.ts
@@ -1,18 +1,26 @@
 /**
  * Pi 0.84.2 parity audit (upstream d268454e, "accept array-form `tools` in
  * the subagent example", #7598): agent frontmatter must accept YAML
- * array-form `tools` — flow (`tools: [read, bash]`) and block sequences —
- * as well as the comma-separated string, and both spellings must produce
- * the same tool set.
+ * array-form `tools` — flow (`tools: [read, bash]`, single- or multi-line)
+ * and block sequences (`tools:` followed by `- read` lines at any
+ * indentation) — as well as the comma-separated string, and every spelling
+ * must produce the same tool set.
  *
- * Atomic's `@bastani/subagents` parses frontmatter with a line-based reader
- * rather than a YAML library, so before this fix a flow form arrived as the
- * literal string `"[read, bash]"` and comma-split into garbage tool names
- * (`["[read", "bash]"]`) that reached the child as a bogus allowlist. The
- * parser now yields sequences as arrays and the loader normalizes either
- * spelling; scalar fields narrow to strings, so a sequence where a scalar
- * belongs is ignored rather than stringified (upstream's own `typeof`
- * narrowing).
+ * Upstream's fix parses agent frontmatter with a real YAML library. Atomic's
+ * first cut hand-rolled a partial sequence reader, which produced garbage
+ * for legal YAML it did not model: a multi-line flow sequence parsed to the
+ * one-element allowlist `["["]` that reached the child, and a zero-indent
+ * block sequence was dropped entirely. Frontmatter now delegates to the
+ * yaml-backed `parseFrontmatter` exported by `@bastani/atomic`, so every
+ * legal YAML spelling parses identically.
+ *
+ * The real parser also yields true booleans and numbers for the unquoted
+ * spellings `serializeAgent` itself writes (`interactive: true`,
+ * `maxSubagentDepth: 3`); the loader accepts those alongside the legacy
+ * quoted strings, an invalid-YAML file reads as no frontmatter so one bad
+ * file cannot take down the rest of the directory, and sequence-valued
+ * custom fields survive an agent update by round-tripping through
+ * `serializeAgent` as flow sequences.
  *
  * These tests run the real `loadAgentsFromDir` against agent files on disk.
  */
@@ -23,6 +31,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, describe, test } from "vitest";
 import { loadAgentsFromDir } from "../../packages/subagents/src/agents/agent-loaders.ts";
+import { serializeAgent } from "../../packages/subagents/src/agents/agent-serializer.ts";
 import { parseFrontmatter } from "../../packages/subagents/src/agents/frontmatter.ts";
 
 const roots: string[] = [];
@@ -45,15 +54,21 @@ function agentFile(frontmatterTools: string, extra = ""): string {
 }
 
 describe("array-form tools frontmatter parity", () => {
-	test("flow, block, and comma-separated tools produce the same tool set", () => {
+	test("every legal YAML array spelling produces the same tool set as the comma form", () => {
 		const dir = writeAgents({
 			"comma.md": agentFile("tools: read, bash\n"),
 			"flow.md": agentFile("tools: [read, bash]\n"),
-			"block.md": agentFile("tools:\n  - read\n  - bash\n"),
+			// A multi-line flow sequence parsed to the garbage one-element
+			// allowlist ["["] under the hand-rolled reader.
+			"multiline-flow.md": agentFile("tools: [\n  read,\n  bash\n]\n"),
+			// A zero-indent block sequence was dropped entirely (tools read as
+			// undefined) because the reader required indented items.
+			"zero-indent-block.md": agentFile("tools:\n- read\n- bash\n"),
+			"indented-block.md": agentFile("tools:\n  - read\n  - bash\n"),
 		});
 
 		const agents = loadAgentsFromDir(dir, "user");
-		assert.equal(agents.length, 3);
+		assert.equal(agents.length, 5);
 
 		const toolSets = agents.map((agent) => agent.tools);
 		for (const tools of toolSets) {
@@ -62,7 +77,7 @@ describe("array-form tools frontmatter parity", () => {
 		// No spelling splits out MCP direct tools when none are declared.
 		assert.deepEqual(
 			agents.map((agent) => agent.mcpDirectTools),
-			[undefined, undefined, undefined],
+			[undefined, undefined, undefined, undefined, undefined],
 		);
 	});
 
@@ -120,6 +135,70 @@ describe("array-form tools frontmatter parity", () => {
 			agents.map((agent) => agent.name),
 			["probe"],
 		);
+	});
+
+	test("unquoted YAML booleans and numbers load, matching serializeAgent's own spellings", () => {
+		const dir = writeAgents({
+			"scalar-types.md": agentFile(
+				"",
+				"interactive: true\ninheritProjectContext: false\ninheritSkills: true\ndefaultProgress: true\nmaxSubagentDepth: 3\n",
+			),
+		});
+
+		const [agent] = loadAgentsFromDir(dir, "user");
+		assert.equal(agent?.interactive, true);
+		assert.equal(agent?.inheritProjectContext, false);
+		assert.equal(agent?.inheritSkills, true);
+		assert.equal(agent?.defaultProgress, true);
+		assert.equal(agent?.maxSubagentDepth, 3);
+	});
+
+	test("quoted boolean and number strings from the line-reader era stay accepted", () => {
+		const dir = writeAgents({
+			"legacy-strings.md": agentFile(
+				"",
+				'interactive: "true"\ninheritProjectContext: "false"\nmaxSubagentDepth: "2"\n',
+			),
+		});
+
+		const [agent] = loadAgentsFromDir(dir, "user");
+		assert.equal(agent?.interactive, true);
+		assert.equal(agent?.inheritProjectContext, false);
+		assert.equal(agent?.maxSubagentDepth, 2);
+	});
+
+	test("one file with invalid YAML frontmatter does not take down the directory", () => {
+		const dir = writeAgents({
+			// A colon-space inside a plain scalar is invalid YAML; the real
+			// parser throws, and the file must read as frontmatter-less
+			// rather than killing the scan that loads its neighbors.
+			"bad-yaml.md": "---\nname: bad\ndescription: Deploy: fast\ntools: read\n---\n\nbody\n",
+			"good.md": agentFile("tools: read\n"),
+		});
+
+		const agents = loadAgentsFromDir(dir, "user");
+		assert.deepEqual(
+			agents.map((agent) => agent.name),
+			["probe"],
+		);
+	});
+
+	test("a sequence-valued custom field survives an agent update round-trip", () => {
+		const dir = writeAgents({
+			"custom.md": agentFile("", "custom: [a, b]\n"),
+		});
+
+		const [loaded] = loadAgentsFromDir(dir, "user");
+		assert.deepEqual(loaded?.extraFields?.custom, ["a", "b"]);
+
+		// agent-management rewrites the file from the loaded config via
+		// serializeAgent; the sequence must come back out, not be deleted.
+		const rewritten = serializeAgent(loaded!);
+		assert.match(rewritten, /^custom: \[a, b\]$/m);
+
+		const roundTripDir = writeAgents({ "custom.md": rewritten });
+		const [reloaded] = loadAgentsFromDir(roundTripDir, "user");
+		assert.deepEqual(reloaded?.extraFields?.custom, ["a", "b"]);
 	});
 
 	test("parseFrontmatter keeps scalar fields as strings alongside sequences", () => {

--- a/test/unit/subagents-frontmatter-array-tools.test.ts
+++ b/test/unit/subagents-frontmatter-array-tools.test.ts
@@ -192,9 +192,11 @@ describe("array-form tools frontmatter parity", () => {
 		assert.deepEqual(loaded?.extraFields?.custom, ["a", "b"]);
 
 		// agent-management rewrites the file from the loaded config via
-		// serializeAgent; the sequence must come back out, not be deleted.
+		// serializeAgent, which renders extra fields through the yaml
+		// emitter as block collections; the sequence must come back out,
+		// not be deleted.
 		const rewritten = serializeAgent(loaded!);
-		assert.match(rewritten, /^custom: \[a, b\]$/m);
+		assert.match(rewritten, /^custom:\n {2}- a\n {2}- b$/m);
 
 		const roundTripDir = writeAgents({ "custom.md": rewritten });
 		const [reloaded] = loadAgentsFromDir(roundTripDir, "user");

--- a/test/unit/subagents-invalid-yaml-diagnostics.test.ts
+++ b/test/unit/subagents-invalid-yaml-diagnostics.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Review repair for the L16 frontmatter switch: moving from the hand-rolled
+ * line reader to the real YAML parser made previously-loadable agent files
+ * vanish with no signal — `description: Deploy: fast` is a nested-mapping
+ * error, not a description, and the loader silently skipped the file. These
+ * tests pin the diagnostic that now accompanies the skip: the loader
+ * reports the file and the parser's message, and `subagent doctor` surfaces
+ * it, so a strictness regression can never look like a deleted agent.
+ */
+
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, test } from "vitest";
+import type { discoverAgentsAll } from "../../packages/subagents/src/agents/agent-discovery.ts";
+import { loadAgentsFromDirWithDiagnostics } from "../../packages/subagents/src/agents/agent-loaders.ts";
+import { buildDoctorReport } from "../../packages/subagents/src/extension/doctor.ts";
+import type { ExtensionConfig } from "../../packages/subagents/src/shared/types-config.ts";
+import type { SubagentState } from "../../packages/subagents/src/shared/types-nested.ts";
+
+const roots: string[] = [];
+
+function writeAgents(files: Record<string, string>): string {
+	const dir = mkdtempSync(join(tmpdir(), "subagent-yaml-diagnostics-"));
+	roots.push(dir);
+	for (const [fileName, content] of Object.entries(files)) {
+		writeFileSync(join(dir, fileName), content, "utf-8");
+	}
+	return dir;
+}
+
+afterAll(() => {
+	for (const root of roots) rmSync(root, { recursive: true, force: true });
+});
+
+const GOOD_AGENT = "---\nname: probe\ndescription: probe agent\ntools: read\n---\n\nDo the thing.\n";
+
+function doctorState(): { config: ExtensionConfig; state: SubagentState } {
+	return {
+		config: {},
+		state: {
+			baseCwd: tmpdir(),
+			currentSessionId: null,
+			foregroundControls: new Map(),
+			lastForegroundControlId: null,
+			lastUiContext: null,
+		},
+	};
+}
+
+describe("invalid-YAML agent files produce load diagnostics", () => {
+	test("a file the YAML parser rejects is reported, not silently skipped", () => {
+		const dir = writeAgents({
+			// A colon-space inside a plain scalar parsed fine under the old
+			// line reader and is a nested-mapping error under the real one.
+			"deploy.md": "---\nname: deploy\ndescription: Deploy: fast\ntools: read\n---\n\nbody\n",
+			"good.md": GOOD_AGENT,
+		});
+
+		const { agents, diagnostics } = loadAgentsFromDirWithDiagnostics(dir, "user");
+		assert.deepEqual(
+			agents.map((agent) => agent.name),
+			["probe"],
+		);
+
+		assert.equal(diagnostics.length, 1);
+		const diagnostic = diagnostics[0]!;
+		assert.equal(diagnostic.path, join(dir, "deploy.md"));
+		assert.ok(diagnostic.message.length > 0, "diagnostic carries the parser's message");
+	});
+
+	test("files without frontmatter or with valid YAML produce no diagnostics", () => {
+		const dir = writeAgents({
+			"note.md": "Just a markdown note that lives next to agents.\n",
+			"good.md": GOOD_AGENT,
+			"sequence.md": "---\nname: seq\ndescription: seq agent\ntools:\n  - read\n  - bash\n---\n\nbody\n",
+		});
+
+		const { agents, diagnostics } = loadAgentsFromDirWithDiagnostics(dir, "user");
+		assert.equal(agents.length, 2);
+		assert.deepEqual(diagnostics, []);
+	});
+
+	test("doctor lists every skipped file with the parser's message", () => {
+		const { config, state } = doctorState();
+		const skippedPath = join(tmpdir(), "agents", "deploy.md");
+		const report = buildDoctorReport({
+			cwd: tmpdir(),
+			config,
+			state,
+			paths: { tempRootDir: tmpdir() },
+			deps: {
+				discoverAgentsAll: () =>
+					({
+						builtin: [],
+						user: [],
+						project: [],
+						userDir: join(tmpdir(), "agents"),
+						projectDir: null,
+						userSettingsPath: join(tmpdir(), "settings.json"),
+						projectSettingsPath: null,
+						diagnostics: [{ path: skippedPath, message: "Nested mappings are not allowed" }],
+					}) as ReturnType<typeof discoverAgentsAll>,
+				discoverAvailableSkills: () => [],
+				diagnoseIntercomBridge: () => ({
+					active: false,
+					mode: "off",
+					wantsIntercom: false,
+					piIntercomAvailable: false,
+					extensionDir: join(tmpdir(), "extensions", "intercom"),
+					orchestratorTarget: undefined,
+					reason: "disabled",
+				}),
+			},
+		});
+
+		assert.match(report, /- agents: total 0/);
+		assert.match(
+			report,
+			new RegExp(
+				`- agents: warning — ${skippedPath}: invalid YAML frontmatter \\(Nested mappings are not allowed\\); file skipped`,
+			),
+		);
+	});
+
+	test("doctor reports no warnings when every file parses", () => {
+		const { config, state } = doctorState();
+		const report = buildDoctorReport({
+			cwd: tmpdir(),
+			config,
+			state,
+			paths: { tempRootDir: tmpdir() },
+			deps: {
+				discoverAgentsAll: () =>
+					({
+						builtin: [],
+						user: [],
+						project: [],
+						userDir: join(tmpdir(), "agents"),
+						projectDir: null,
+						userSettingsPath: join(tmpdir(), "settings.json"),
+						projectSettingsPath: null,
+						diagnostics: [],
+					}) as ReturnType<typeof discoverAgentsAll>,
+				discoverAvailableSkills: () => [],
+				diagnoseIntercomBridge: () => ({
+					active: false,
+					mode: "off",
+					wantsIntercom: false,
+					piIntercomAvailable: false,
+					extensionDir: join(tmpdir(), "extensions", "intercom"),
+					orchestratorTarget: undefined,
+					reason: "disabled",
+				}),
+			},
+		});
+
+		assert.doesNotMatch(report, /agents: warning/);
+	});
+});

--- a/test/unit/subagents-invalid-yaml-diagnostics.test.ts
+++ b/test/unit/subagents-invalid-yaml-diagnostics.test.ts
@@ -116,11 +116,13 @@ describe("invalid-YAML agent files produce load diagnostics", () => {
 		});
 
 		assert.match(report, /- agents: total 0/);
-		assert.match(
-			report,
-			new RegExp(
-				`- agents: warning — ${skippedPath}: invalid YAML frontmatter \\(Nested mappings are not allowed\\); file skipped`,
+		// The path is data, not a pattern: on Windows it contains backslashes, which a
+		// RegExp reads as escapes and which therefore never match the reported line.
+		assert.ok(
+			report.includes(
+				`- agents: warning — ${skippedPath}: invalid YAML frontmatter (Nested mappings are not allowed); file skipped`,
 			),
+			report,
 		);
 	});
 

--- a/test/unit/subagents-parent-config-inheritance.test.ts
+++ b/test/unit/subagents-parent-config-inheritance.test.ts
@@ -13,7 +13,9 @@
  * of its own started on the child's settings default instead of the
  * dispatching session's level. The fix threads `currentThinkingLevel` through
  * `RunSyncOptions` and applies it under the same condition upstream uses:
- * only when neither the agent's frontmatter nor the caller named a model.
+ * only when nothing the agent configured names a model — no frontmatter
+ * `model`, no `fallbackModels` (whose chain outranks the parent's model in
+ * `buildModelCandidates`), and no per-call override.
  *
  * Tool configuration is pinned too: an agent that omits `tools` must leave
  * the child's spec without an allowlist so `createAgentSession` keeps its
@@ -197,6 +199,22 @@ describe("subagent inherits the dispatching session's configuration", () => {
 		assert.deepEqual(spec.model, configuredModel);
 		// Upstream gates inheritance on `!agent.model`; a child dispatched onto
 		// a different model keeps that model's own thinking configuration.
+		assert.equal(spec.thinkingLevel, undefined);
+	});
+
+	test("an agent whose fallback chain selects its own model does not inherit the thinking level", async () => {
+		const { spec, candidate } = await dispatchAndCapture({
+			agent: agentConfig({ fallbackModels: [CONFIGURED_MODEL_ID] }),
+			thinking: PARENT_THINKING_LEVEL,
+		});
+
+		// `buildModelCandidates` orders [primary, ...fallbacks, parent], so an
+		// agent with fallbackModels and no primary runs on its own first
+		// fallback — the parent's model is never selected. The child therefore
+		// keeps its own thinking configuration: leaking the parent's level
+		// here is the same defect as leaking it for a declared `model`.
+		assert.equal(candidate.modelId, CONFIGURED_MODEL_ID);
+		assert.deepEqual(spec.model, configuredModel);
 		assert.equal(spec.thinkingLevel, undefined);
 	});
 

--- a/test/unit/subagents-parent-config-inheritance.test.ts
+++ b/test/unit/subagents-parent-config-inheritance.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Pi 0.84.2 parity audit (upstream e3798ca9, "inherit subagent session
+ * config", #7897): a subagent dispatched by a session runs, unless its own
+ * definition says otherwise, on that session's model, thinking level, and
+ * tool configuration. Atomic ships `@bastani/subagents` instead of upstream's
+ * example extension, so the parity claims are pinned here against Atomic's
+ * own dispatch seam.
+ *
+ * Model inheritance was already structural — the parent's model is the
+ * trailing candidate in `buildModelCandidates` — but the parent's thinking
+ * level never reached the child spec: `spec.thinkingLevel` fell back from the
+ * candidate suffix straight to `agent.thinking`, so an agent without a model
+ * of its own started on the child's settings default instead of the
+ * dispatching session's level. The fix threads `currentThinkingLevel` through
+ * `RunSyncOptions` and applies it under the same condition upstream uses:
+ * only when neither the agent's frontmatter nor the caller named a model.
+ *
+ * Tool configuration is pinned too: an agent that omits `tools` must leave
+ * the child's spec without an allowlist so `createAgentSession` keeps its
+ * default tool set (upstream's no-`--tools` child), while an agent that
+ * declares `tools` produces exactly that allowlist.
+ *
+ * The assertions sit on the `ChildSpec` handed to `startAttempt` — the last
+ * value shaped by dispatch before the runner builds the child session.
+ */
+
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Api, Model } from "@earendil-works/pi-ai/compat";
+import { afterAll, describe, test, vi } from "vitest";
+import type { AgentConfig } from "../../packages/subagents/src/agents/agent-types.ts";
+import type { AttemptOutcome, ChildSpec, ModelCandidate } from "../../packages/subagents/src/runs/inprocess/runner.ts";
+import { createCandidateModelResolver } from "../../packages/subagents/src/shared/model-resolution.ts";
+
+const harness = vi.hoisted(() => ({
+	attempts: [] as { spec: unknown; candidate: unknown }[],
+}));
+
+/**
+ * The natives-backed control plane is reduced to the four calls
+ * `runSingleInProcess` makes around one attempt; the double records the
+ * attempt inputs and returns a settled outcome.
+ */
+vi.mock("../../packages/subagents/src/runs/inprocess/control-registry.ts", () => {
+	const outcome = {
+		status: "ok" as const,
+		output: "done",
+		envelope: "done",
+		path: "child/0",
+		stats: {
+			sessionFile: undefined,
+			sessionId: "test-session",
+			userMessages: 1,
+			assistantMessages: 1,
+			toolCalls: 0,
+			toolResults: 0,
+			totalMessages: 2,
+			tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			cost: 0,
+		},
+	};
+	const control = {
+		registerAgents: () => undefined,
+		admitChildSession: (spec: unknown) => ({
+			admitted: {
+				identity: { path: "child/0", depth: 1 },
+				spec,
+				policy: { cwd: "" },
+				sessionDir: "",
+			},
+		}),
+		startAttempt: (admitted: { spec: unknown }, candidate: unknown) => {
+			harness.attempts.push({ spec: admitted.spec, candidate });
+			return {
+				status: "running",
+				promise: Promise.resolve(outcome as AttemptOutcome),
+			};
+		},
+		registerNestedAttempt: () => undefined,
+		continueDetached: () => undefined,
+		deliverChildResult: async () => undefined,
+		getDeliveredResult: () => undefined,
+	};
+	return { getOrCreateSubagentControl: () => control };
+});
+
+const { runSingleInProcess } = await import("../../packages/subagents/src/runs/foreground/inprocess-run-sync.ts");
+
+const PARENT_MODEL_ID = "anthropic/claude-fable-5";
+const CONFIGURED_MODEL_ID = "openai-codex/gpt-5.6-luna";
+const PARENT_THINKING_LEVEL = "high";
+
+function model(provider: string, id: string): Model<Api> {
+	return {
+		id,
+		name: id,
+		api: "openai-completions",
+		provider,
+		baseUrl: `https://example.invalid/${provider}`,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 64_000,
+	};
+}
+
+const configuredModel = model("openai-codex", "gpt-5.6-luna");
+const parentModel = model("anthropic", "claude-fable-5");
+
+/** Stands in for `ctx.modelRegistry`, with both providers authenticated. */
+const registry = {
+	getAvailable: () => [configuredModel, parentModel],
+	find: (provider: string, id: string) =>
+		[configuredModel, parentModel].find((entry) => entry.provider === provider && entry.id === id),
+	hasConfiguredAuth: () => true,
+};
+
+const roots: string[] = [];
+
+function makeCwd(): string {
+	const cwd = mkdtempSync(join(tmpdir(), "subagent-inherit-"));
+	roots.push(cwd);
+	return cwd;
+}
+
+function agentConfig(overrides: Partial<AgentConfig>): AgentConfig {
+	return {
+		name: "worker",
+		description: "worker",
+		systemPromptMode: "append",
+		inheritProjectContext: true,
+		inheritSkills: true,
+		systemPrompt: "worker",
+		source: "user",
+		filePath: "/tmp/worker.md",
+		...overrides,
+	} as AgentConfig;
+}
+
+async function dispatchAndCapture(options: {
+	agent: AgentConfig;
+	modelOverride?: string;
+	thinking?: string;
+}): Promise<{ spec: ChildSpec; candidate: ModelCandidate }> {
+	harness.attempts.length = 0;
+	const cwd = makeCwd();
+	await runSingleInProcess(cwd, options.agent, "do the thing", {
+		cwd,
+		runId: "run-1",
+		testSession: { output: "done" },
+		availableModels: [
+			{ provider: "openai-codex", id: "gpt-5.6-luna", fullId: CONFIGURED_MODEL_ID },
+			{ provider: "anthropic", id: "claude-fable-5", fullId: PARENT_MODEL_ID },
+		],
+		knownModelProviders: ["openai-codex", "anthropic"],
+		preferredModelProvider: "anthropic",
+		currentModel: PARENT_MODEL_ID,
+		...(options.thinking === undefined ? {} : { currentThinkingLevel: options.thinking }),
+		...(options.modelOverride === undefined ? {} : { modelOverride: options.modelOverride }),
+		resolveCandidateModel: createCandidateModelResolver(registry, "anthropic"),
+	});
+	assert.equal(harness.attempts.length, 1, "exactly one attempt should start");
+	const captured = harness.attempts[0]!;
+	return { spec: captured.spec as ChildSpec, candidate: captured.candidate as ModelCandidate };
+}
+
+afterAll(() => {
+	for (const root of roots) rmSync(root, { recursive: true, force: true });
+});
+
+describe("subagent inherits the dispatching session's configuration", () => {
+	test("an agent without a model inherits the parent session's model and thinking level", async () => {
+		const { spec, candidate } = await dispatchAndCapture({
+			agent: agentConfig({}),
+			thinking: PARENT_THINKING_LEVEL,
+		});
+
+		// The parent's model is the inherited candidate and reaches the child
+		// session as a resolved Model, not just a candidate string.
+		assert.equal(candidate.modelId, PARENT_MODEL_ID);
+		assert.deepEqual(candidate.model, parentModel);
+		assert.deepEqual(spec.model, parentModel);
+		// The parent's active thinking level rides along with the inherited
+		// model, exactly as upstream's dispatchDefaults does.
+		assert.equal(spec.thinkingLevel, PARENT_THINKING_LEVEL);
+	});
+
+	test("an agent that pins its own model does not inherit the parent's thinking level", async () => {
+		const { spec } = await dispatchAndCapture({
+			agent: agentConfig({ model: CONFIGURED_MODEL_ID }),
+			thinking: PARENT_THINKING_LEVEL,
+		});
+
+		assert.deepEqual(spec.model, configuredModel);
+		// Upstream gates inheritance on `!agent.model`; a child dispatched onto
+		// a different model keeps that model's own thinking configuration.
+		assert.equal(spec.thinkingLevel, undefined);
+	});
+
+	test("the agent's declared thinking wins over the inherited level", async () => {
+		const { spec } = await dispatchAndCapture({
+			agent: agentConfig({ thinking: "low" }),
+			thinking: PARENT_THINKING_LEVEL,
+		});
+
+		assert.equal(spec.thinkingLevel, "low");
+	});
+
+	test("a caller-supplied model override blocks thinking-level inheritance", async () => {
+		const { spec } = await dispatchAndCapture({
+			agent: agentConfig({}),
+			modelOverride: CONFIGURED_MODEL_ID,
+			thinking: PARENT_THINKING_LEVEL,
+		});
+
+		assert.deepEqual(spec.model, configuredModel);
+		// An explicit per-call model is a pinned model: no dispatch-config
+		// inheritance applies.
+		assert.equal(spec.thinkingLevel, undefined);
+	});
+
+	test("an agent that omits tools leaves the child on the default tool configuration", async () => {
+		const { spec } = await dispatchAndCapture({ agent: agentConfig({}) });
+
+		// `tools: undefined` is what `createAgentSession` maps to the default
+		// tool set; an empty array here would mean a child with no tools.
+		assert.equal(spec.tools, undefined);
+	});
+
+	test("an agent that declares tools produces exactly that allowlist", async () => {
+		const { spec } = await dispatchAndCapture({ agent: agentConfig({ tools: ["read", "bash"] }) });
+
+		assert.deepEqual(spec.tools, ["read", "bash"]);
+	});
+});


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789438597&installation_model_id=10562&pr_number=2436&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2436&signature=f4db1f7686ccc60fcf116d86be4f78e1175c496013059f2222a4f3d2f8f3a421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds YAML-backed subagent frontmatter parsing, diagnostics for skipped agent files, preservation of typed custom fields, array-form tools, and parent thinking-level inheritance. A reproduced management flow shows that YAML-sensitive descriptions can be saved into invalid frontmatter and then cause the agent to be skipped during discovery. Source-convention and release-note requirements also need to be completed before merge.

<h3>Confidence Score: 4/5</h3>

Not ready to merge until agent descriptions are serialized as YAML-safe values and the required repository convention and release-note updates are addressed.

The description failure was reproduced through the real create, serialization, parsing, and discovery flow, including the parser diagnostic and skipped agent. The remaining findings are explicit repository-rule requirements.

**Files Needing Attention:** `packages/subagents/src/agents/agent-serializer.ts` needs YAML-safe description serialization. `packages/subagents/src/agents/frontmatter.ts`, related imports, and `packages/subagents/CHANGELOG.md` need the required convention and documentation updates.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding.
- The agent reproduction script and its output were captured as artifacts to support the P1 finding and enable review.
- General-contract-validation-proof confirmed the repro path, showing the description is emitted without YAML escaping and that the repro assertions exited with code 0.

<a href="https://app.greptile.com/trex/runs/19084914/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `packages/subagents/src/agents/agent-serializer.ts`, line 64 ([link](https://github.com/bastani-inc/atomic/blob/fc0dadb938d6eeaf06b0cc03ec27298ca79eb3b5/packages/subagents/src/agents/agent-serializer.ts#L64)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Unescaped description breaks discovery**

   When agent management creates or updates a description containing YAML-significant text such as `Deploy: fast`, `serializeAgent` emits it as an unquoted scalar. The strict parser then rejects the generated frontmatter and discovery skips the agent entirely.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Agent description colon repro script](https://app.greptile.com/trex/artifacts/21145f76-a516-4535-bd48-b7d42a3db582)**

   - This authored Bun script invokes the real management, serialization, parsing, and discovery path with the YAML-sensitive description; it is the executable reproduction.

   **[Agent description colon repro output](https://app.greptile.com/trex/artifacts/eb0813bb-2e0f-402c-bab7-2cf43fcae869)**

   - Captured output from \`bun trex-artifacts/agent-description-colon-repro.ts\` in \`/home/user/repo\`; it shows the invalid serialized line, strict-parser error, one diagnostic, missing agent, passing assertions, and exit code 0, confirming the bug.

   <a href="https://app.greptile.com/trex/runs/19084914/artifacts?artifact=21145f76-a516-4535-bd48-b7d42a3db582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/subagents/src/agents/agent-serializer.ts
   Line: 64

   Comment:
   **Unescaped description breaks discovery**

   When agent management creates or updates a description containing YAML-significant text such as `Deploy: fast`, `serializeAgent` emits it as an unquoted scalar. The strict parser then rejects the generated frontmatter and discovery skips the agent entirely.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>


2. `packages/subagents/README.md`, line 350-356 ([link](https://github.com/bastani-inc/atomic/blob/fc0dadb938d6eeaf06b0cc03ec27298ca79eb3b5/packages/subagents/README.md#L350-L356)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Shipped changes lack release notes**

   This PR adds user-visible YAML parsing, diagnostics, array-form tools, and parent thinking inheritance without an entry in `packages/subagents/CHANGELOG.md`. Add these shipped behavior changes under the package's Unreleased section so users receive migration and feature guidance.

   **Context Used:** AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: packages/subagents/README.md
   Line: 350-356
   
   Comment:
   **Shipped changes lack release notes**
   
   This PR adds user-visible YAML parsing, diagnostics, array-form tools, and parent thinking inheritance without an entry in `packages/subagents/CHANGELOG.md`. Add these shipped behavior changes under the package's Unreleased section so users receive migration and feature guidance.
   
   **Context Used:** AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

3. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Colon-space agent descriptions are serialized as invalid YAML and skipped by discovery**

   - **Bug**
     - Managing an agent with description `Deploy: fast` writes an invalid frontmatter line (`description: Deploy: fast`). The strict frontmatter parser rejects it, and discovery skips the otherwise successfully created agent.
   - **Cause**
     - `serializeAgent` interpolates the description directly at `packages/subagents/src/agents/agent-serializer.ts:64` rather than emitting it through a YAML serializer or otherwise quoting YAML-sensitive scalar values.
   - **Fix**
     - Serialize `description` with the YAML emitter (or an equivalent YAML-safe scalar encoder), then add a regression test covering a description containing `: ` through management and discovery.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/subagents/src/agents/agent-serializer.ts:64
**Unescaped description breaks discovery**

When agent management creates or updates a description containing YAML-significant text such as `Deploy: fast`, `serializeAgent` emits it as an unquoted scalar. The strict parser then rejects the generated frontmatter and discovery skips the agent entirely.

### Issue 2
packages/subagents/src/agents/frontmatter.ts:16-18
**New code violates source conventions**

The new parser introduces ambiguous `unknown` types, while related new imports in `agent-types.ts` and `agent-serializer.ts` use `.ts` specifiers. Replace these with specific types and the repository-required `.js` TypeScript ESM specifiers so this implementation follows the source conventions.

### Issue 3
packages/subagents/README.md:350-356
**Shipped changes lack release notes**

This PR adds user-visible YAML parsing, diagnostics, array-form tools, and parent thinking inheritance without an entry in `packages/subagents/CHANGELOG.md`. Add these shipped behavior changes under the package's Unreleased section so users receive migration and feature guidance.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(subagents): compare the doctor&#39;s sk..."](https://github.com/bastani-inc/atomic/commit/fc0dadb938d6eeaf06b0cc03ec27298ca79eb3b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53723786)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->