### PR TITLE
fix(core): distinguish never-named sessions from named-then-cleared

### DIFF
--- a/packages/coding-agent/docs/session-format.md
+++ b/packages/coding-agent/docs/session-format.md
@@ -307,6 +307,8 @@ Session metadata (e.g., user-defined display name). Set via `/name`, `--name` / 
 
 The session name is displayed in the session selector (`/resume`) instead of the first message when set.
 
+Appending a `session_info` entry with an empty `name` clears the title. The distinction is durable: a cleared session keeps its trailing empty-name entry, while a never-named session has no `session_info` entry at all. Readers can tell them apart through `getSessionNameState()` (`{ hasName: false }` for never-named, `{ hasName: true }` for cleared) and through the `hasName` flag on listed `SessionInfo` rows; the bare `name` string is `undefined` in both cases.
+
 ### SessionSummaryEntry
 
 A generated one-line description of the session, written automatically once the agent goes idle and shown in the session selector. Never sent to the LLM.
@@ -433,7 +435,7 @@ for (const stage of stages.filter((session) => session.internal)) {
 - `appendModelChange(provider, modelId)` - Record model change
 - `appendCompaction(compactedText, firstKeptEntryId, tokensBefore, details)` - Add a durable verbatim-line compaction boundary; pass `null` when no pre-boundary message is retained
 - `appendCustomEntry(customType, data?)` - Extension state (not in context)
-- `appendSessionInfo(name)` - Set session display name
+- `appendSessionInfo(name)` - Set session display name; an empty string clears it
 - `appendSessionSummary(summary, summarizedThroughId, usage?)` - Store a generated resume-picker summary, anchored to the message it describes
 - `appendCustomMessageEntry(customType, content, display, details?)` - Extension message (in context)
 - `appendLabelChange(targetId, label)` - Set/clear label
@@ -454,7 +456,8 @@ for (const stage of stages.filter((session) => session.internal)) {
 - `buildSessionContext()` - Get messages, thinkingLevel, and model for LLM
 - `getEntries()` - All entries (excluding header)
 - `getHeader()` - Session header metadata
-- `getSessionName()` - Get display name from latest session_info entry
+- `getSessionName()` - Get display name from latest session_info entry (`undefined` when cleared or never named)
+- `getSessionNameState()` - Get the name state: `{ hasName: false }` when never named, `{ hasName: true }` when the latest entry cleared it, `{ hasName: true, name }` when currently named
 - `getCwd()` - Working directory
 - `getSessionDir()` - Session storage directory
 - `getSessionId()` - Session UUID

--- a/packages/coding-agent/src/core/session-manager-core.ts
+++ b/packages/coding-agent/src/core/session-manager-core.ts
@@ -43,6 +43,7 @@ import type {
 	SessionHeader,
 	SessionInfo,
 	SessionListProgress,
+	SessionNameState,
 	SessionTreeNode,
 	SessionWorkflowMetadata,
 } from "./session-manager-types.ts";
@@ -296,6 +297,15 @@ export class SessionManager {
 
 	/** Get the current session name from the latest session_info entry, if any. */
 	getSessionName(): string | undefined {
+		return this.getSessionNameState().name;
+	}
+
+	/**
+	 * Get the session name state. `hasName` is true for a session that was named and
+	 * then cleared even though `name` is undefined; a never-named session reports
+	 * `hasName: false`. Read-side only: the JSONL already records the distinction.
+	 */
+	getSessionNameState(): SessionNameState {
 		return getLatestSessionName(this.getEntries());
 	}
 

--- a/packages/coding-agent/src/core/session-manager-entries.ts
+++ b/packages/coding-agent/src/core/session-manager-entries.ts
@@ -17,6 +17,7 @@ import {
 	type SessionHeader,
 	type SessionInfoEntry,
 	type SessionMessageEntry,
+	type SessionNameState,
 	type SessionSummaryEntry,
 	type SessionWorkflowMetadata,
 	type ThinkingLevelChangeEntry,
@@ -199,16 +200,18 @@ export function getLatestSessionSummary(entries: FileEntry[]): SessionSummaryEnt
 	return undefined;
 }
 
-export function getLatestSessionName(entries: SessionEntry[]): string | undefined {
-	// Walk entries in reverse to find the latest session_info entry.
-	// Empty names explicitly clear the session title.
+export function getLatestSessionName(entries: SessionEntry[]): SessionNameState {
+	// Walk entries in reverse to find the latest session_info entry. An existing entry
+	// with an empty name is an explicit clear, not a never-named session: the fact that
+	// a session was named is separate from the name it currently holds (upstream 7bdb16c2).
 	for (let i = entries.length - 1; i >= 0; i--) {
 		const entry = entries[i];
 		if (entry.type === "session_info") {
-			return entry.name?.trim() || undefined;
+			const name = entry.name?.trim() || undefined;
+			return { hasName: true, ...(name !== undefined ? { name } : {}) };
 		}
 	}
-	return undefined;
+	return { hasName: false };
 }
 
 export function createCustomMessageEntry<T = unknown>(

--- a/packages/coding-agent/src/core/session-manager-list.ts
+++ b/packages/coding-agent/src/core/session-manager-list.ts
@@ -156,12 +156,15 @@ async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
 		let firstMessage = "";
 		const allMessages: string[] = [];
 		let name: string | undefined;
+		let hasName = false;
 
 		for (const entry of entries) {
-			// Extract session name (use latest, including explicit clears)
+			// Extract session name state (use latest, including explicit clears:
+			// a latest empty name means cleared, no session_info entry means never named)
 			if (entry.type === "session_info") {
 				const infoEntry = entry as SessionInfoEntry;
 				name = infoEntry.name?.trim() || undefined;
+				hasName = true;
 			}
 
 			if (entry.type !== "message") continue;
@@ -202,6 +205,7 @@ async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
 			id: (header as SessionHeader).id,
 			cwd,
 			name,
+			...(hasName ? { hasName: true } : {}),
 			parentSessionPath,
 			...(internal ? { internal } : {}),
 			...(workflow ? { workflow } : {}),

--- a/packages/coding-agent/src/core/session-manager-types.ts
+++ b/packages/coding-agent/src/core/session-manager-types.ts
@@ -135,6 +135,25 @@ export interface SessionInfoEntry extends SessionEntryBase {
 	name?: string;
 }
 
+/**
+ * Session name read state, mirroring pi's has_session_name / session_name pair
+ * (upstream 7bdb16c2): the fact that a session was ever named is separate from the
+ * name it currently holds. The distinction is already durable in the JSONL — a clear
+ * appends a `session_info` entry with an empty name, a never-named session has none —
+ * so this is a read-side shape, not a storage change.
+ *
+ * - `{ hasName: false }` — no `session_info` entry exists; the session was never named.
+ * - `{ hasName: true }` — the latest `session_info` entry has an empty name; the session
+ *   was named and then cleared.
+ * - `{ hasName: true, name: "…" }` — the session currently holds this name.
+ */
+export interface SessionNameState {
+	/** True when a `session_info` entry exists, even if its latest name is empty (cleared). */
+	hasName: boolean;
+	/** Current name. Undefined for both a cleared and a never-named session. */
+	name?: string;
+}
+
 /** Session summary metadata entry. */
 export interface SessionSummaryEntry extends SessionEntryBase {
 	type: "session_summary";
@@ -211,8 +230,13 @@ export interface SessionInfo {
 	id: string;
 	/** Working directory where the session was started. Empty string for old sessions. */
 	cwd: string;
-	/** User-defined display name from session_info entries. */
+	/**
+	 * User-defined display name from session_info entries. Undefined both for a
+	 * never-named session and for one whose name was cleared; `hasName` separates them.
+	 */
 	name?: string;
+	/** True when a session_info entry exists, even if the name was later cleared. */
+	hasName?: boolean;
 	/** Path to the parent session (if this session was forked). */
 	parentSessionPath?: string;
 	/** True when this session was created by automated machinery (e.g. a workflow stage). */
@@ -248,4 +272,5 @@ export type ReadonlySessionManager = Pick<
 	| "getEntries"
 	| "getTree"
 	| "getSessionName"
+	| "getSessionNameState"
 >;

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -29,6 +29,7 @@ export type {
 	SessionInfoEntry,
 	SessionListProgress,
 	SessionMessageEntry,
+	SessionNameState,
 	SessionTreeNode,
 	SessionWorkflowMetadata,
 	ThinkingLevelChangeEntry,

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -238,6 +238,7 @@ export {
 	type SessionInfoEntry,
 	SessionManager,
 	type SessionMessageEntry,
+	type SessionNameState,
 	type SessionTreeNode,
 	type SessionWorkflowMetadata,
 	sessionEntryToContextMessages,

--- a/packages/coding-agent/src/modes/interactive/components/session-selector-search.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector-search.ts
@@ -27,6 +27,10 @@ function getSessionSearchText(session: SessionInfo): string {
 	return `${session.id} ${session.name ?? ""} ${session.summary ?? ""} ${session.allMessagesText} ${session.cwd}`;
 }
 
+/**
+ * True while the session currently holds a non-empty name. A name that was cleared
+ * (`hasName` true, `name` undefined) filters as unnamed: the picker has no title to show.
+ */
 export function hasSessionName(session: SessionInfo): boolean {
 	return Boolean(session.name?.trim());
 }

--- a/packages/coding-agent/src/server/create-harness.ts
+++ b/packages/coding-agent/src/server/create-harness.ts
@@ -273,6 +273,7 @@ function createHarnessSessionManager(metadataId: string, sessionFile: string | u
 		getEntries: () => unsupportedHarnessOperation("sessionManager.getEntries()"),
 		getTree: () => unsupportedHarnessOperation("sessionManager.getTree()"),
 		getSessionName: () => unsupportedHarnessOperation("sessionManager.getSessionName()"),
+		getSessionNameState: () => unsupportedHarnessOperation("sessionManager.getSessionNameState()"),
 	};
 }
 

--- a/packages/coding-agent/test/pi-0.84.2-session-name-state.test.ts
+++ b/packages/coding-agent/test/pi-0.84.2-session-name-state.test.ts
@@ -1,0 +1,162 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type SessionHeader, SessionManager } from "../src/core/session-manager.ts";
+
+/**
+ * Upstream 7bdb16c2 gave pi's storage a has_session_name / session_name pair so a cleared
+ * name stops reading as "never named". Atomic's JSONL already records the distinction — a
+ * clear appends a `session_info` entry with `name: ""`, a never-named session has none —
+ * so this layer surfaces it at the read side only: `getLatestSessionName` returns a name
+ * state and the `SessionInfo` list reducer keeps `hasName` alongside `name`.
+ */
+describe("pi 0.84.2 session name state", () => {
+	let dir: string;
+	const cwd = "/project";
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "session-name-state-"));
+	});
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	function writeSessionFile(id: string, lines: string[]): string {
+		const header: SessionHeader = {
+			type: "session",
+			version: 3,
+			id,
+			timestamp: "2025-01-01T00:00:00Z",
+			cwd,
+		};
+		const path = join(dir, `${header.timestamp.replace(/[:.]/g, "-")}_${id}.jsonl`);
+		writeFileSync(path, `${JSON.stringify(header)}\n${lines.join("\n")}\n`);
+		return path;
+	}
+
+	function userMessage(id: string, parentId: string | null, text: string): string {
+		return JSON.stringify({
+			type: "message",
+			id,
+			parentId,
+			timestamp: "2025-01-01T00:00:01Z",
+			message: { role: "user", content: text, timestamp: 1 },
+		});
+	}
+
+	function sessionInfo(id: string, parentId: string | null, name: string): string {
+		return JSON.stringify({
+			type: "session_info",
+			id,
+			parentId,
+			timestamp: "2025-01-01T00:00:02Z",
+			name,
+		});
+	}
+
+	it("cleared-session-name-differs-from-never-named", async () => {
+		const clearedPath = writeSessionFile("cleared", [
+			userMessage("m1", null, "chase the flaky test"),
+			sessionInfo("n1", "m1", "Bug hunt"),
+			sessionInfo("n2", "n1", ""),
+		]);
+		const neverPath = writeSessionFile("never", [userMessage("m1", null, "chase the flaky test")]);
+
+		// The list reducer keeps the distinction per session_info presence.
+		const sessions = await SessionManager.list(cwd, dir);
+		const cleared = sessions.find((s) => s.id === "cleared");
+		const never = sessions.find((s) => s.id === "never");
+		expect(cleared).toBeDefined();
+		expect(never).toBeDefined();
+		expect(cleared?.name).toBeUndefined();
+		expect(cleared?.hasName).toBe(true);
+		expect(never?.name).toBeUndefined();
+		expect(never?.hasName).toBeFalsy();
+
+		// Opening the same files reports the same states through SessionManager.
+		const clearedSession = SessionManager.open(clearedPath);
+		expect(clearedSession.getSessionNameState()).toEqual({ hasName: true });
+		const neverSession = SessionManager.open(neverPath);
+		expect(neverSession.getSessionNameState()).toEqual({ hasName: false });
+
+		// The bare-string surface is unchanged: both still read as nameless.
+		expect(clearedSession.getSessionName()).toBeUndefined();
+		expect(neverSession.getSessionName()).toBeUndefined();
+	});
+
+	it("reports the latest name while the session stays named", async () => {
+		const path = writeSessionFile("named", [
+			userMessage("m1", null, "chase the flaky test"),
+			sessionInfo("n1", "m1", "First title"),
+			sessionInfo("n2", "n1", "Second title"),
+		]);
+
+		const sessions = await SessionManager.list(cwd, dir);
+		expect(sessions.find((s) => s.id === "named")).toMatchObject({
+			name: "Second title",
+			hasName: true,
+		});
+
+		const session = SessionManager.open(path);
+		expect(session.getSessionNameState()).toEqual({ hasName: true, name: "Second title" });
+		expect(session.getSessionName()).toBe("Second title");
+	});
+
+	it("treats a whitespace-only latest name as a clear", () => {
+		const path = writeSessionFile("blank", [
+			userMessage("m1", null, "chase the flaky test"),
+			sessionInfo("n1", "m1", "Bug hunt"),
+			sessionInfo("n2", "n1", "   "),
+		]);
+
+		expect(SessionManager.open(path).getSessionNameState()).toEqual({ hasName: true });
+	});
+
+	it("keeps the distinction across the live name and clear path", () => {
+		const session = SessionManager.inMemory(cwd);
+		expect(session.getSessionNameState()).toEqual({ hasName: false });
+
+		session.appendSessionInfo("Sprint");
+		expect(session.getSessionNameState()).toEqual({ hasName: true, name: "Sprint" });
+
+		session.appendSessionInfo("");
+		expect(session.getSessionNameState()).toEqual({ hasName: true });
+		expect(session.getSessionName()).toBeUndefined();
+	});
+
+	it("still writes a clear as a session_info entry with an empty name", () => {
+		const session = SessionManager.create(cwd, dir);
+		session.appendMessage({ role: "user", content: "name this session", timestamp: 1 });
+		session.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "done" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "test",
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: 2,
+		});
+		session.appendSessionInfo("Sprint");
+		session.appendSessionInfo("");
+		session.flush();
+
+		// The storage format is unchanged: a clear is a session_info entry with name "".
+		const file = session.getSessionFile();
+		expect(file).toBeDefined();
+		const infoEntries = readFileSync(file!, "utf8")
+			.trim()
+			.split("\n")
+			.map((line) => JSON.parse(line) as { type: string; name?: string })
+			.filter((entry) => entry.type === "session_info");
+		expect(infoEntries.map((entry) => entry.name)).toEqual(["Sprint", ""]);
+	});
+});


### PR DESCRIPTION
Upstream 7bdb16c2 gave pi's storage a has_session_name / session_name
pair so a cleared title stops reading as "never named" (spec §5.6
gap 7). Atomic's JSONL already records the distinction durably — a
clear appends a session_info entry with name "", a never-named session
has none — but both readers collapsed it: getLatestSessionName reduced
everything to string | undefined with `|| undefined`, and the
SessionInfo list reducer did the same, so no read surface could tell
the two states apart.

Read-side only; no storage change, no migration, and the SQLite
session backend is not adopted:

- SessionNameState ({ hasName, name? }) mirrors pi's pair and is
  exported from the package index alongside SessionInfo.
- getLatestSessionName returns the state; SessionManager.getSessionName
  keeps its bare-string contract via .name, and the new
  getSessionNameState() exposes the state (also picked into
  ReadonlySessionManager, with the matching create-harness stub).
- The SessionInfo list reducer records hasName alongside name.
- The picker's named filter still filters on the current name; its
  hasSessionName helper now documents that a cleared name filters as
  unnamed.

Named regression cleared-session-name-differs-from-never-named runs
against hand-written existing-shape session files and asserts both
readers (list reducer and SessionManager.open) keep the states apart,
that the bare-string surface is unchanged, and that the live name/clear
path still writes the clear as name "". docs/session-format.md
documents the durable distinction and the new reader.

Assistant-model: Claude Opus 5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789440732&installation_model_id=10562&pr_number=2437&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2437&signature=a6e8d3e1f61498e25356e4f8f4ac436cb51bd2391f916f3f8eb58d7b626f2522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change exposes whether a session was never named or was named and later cleared, while retaining the existing bare-string session-name behavior. The new regression coverage and public API need to follow the repository’s required assertion and release-note conventions.

<h3>Confidence Score: 4/5</h3>

The session-name state behavior is narrowly scoped and preserves the existing bare-string API, but the required test and release-note conventions still need attention.

There is one non-security P2 finding. Under the scoring policy, a nonempty set containing only P2 findings receives a score of 4.

**Files Needing Attention:** packages/coding-agent/test/pi-0.84.2-session-name-state.test.ts and packages/coding-agent/CHANGELOG.md

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/test/pi-0.84.2-session-name-state.test.ts:4
**Test style and release notes**

The new regression suite uses Vitest's `expect` API instead of the required `node:assert/strict` assertion style, while the newly exported `SessionNameState` API and user-visible fix also lack the required coding-agent changelog entry. This leaves the test inconsistent with repository conventions and the shipped behavior absent from release notes.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(core): distinguish never-named sessi..."](https://github.com/bastani-inc/atomic/commit/afcceac5746477ca158dd43fca373ee0c85a248d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53723790)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->