### PR TITLE
fix(evals): stop Harbor crashing on a corrupt agent transcript

### DIFF
--- a/evals/atomic_harbor.py
+++ b/evals/atomic_harbor.py
@@ -573,10 +573,6 @@ class Atomic(BaseInstalledAgent):
             output_text = output_file.read_bytes().decode("utf-8", errors="replace")
         except OSError:
             output_text = ""
-        if "\ufffd" in output_text:
-            self._malformed_jsonl_lines[str(output_file)] = (
-                self._malformed_jsonl_lines.get(str(output_file), 0) + 1
-            )
         for line in output_text.splitlines():
             line = line.strip()
             if not line:
@@ -584,10 +580,6 @@ class Atomic(BaseInstalledAgent):
             try:
                 event = json.loads(line)
             except json.JSONDecodeError:
-                if line.startswith(("{", "[")):
-                    self._malformed_jsonl_lines[str(output_file)] = (
-                        self._malformed_jsonl_lines.get(str(output_file), 0) + 1
-                    )
                 continue
             if not isinstance(event, dict) or event.get("type") != "message_end":
                 continue


### PR DESCRIPTION
Greptile P1 on #2414, raised after that PR merged.

Removing the status layer took out `_malformed_jsonl_lines`' initializer and its session-file writers, but left two writers on the `atomic.txt` path. A transcript with invalid UTF-8 or a malformed JSON line raised `AttributeError` inside `populate_context_post_run`, losing the whole result context for that trial.

Nothing reads that counter any more, so both writers go.

## Verified

Against a transcript carrying both faults (invalid UTF-8 byte plus a non-JSON line):

- before: `AttributeError: 'Atomic' object has no attribute '_malformed_jsonl_lines'`
- after: post-run completes on Harbor **and** Pier

Also swept both adapters for attributes read but never assigned: only `_get_env`, which is inherited from the base agent.

Python-only diff, one file, -8 lines.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789444172&installation_model_id=10562&pr_number=2438&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2438&signature=78b534c3743b0ee95de4aed12c795efb29358c3fd68d5fe1d5a8bdbf596664d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change removes obsolete malformed-transcript counter writes from Harbor post-run context collection. A direct behavior check confirmed that invalid UTF-8 and malformed JSON lines in `atomic.txt` or copied session transcripts no longer interrupt context collection, while valid assistant usage events retain their token, cache, cost, and step accounting. No defects were found.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on direct execution of the affected context-collection behavior with corrupt and valid transcript inputs.

The exercised failure path now completes without an exception, and a valid `message_end` event retained the expected input, output, cache, cost, and agent-step values. No review comments remain.

**Files Needing Attention:** No files need further attention; `evals/atomic_harbor.py` was exercised directly.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran an executable harness against both the parent revision and the PR revision of Atomic.populate\_context\_post\_run.
- During the run, the parent revision produced an AttributeError for corrupt atomic.txt, while the PR revision completed without an exception and copied session transcript inputs, and the harness emitted a valid assistant message\_end event with input 112, output 20, cache 12, cost 1.27, and one agent step.
- Side-by-side context outputs were captured using the harness source; no repository-tracked code changes were made, and Harbor sandbox E2E could not be run due to missing setup documents and uninitialized eval submodules.

<a href="https://app.greptile.com/trex/runs/19077194/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): stop Harbor crashing on a co..."](https://github.com/bastani-inc/atomic/commit/57840811d690057a1cf45d8b92efd4788b0e59ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53710326)</sub>

<!-- /greptile_comment -->