### PR TITLE
feat(core): surface the Workers AI binding path for Cloudflare AI Gateway

### DIFF
--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -321,6 +321,94 @@ AI Gateway authentication uses `CLOUDFLARE_API_KEY` as `cf-aig-authorization`. U
 
 For normal Atomic usage, prefer unified billing or stored BYOK. Inline BYOK requires configuring an additional upstream `Authorization` header for the Cloudflare AI Gateway provider, for example via a `models.json` provider/model override.
 
+#### Workers AI binding (no API token)
+
+When Atomic's engine runs inside a Cloudflare Worker in the gateway's own account, requests can route through the [Workers AI binding](https://developers.cloudflare.com/ai-gateway/usage/workers-ai-binding/) (`env.AI`) instead of HTTPS. Binding calls are pre-authenticated in-account, so this path needs **no `CLOUDFLARE_API_KEY` at all**. Atomic re-exports the transport as `createGatewayBindingFetch` from `@bastani/atomic`.
+
+Declare the binding and the endpoint vars (the vars also satisfy the account/gateway resolution the gateway prefix needs):
+
+```toml
+# wrangler.toml
+[ai]
+binding = "AI"
+
+[vars]
+CLOUDFLARE_ACCOUNT_ID = "your-account-id"
+CLOUDFLARE_GATEWAY_ID = "your-gateway-slug"   # dash.cloudflare.com → AI → AI Gateway
+```
+
+Then register a provider override whose `streamSimple` swaps in the binding transport. The extension must be created where `env` is in scope — an inline extension factory passed to the resource loader does that:
+
+```typescript
+import {
+  CLOUDFLARE_GATEWAY_BINDING_AUTH_SENTINEL,
+  createAgentSession,
+  createGatewayBindingFetch,
+  DefaultResourceLoader,
+  type AiGatewayBinding,
+} from "@bastani/atomic";
+import { streamSimple as anthropicStreamSimple } from "@earendil-works/pi-ai/api/anthropic-messages";
+
+// `AI` is the Workers AI binding; `AiGatewayBinding` is the structural type for it,
+// so the snippet needs no `@cloudflare/workers-types` dependency.
+interface Env {
+  AI: AiGatewayBinding;
+  CLOUDFLARE_ACCOUNT_ID: string;
+  CLOUDFLARE_GATEWAY_ID: string;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const gatewayPrefix = `https://gateway.ai.cloudflare.com/v1/${env.CLOUDFLARE_ACCOUNT_ID}/${env.CLOUDFLARE_GATEWAY_ID}`;
+    const loader = new DefaultResourceLoader({
+      cwd: "/workspace",
+      agentDir: "/workspace/.atomic/agent",
+      extensionFactories: [
+        {
+          name: "cloudflare-gateway-binding",
+          factory: (pi) => {
+            pi.registerProvider("cloudflare-ai-gateway", {
+              // Placeholder credential: it marks the provider configured and becomes
+              // `cf-aig-authorization: Bearer cloudflare-gateway-binding`, which the
+              // transport strips before the binding call. Never sent to the gateway.
+              apiKey: CLOUDFLARE_GATEWAY_BINDING_AUTH_SENTINEL,
+              api: "anthropic-messages",
+              streamSimple: (model, context, options) =>
+                anthropicStreamSimple(
+                  {
+                    ...model,
+                    baseUrl: (model.baseUrl ?? gatewayPrefix)
+                      .replaceAll("{CLOUDFLARE_ACCOUNT_ID}", env.CLOUDFLARE_ACCOUNT_ID)
+                      .replaceAll("{CLOUDFLARE_GATEWAY_ID}", env.CLOUDFLARE_GATEWAY_ID)
+                  },
+                  context,
+                  {
+                    ...options,
+                    fetch: createGatewayBindingFetch({
+                      binding: env.AI,
+                      gateway: env.CLOUDFLARE_GATEWAY_ID,
+                      baseUrl: gatewayPrefix
+                    })
+                  }
+                )
+            });
+          }
+        }
+      ]
+    });
+
+    const { session } = await createAgentSession({
+      resourceLoader: loader
+      // Pass `model:` with a cloudflare-ai-gateway entry (e.g. claude-sonnet-4-5)
+      // resolved from your ModelRuntime, or leave it out to use the saved default.
+    });
+    // ...run the session and return a Response
+  }
+};
+```
+
+Every request under the gateway prefix becomes one `env.AI.gateway(id).run({ provider, endpoint, headers, query })` call in the provider's native wire format, so streaming behaves identically to the HTTPS route. The transport serves only its gateway-bound client: URLs outside the prefix, and in-prefix requests the universal endpoint cannot express (non-POST, non-JSON body), reject with a descriptive error rather than being forwarded. Repeat the same pattern with `@earendil-works/pi-ai/api/openai-completions` (or `openai-responses`) to cover the `/openai` and `/compat` passthrough models of the same provider.
+
 ### Cloudflare Workers AI
 
 `CLOUDFLARE_API_KEY` can be set via `/login`. `CLOUDFLARE_ACCOUNT_ID` must be set as an environment variable.

--- a/packages/coding-agent/src/core/cloudflare-gateway-binding.ts
+++ b/packages/coding-agent/src/core/cloudflare-gateway-binding.ts
@@ -1,0 +1,17 @@
+/**
+ * Cloudflare AI Gateway transport over the Workers AI binding.
+ *
+ * pi-ai ships this transport (upstream #7901); Atomic re-exports it so SDK users and
+ * extension authors can route gateway requests through `env.AI` with **no API token**:
+ * binding calls are pre-authenticated in the gateway's own account. The HTTPS route with
+ * `CLOUDFLARE_API_KEY` stays the default for everywhere else. See
+ * `docs/providers.md` → "Cloudflare AI Gateway" for a working provider-extension example.
+ */
+export {
+	type AiGatewayBinding,
+	type AiGatewayBindingGateway,
+	type AiGatewayUniversalRequestLike,
+	CLOUDFLARE_GATEWAY_BINDING_AUTH_SENTINEL,
+	createGatewayBindingFetch,
+	type GatewayBindingFetchOptions,
+} from "@earendil-works/pi-ai/api/cloudflare-gateway-binding";

--- a/packages/coding-agent/src/core/extensions/loader-virtual-modules.ts
+++ b/packages/coding-agent/src/core/extensions/loader-virtual-modules.ts
@@ -15,24 +15,38 @@ let _virtualModules: Record<string, object> | null = null;
 let _virtualModulesPromise: Promise<Record<string, object>> | null = null;
 
 async function loadVirtualModules(): Promise<Record<string, object>> {
-	const [typebox, typeboxCompile, typeboxValue, piAgentCore, piTui, piTuiLayout, piAi, piAiOauth, piCodingAgent] =
-		await Promise.all([
-			import("typebox"),
-			import("typebox/compile"),
-			import("typebox/value"),
-			import("@earendil-works/pi-agent-core"),
-			import("@earendil-works/pi-tui"),
-			import("@earendil-works/pi-tui/dist/layout.js"),
-			// pi 0.80.2: the old global pi-ai API moved off the root entrypoint onto
-			// `/compat` (a strict superset). Extensions still `import ... from
-			// "@earendil-works/pi-ai"`, so we load the compat module here and key it
-			// under the root specifier below to keep every extension working unchanged.
-			import("@earendil-works/pi-ai/compat"),
-			import("@earendil-works/pi-ai/oauth"),
-			// NOTE: This import works because loader.ts exports are NOT re-exported from index.ts,
-			// avoiding a circular dependency while preserving the package-name extension import path.
-			import("../../index.ts"),
-		]);
+	const [
+		typebox,
+		typeboxCompile,
+		typeboxValue,
+		piAgentCore,
+		piTui,
+		piTuiLayout,
+		piAi,
+		piAiOauth,
+		piAiCloudflareGatewayBinding,
+		piCodingAgent,
+	] = await Promise.all([
+		import("typebox"),
+		import("typebox/compile"),
+		import("typebox/value"),
+		import("@earendil-works/pi-agent-core"),
+		import("@earendil-works/pi-tui"),
+		import("@earendil-works/pi-tui/dist/layout.js"),
+		// pi 0.80.2: the old global pi-ai API moved off the root entrypoint onto
+		// `/compat` (a strict superset). Extensions still `import ... from
+		// "@earendil-works/pi-ai"`, so we load the compat module here and key it
+		// under the root specifier below to keep every extension working unchanged.
+		import("@earendil-works/pi-ai/compat"),
+		import("@earendil-works/pi-ai/oauth"),
+		// Re-exported from `@bastani/atomic`; jiti-loaded extensions (the builtin
+		// packages import the host entry) reach this specifier, so it needs a key
+		// of its own instead of falling through to the compat/root prefix alias.
+		import("@earendil-works/pi-ai/api/cloudflare-gateway-binding"),
+		// NOTE: This import works because loader.ts exports are NOT re-exported from index.ts,
+		// avoiding a circular dependency while preserving the package-name extension import path.
+		import("../../index.ts"),
+	]);
 
 	return {
 		typebox,
@@ -47,6 +61,7 @@ async function loadVirtualModules(): Promise<Record<string, object>> {
 		"@earendil-works/pi-ai": piAi,
 		"@earendil-works/pi-ai/compat": piAi,
 		"@earendil-works/pi-ai/oauth": piAiOauth,
+		"@earendil-works/pi-ai/api/cloudflare-gateway-binding": piAiCloudflareGatewayBinding,
 		"@bastani/atomic": piCodingAgent,
 		"@mariozechner/pi-agent-core": piAgentCore,
 		"@mariozechner/pi-tui": piTui,
@@ -54,6 +69,7 @@ async function loadVirtualModules(): Promise<Record<string, object>> {
 		"@mariozechner/pi-ai": piAi,
 		"@mariozechner/pi-ai/compat": piAi,
 		"@mariozechner/pi-ai/oauth": piAiOauth,
+		"@mariozechner/pi-ai/api/cloudflare-gateway-binding": piAiCloudflareGatewayBinding,
 	};
 }
 
@@ -422,6 +438,10 @@ function getAliases(): Record<string, string> {
 	const piAiEntry = resolveWorkspaceOrImport("ai/dist/compat.js", "@earendil-works/pi-ai");
 	const piAiOauthEntry = resolveWorkspaceOrImport("ai/dist/oauth.js", "@earendil-works/pi-ai");
 	const piAiProvidersEntry = resolveWorkspaceOrImport("ai/dist/providers/all.js", "@earendil-works/pi-ai");
+	const piAiGatewayBindingEntry = resolveWorkspaceOrImport(
+		"ai/dist/api/cloudflare-gateway-binding.js",
+		"@earendil-works/pi-ai",
+	);
 
 	_aliases = {
 		"@bastani/atomic": piCodingAgentEntry,
@@ -432,6 +452,7 @@ function getAliases(): Record<string, string> {
 		"@earendil-works/pi-ai/oauth": piAiOauthEntry,
 		"@earendil-works/pi-ai/providers/all": piAiProvidersEntry,
 		"@earendil-works/pi-ai/compat": piAiEntry,
+		"@earendil-works/pi-ai/api/cloudflare-gateway-binding": piAiGatewayBindingEntry,
 		"@earendil-works/pi-ai": piAiEntry,
 		"@mariozechner/pi-agent-core": piAgentCoreEntry,
 		"@mariozechner/pi-tui/dist/layout.js": piTuiLayoutEntry,
@@ -439,6 +460,7 @@ function getAliases(): Record<string, string> {
 		"@mariozechner/pi-ai/oauth": piAiOauthEntry,
 		"@mariozechner/pi-ai/providers/all": piAiProvidersEntry,
 		"@mariozechner/pi-ai/compat": piAiEntry,
+		"@mariozechner/pi-ai/api/cloudflare-gateway-binding": piAiGatewayBindingEntry,
 		"@mariozechner/pi-ai": piAiEntry,
 		typebox: typeboxEntry,
 		"typebox/compile": typeboxCompileEntry,

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -64,6 +64,15 @@ export {
 	runCallback,
 	runSynchronousCallback,
 } from "./core/callback-activity.ts";
+// Cloudflare AI Gateway over the Workers AI binding (no API token; see docs/providers.md)
+export {
+	type AiGatewayBinding,
+	type AiGatewayBindingGateway,
+	type AiGatewayUniversalRequestLike,
+	CLOUDFLARE_GATEWAY_BINDING_AUTH_SENTINEL,
+	createGatewayBindingFetch,
+	type GatewayBindingFetchOptions,
+} from "./core/cloudflare-gateway-binding.ts";
 export {
 	CODEX_FAST_MODE_SERVICE_TIER,
 	type CodexFastModeResolvedSettings,

--- a/packages/coding-agent/test/cloudflare-gateway-binding.test.ts
+++ b/packages/coding-agent/test/cloudflare-gateway-binding.test.ts
@@ -1,0 +1,175 @@
+import { streamSimple as anthropicMessagesStreamSimple } from "@earendil-works/pi-ai/api/anthropic-messages";
+import * as piAiCloudflareGatewayBinding from "@earendil-works/pi-ai/api/cloudflare-gateway-binding";
+import { describe, expect, it } from "vitest";
+import { AuthStorage } from "../src/core/auth-storage.ts";
+import { ModelRuntime } from "../src/core/model-runtime.ts";
+import {
+	type AiGatewayBinding,
+	type AiGatewayUniversalRequestLike,
+	CLOUDFLARE_GATEWAY_BINDING_AUTH_SENTINEL,
+	createGatewayBindingFetch,
+} from "../src/index.ts";
+
+const ACCOUNT_ID = "acct";
+const GATEWAY_ID = "gw";
+const GATEWAY_PREFIX = `https://gateway.ai.cloudflare.com/v1/${ACCOUNT_ID}/${GATEWAY_ID}`;
+
+interface RecordedRun {
+	gatewayId: string;
+	data: AiGatewayUniversalRequestLike;
+}
+
+function createFakeBinding(responseBody: string): { binding: AiGatewayBinding; runs: RecordedRun[] } {
+	const runs: RecordedRun[] = [];
+	const binding: AiGatewayBinding = {
+		gateway(gatewayId: string) {
+			return {
+				run: async (data: AiGatewayUniversalRequestLike) => {
+					runs.push({ gatewayId, data });
+					return new Response(responseBody, {
+						status: 200,
+						headers: { "content-type": "text/event-stream" },
+					});
+				},
+			};
+		},
+	};
+	return { binding, runs };
+}
+
+/** A minimal, well-formed Anthropic streaming response the pi-ai adapter can consume. */
+const ANTHROPIC_SSE = `${[
+	'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_binding","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-5","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":3,"output_tokens":1}}}',
+	'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+	'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello from the binding"}}',
+	'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}',
+	'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":1}}',
+	'event: message_stop\ndata: {"type":"message_stop"}',
+].join("\n\n")}\n\n`;
+
+describe("Cloudflare AI Gateway Workers AI binding transport", () => {
+	it("re-exports pi-ai's binding transport from the public surface", () => {
+		expect(createGatewayBindingFetch).toBe(piAiCloudflareGatewayBinding.createGatewayBindingFetch);
+		expect(CLOUDFLARE_GATEWAY_BINDING_AUTH_SENTINEL).toBe("cloudflare-gateway-binding");
+	});
+
+	it("translates a gateway-prefixed POST into one universal-endpoint binding call", async () => {
+		const { binding, runs } = createFakeBinding(ANTHROPIC_SSE);
+		const fetch = createGatewayBindingFetch({ binding, gateway: GATEWAY_ID, baseUrl: GATEWAY_PREFIX });
+
+		const body = { model: "claude-sonnet-4-5", stream: true, max_tokens: 64 };
+		const response = await fetch(`${GATEWAY_PREFIX}/anthropic/v1/messages?beta=true`, {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				"cf-aig-authorization": `Bearer ${CLOUDFLARE_GATEWAY_BINDING_AUTH_SENTINEL}`,
+				host: "gateway.ai.cloudflare.com",
+			},
+			body: JSON.stringify(body),
+		});
+
+		expect(response.status).toBe(200);
+		expect(runs).toHaveLength(1);
+		expect(runs[0].gatewayId).toBe(GATEWAY_ID);
+		expect(runs[0].data.provider).toBe("anthropic");
+		expect(runs[0].data.endpoint).toBe("v1/messages?beta=true");
+		expect(runs[0].data.query).toEqual(body);
+		// Gateway auth never reaches the binding: binding calls are pre-authenticated,
+		// and a sentinel on the wire would be read as a BYOK provider key.
+		expect(runs[0].data.headers).not.toHaveProperty("cf-aig-authorization");
+		expect(runs[0].data.headers).not.toHaveProperty("host");
+		expect(runs[0].data.headers["content-type"]).toBe("application/json");
+	});
+
+	it("rejects URLs outside the configured gateway prefix instead of forwarding them", async () => {
+		const { binding } = createFakeBinding(ANTHROPIC_SSE);
+		const fetch = createGatewayBindingFetch({ binding, gateway: GATEWAY_ID, baseUrl: GATEWAY_PREFIX });
+
+		await expect(fetch("https://api.anthropic.com/v1/messages", { method: "POST", body: "{}" })).rejects.toThrow(
+			/outside the configured gateway prefix/,
+		);
+	});
+
+	it("rejects in-prefix requests the universal endpoint cannot express", async () => {
+		const { binding } = createFakeBinding(ANTHROPIC_SSE);
+		const fetch = createGatewayBindingFetch({ binding, gateway: GATEWAY_ID, baseUrl: GATEWAY_PREFIX });
+
+		await expect(fetch(`${GATEWAY_PREFIX}/anthropic/v1/messages`)).rejects.toThrow(/only POST is supported/);
+		await expect(
+			fetch(`${GATEWAY_PREFIX}/anthropic/v1/messages`, { method: "POST", body: "not json" }),
+		).rejects.toThrow(/non-JSON body/);
+	});
+
+	it("completes a ModelRuntime turn through the binding with no Cloudflare API token", async () => {
+		const previousAccount = process.env.CLOUDFLARE_ACCOUNT_ID;
+		const previousGateway = process.env.CLOUDFLARE_GATEWAY_ID;
+		process.env.CLOUDFLARE_ACCOUNT_ID = ACCOUNT_ID;
+		process.env.CLOUDFLARE_GATEWAY_ID = GATEWAY_ID;
+		try {
+			const modelRuntime = await ModelRuntime.create({
+				credentials: AuthStorage.inMemory(),
+				modelsPath: null,
+			});
+			const { binding, runs } = createFakeBinding(ANTHROPIC_SSE);
+
+			// The provider-extension shape documented in docs/providers.md →
+			// "Cloudflare AI Gateway" → "Workers AI binding (no API token)".
+			modelRuntime.registerProvider("cloudflare-ai-gateway", {
+				apiKey: CLOUDFLARE_GATEWAY_BINDING_AUTH_SENTINEL,
+				api: "anthropic-messages",
+				streamSimple: (model, context, options) =>
+					anthropicMessagesStreamSimple(
+						{
+							...model,
+							baseUrl: (model.baseUrl ?? GATEWAY_PREFIX)
+								.replaceAll("{CLOUDFLARE_ACCOUNT_ID}", options?.env?.CLOUDFLARE_ACCOUNT_ID ?? "")
+								.replaceAll("{CLOUDFLARE_GATEWAY_ID}", options?.env?.CLOUDFLARE_GATEWAY_ID ?? ""),
+						},
+						context,
+						{
+							...options,
+							fetch: createGatewayBindingFetch({
+								binding,
+								gateway: GATEWAY_ID,
+								baseUrl: GATEWAY_PREFIX,
+							}),
+						},
+					),
+			});
+
+			const model = modelRuntime.getModel("cloudflare-ai-gateway", "claude-sonnet-4-5");
+			expect(model).toBeDefined();
+			if (!model) throw new Error("cloudflare-ai-gateway/claude-sonnet-4-5 missing from the catalog");
+
+			const resolution = await modelRuntime.getAuth(model);
+			expect(resolution?.auth.apiKey).toBeUndefined();
+			expect(resolution?.auth.headers?.["cf-aig-authorization"]).toBe(
+				`Bearer ${CLOUDFLARE_GATEWAY_BINDING_AUTH_SENTINEL}`,
+			);
+			expect(resolution?.env).toEqual({
+				CLOUDFLARE_ACCOUNT_ID: ACCOUNT_ID,
+				CLOUDFLARE_GATEWAY_ID: GATEWAY_ID,
+			});
+
+			const result = await modelRuntime.complete(model, {
+				messages: [{ role: "user", content: "Say hello" }],
+			});
+
+			expect(result.stopReason).toBe("stop");
+			expect(result.content).toEqual([{ type: "text", text: "Hello from the binding" }]);
+			expect(runs).toHaveLength(1);
+			expect(runs[0].gatewayId).toBe(GATEWAY_ID);
+			expect(runs[0].data.provider).toBe("anthropic");
+			expect(runs[0].data.endpoint).toBe("v1/messages");
+			expect(runs[0].data.query).toMatchObject({ model: "claude-sonnet-4-5", stream: true });
+			expect(runs[0].data.headers).not.toHaveProperty("cf-aig-authorization");
+			expect(runs[0].data.headers).not.toHaveProperty("authorization");
+			expect(runs[0].data.headers).not.toHaveProperty("x-api-key");
+		} finally {
+			if (previousAccount === undefined) delete process.env.CLOUDFLARE_ACCOUNT_ID;
+			else process.env.CLOUDFLARE_ACCOUNT_ID = previousAccount;
+			if (previousGateway === undefined) delete process.env.CLOUDFLARE_GATEWAY_ID;
+			else process.env.CLOUDFLARE_GATEWAY_ID = previousGateway;
+		}
+	});
+});

--- a/packages/coding-agent/test/extensions-loader-virtual-modules.test.ts
+++ b/packages/coding-agent/test/extensions-loader-virtual-modules.test.ts
@@ -64,6 +64,29 @@ describe("extension loader pi-ai compat aliases", () => {
 		REAL_EXTENSION_LOADER_TEST_TIMEOUT_MS,
 	);
 
+	it(
+		"maps the Cloudflare gateway binding transport through both loader resolution paths",
+		async () => {
+			// Re-exported from `@bastani/atomic`, so jiti-loaded extensions that import
+			// the host entry reach this specifier; without its own alias key it falls
+			// through to the compat/root prefix alias and fails to load.
+			const specifiers = [
+				"@earendil-works/pi-ai/api/cloudflare-gateway-binding",
+				"@mariozechner/pi-ai/api/cloudflare-gateway-binding",
+			] as const;
+			const aliases = extensionLoaderTestHooks.getAliases();
+			const modules = await extensionLoaderTestHooks.loadVirtualModules();
+			for (const specifier of specifiers) {
+				expect(aliases[specifier]).toMatch(/[\\/]cloudflare-gateway-binding\.js$/);
+				expect(fs.existsSync(aliases[specifier]!)).toBe(true);
+				const binding = modules[specifier] as { createGatewayBindingFetch?: object };
+				expect(typeof binding.createGatewayBindingFetch).toBe("function");
+			}
+			expect(modules[specifiers[0]]).toBe(modules[specifiers[1]]);
+		},
+		REAL_EXTENSION_LOADER_TEST_TIMEOUT_MS,
+	);
+
 	it("confirms compat is the legacy API surface while root stays core-only", async () => {
 		const root = (await import("@earendil-works/pi-ai")) as PiAiExports;
 		const compat = (await import("@earendil-works/pi-ai/compat")) as PiAiExports;


### PR DESCRIPTION
Close pi 0.84.2 migration gap 3 (upstream 23002907): pi-ai ships a
transport that routes AI Gateway requests through a Workers AI binding
(env.AI.gateway(id).run(...)) with no API token, but Atomic re-exported
nothing and docs/providers.md documented CLOUDFLARE_API_KEY as the only
route.

- Re-export createGatewayBindingFetch, CLOUDFLARE_GATEWAY_BINDING_AUTH_
  SENTINEL, and the binding types from @bastani/atomic via
  src/core/cloudflare-gateway-binding.ts
- Document the binding path in docs/providers.md with a working
  provider-extension example: inline extension factory, sentinel as the
  placeholder credential (resolved to cf-aig-authorization and stripped
  before the binding call), endpoint placeholders materialized from the
  resolved provider env
- Teach the extension loader the new specifier: the re-export puts
  @earendil-works/pi-ai/api/cloudflare-gateway-binding inside the module
  graph jiti evaluates for builtin extensions, and without its own key
  the root/compat prefix alias mangled it to dist/compat.js/api/... and
  broke loading of every builtin extension tool. Add the key to both
  resolution paths (jiti alias map and the compiled binary's virtual
  modules, plus the @mariozechner mirrors)
- Cover the new exports and the transport contract (prefix translation,
  sentinel stripping, out-of-prefix and unexpressible-request refusals),
  a full ModelRuntime turn through a fake binding with no
  CLOUDFLARE_API_KEY, and the loader alias through both paths

Assistant-model: Claude Opus 5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789446047&installation_model_id=10562&pr_number=2440&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2440&signature=fd6952ee15a9a9af523bc3a996768b50ce83d922e174cc0bfc824ac486c00ef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change publishes the Cloudflare AI Gateway Workers binding transport, makes it resolvable through both extension-loader paths, documents token-free Workers configuration, and adds transport coverage.

The Workers example must reload its caller-created resource loader before creating a session; otherwise its inline provider factory is not registered. The new test file also needs the repository-required `node:assert/strict` assertion style, and the newly exported public API needs an Unreleased changelog entry.

### T-Rex validation blocked

A focused runtime check of the documented loader flow could not run because the validation tool exhausted its execution-step limit before it could create the probe and upload its output. No credential, package, package manager, or service was missing.

<h3>Confidence Score: 4/5</h3>

The implementation should not merge until the documented Workers setup initializes its inline provider and the repository requirements are met.

The affected documentation and repository-rule violations are directly identifiable from the changed files. The provider initialization path is supported by the loader and session construction code, although the dedicated runtime probe could not complete.

**Files Needing Attention:** `packages/coding-agent/docs/providers.md` needs a loader reload before session construction; `packages/coding-agent/test/cloudflare-gateway-binding.test.ts` needs assertion-style cleanup; and `packages/coding-agent/CHANGELOG.md` needs an Unreleased entry for the public export.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Attempted to run the focused runtime probe for the caller-provided resource-loader flow, but it could not be created or run before the validation tool exhausted its execution-step limit; no script output or uploaded artifact was produced.
- T-Rex produced proof for a posted P1 finding; see the corresponding review comment for finding details.
- No execution proof is available in this session: no focused runtime script was run and no Greptile artifact reference was returned.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/docs/providers.md:400-404
**Inline gateway provider is never loaded**

The example passes a fresh `DefaultResourceLoader` to `createAgentSession`, but caller-supplied loaders are not reloaded there. Without `await loader.reload()`, the inline factory never runs and `cloudflare-ai-gateway` is not registered, leaving the session unable to resolve or invoke the documented binding-backed model.

### Issue 2
packages/coding-agent/test/cloudflare-gateway-binding.test.ts:3
**Required assertion convention is bypassed**

This new suite imports and uses Vitest's `expect` API throughout, while coding-agent tests are required to use `node:assert/strict`. Keeping this pattern introduces an inconsistent assertion style that future tests can copy.

### Issue 3
packages/coding-agent/src/index.ts:65-74
**Public API is absent from release notes**

These exports add a shipped, user-facing Workers AI binding feature, but the PR does not update `packages/coding-agent/CHANGELOG.md` under `Unreleased`. The next package release would therefore omit this integration from its release notes.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(core): surface the Workers AI bindi..."](https://github.com/bastani-inc/atomic/commit/2282badc61d3c75b1da8d46bac816bba7a3d7b79) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53723796)</sub>

> Greptile also left **4 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->