### PR TITLE
docs(sdk): document the ModelRuntime model-catalog options

### DIFF
--- a/packages/coding-agent/docs/sdk.md
+++ b/packages/coding-agent/docs/sdk.md
@@ -46,7 +46,7 @@ const { session } = await createAgentSession({
 });
 ```
 
-`ModelRuntime.create()` accepts custom `authPath`, `modelsPath`, credential storage, and runtime auth overrides. `ModelRegistry` and `AuthStorage` remain available as Atomic's synchronous compatibility facades. Use `readStoredCredential(provider, authPath?)` for a lightweight read of one stored provider credential.
+`ModelRuntime.create()` accepts custom `authPath`, `modelsPath`, credential storage, and runtime auth overrides, plus the model-catalog options `allowModelNetwork`, `modelRefreshTimeoutMs`, `modelsStorePath`, and `modelsStore` (see [Model catalog persistence and refresh](#model-catalog-persistence-and-refresh)). `ModelRegistry` and `AuthStorage` remain available as Atomic's synchronous compatibility facades. Use `readStoredCredential(provider, authPath?)` for a lightweight read of one stored provider credential.
 
 Extensions supplied directly to SDK sessions can use the exported `InlineExtension` type. Extension APIs and event types include native `registerProvider(Provider)`, `registerEntryRenderer`, `entry_appended`, `before_provider_headers`, and `agent_settled`.
 
@@ -484,6 +484,31 @@ If no model is provided:
 3. Falls back to first available model
 
 > See [examples/sdk/02-custom-model.ts](https://github.com/bastani-inc/atomic/blob/main/packages/coding-agent/examples/sdk/02-custom-model.ts)
+
+#### Model catalog persistence and refresh
+
+`ModelRuntime.create()` restores cached catalogs from local persistence but does not contact
+pi.dev unless you opt in. `allowModelNetwork` (default `false`) enables a create-time network
+refresh, and `modelRefreshTimeoutMs` (default `15_000`) bounds how long that refresh may run
+before it is aborted. Pass `refreshOnCreate: false` to skip the initial catalog and
+availability refresh entirely; built-in models remain available.
+
+```typescript
+const refreshedRuntime = await ModelRuntime.create({
+  allowModelNetwork: true,
+  modelRefreshTimeoutMs: 15_000,
+});
+```
+
+Remote catalogs are persisted locally so later runtimes can restore them without a network
+request. The default file is `models-store.json` next to `models.json` — with the default
+`modelsPath` that is `~/.atomic/agent/models-store.json`. Set `modelsStorePath` to choose
+another location, or inject `modelsStore` to control persistence entirely; a runtime created
+with `modelsPath: null` keeps its store in memory. Network refreshes are throttled to once
+per provider every four hours unless forced. To force an immediate refresh, call
+`await modelRuntime.refresh({ allowNetwork: true, force: true, signal })`. Setting
+`ATOMIC_OFFLINE` (legacy alias `PI_OFFLINE`) disables model network access, and a
+`refresh()` call that omits `allowNetwork` follows that same runtime network policy.
 
 ### API Keys and OAuth
 

--- a/test/unit/sdk-model-catalog-docs.test.ts
+++ b/test/unit/sdk-model-catalog-docs.test.ts
@@ -1,0 +1,214 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import type { Credential, CredentialInfo, CredentialStore, ModelsStore, ModelsStoreEntry } from "@earendil-works/pi-ai";
+import { afterAll, beforeAll, describe, test } from "vitest";
+import { ModelRuntime } from "../../packages/coding-agent/src/core/model-runtime.js";
+import { REMOTE_CATALOG_REFRESH_INTERVAL_MS } from "../../packages/coding-agent/src/core/remote-catalog-provider.js";
+import { moduleDir } from "../helpers/runtime.js";
+
+const repoRoot = resolve(moduleDir(import.meta.url), "../..");
+const sdkDocs = readFileSync(join(repoRoot, "packages/coding-agent/docs/sdk.md"), "utf8");
+const modelRuntimeSource = readFileSync(join(repoRoot, "packages/coding-agent/src/core/model-runtime.ts"), "utf8");
+
+describe("ModelRuntime catalog SDK documentation", () => {
+	test("documents every catalog option the implementation ships", () => {
+		for (const option of ["allowModelNetwork", "modelRefreshTimeoutMs", "modelsStorePath", "modelsStore"]) {
+			assert.ok(sdkDocs.includes(option), `docs/sdk.md must document ${option}`);
+		}
+		assert.ok(
+			sdkDocs.includes("(see [Model catalog persistence and refresh]"),
+			"the quick-start create() sentence links the catalog section",
+		);
+		assert.match(sdkDocs, /refresh\(\{ allowNetwork: true, force: true, signal \}\)/u);
+	});
+
+	test("documented modelRefreshTimeoutMs default matches the implementation", () => {
+		const documented = /`modelRefreshTimeoutMs` \(default `(\d[\d_]*)`\)/u.exec(sdkDocs);
+		assert.ok(documented, "docs/sdk.md states the modelRefreshTimeoutMs default");
+		const implemented = /modelRefreshTimeoutMs\s*\?\?\s*(\d[\d_]*)/u.exec(modelRuntimeSource);
+		assert.ok(implemented, "ModelRuntime.create defaults modelRefreshTimeoutMs inline");
+		assert.equal(
+			documented[1],
+			implemented[1],
+			"the default printed in docs/sdk.md must equal the default in model-runtime.ts",
+		);
+	});
+
+	test("documented allowModelNetwork default of false matches the implementation", () => {
+		assert.match(sdkDocs, /`allowModelNetwork` \(default `false`\)/u);
+		// Only an explicit true opts in; every other value — including omitted — stays offline.
+		assert.match(modelRuntimeSource, /options\.allowModelNetwork === true/u);
+	});
+
+	test("documented four-hour throttle matches REMOTE_CATALOG_REFRESH_INTERVAL_MS", () => {
+		assert.equal(REMOTE_CATALOG_REFRESH_INTERVAL_MS, 4 * 60 * 60 * 1000);
+		assert.match(sdkDocs, /throttled to once\s+per provider every four hours/u);
+	});
+
+	test("documented models-store location matches the implementation", () => {
+		assert.match(modelRuntimeSource, /join\(dirname\(modelsPath\), "models-store\.json"\)/u);
+		assert.match(sdkDocs, /`models-store\.json` next to `models\.json`/u);
+		assert.match(sdkDocs, /~\/\.atomic\/agent\/models-store\.json/u);
+	});
+
+	test("documented offline switch matches the implementation", () => {
+		assert.match(sdkDocs, /`ATOMIC_OFFLINE` \(legacy alias `PI_OFFLINE`\)/u);
+		assert.match(modelRuntimeSource, /!isOfflineModeEnabled\(\)/u);
+	});
+});
+
+/** One api-key credential so the anthropic provider resolves auth and runs its network phase. */
+class StaticCredentialStore implements CredentialStore {
+	async read(providerId: string): Promise<Credential | undefined> {
+		return providerId === "anthropic" ? { type: "api_key", key: "sk-docs-test" } : undefined;
+	}
+	async list(): Promise<readonly CredentialInfo[]> {
+		return [{ providerId: "anthropic", type: "api_key" }];
+	}
+	async modify(): Promise<Credential | undefined> {
+		return undefined;
+	}
+	async delete(): Promise<void> {}
+}
+
+class RecordingModelsStore implements ModelsStore {
+	readonly writes: Array<{ providerId: string; entry: ModelsStoreEntry }> = [];
+	async read(): Promise<ModelsStoreEntry | undefined> {
+		return undefined;
+	}
+	async write(providerId: string, entry: ModelsStoreEntry): Promise<void> {
+		this.writes.push({ providerId, entry });
+	}
+	async delete(): Promise<void> {}
+}
+
+describe("ModelRuntime catalog behavior behind the documentation", () => {
+	let requests = 0;
+	let server: http.Server;
+	let baseUrl: string;
+
+	beforeAll(async () => {
+		server = http.createServer((_req, res) => {
+			requests += 1;
+			res.writeHead(404, { "content-type": "application/json" });
+			res.end("{}");
+		});
+		await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+		baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+	});
+
+	afterAll(async () => {
+		server.closeAllConnections();
+		await new Promise<void>((resolve) => server.close(() => resolve()));
+	});
+
+	test("create() stays offline by default, persists beside models.json when opted in, throttles, and forces", async () => {
+		const offlineDir = mkdtempSync(join(tmpdir(), "atomic-catalog-default-"));
+		const onlineDir = mkdtempSync(join(tmpdir(), "atomic-catalog-optin-"));
+		try {
+			const beforeCreate = requests;
+			await ModelRuntime.create({
+				credentials: new StaticCredentialStore(),
+				modelsPath: join(offlineDir, "models.json"),
+				catalogBaseUrl: baseUrl,
+			});
+			assert.equal(
+				requests,
+				beforeCreate,
+				"create() without allowModelNetwork contacts no catalog even with credentials present",
+			);
+
+			const runtime = await ModelRuntime.create({
+				credentials: new StaticCredentialStore(),
+				modelsPath: join(onlineDir, "models.json"),
+				catalogBaseUrl: baseUrl,
+				allowModelNetwork: true,
+			});
+			assert.ok(requests > beforeCreate, "allowModelNetwork: true runs the create-time network refresh");
+			assert.ok(
+				existsSync(join(onlineDir, "models-store.json")),
+				"the default store lands at models-store.json beside models.json",
+			);
+			const afterOptIn = requests;
+
+			await ModelRuntime.create({
+				credentials: new StaticCredentialStore(),
+				modelsPath: join(onlineDir, "models.json"),
+				catalogBaseUrl: baseUrl,
+				allowModelNetwork: true,
+			});
+			assert.equal(
+				requests,
+				afterOptIn,
+				"a second create within the four-hour window restores from the store without network",
+			);
+
+			const forced = await runtime.refresh({ allowNetwork: true, force: true });
+			assert.equal(forced.aborted, false);
+			assert.equal(forced.errors.size, 0);
+			assert.ok(requests > afterOptIn, "force: true bypasses the four-hour throttle");
+		} finally {
+			rmSync(offlineDir, { recursive: true, force: true });
+			rmSync(onlineDir, { recursive: true, force: true });
+		}
+	});
+
+	test("modelsStorePath relocates the store and modelsStore replaces persistence entirely", async () => {
+		const overridden = mkdtempSync(join(tmpdir(), "atomic-catalog-store-path-"));
+		const injected = mkdtempSync(join(tmpdir(), "atomic-catalog-store-injected-"));
+		try {
+			await ModelRuntime.create({
+				credentials: new StaticCredentialStore(),
+				modelsPath: join(overridden, "models.json"),
+				modelsStorePath: join(overridden, "elsewhere.json"),
+				catalogBaseUrl: baseUrl,
+				allowModelNetwork: true,
+			});
+			assert.ok(existsSync(join(overridden, "elsewhere.json")), "the store follows modelsStorePath");
+			assert.equal(
+				existsSync(join(overridden, "models-store.json")),
+				false,
+				"the default store file is not created when modelsStorePath is set",
+			);
+
+			const store = new RecordingModelsStore();
+			await ModelRuntime.create({
+				credentials: new StaticCredentialStore(),
+				modelsPath: join(injected, "models.json"),
+				modelsStore: store,
+				catalogBaseUrl: baseUrl,
+				allowModelNetwork: true,
+			});
+			assert.ok(store.writes.length > 0, "an injected modelsStore receives every persisted catalog");
+			assert.ok(
+				!existsSync(join(injected, "models-store.json")) && !existsSync(join(injected, "elsewhere.json")),
+				"no store file is written when modelsStore is injected",
+			);
+		} finally {
+			rmSync(overridden, { recursive: true, force: true });
+			rmSync(injected, { recursive: true, force: true });
+		}
+	});
+
+	test("ATOMIC_OFFLINE disables the create-time network refresh even with allowModelNetwork", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "atomic-catalog-offline-"));
+		const before = requests;
+		process.env.ATOMIC_OFFLINE = "1";
+		try {
+			await ModelRuntime.create({
+				credentials: new StaticCredentialStore(),
+				modelsPath: join(dir, "models.json"),
+				catalogBaseUrl: baseUrl,
+				allowModelNetwork: true,
+			});
+			assert.equal(requests, before, "no catalog request leaves an offline runtime");
+		} finally {
+			delete process.env.ATOMIC_OFFLINE;
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
Close pi 0.84.2 migration gap 10 (pairs with upstream 581d75a8):
Atomic already implements allowModelNetwork, modelRefreshTimeoutMs,
modelsStorePath, modelsStore, and refresh({ allowNetwork, force,
signal }) at core/model-runtime.ts, but docs/sdk.md mentioned none of
them — a public SDK surface with zero documentation.

- Name the four catalog options in the Quick Start create() sentence
  and add a "Model catalog persistence and refresh" subsection to the
  Model section: create() restores cached catalogs but stays offline
  unless allowModelNetwork opts in, modelRefreshTimeoutMs bounds the
  create-time refresh, models-store.json lands beside models.json
  (~/.atomic/agent/models-store.json by default), network refreshes
  are throttled to once per provider every four hours unless forced,
  and ATOMIC_OFFLINE (legacy PI_OFFLINE) disables network access
- Every default stated is verified against the implementation, not
  assumed: a doc-contract test pins the documented 15_000 literal to
  the source's inline `?? 15_000` default, the four-hour prose to
  REMOTE_CATALOG_REFRESH_INTERVAL_MS, and the offline sentence to
  !isOfflineModeEnabled()
- Behavioral half drives a real ModelRuntime against a local catalog
  server with an injected credential store: create() without
  allowModelNetwork sends no request even with credentials present,
  opting in persists to models-store.json beside models.json, a second
  create restores from the store with zero requests inside the
  throttle window, force bypasses it, modelsStorePath relocates the
  file, modelsStore injection persists with no file, and
  ATOMIC_OFFLINE=1 suppresses the create-time refresh

Docs-only layer; no source change.

Assistant-model: Claude Opus 5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789447686&installation_model_id=10562&pr_number=2441&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2441&signature=5d82fa0c53b624ace9438936bf985ce4347e0225c2dcb0ec71531de799d08258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change documents ModelRuntime’s model-catalog persistence and refresh controls, including network opt-in, timeout limits, local store configuration, refresh throttling, forced refresh, and offline behavior. It also adds focused tests covering those documented SDK semantics.

The ModelRuntime catalog tests passed all nine checks using a local HTTP catalog server and temporary persistence directories. The exercised flows confirmed offline-by-default creation, opt-in refresh, persisted-store placement and overrides, four-hour throttling, forced refresh, and `ATOMIC_OFFLINE` behavior.

Merge safety: safe to merge.

<h3>Confidence Score: 5/5</h3>

The documented SDK behavior matches the exercised ModelRuntime catalog behavior and is safe to merge.

The focused test suite passed all nine checks against a loopback HTTP server and temporary local persistence, directly exercising the public catalog-refresh and storage behavior described by the documentation.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before comparison, the targeted test did not exist on origin/main, establishing the baseline for test coverage.
- After running the targeted test, all 9 assertions passed, including HTTP/no-request checks and persisted-store verifications.
- No review script was authored for this proof-of-work.

<a href="https://app.greptile.com/trex/runs/19084928/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(sdk): document the ModelRuntime mod..."](https://github.com/bastani-inc/atomic/commit/4cb0c70399686bb19b96629921d5d4404c0ad4f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53723807)</sub>

<!-- /greptile_comment -->