### PR TITLE
docs(providers): correct the custom-provider reference list

### DIFF
--- a/packages/coding-agent/docs/custom-provider.md
+++ b/packages/coding-agent/docs/custom-provider.md
@@ -196,7 +196,7 @@ The `api` field determines which streaming implementation is used:
 | `openai-responses` | OpenAI Responses API |
 | `azure-openai-responses` | Azure OpenAI Responses API |
 | `openai-codex-responses` | OpenAI Codex Responses API |
-| `mistral-conversations` | Mistral SDK Conversations/Chat streaming |
+| `mistral-conversations` | Native Mistral Chat Completions streaming |
 | `google-generative-ai` | Google Generative AI API |
 | `google-vertex` | Google Vertex AI API |
 | `bedrock-converse-stream` | Amazon Bedrock Converse API |
@@ -373,18 +373,19 @@ interface OAuthCredentials {
 
 ## Custom Streaming API
 
-For providers with non-standard APIs, implement `streamSimple`. Study the existing provider implementations before writing your own:
-
+For providers with non-standard APIs, implement `streamSimple`. Study the existing streaming implementations before writing your own:
 
 **Reference implementations:**
 
-Atomic uses provider implementations from its installed `@earendil-works/pi-ai` dependency. Inspect the compiled declarations and JavaScript under `node_modules/@earendil-works/pi-ai/dist/providers/`, including:
-- `anthropic.d.ts` / `anthropic.js` - Anthropic Messages API
-- `mistral.d.ts` / `mistral.js` - Mistral Conversations API
+Atomic uses provider implementations from its installed `@earendil-works/pi-ai` dependency. The streaming implementations behind the `api` field live under `node_modules/@earendil-works/pi-ai/dist/api/`, including:
+- `anthropic-messages.d.ts` / `anthropic-messages.js` - Anthropic Messages API
+- `mistral-conversations.d.ts` / `mistral-conversations.js` - Mistral Conversations/Chat streaming
 - `openai-completions.d.ts` / `openai-completions.js` - OpenAI Chat Completions
 - `openai-responses.d.ts` / `openai-responses.js` - OpenAI Responses API
-- `google.d.ts` / `google.js` - Google Generative AI
-- `amazon-bedrock.d.ts` / `amazon-bedrock.js` - AWS Bedrock
+- `google-generative-ai.d.ts` / `google-generative-ai.js` - Google Generative AI
+- `bedrock-converse-stream.d.ts` / `bedrock-converse-stream.js` - Amazon Bedrock Converse API
+Per-vendor provider configurations (base URLs, auth, model catalogs) live under `dist/providers/`, for example `anthropic.d.ts` / `anthropic.js` and `mistral.d.ts` / `mistral.js`.
+
 ### Stream Pattern
 
 All providers follow the same pattern:

--- a/test/unit/custom-provider-reference-docs.test.ts
+++ b/test/unit/custom-provider-reference-docs.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, test } from "vitest";
+import { moduleDir } from "../helpers/runtime.js";
+
+const repoRoot = resolve(moduleDir(import.meta.url), "../..");
+const doc = readFileSync(join(repoRoot, "packages/coding-agent/docs/custom-provider.md"), "utf8");
+
+// npm hoists the six pi packages into the root node_modules; the artifacts
+// suite (pi-0.82.1-artifacts.test.ts) asserts that install, so this suite only
+// has to read it. Every path the doc names is checked against this tree, which
+// is exactly what a reader following the doc would find.
+const piAiDist = join(repoRoot, "node_modules", "@earendil-works", "pi-ai", "dist");
+
+/** One heading-bounded slice of the doc, failing loudly when a marker moves. */
+function section(startMarker: string, endMarker: string): string {
+	const start = doc.indexOf(startMarker);
+	assert.ok(start !== -1, `custom-provider.md must still contain "${startMarker}"`);
+	const end = doc.indexOf(endMarker, start);
+	assert.ok(end !== -1, `custom-provider.md must still contain "${endMarker}" after "${startMarker}"`);
+	return doc.slice(start, end);
+}
+
+const referenceBlock = section("**Reference implementations:**", "### Stream Pattern");
+const apiTypesBlock = section("### API Types", "### Auth Header");
+
+function assertDistModuleExists(directory: "api" | "providers", name: string): void {
+	for (const extension of [".d.ts", ".js"]) {
+		const path = join(piAiDist, directory, `${name}${extension}`);
+		assert.ok(
+			existsSync(path),
+			`docs/custom-provider.md names ${directory}/${name}${extension}, which must exist in the installed @earendil-works/pi-ai tree`,
+		);
+	}
+}
+
+describe("custom provider reference list", () => {
+	test("streams readers to dist/api, not dist/providers", () => {
+		const firstBullet = referenceBlock.indexOf("- `");
+		assert.ok(firstBullet !== -1, "the reference block still carries a file list");
+		const intro = referenceBlock.slice(0, firstBullet);
+		assert.match(
+			intro,
+			/dist\/api\//u,
+			"the streaming reference list must live under dist/api/ in the installed pi-ai package",
+		);
+		// The original defect: this sentence sent readers to dist/providers/,
+		// where openai-completions and openai-responses do not exist.
+		assert.doesNotMatch(
+			intro,
+			/dist\/providers\//u,
+			"the streaming reference list must not point at dist/providers/",
+		);
+	});
+
+	test("every module in the reference list resolves in the installed tree", () => {
+		const bullets = [...referenceBlock.matchAll(/^- `([\w.-]+)\.d\.ts` \/ `[\w.-]+\.js` - /gmu)].map((m) => m[1]);
+		assert.ok(bullets.length > 0, "the reference list still names at least one dist/api module");
+		for (const name of bullets) assertDistModuleExists("api", name);
+
+		// The six transports the original list meant to name. Two of them
+		// (openai-completions, openai-responses) never existed under
+		// dist/providers/, and the other four live there only as per-vendor
+		// configs, not as streaming implementations.
+		for (const name of [
+			"anthropic-messages",
+			"mistral-conversations",
+			"openai-completions",
+			"openai-responses",
+			"google-generative-ai",
+			"bedrock-converse-stream",
+		]) {
+			assert.ok(bullets.includes(name), `the reference list must name dist/api/${name}`);
+		}
+	});
+
+	test("per-vendor config examples resolve under dist/providers", () => {
+		const perVendor = /Per-vendor[^\n]*/u.exec(referenceBlock)?.[0];
+		assert.ok(
+			perVendor,
+			"the reference block must still explain that dist/providers/ holds per-vendor configurations",
+		);
+		assert.match(perVendor, /dist\/providers\//u);
+		const names = [...perVendor.matchAll(/`([\w.-]+)\.(?:d\.ts|js)`/gu)].map((m) => m[1]);
+		assert.ok(names.length > 0, "the per-vendor sentence still names example files");
+		for (const name of new Set(names)) assertDistModuleExists("providers", name);
+	});
+
+	test("every api value the table offers is a real dist/api module", () => {
+		const rows = [...apiTypesBlock.matchAll(/^\| `([a-z0-9-]+)` \|/gmu)].map((m) => m[1]);
+		assert.ok(rows.length >= 9, `the API Types table still lists its transports (found ${rows.length})`);
+		for (const name of rows) assertDistModuleExists("api", name);
+	});
+
+	test("the Mistral transport is stated as native, matching pi-ai 0.84.2", () => {
+		// Upstream 9dd90a49 replaced @mistralai/mistralai with a native HTTP
+		// transport; the table row must not claim an SDK that is no longer
+		// installed anywhere in the tree.
+		assert.match(apiTypesBlock, /\| `mistral-conversations` \| Native Mistral Chat Completions streaming \|/u);
+		assert.equal(doc.includes("Mistral SDK"), false, "the doc must not claim a Mistral SDK transport");
+	});
+});


### PR DESCRIPTION
Close pi 0.84.2 migration gap 11. The "Reference implementations" list
sent readers to node_modules/@earendil-works/pi-ai/dist/providers/ for
the streaming implementations behind the api field; those live in
dist/api/, dist/providers/ holds per-vendor configs, and two of the six
named files (openai-completions.d.ts, openai-responses.d.ts) did not
exist at the documented location at all.

- Point the list at dist/api/ and name the real modules:
  anthropic-messages, mistral-conversations, openai-completions,
  openai-responses, google-generative-ai, bedrock-converse-stream
- Keep dist/providers/ in the picture, described as what it actually
  holds: per-vendor base URLs, auth, and model catalogs
- Restate the mistral-conversations table row as "Native Mistral Chat
  Completions streaming" (upstream 9dd90a49): pi-ai 0.84.2 dropped
  @mistralai/mistralai for a native HTTP transport, so the row must not
  claim an SDK that is no longer installed anywhere in the tree
- Doc-contract test resolves every path the list names against the
  installed node_modules tree, pins the six modules that motivated the
  fix, guards the intro sentence against pointing back at
  dist/providers/, and rejects any remaining "Mistral SDK" claim; four
  of its five tests fail against the pre-fix doc

Assistant-model: Claude Opus 5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789449238&installation_model_id=10562&pr_number=2442&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2442&signature=fb8de183a3ccacbfb5e2fc3175956e80a3394519cd49f1b97de68b3c892b5edb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change corrects the custom-provider guide so streaming implementation references point to `@earendil-works/pi-ai/dist/api/`, while per-vendor configuration examples remain under `dist/providers/`. It also adds a focused contract test for those references.

The documented paths were checked against the installed package: all referenced API transports and provider configuration examples resolve with both declaration and runtime files. The focused Vitest test passed all five checks. The possible documentation-path failure was disproved because readers are now directed to files that exist in the documented locations.

No defects were found. The change is safe to merge.

<h3>Confidence Score: 5/5</h3>

The documentation accurately directs extension authors to installed pi-ai streaming and provider configuration modules, and its contract test passes.

No review findings remain after checking the documented package paths and running the focused unit test successfully.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before capture, verified that all six legacy streaming names are absent under dist/providers.
- Parsed packages/coding-agent/docs/custom-provider.md and confirmed all 11 documented API and provider module references resolve in the installed pi-ai package.
- Ran npx vitest --run --project unit test/unit/custom-provider-reference-docs.test.ts from the repository root and observed one passing test file with five passing tests.
- After capture, confirmed that every documented module exists under its documented directory with both declaration and runtime files.
- The source capture and output captures were collected, including the exact documentation, contract-test source, commands, working directory, observed output, and exit codes.

<a href="https://app.greptile.com/trex/runs/19084932/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(providers): correct the custom-prov..."](https://github.com/bastani-inc/atomic/commit/2ae060de4a4cd4d8cada292c364837f6ca19a30b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53723811)</sub>

<!-- /greptile_comment -->