### PR TITLE
fix(subagents): bound in-process JSONL artifacts

### DIFF
--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - A subagent that pins no model of its own now inherits the dispatching session's thinking level alongside its model, matching the parent's tool configuration inheritance. The agent's declared `thinking` and any candidate `:level` suffix still take precedence.
+- In-process JSONL event artifacts now honor `includeJsonl: false` and enforce the existing 50 MiB cap when enabled, preventing unbounded artifact growth ([#2445](https://github.com/bastani-inc/atomic/issues/2445)).
 
 ## [0.9.13] - 2026-08-13
 

--- a/packages/subagents/README.md
+++ b/packages/subagents/README.md
@@ -727,7 +727,7 @@ Debug artifacts live under `{sessionDir}/subagent-artifacts/` or a user-scoped t
 
 - `{runId}_{agent}_input.md`
 - `{runId}_{agent}_output.md`
-- `{runId}_{agent}.jsonl`
+- `{runId}_{agent}.jsonl` when `includeJsonl: true` (capped at 50 MiB)
 - `{runId}_{agent}_meta.json`
 
 Metadata records timing, usage, typed status, termination cause, final model, attempted models, and fallback attempt outcomes.
@@ -742,7 +742,7 @@ Foreground runs persist their session and user-facing artifacts beside the paren
 {parent-session-dir}/subagent-artifacts/
   {runId}_{agent}_input.md
   {runId}_{agent}_output.md
-  {runId}_{agent}.jsonl
+  {runId}_{agent}.jsonl          # only when includeJsonl: true; max 50 MiB
   {runId}_{agent}_meta.json
   run-history.jsonl
 ```

--- a/packages/subagents/src/runs/foreground/inprocess-run-sync.ts
+++ b/packages/subagents/src/runs/foreground/inprocess-run-sync.ts
@@ -287,7 +287,7 @@ export async function runSingleInProcess(
 						: {}),
 				}
 			: undefined,
-		artifactJsonlPath: options.artifactConfig?.includeJsonl !== false ? artifactPaths?.jsonlPath : undefined,
+		artifactJsonlPath: options.artifactConfig?.includeJsonl === true ? artifactPaths?.jsonlPath : undefined,
 		...(fallbackCandidates.length ? { fallbackModels: fallbackCandidates } : {}),
 		onProgress: options.onUpdate
 			? (progress) => {

--- a/packages/subagents/src/runs/foreground/inprocess-run-sync.ts
+++ b/packages/subagents/src/runs/foreground/inprocess-run-sync.ts
@@ -287,7 +287,7 @@ export async function runSingleInProcess(
 						: {}),
 				}
 			: undefined,
-		artifactJsonlPath: artifactPaths?.jsonlPath,
+		artifactJsonlPath: options.artifactConfig?.includeJsonl !== false ? artifactPaths?.jsonlPath : undefined,
 		...(fallbackCandidates.length ? { fallbackModels: fallbackCandidates } : {}),
 		onProgress: options.onUpdate
 			? (progress) => {

--- a/packages/subagents/src/runs/inprocess/runner.ts
+++ b/packages/subagents/src/runs/inprocess/runner.ts
@@ -31,6 +31,7 @@ import {
 	resolveSubagentCodexFastModeScope,
 	resolveSubagentModelFastMode,
 } from "../../shared/fast-mode.ts";
+import { DEFAULT_MAX_JSONL_BYTES } from "../../shared/jsonl-writer.ts";
 import { resolveEffectiveThinking } from "../../shared/model-info.ts";
 import {
 	type AgentProgress,
@@ -73,6 +74,8 @@ export interface TestSessionOptions {
 	readonly sessionModel?: string;
 	/** Test-only effective thinking level exposed through the AgentSession accessors. */
 	readonly sessionThinkingLevel?: string;
+	/** Test-only session events emitted in order after the initial agent_start event. */
+	readonly events?: readonly AgentSessionEvent[];
 }
 
 export interface ChildSpec {
@@ -403,6 +406,9 @@ function createTestSession(sessionManager: SessionManager, spec: ChildSpec): Age
 				]);
 				if (gateResult === "aborted") return "";
 			}
+			for (const event of testOptions.events ?? []) {
+				for (const listener of listeners) listener(event);
+			}
 			if (testOptions.fallbackModel) {
 				for (const listener of listeners) {
 					listener({
@@ -587,8 +593,16 @@ export function progressEmissionFor(eventType: AgentSessionEvent["type"]): Progr
 
 function writeEvent(pathValue: string | undefined, event: AgentSessionEvent): void {
 	if (!pathValue) return;
+	const line = `${JSON.stringify(event)}\n`;
+	let existingBytes = 0;
+	try {
+		existingBytes = statSync(pathValue).size;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+	}
+	if (existingBytes + Buffer.byteLength(line, "utf8") > DEFAULT_MAX_JSONL_BYTES) return;
 	mkdirSync(dirname(pathValue), { recursive: true });
-	appendFileSync(pathValue, `${JSON.stringify(event)}\n`, "utf8");
+	appendFileSync(pathValue, line, "utf8");
 }
 
 /**

--- a/packages/subagents/src/shared/jsonl-writer.ts
+++ b/packages/subagents/src/shared/jsonl-writer.ts
@@ -12,7 +12,7 @@ export interface JsonlWriteStream {
 	end(callback?: () => void): void;
 }
 
-const DEFAULT_MAX_JSONL_BYTES = 50 * 1024 * 1024;
+export const DEFAULT_MAX_JSONL_BYTES = 50 * 1024 * 1024;
 
 interface JsonlWriterDeps {
 	createWriteStream?: (filePath: string) => JsonlWriteStream;

--- a/packages/subagents/src/shared/types-config.ts
+++ b/packages/subagents/src/shared/types-config.ts
@@ -2,7 +2,7 @@
  * Configuration, execution option, display, and event bus types.
  */
 
-import type { SessionWorkflowMetadata } from "@bastani/atomic";
+import type { AgentSessionEvent, SessionWorkflowMetadata } from "@bastani/atomic";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { CandidateModelResolver } from "./model-resolution.ts";
 import type { NestedRouteInfo } from "./types-nested.ts";
@@ -141,6 +141,8 @@ export interface RunSyncOptions {
 				sessionModel?: string;
 				/** Test-only effective thinking level exposed through the AgentSession accessors. */
 				sessionThinkingLevel?: string;
+				/** Test-only session events emitted in order after the initial agent_start event. */
+				events?: readonly AgentSessionEvent[];
 		  };
 }
 

--- a/test/unit/subagents-inprocess-runner.test.ts
+++ b/test/unit/subagents-inprocess-runner.test.ts
@@ -1,7 +1,17 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
+import type { AgentSessionEvent } from "@bastani/atomic";
 import { test } from "vitest";
 import type { AgentConfig } from "../../packages/subagents/src/agents/agent-types.ts";
 import { runSingleInProcess } from "../../packages/subagents/src/runs/foreground/inprocess-run-sync.ts";
@@ -18,7 +28,7 @@ import {
 	inProcessChildBuiltinPackagePaths,
 	SubagentControlRuntime,
 } from "../../packages/subagents/src/runs/inprocess/runner.ts";
-import { MAX_SUBAGENT_NESTING_DEPTH } from "../../packages/subagents/src/shared/types.ts";
+import { DEFAULT_ARTIFACT_CONFIG, MAX_SUBAGENT_NESTING_DEPTH } from "../../packages/subagents/src/shared/types.ts";
 import { resultStatusLine } from "../../packages/subagents/src/tui/render-status-progress.js";
 import { sleep } from "../helpers/runtime.ts";
 
@@ -423,6 +433,123 @@ test("parallel siblings share one control plane and persist distinct terminal ar
 		const resumed = await control.resumeChild(thirdPath, "inspect one more fixture", {});
 		assert.equal(resumed.status, "ok", resumed.status === "error" ? resumed.cause : undefined);
 		assert.equal(resumed.path, thirdPath);
+	} finally {
+		clearSubagentControls();
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("in-process artifacts with includeJsonl false do not create a JSONL artifact", async () => {
+	const root = mkdtempSync(join(tmpdir(), "atomic-inprocess-jsonl-disabled-"));
+	const artifactsDir = join(root, "artifacts");
+	clearSubagentControls();
+	try {
+		assert.equal(DEFAULT_ARTIFACT_CONFIG.includeJsonl, false);
+		const result = await runSingleInProcess(root, sampleAgent(), "inspect fixture", {
+			cwd: root,
+			runId: "jsonl-disabled-parent",
+			sessionDir: join(root, "sessions"),
+			artifactsDir,
+			artifactConfig: {
+				...DEFAULT_ARTIFACT_CONFIG,
+				includeJsonl: false,
+			},
+			testSession: { output: "jsonl disabled" },
+		});
+
+		assert.equal(result.status, "ok");
+		assert.ok(result.artifactPaths);
+		assert.equal(existsSync(result.artifactPaths.jsonlPath), false);
+		assert.equal(existsSync(result.artifactPaths.outputPath), true);
+		assert.equal(existsSync(result.artifactPaths.metadataPath), true);
+		assert.deepEqual(
+			readdirSync(artifactsDir).filter((name) => name.endsWith(".jsonl") && name !== "run-history.jsonl"),
+			[],
+		);
+	} finally {
+		clearSubagentControls();
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("in-process enabled JSONL writing stays within 50 MiB while child events continue", async () => {
+	const root = mkdtempSync(join(tmpdir(), "atomic-inprocess-jsonl-cap-"));
+	const artifactsDir = join(root, "artifacts");
+	const capBytes = 50 * 1024 * 1024;
+	const payload = "x".repeat(1024 * 1024);
+	const events: AgentSessionEvent[] = [
+		...Array.from(
+			{ length: 51 },
+			(_, index): AgentSessionEvent => ({
+				type: "bash_execution_update",
+				id: `event-${index}`,
+				channel: "stdout",
+				delta: `event-${index}-${payload}`,
+			}),
+		),
+		{
+			type: "model_fallback_start",
+			from: "provider/initial",
+			to: "provider/fallback",
+			reason: "post-cap event",
+			attempt: 1,
+		},
+	];
+	const serializedEvents = [{ type: "agent_start" } as AgentSessionEvent, ...events].map((event) =>
+		JSON.stringify(event),
+	);
+	const expectedLines: string[] = [];
+	let expectedBytes = 0;
+	for (const line of serializedEvents) {
+		const lineBytes = Buffer.byteLength(`${line}\n`, "utf8");
+		if (expectedBytes + lineBytes <= capBytes) {
+			expectedLines.push(line);
+			expectedBytes += lineBytes;
+		}
+	}
+	assert.equal(expectedLines.length, 51, "fixture should retain ordered events near the production cap");
+	assert.ok(expectedBytes > capBytes - 2 * 1024 * 1024, "fixture should fill the production cap");
+	assert.ok(
+		serializedEvents.length > expectedLines.length,
+		"the fixture must drive the writer beyond the production cap",
+	);
+	clearSubagentControls();
+	try {
+		const result = await runSingleInProcess(
+			root,
+			{ ...sampleAgent(), model: "provider/initial" },
+			"inspect fixture",
+			{
+				cwd: root,
+				runId: "jsonl-cap-parent",
+				sessionDir: join(root, "sessions"),
+				artifactsDir,
+				artifactConfig: {
+					...DEFAULT_ARTIFACT_CONFIG,
+					includeJsonl: true,
+				},
+				testSession: { output: "child completed", events },
+			},
+		);
+
+		assert.equal(result.status, "ok");
+		assert.equal(result.finalOutput, "child completed");
+		assert.deepEqual(result.attemptedModels, ["provider/initial", "provider/fallback"]);
+		assert.ok(result.artifactPaths);
+		assert.equal(existsSync(result.artifactPaths.jsonlPath), true);
+		const jsonlBytes = statSync(result.artifactPaths.jsonlPath).size;
+		assert.equal(jsonlBytes, expectedBytes);
+		const actualLines = readFileSync(result.artifactPaths.jsonlPath, "utf8").trimEnd().split("\n");
+		assert.deepEqual(actualLines, expectedLines);
+		assert.equal(
+			actualLines.some((line) => line.includes('"id":"event-49"')),
+			false,
+		);
+		assert.equal(
+			actualLines.some((line) => line.includes('"id":"event-50"')),
+			false,
+		);
+		assert.equal(actualLines.at(-1)?.includes('"type":"model_fallback_start"'), true);
 	} finally {
 		clearSubagentControls();
 		rmSync(root, { recursive: true, force: true });

--- a/test/unit/subagents-inprocess-runner.test.ts
+++ b/test/unit/subagents-inprocess-runner.test.ts
@@ -439,6 +439,35 @@ test("parallel siblings share one control plane and persist distinct terminal ar
 	}
 });
 
+test("in-process artifacts with omitted artifact config honor the default JSONL opt-out", async () => {
+	const root = mkdtempSync(join(tmpdir(), "atomic-inprocess-jsonl-default-"));
+	const artifactsDir = join(root, "artifacts");
+	clearSubagentControls();
+	try {
+		assert.equal(DEFAULT_ARTIFACT_CONFIG.includeJsonl, false);
+		const result = await runSingleInProcess(root, sampleAgent(), "inspect fixture", {
+			cwd: root,
+			runId: "jsonl-default-parent",
+			sessionDir: join(root, "sessions"),
+			artifactsDir,
+			testSession: { output: "jsonl default" },
+		});
+
+		assert.equal(result.status, "ok");
+		assert.ok(result.artifactPaths);
+		assert.equal(existsSync(result.artifactPaths.jsonlPath), false);
+		assert.equal(existsSync(result.artifactPaths.outputPath), true);
+		assert.equal(existsSync(result.artifactPaths.metadataPath), true);
+		assert.deepEqual(
+			readdirSync(artifactsDir).filter((name) => name.endsWith(".jsonl") && name !== "run-history.jsonl"),
+			[],
+		);
+	} finally {
+		clearSubagentControls();
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
 test("in-process artifacts with includeJsonl false do not create a JSONL artifact", async () => {
 	const root = mkdtempSync(join(tmpdir(), "atomic-inprocess-jsonl-disabled-"));
 	const artifactsDir = join(root, "artifacts");


### PR DESCRIPTION
## Summary

Fix the in-process subagent artifact path so JSONL event capture stays opt-in and bounded. Omitted artifact configuration and `includeJsonl: false` now create no JSONL file, while enabled logs stop at the existing 50 MiB limit without stopping child event processing.

## Changes

- Pass a JSONL artifact path to in-process children only when `includeJsonl === true`.
- Enforce the shared 50 MiB cap with UTF-8 byte accounting before each in-process append.
- Add named regressions for omitted config, explicit opt-out, and writes driven past the production cap.
- Keep output and metadata artifacts enabled when JSONL is off, and document the opt-in limit in the subagents README and `[Unreleased]` changelog.

## Validation

- `npm run check` — passed
- `npm run test:unit` — 6,409 passed, 2 skipped
- `npm run test:integration` — 494 passed, 1 skipped
- `npm run test:ci-contracts` — 45 passed
- `npm --workspace=@bastani/atomic run test` — 3,865 passed, 39 skipped
- Focused in-process runner suite — 20 passed
- Pre-push hooks — passed

Closes #2445

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789471109&installation_model_id=10562&pr_number=2448&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2448&signature=4597b90f571dbb7923b9fe18ad3628d6943e75e90154d6fc2d20ba506492d83f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes in-process JSONL artifacts opt-in and limits their size. Repeated JSONL writes were exercised and showed that enabled artifact capture synchronously reads file metadata before every event append. Retain a per-artifact byte count so high-volume event delivery does not incur an additional blocking filesystem lookup for each line.

<h3>Confidence Score: 4/5</h3>

Not ready to merge as-is because enabled JSONL capture adds avoidable synchronous filesystem metadata work to every captured event.

The affected write path was directly exercised with and without an artifact path, confirming a one-to-one relationship between captured events and synchronous file-stat calls.

**Files Needing Attention:** packages/subagents/src/runs/inprocess/runner.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P2 finding, supported by artifacts: Targeted statSync capture harness; Artifact-disabled multi-event execution log; Artifact-enabled multi-event execution log.
- T-Rex produced a second proof for another posted P2 finding, with no artifacts attached.
- T-Rex ran the general contract validation harness to verify per-event statSync capture, including both no-artifact and with-artifact scenarios.
- For the no-artifact run, the validation reported eventCount 8, statSyncCallCount 0, appendedLineCount 0, and exit code 0.
- For the with-artifact run, the validation reported eventCount 8, statSyncCallCount 8, eight identical JSONL paths captured, appendedLineCount 8, and exit code 0, demonstrating the distinct behavior when the artifact is enabled.

<a href="https://app.greptile.com/trex/runs/19096713/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/subagents/src/runs/inprocess/runner.ts:599
**Per-event synchronous JSONL metadata lookup**

Each captured session event calls `statSync(pathValue)` before it is appended. JSONL capture can receive high-frequency streaming events, so this adds a blocking metadata lookup for every line in addition to the synchronous append. Retain the artifact byte count in writer state, initialized once, and increment it after each successful append instead.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(subagents): honor default JSONL opt-..."](https://github.com/bastani-inc/atomic/commit/a69bf1f651956932e7d45f1caa2a24f460ddee7a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53748803)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->