### PR TITLE
chore(deps): consolidate seven Dependabot updates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -196,7 +196,7 @@ jobs:
       - name: Install cargo-zigbuild for portable Linux builds
         if: matrix.platform == 'linux'
         timeout-minutes: 3
-        uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
+        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
         with:
           tool: cargo-zigbuild@0.23.0
       - name: Install Windows cross-compile tooling
@@ -208,7 +208,7 @@ jobs:
       - name: Install cargo-xwin
         if: matrix.platform == 'win32'
         timeout-minutes: 3
-        uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
+        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
         with:
           tool: cargo-xwin@0.23.0
       # Pinned so the populate step, the build step, and actions/cache agree

--- a/.github/workflows/warm-toolchain-cache.yml
+++ b/.github/workflows/warm-toolchain-cache.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: Install cargo-xwin
         timeout-minutes: 3
-        uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
+        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
         with:
           tool: cargo-xwin@0.23.0
       - name: Resolve MSVC CRT cache directory

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,13 +450,14 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.12.0"
+version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f71d6bc097c4a6eb853c3f24991ab8c9f50f57d1f719e305175541482217e36"
+checksum = "459197f1592f4c3dbbf9c1b13f5a4599a343e4ef66b96bc340e2a518b36a6662"
 dependencies = [
  "bitflags 2.13.0",
  "ctor",
  "futures",
+ "libc",
  "napi-build",
  "napi-sys",
  "nohash-hasher",
@@ -466,15 +467,15 @@ dependencies = [
 
 [[package]]
 name = "napi-build"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5282704fbe8d49b0cf8b08e3f33233416a528658f205c7e5ace63b582de0b11c"
+checksum = "60fdf9b392c50e7c4170fa633bd909490ed7835cea4c046776d1a4dd8d2ae0ab"
 
 [[package]]
 name = "napi-derive"
-version = "3.6.2"
+version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9002b2940f0184444754546e0fcd15182f56948e6f381968b019d549387c42"
+checksum = "0fa55ea69990c90b888e9e77044410e304ce7f35de599dc6d0b5c1923d2e59af"
 dependencies = [
  "convert_case",
  "ctor",
@@ -486,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "6.1.1"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d60b5d773ad46c698c8cc2cd9fde0b283d39cbb7f71c04bee633c7bdba4423bd"
+checksum = "df4056ac7c18e4438ccf0edaed4340ca0d269278c8ec19284f7b23cb039fd0ae"
 dependencies = [
  "convert_case",
  "proc-macro2",

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.8/schema.json",
 	"linter": {
 		"enabled": true,
 		"rules": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       ],
       "devDependencies": {
         "@babel/parser": "8.0.4",
-        "@biomejs/biome": "2.5.6",
+        "@biomejs/biome": "2.5.8",
         "@j178/prek": "0.4.11",
         "@types/bun": "1.3.14",
         "@types/tar-stream": "3.1.4",
@@ -567,9 +567,9 @@
       "link": true
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.6.tgz",
-      "integrity": "sha512-lxVNjv7UF6KfhMJfL9gaUHbWdJdHbsAj6OSmwSYNdhRuG67NxNQ4Xdvh3TUxsSK9sBzJBQhEJj3AopmmNJ5pSA==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.8.tgz",
+      "integrity": "sha512-aeAeeJB9fSDc7Gq+2GqpQxA0qBj6gj1k2R6L1cYqGePKP/baIq1WX8y6B+D+nRsO5ViQL22K/8IwbqERW0q1nw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -583,20 +583,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.5.6",
-        "@biomejs/cli-darwin-x64": "2.5.6",
-        "@biomejs/cli-linux-arm64": "2.5.6",
-        "@biomejs/cli-linux-arm64-musl": "2.5.6",
-        "@biomejs/cli-linux-x64": "2.5.6",
-        "@biomejs/cli-linux-x64-musl": "2.5.6",
-        "@biomejs/cli-win32-arm64": "2.5.6",
-        "@biomejs/cli-win32-x64": "2.5.6"
+        "@biomejs/cli-darwin-arm64": "2.5.8",
+        "@biomejs/cli-darwin-x64": "2.5.8",
+        "@biomejs/cli-linux-arm64": "2.5.8",
+        "@biomejs/cli-linux-arm64-musl": "2.5.8",
+        "@biomejs/cli-linux-x64": "2.5.8",
+        "@biomejs/cli-linux-x64-musl": "2.5.8",
+        "@biomejs/cli-win32-arm64": "2.5.8",
+        "@biomejs/cli-win32-x64": "2.5.8"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.6.tgz",
-      "integrity": "sha512-zMOLZP4oMrjh6m1zcSj1ud2awUPgTuMVbmQhYYWL7J8HwCnbHHBvTm7VBTRuY7epT5bez76IpKYQ11ZAqHFlnw==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.8.tgz",
+      "integrity": "sha512-mk1QON9PHllvvLN5gU3f4rMxeh4syK5p9OvKyWH6/W8ueh04uaC8TUXXByhGufWf/y5mQc03ZLM45zU+cmqMjA==",
       "cpu": [
         "arm64"
       ],
@@ -611,9 +611,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.6.tgz",
-      "integrity": "sha512-JAC1VqzvO7Th5ZplU0G2uGfkZbxEe9uDDektPAhF0JLusoz1w+T4okp2bkykI0bbaO2vslKiRfj4gU43JaGreA==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.8.tgz",
+      "integrity": "sha512-bsGwFMBNyHPyiLSsQcZJxdoRrg1V4JL+d7wEsvUBczlP9U9lwM+7mzQHxI4o1mhBsTmdOBbAb6fHU3Z3snN45w==",
       "cpu": [
         "x64"
       ],
@@ -628,9 +628,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.6.tgz",
-      "integrity": "sha512-6XsYwCFkp5sMxl85ffhgeGpGgs6A7dRYFnkceZ7WVxvycuTnGdD5xa534Z3xfrBQ0JCMK/mujT6ZNPJoghedwg==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.8.tgz",
+      "integrity": "sha512-XmFiA0WPYFC+uiUDC8WRFzAIH9bo7vwQLav38Uoq4ETC+T/+uBi0TsYGJECkugY3r8USl3jc+Ae2/irAF6F2lQ==",
       "cpu": [
         "arm64"
       ],
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.6.tgz",
-      "integrity": "sha512-eUa3jeeYvfMt19LBeh6E5PUZpxnTC4JqNWo+EDjTtQjAr2xLGnWaxACtVU1DQqmHYbvThlJzLX+ZsYgrqh2qVw==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.8.tgz",
+      "integrity": "sha512-VcJNbstduTHx83NGAdhp78/JOcP45BZHXL7yNsfI1uGzdUgegAz2s+mSoT7wK6PBNzLoqG0zDOXaz/RQYVtSiw==",
       "cpu": [
         "arm64"
       ],
@@ -668,9 +668,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.6.tgz",
-      "integrity": "sha512-Pop9VXCFUhFTMfFefZ39S+u2rOPyNp5iHlxbZRwXGACHLy2r0jjiRgJHmaEKJzL3SyxlVeGShXhvvElvWowonA==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.8.tgz",
+      "integrity": "sha512-S5wcm9OBDvLHodD4PUaN488hCpco9QD/9ZxuYJiw4euWtr/oQvLR72z2ixItH8Wd5BCm6FZaeb+YNvOoM1xHtQ==",
       "cpu": [
         "x64"
       ],
@@ -688,9 +688,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.6.tgz",
-      "integrity": "sha512-2Vp13QdKysH3HIWLaYLhUUwbK+jbZonJD1K+Lr0d0RO4wH7mkYd43vJixEDm8cUWrowoRz4UUHF1nm9Ae7ym8A==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.8.tgz",
+      "integrity": "sha512-kKmiyokeISRGq2FLwvr+TzsgBusfxaZ0FZNLcOYOpCK/78tRrEjeEBLvq3xLZMpqbANgJdRPI7vZX8ZL37u9/w==",
       "cpu": [
         "x64"
       ],
@@ -708,9 +708,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.6.tgz",
-      "integrity": "sha512-tDGshcm6BdkZOCGnTDX0Y8/U4IfBSlnUU7T56nNDuPEfed+aHg+u8G36NB43fJVl0Os6+QURXIE1yuD7AaEofA==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.8.tgz",
+      "integrity": "sha512-nILH0mzm3Hi3iEdd7o7GpB8kBR/mSQwfQG/tyBqyNrY2GFtcgwfV9nV8xLmbtUpMNY/Oi0Ml1XgfR4flOdq+AA==",
       "cpu": [
         "arm64"
       ],
@@ -725,9 +725,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.6.tgz",
-      "integrity": "sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.8.tgz",
+      "integrity": "sha512-I2czzXTY61f3nFJxXoMDq80t7MivxDEnCjE+8sDKoFfcKMaoQdkqhIFQ3KyY0XLzeSpUBYeNAXgD+iOV/BU0VA==",
       "cpu": [
         "x64"
       ],
@@ -2753,34 +2753,34 @@
       }
     },
     "node_modules/@napi-rs/wasm-tools": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools/-/wasm-tools-1.0.1.tgz",
-      "integrity": "sha512-enkZYyuCdo+9jneCPE/0fjIta4wWnvVN9hBo2HuiMpRF0q3lzv1J6b/cl7i0mxZUKhBrV3aCKDBQnCOhwKbPmQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools/-/wasm-tools-1.1.0.tgz",
+      "integrity": "sha512-VjHyKEqXAwYZK+HY7iJctYvRm3TFEbaQxeZwvAG1QRkoo1a39phMY8J6x9tUEqJI03W6MysB8F2jacI6wvcx+w==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       },
       "optionalDependencies": {
-        "@napi-rs/wasm-tools-android-arm-eabi": "1.0.1",
-        "@napi-rs/wasm-tools-android-arm64": "1.0.1",
-        "@napi-rs/wasm-tools-darwin-arm64": "1.0.1",
-        "@napi-rs/wasm-tools-darwin-x64": "1.0.1",
-        "@napi-rs/wasm-tools-freebsd-x64": "1.0.1",
-        "@napi-rs/wasm-tools-linux-arm64-gnu": "1.0.1",
-        "@napi-rs/wasm-tools-linux-arm64-musl": "1.0.1",
-        "@napi-rs/wasm-tools-linux-x64-gnu": "1.0.1",
-        "@napi-rs/wasm-tools-linux-x64-musl": "1.0.1",
-        "@napi-rs/wasm-tools-wasm32-wasi": "1.0.1",
-        "@napi-rs/wasm-tools-win32-arm64-msvc": "1.0.1",
-        "@napi-rs/wasm-tools-win32-ia32-msvc": "1.0.1",
-        "@napi-rs/wasm-tools-win32-x64-msvc": "1.0.1"
+        "@napi-rs/wasm-tools-android-arm-eabi": "1.1.0",
+        "@napi-rs/wasm-tools-android-arm64": "1.1.0",
+        "@napi-rs/wasm-tools-darwin-arm64": "1.1.0",
+        "@napi-rs/wasm-tools-darwin-x64": "1.1.0",
+        "@napi-rs/wasm-tools-freebsd-x64": "1.1.0",
+        "@napi-rs/wasm-tools-linux-arm64-gnu": "1.1.0",
+        "@napi-rs/wasm-tools-linux-arm64-musl": "1.1.0",
+        "@napi-rs/wasm-tools-linux-x64-gnu": "1.1.0",
+        "@napi-rs/wasm-tools-linux-x64-musl": "1.1.0",
+        "@napi-rs/wasm-tools-wasm32-wasi": "1.1.0",
+        "@napi-rs/wasm-tools-win32-arm64-msvc": "1.1.0",
+        "@napi-rs/wasm-tools-win32-ia32-msvc": "1.1.0",
+        "@napi-rs/wasm-tools-win32-x64-msvc": "1.1.0"
       }
     },
     "node_modules/@napi-rs/wasm-tools-android-arm-eabi": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-android-arm-eabi/-/wasm-tools-android-arm-eabi-1.0.1.tgz",
-      "integrity": "sha512-lr07E/l571Gft5v4aA1dI8koJEmF1F0UigBbsqg9OWNzg80H3lDPO+auv85y3T/NHE3GirDk7x/D3sLO57vayw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-android-arm-eabi/-/wasm-tools-android-arm-eabi-1.1.0.tgz",
+      "integrity": "sha512-p6J8PB59I8d/XItXB/go5JH6nKW+xIbpzaL43EBTV0hi7mrS/Z4gs+MsB04ZrlqZN29BdZV8fChRyasuXLhRaA==",
       "cpu": [
         "arm"
       ],
@@ -2791,13 +2791,13 @@
         "android"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       }
     },
     "node_modules/@napi-rs/wasm-tools-android-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-android-arm64/-/wasm-tools-android-arm64-1.0.1.tgz",
-      "integrity": "sha512-WDR7S+aRLV6LtBJAg5fmjKkTZIdrEnnQxgdsb7Cf8pYiMWBHLU+LC49OUVppQ2YSPY0+GeYm9yuZWW3kLjJ7Bg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-android-arm64/-/wasm-tools-android-arm64-1.1.0.tgz",
+      "integrity": "sha512-lWoKN3suypeBSCIRPIw+++sH9V2K6nQkhtdt1opu7XY3v9JwLs6Gw063HWRqkNjphlYpkd/Qy8XcfSPGbJj7nQ==",
       "cpu": [
         "arm64"
       ],
@@ -2808,13 +2808,13 @@
         "android"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       }
     },
     "node_modules/@napi-rs/wasm-tools-darwin-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-darwin-arm64/-/wasm-tools-darwin-arm64-1.0.1.tgz",
-      "integrity": "sha512-qWTI+EEkiN0oIn/N2gQo7+TVYil+AJ20jjuzD2vATS6uIjVz+Updeqmszi7zq7rdFTLp6Ea3/z4kDKIfZwmR9g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-darwin-arm64/-/wasm-tools-darwin-arm64-1.1.0.tgz",
+      "integrity": "sha512-jfw5vyNDUf6oe0kP8lMveFN9U7cLk1cUosS7uMIfw/xmqmopYfKQ198DAx2g/6aEF7Tm+CqER2gpMpYKui30LA==",
       "cpu": [
         "arm64"
       ],
@@ -2825,13 +2825,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       }
     },
     "node_modules/@napi-rs/wasm-tools-darwin-x64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-darwin-x64/-/wasm-tools-darwin-x64-1.0.1.tgz",
-      "integrity": "sha512-bA6hubqtHROR5UI3tToAF/c6TDmaAgF0SWgo4rADHtQ4wdn0JeogvOk50gs2TYVhKPE2ZD2+qqt7oBKB+sxW3A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-darwin-x64/-/wasm-tools-darwin-x64-1.1.0.tgz",
+      "integrity": "sha512-R+pjeudAB7BYdH1vKkOJM61Tfv5jB6uXkxmFscYd+KKpdUpWBlNG+s4hr0w4i1rMBM91VhIAETZn2pz+MDHK9A==",
       "cpu": [
         "x64"
       ],
@@ -2842,13 +2842,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       }
     },
     "node_modules/@napi-rs/wasm-tools-freebsd-x64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-freebsd-x64/-/wasm-tools-freebsd-x64-1.0.1.tgz",
-      "integrity": "sha512-90+KLBkD9hZEjPQW1MDfwSt5J1L46EUKacpCZWyRuL6iIEO5CgWU0V/JnEgFsDOGyyYtiTvHc5bUdUTWd4I9Vg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-freebsd-x64/-/wasm-tools-freebsd-x64-1.1.0.tgz",
+      "integrity": "sha512-hQJTe+aazrT++Vgm6I4lUd9099ItUCFYdd+aKg6Ys6nax6d/cZ1barDLTwA2lwOoVDsXMekJI/FOL6ZvVlIYBg==",
       "cpu": [
         "x64"
       ],
@@ -2859,81 +2859,93 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       }
     },
     "node_modules/@napi-rs/wasm-tools-linux-arm64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-linux-arm64-gnu/-/wasm-tools-linux-arm64-gnu-1.0.1.tgz",
-      "integrity": "sha512-rG0QlS65x9K/u3HrKafDf8cFKj5wV2JHGfl8abWgKew0GVPyp6vfsDweOwHbWAjcHtp2LHi6JHoW80/MTHm52Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-linux-arm64-gnu/-/wasm-tools-linux-arm64-gnu-1.1.0.tgz",
+      "integrity": "sha512-1TAXJxUHsWGar90k3W/MknavvBMwOWzjh7Q6Spxo8twRcWJbBD5Kow/Q2KhhDq5hxh2sKGDXn3uLc1tdtz4WUg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       }
     },
     "node_modules/@napi-rs/wasm-tools-linux-arm64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-linux-arm64-musl/-/wasm-tools-linux-arm64-musl-1.0.1.tgz",
-      "integrity": "sha512-jAasbIvjZXCgX0TCuEFQr+4D6Lla/3AAVx2LmDuMjgG4xoIXzjKWl7c4chuaD+TI+prWT0X6LJcdzFT+ROKGHQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-linux-arm64-musl/-/wasm-tools-linux-arm64-musl-1.1.0.tgz",
+      "integrity": "sha512-7rw3nlubTjNAVRH2LwphCxHy1b/N2/TerXocQ6XRn4Q+buaY1Z7P/hbdALy1i1ex2yfOU2Xcij7ib7ZLi/lKfw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       }
     },
     "node_modules/@napi-rs/wasm-tools-linux-x64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-linux-x64-gnu/-/wasm-tools-linux-x64-gnu-1.0.1.tgz",
-      "integrity": "sha512-Plgk5rPqqK2nocBGajkMVbGm010Z7dnUgq0wtnYRZbzWWxwWcXfZMPa8EYxrK4eE8SzpI7VlZP1tdVsdjgGwMw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-linux-x64-gnu/-/wasm-tools-linux-x64-gnu-1.1.0.tgz",
+      "integrity": "sha512-1sel0t9MRjI/tdT89M8Dd6gPfANeeFP24Xa46R11WeHNwhjsXXZh+xUk50uWCRTSGcaCy3ugm3AMK/lmHYQJkg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       }
     },
     "node_modules/@napi-rs/wasm-tools-linux-x64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-linux-x64-musl/-/wasm-tools-linux-x64-musl-1.0.1.tgz",
-      "integrity": "sha512-GW7AzGuWxtQkyHknHWYFdR0CHmW6is8rG2Rf4V6GNmMpmwtXt/ItWYWtBe4zqJWycMNazpfZKSw/BpT7/MVCXQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-linux-x64-musl/-/wasm-tools-linux-x64-musl-1.1.0.tgz",
+      "integrity": "sha512-o2jH5AMfor4EKF2HII1LBnMQxoWu7+usPifTEY8Zk6e9OiSi4EJkAXf9v3ANlX7TI2V/cUEV34OEW7r10GiVIA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       }
     },
     "node_modules/@napi-rs/wasm-tools-wasm32-wasi": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-wasm32-wasi/-/wasm-tools-wasm32-wasi-1.0.1.tgz",
-      "integrity": "sha512-/nQVSTrqSsn7YdAc2R7Ips/tnw5SPUcl3D7QrXCNGPqjbatIspnaexvaOYNyKMU6xPu+pc0BTnKVmqhlJJCPLA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-wasm32-wasi/-/wasm-tools-wasm32-wasi-1.1.0.tgz",
+      "integrity": "sha512-s6YDtDR1UWrsqJPtaxf+JLYLceWVyn3l8OpQYElHkDhf3Qfz9R6Ba3S0OgznTBv38L5/TIHysQ9Q4yO73Z0csg==",
       "cpu": [
         "wasm32"
       ],
@@ -2941,16 +2953,52 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.0.3"
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@napi-rs/wasm-tools-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-tools-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-tools-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-tools-win32-arm64-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-win32-arm64-msvc/-/wasm-tools-win32-arm64-msvc-1.0.1.tgz",
-      "integrity": "sha512-PFi7oJIBu5w7Qzh3dwFea3sHRO3pojMsaEnUIy22QvsW+UJfNQwJCryVrpoUt8m4QyZXI+saEq/0r4GwdoHYFQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-win32-arm64-msvc/-/wasm-tools-win32-arm64-msvc-1.1.0.tgz",
+      "integrity": "sha512-x+NuxbG84VxU68tU8w7Rf5lSyq0l584M6dVlke5DTweHYFZoMyeqkpbwEq+qsyAX6ivfipK8xRsmFwamb5uDnA==",
       "cpu": [
         "arm64"
       ],
@@ -2961,13 +3009,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       }
     },
     "node_modules/@napi-rs/wasm-tools-win32-ia32-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-win32-ia32-msvc/-/wasm-tools-win32-ia32-msvc-1.0.1.tgz",
-      "integrity": "sha512-gXkuYzxQsgkj05Zaq+KQTkHIN83dFAwMcTKa2aQcpYPRImFm2AQzEyLtpXmyCWzJ0F9ZYAOmbSyrNew8/us6bw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-win32-ia32-msvc/-/wasm-tools-win32-ia32-msvc-1.1.0.tgz",
+      "integrity": "sha512-mdD96QDEp70SX67rXFTY6c725nVYeqEEjyDqzzbNh6u1APj7CI7IMNpMmvE75XbCRl4C2MHZVU4U6AWdAzvyQQ==",
       "cpu": [
         "ia32"
       ],
@@ -2978,13 +3026,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       }
     },
     "node_modules/@napi-rs/wasm-tools-win32-x64-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-win32-x64-msvc/-/wasm-tools-win32-x64-msvc-1.0.1.tgz",
-      "integrity": "sha512-rEAf05nol3e3eei2sRButmgXP+6ATgm0/38MKhz9Isne82T4rPIMYsCIFj0kOisaGeVwoi2fnm7O9oWp5YVnYQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-win32-x64-msvc/-/wasm-tools-win32-x64-msvc-1.1.0.tgz",
+      "integrity": "sha512-bVVjuvhlyVX++3eJXfDR63cXdw1ay5QYac6iq0MKQw8wZARInTM+bXCtByDT4fzVFI3+7ZthYb/ERWRdBNIqgQ==",
       "cpu": [
         "x64"
       ],
@@ -2995,7 +3043,7 @@
         "win32"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.22.0"
       }
     },
     "node_modules/@nodable/entities": {
@@ -9217,7 +9265,7 @@
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@mozilla/readability": "^0.6.0",
         "@silvia-odwyer/photon-node": "0.3.4",
-        "chalk": "5.6.2",
+        "chalk": "6.0.0",
         "cross-spawn": "7.0.6",
         "diff": "8.0.4",
         "embedded-postgres": "18.4.0-beta.17",
@@ -9264,6 +9312,18 @@
       },
       "optionalDependencies": {
         "@mariozechner/clipboard": "0.3.9"
+      }
+    },
+    "packages/coding-agent/node_modules/chalk": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-6.0.0.tgz",
+      "integrity": "sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "packages/intercom": {
@@ -9326,7 +9386,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@napi-rs/cli": "3.8.2"
+        "@napi-rs/cli": "3.8.6"
       },
       "engines": {
         "bun": ">=1.3.14",
@@ -9334,19 +9394,18 @@
       }
     },
     "packages/natives/node_modules/@napi-rs/cli": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-3.8.2.tgz",
-      "integrity": "sha512-iFmp3Lo/ipXoJI1I/6V/xU4hQV42bXS3A7j8C+Wt3LOtYY7HFCilkhyUkN1igLJFXWMICq95kNxhNcwzNRd+Kw==",
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-3.8.6.tgz",
+      "integrity": "sha512-FnJ9fghsV9Q4zh2aJGPSvQiUlJRC27B6KhzAXcIW2rlSD8keak3mhXw4tJYa3KJkP9whETfsPwqp/DJRnQg5ng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^8.5.2",
         "@napi-rs/cross-toolchain": "^1.0.3",
-        "@napi-rs/wasm-tools": "^1.0.1",
+        "@napi-rs/wasm-tools": "^1.1.0",
         "@octokit/rest": "^22.0.1",
         "clipanion": "^4.0.0-rc.4",
         "colorette": "^2.0.20",
-        "emnapi": "2.0.0-alpha.3",
         "es-toolkit": "^1.47.0",
         "js-yaml": "^4.2.0",
         "obug": "^2.1.2",
@@ -9366,25 +9425,18 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/runtime": "2.0.0-alpha.3"
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4",
+        "emnapi": "^1.7.1 || ^2.0.0-alpha.4"
       },
       "peerDependenciesMeta": {
+        "@emnapi/core": {
+          "optional": true
+        },
         "@emnapi/runtime": {
           "optional": true
-        }
-      }
-    },
-    "packages/natives/node_modules/emnapi": {
-      "version": "2.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/emnapi/-/emnapi-2.0.0-alpha.3.tgz",
-      "integrity": "sha512-K9bc9Xx4OwSfhJpdSOpcfIKzn7/6emuubaIorf6I5e7WBAM79665rf6iHr9y50NL4qYMUP/AheTpD1Z4yU1EBw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "node-addon-api": ">= 6.1.0"
-      },
-      "peerDependenciesMeta": {
-        "node-addon-api": {
+        },
+        "emnapi": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@babel/parser": "8.0.4",
-    "@biomejs/biome": "2.5.6",
+    "@biomejs/biome": "2.5.8",
     "@j178/prek": "0.4.11",
     "@types/bun": "1.3.14",
     "@types/tar-stream": "3.1.4",

--- a/packages/coding-agent/npm-shrinkwrap.json
+++ b/packages/coding-agent/npm-shrinkwrap.json
@@ -20,7 +20,7 @@
 				"@modelcontextprotocol/sdk": "^1.30.0",
 				"@mozilla/readability": "^0.6.0",
 				"@silvia-odwyer/photon-node": "0.3.4",
-				"chalk": "5.6.2",
+				"chalk": "6.0.0",
 				"cross-spawn": "7.0.6",
 				"diff": "8.0.4",
 				"embedded-postgres": "18.4.0-beta.17",
@@ -1694,12 +1694,12 @@
 			}
 		},
 		"node_modules/chalk": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-6.0.0.tgz",
+			"integrity": "sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg==",
 			"license": "MIT",
 			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+				"node": ">=22"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
@@ -3157,6 +3157,18 @@
 			},
 			"bin": {
 				"markit": "dist/main.js"
+			}
+		},
+		"node_modules/markit-ai/node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
 		"node_modules/markit-ai/node_modules/commander": {

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -94,7 +94,7 @@
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@mozilla/readability": "^0.6.0",
     "@silvia-odwyer/photon-node": "0.3.4",
-    "chalk": "5.6.2",
+    "chalk": "6.0.0",
     "cross-spawn": "7.0.6",
     "diff": "8.0.4",
     "embedded-postgres": "18.4.0-beta.17",

--- a/packages/natives/package.json
+++ b/packages/natives/package.json
@@ -28,7 +28,7 @@
     "prepublish:native": "napi prepublish --npm-dir npm --tag-style npm --no-gh-release"
   },
   "devDependencies": {
-    "@napi-rs/cli": "3.8.2"
+    "@napi-rs/cli": "3.8.6"
   },
   "engines": {
     "bun": ">=1.3.14",

--- a/scripts/generate-coding-agent-shrinkwrap.mjs
+++ b/scripts/generate-coding-agent-shrinkwrap.mjs
@@ -3,10 +3,12 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, posix, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { satisfies } from "semver";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, "..");
 const codingAgentDir = join(repoRoot, "packages/coding-agent");
+const codingAgentLockPrefix = "packages/coding-agent/";
 const rootLockfilePath = join(repoRoot, "package-lock.json");
 const shrinkwrapPath = join(codingAgentDir, "npm-shrinkwrap.json");
 const internalPackageNames = new Set(["@bastani/atomic-natives"]);
@@ -224,6 +226,36 @@ function getInternalWorkspaces(lockPackages) {
 	return workspaces;
 }
 
+function publishedLockPath(lockPath) {
+	return lockPath.startsWith(codingAgentLockPrefix) ? lockPath.slice(codingAgentLockPrefix.length) : lockPath;
+}
+
+function choosePublishedPath(lockPath, packageName, outputFrom, addedPaths, sourceToOutput) {
+	const existingOutputPath = sourceToOutput.get(lockPath);
+	if (existingOutputPath !== undefined) {
+		return existingOutputPath;
+	}
+
+	const baseOutputPath = publishedLockPath(lockPath);
+	if (!addedPaths.has(baseOutputPath)) {
+		return baseOutputPath;
+	}
+
+	let parent = outputFrom;
+	while (parent) {
+		const nestedOutputPath = `${parent}/node_modules/${packageName}`;
+		if (!addedPaths.has(nestedOutputPath)) {
+			return nestedOutputPath;
+		}
+		parent = posix.dirname(parent);
+		if (parent === ".") {
+			break;
+		}
+	}
+
+	throw new Error(`Cannot place ${packageName} resolved from ${lockPath} in the published shrinkwrap`);
+}
+
 function resolveExternalDependency(lockPackages, packageName, fromLockPath) {
 	const candidateDirs = [];
 	let current = fromLockPath;
@@ -273,28 +305,38 @@ function addGeneratedInternalPackage(shrinkwrapPackages, addedPaths, queue, name
 	addedPaths.add(outputPath);
 
 	for (const dependencyName of Object.keys(packageDependencies(entry))) {
-		queue.push({ name: dependencyName, from: outputPath });
+		queue.push({ name: dependencyName, from: outputPath, outputFrom: outputPath });
 	}
 }
 
-function addExternalPackage(lockPackages, shrinkwrapPackages, addedPaths, queue, name, from) {
+function addExternalPackage(
+	lockPackages,
+	shrinkwrapPackages,
+	addedPaths,
+	sourceToOutput,
+	queue,
+	name,
+	from,
+	outputFrom,
+) {
 	const lockPath = resolveExternalDependency(lockPackages, name, from);
-	if (addedPaths.has(lockPath)) {
+	if (sourceToOutput.has(lockPath)) {
 		return;
 	}
 
 	const entry = lockPackages[lockPath];
-	shrinkwrapPackages[lockPath] = copyLockEntry(entry);
-	addedPaths.add(lockPath);
+	const outputPath = choosePublishedPath(lockPath, name, outputFrom, addedPaths, sourceToOutput);
+	shrinkwrapPackages[outputPath] = copyLockEntry(entry);
+	addedPaths.add(outputPath);
+	sourceToOutput.set(lockPath, outputPath);
 
 	for (const dependencyName of Object.keys(packageDependencies(entry))) {
-		queue.push({ name: dependencyName, from: lockPath });
+		queue.push({ name: dependencyName, from: lockPath, outputFrom: outputPath });
 	}
 }
 
 function validateShrinkwrap(shrinkwrap, internalNames) {
 	const errors = [];
-	const includedPaths = new Set(Object.keys(shrinkwrap.packages));
 	const includedPackageNames = new Set();
 	const seenAllowedInstallScriptPackages = new Set();
 
@@ -338,13 +380,24 @@ function validateShrinkwrap(shrinkwrap, internalNames) {
 	}
 
 	for (const [lockPath, entry] of Object.entries(shrinkwrap.packages)) {
-		for (const dependencyName of Object.keys(packageDependencies(entry))) {
-			const dependencyIncluded = [...includedPaths].some(
-				(candidate) =>
-					candidate === `node_modules/${dependencyName}` || candidate.endsWith(`/node_modules/${dependencyName}`),
-			);
-			if (!dependencyIncluded) {
+		for (const [dependencyName, dependencyRange] of Object.entries(packageDependencies(entry))) {
+			let dependencyPath;
+			try {
+				dependencyPath = resolveExternalDependency(shrinkwrap.packages, dependencyName, lockPath);
+			} catch {
 				errors.push(`${lockPath || "root"} dependency ${dependencyName} is missing`);
+				continue;
+			}
+
+			const dependencyEntry = shrinkwrap.packages[dependencyPath];
+			if (!dependencyEntry?.version) {
+				errors.push(`${lockPath || "root"} dependency ${dependencyName} is missing`);
+				continue;
+			}
+			if (!satisfies(dependencyEntry.version, dependencyRange)) {
+				errors.push(
+					`${lockPath || "root"} dependency ${dependencyName}@${dependencyRange} resolves to ${dependencyEntry.version}`,
+				);
 			}
 		}
 	}
@@ -375,8 +428,13 @@ async function generateShrinkwrap() {
 		"": copyPackageJsonEntry(codingAgentPackage, { includeName: true }),
 	};
 	const addedPaths = new Set([""]);
+	const sourceToOutput = new Map();
 	const internalNames = new Set();
-	const queue = Object.keys(packageDependencies(codingAgentPackage)).map((name) => ({ name, from: "" }));
+	const queue = Object.keys(packageDependencies(codingAgentPackage)).map((name) => ({
+		name,
+		from: "packages/coding-agent",
+		outputFrom: "",
+	}));
 
 	while (queue.length > 0) {
 		const item = queue.shift();
@@ -394,7 +452,16 @@ async function generateShrinkwrap() {
 			continue;
 		}
 
-		addExternalPackage(lockPackages, shrinkwrapPackages, addedPaths, queue, item.name, item.from);
+		addExternalPackage(
+			lockPackages,
+			shrinkwrapPackages,
+			addedPaths,
+			sourceToOutput,
+			queue,
+			item.name,
+			item.from,
+			item.outputFrom,
+		);
 	}
 
 	const shrinkwrap = {

--- a/scripts/generate-coding-agent-shrinkwrap.test.mjs
+++ b/scripts/generate-coding-agent-shrinkwrap.test.mjs
@@ -26,6 +26,11 @@ test("the generated shrinkwrap matches the committed one", async () => {
 		"packages/coding-agent/npm-shrinkwrap.json is stale; run `npm run shrinkwrap:coding-agent`",
 	);
 });
+test("the published tree keeps coding-agent dependencies on satisfying versions", async () => {
+	const generated = await generateShrinkwrap();
+	assert.equal(generated.packages["node_modules/chalk"]?.version, "6.0.0");
+	assert.equal(generated.packages["node_modules/markit-ai/node_modules/chalk"]?.version, "5.6.2");
+});
 
 test("the shrinkwrap is derived from the lockfile npm ci verifies", async () => {
 	const generated = await generateShrinkwrap();
@@ -35,13 +40,21 @@ test("the shrinkwrap is derived from the lockfile npm ci verifies", async () => 
 	assert.equal(generated.name, "@bastani/atomic");
 
 	// Every resolved dependency must carry the exact version and integrity the
-	// root lockfile pinned. A shrinkwrap that drifted from it would ship users a
-	// dependency set no CI job ever installed -- which is precisely what two
-	// coexisting lockfiles allowed before install moved to npm.
+	// root lockfile pinned. Remapped workspace-local paths are matched by their
+	// integrity because the published tree is rooted at packages/coding-agent.
+	// A shrinkwrap that drifted from the root lock would ship users a dependency
+	// set no CI job ever installed -- which is precisely what two coexisting
+	// lockfiles allowed before install moved to npm.
 	let compared = 0;
 	for (const [path, entry] of Object.entries(generated.packages)) {
 		if (path === "" || entry.version === undefined) continue;
-		const source = lock.packages[path];
+		const pathSource = lock.packages[path];
+		const source =
+			pathSource?.integrity === entry.integrity
+				? pathSource
+				: Object.values(lock.packages).find(
+						(candidate) => candidate.integrity !== undefined && candidate.integrity === entry.integrity,
+					);
 		// Workspace packages are links in the root lockfile and carry no version of
 		// their own; the shrinkwrap materialises them.
 		if (source === undefined || source.link === true || source.version === undefined) continue;

--- a/test/unit/semver-7.8.0-pin-regression.test.ts
+++ b/test/unit/semver-7.8.0-pin-regression.test.ts
@@ -122,7 +122,7 @@ interface SemverApi {
 const pinned: SemverApi = { compare, maxSatisfying, rcompare, satisfies, valid, validRange };
 
 /**
- * `@napi-rs/cli` 3.8.2 declares `semver@^7.8.2`, which the pin does not satisfy.
+ * `@napi-rs/cli` 3.8.6 declares `semver@^7.8.2`, which the pin does not satisfy.
  * A flat `semver` override held it below that range and `npm ls` reported the
  * edge invalid, so the override is scoped instead: everything collapses onto
  * 7.8.0 except the CLI, which keeps 7.8.5. The CLI is a build-time
@@ -625,12 +625,14 @@ describe("semver pinned at 7.8.0", () => {
 		assert.equal(natives.dependencies?.semver, undefined, "packages/natives must not declare a semver dependency");
 		assert.equal(natives.devDependencies.semver, undefined, "packages/natives must not declare a semver dependency");
 
-		// The declared range this measurement is about. If @napi-rs/cli moves off
-		// 3.8.2 its semver surface has to be re-measured, so pin the version the
-		// table above was taken against. 3.8.2 was diffed against 3.8.1: its
-		// dependency table, semver imports and restrictWasiNodeEngine body are
-		// byte-identical, so the 3.8.1 measurement carries over unchanged.
-		assert.equal(natives.devDependencies["@napi-rs/cli"], "3.8.2");
+		// The declared range this measurement is about remains `semver@^7.8.2` in 3.8.6.
+		// Both semver import statements are unchanged, and the `restrictWasiNodeEngine`
+		// body is byte-identical to 3.8.2, so the existing semver measurement carries
+		// over unchanged. The dependency table is not identical: `@napi-rs/wasm-tools`
+		// moved from `^1.0.1` to `^1.1.0` and `emnapi` was dropped, but neither delta
+		// touches the semver surface measured here. If the CLI moves off this pinned
+		// version, re-measure that surface.
+		assert.equal(natives.devDependencies["@napi-rs/cli"], "3.8.6");
 		assert.ok(
 			BASELINE_NAPI_WASI_ENGINE.has(natives.engines.node),
 			`packages/natives engines.node ${natives.engines.node} is not in BASELINE_NAPI_WASI_ENGINE`,

--- a/test/unit/stage-chat-search.test.ts
+++ b/test/unit/stage-chat-search.test.ts
@@ -13,13 +13,13 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { getKeybindings, ScrollView, setKeybindings, Text, type TuiAltScreen, VStack } from "@earendil-works/pi-tui";
-import chalk from "chalk";
 import { describe, test } from "vitest";
 import { KeybindingsManager } from "../../packages/coding-agent/src/core/keybindings.ts";
 import {
 	isFullscreenViewportAction,
 	shouldHandleFullscreenViewportInput,
 } from "../../packages/coding-agent/src/modes/interactive/interactive-mode-base.ts";
+import { chalk } from "../../packages/coding-agent/src/modes/interactive/interactive-mode-deps.ts";
 import { createFullscreenTui } from "../../packages/coding-agent/src/modes/interactive/interactive-tui.ts";
 import type { Theme } from "../../packages/coding-agent/src/modes/interactive/theme/theme-class.ts";
 import { loadThemeFromContent } from "../../packages/coding-agent/src/modes/interactive/theme/theme-loading.ts";


### PR DESCRIPTION
Consolidates seven open Dependabot updates into one branch off `origin/main`, so CI runs once instead of seven times.

## Superseded pull requests

| PR | Change | Where |
|---|---|---|
| #2390 | `@napi-rs/cli` 3.8.2 → 3.8.6 | `packages/natives/package.json` |
| #2392 | `napi-derive` 3.6.2 → 3.6.3 | `Cargo.lock` |
| #2394 | `napi` 3.12.0 → 3.12.1 | `Cargo.lock` |
| #2395 | `chalk` 5.6.2 → 6.0.0 | `packages/coding-agent/package.json` |
| #2396 | `napi-build` 2.4.0 → 2.4.1 | `Cargo.lock` |
| #2397 | `taiki-e/install-action` 2.85.10 → 2.85.13 | `publish.yml`, `warm-toolchain-cache.yml` |
| #2399 | `@biomejs/biome` 2.5.6 → 2.5.8 | root `package.json`, `biome.json` |

Supersedes #2390, #2392, #2394, #2395, #2396, #2397, and #2399. Please close those once this merges.

## What is in the diff beyond the seven bumps

**`napi-derive-backend` 6.1.1 → 6.1.2.** Transitive of `napi-derive` 3.6.3; `Cargo.lock` is not internally consistent without it.

**`libc` added to `napi`'s dependency list in `Cargo.lock`.** Upstream added it in 3.12.1.

**`test/unit/stage-chat-search.test.ts` imports `chalk` from `interactive-mode-deps.ts`.** Chalk 6 is ESM-only from the workspace root's perspective, and the root suite resolves the hoisted 5.6.2 copy rather than coding-agent's nested 6.0.0. Routing through the package's own dependency module makes the test measure the version the package actually ships.

**`test/unit/semver-7.8.0-pin-regression.test.ts` re-pinned to `@napi-rs/cli` 3.8.6.** That test deliberately pins the CLI version its semver measurement was taken against. Re-measured against 3.8.6: the declared range is still `semver@^7.8.2`, both semver imports are unchanged, and the `restrictWasiNodeEngine` body is byte-identical to 3.8.2. The dependency table did move — `@napi-rs/wasm-tools` `^1.0.1` → `^1.1.0`, `emnapi` dropped — but neither touches the measured semver surface. The comment records this rather than implying byte-identity.

**`scripts/generate-coding-agent-shrinkwrap.mjs` fix.** This is the one change larger than a version bump, and it is worth a reviewer's attention.

## The shrinkwrap bug this surfaced

`packages/coding-agent/npm-shrinkwrap.json` declared `chalk 6.0.0` in its root block while its tree still locked `5.6.2`. A production `npm ci --ignore-scripts --dry-run` against the published shrinkwrap failed with:

```
EUSAGE  Invalid: lock file's chalk@5.6.2 does not satisfy chalk@6.0.0
```

The cause was in the generator, not the bump. Line 379 seeded coding-agent's own direct dependencies with `from: ""`; `resolveExternalDependency`'s `while (current)` loop never runs on an empty string, so the walk collapsed to the repository root and bound the hoisted `chalk` 5.6.2 — present for `markit-ai` — instead of the nested 6.0.0.

The fix seeds from `packages/coding-agent`, remaps resolved paths into the published tree's coordinate space, and handles the resulting collision. The emitted topology is now `node_modules/chalk` at 6.0.0 for coding-agent and `node_modules/markit-ai/node_modules/chalk` at 5.6.2 for `markit-ai`. Neither copy is dropped.

`validateShrinkwrap` also previously asserted only that a dependency *name* appeared somewhere in the tree, which is why this passed silently. It now performs real node resolution plus a `semver.satisfies` range check, so `npm run check` catches this class. Replaying the original buggy seed against the new validation fails with `root dependency chalk@6.0.0 resolves to 5.6.2`, exit 1, where the old code passed.

The existing "derived from the lockfile" test was adjusted to match remapped paths by integrity rather than by path. 348 of 358 entries are still compared against the root lock against a `compared > 100` threshold, so coverage widened rather than narrowed.

This changes shared release tooling and will affect every future shrinkwrap regeneration, not just this one.

## Verification

| Command | Result |
|---|---|
| `npm run check` | exit 0, 2518 files, shrinkwrap up to date |
| `npm run test:all` | 6487 passed / 2 skipped; 495 passed / 1 skipped |
| `npm run test --workspace=@bastani/atomic` | 3891 passed / 39 skipped |
| `npm run test:scripts` | 4/4 |
| `npm run test:ci-contracts` | 45/45 |
| prod-only `npm ci --ignore-scripts --dry-run` | red → green: `EUSAGE` → `added 335 packages`, exit 0 |

The unit, integration, and CI-contract suites ran again on push via the prek hooks and passed.

## Invariants

`package-lock.json` remains the only npm lockfile; no yarn, pnpm, or bun lockfile was written. All seven `packages/*/package.json` files keep the `0.0.0` versionless release-base placeholder. No package changelog entry was added — this is dependency and CI maintenance. No unrelated dependency version moved.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789507452&installation_model_id=10562&pr_number=2458&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2458&signature=0fcc33a7011da82bc2110e95fd61d6c5e7e010f12f27d6f7151b8a62dd13bf79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change updates dependency tooling and regenerates the coding-agent shrinkwrap while adding topology and range validation. A reproduced failure shows that the shrinkwrap validator accepts a dependency located beneath an unrelated sibling package even though Node cannot resolve it from the declaring consumer. Restricting dependency lookup to Node-reachable ancestor locations is required before merging.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until shrinkwrap dependency resolution rejects packages outside the requesting package's Node resolution ancestry.

A focused execution used the repository's resolver and validator with a real temporary module layout, and demonstrated that validation accepts a graph for which Node resolution from the consumer fails.

**Files Needing Attention:** scripts/generate-coding-agent-shrinkwrap.mjs needs its unique-suffix fallback constrained or removed, along with a regression test for dependencies nested beneath unrelated siblings.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding and attached a JavaScript artifact and a log to support the finding.
- A general contract validation was executed to verify a unique-suffix fallback, showing the resolver selecting node\_modules/unrelated/node\_modules/target, Node searching consumer/root ancestors, and the validator reporting accepted, while the harness did not modify repository sources.

<a href="https://app.greptile.com/trex/runs/19129302/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `scripts/generate-coding-agent-shrinkwrap.mjs`, line 287-294 ([link](https://github.com/bastani-inc/atomic/blob/222ef9f6011b3b1ae16ac019b4c55c62afc0d6c5/scripts/generate-coding-agent-shrinkwrap.mjs#L287-L294)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Unique-suffix resolution accepts unreachable dependencies**

   After checking Node-style ancestor locations, `resolveExternalDependency` accepts a uniquely named package anywhere in the lockfile. A dependency nested beneath an unrelated sibling is therefore treated as satisfying a consumer's dependency even though Node cannot resolve it from that consumer. The shrinkwrap validation can approve a published dependency graph that fails at runtime with `MODULE_NOT_FOUND`. Restrict resolution to the consumer's ancestor `node_modules` chain and add a regression case with the dependency nested under an unrelated sibling.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Evidence from the check](https://app.greptile.com/trex/artifacts/93888cb1-5226-41c1-84c1-ec05189053df)**

   - The authored narrow harness loads the repository resolver and validator, creates the real temporary Node module layout, and asserts the mismatch, ending with the confirmed defect condition.

   **[Command output from the check](https://app.greptile.com/trex/artifacts/1d81a52b-6644-4f31-b239-3e7f95c625e9)**

   - Executed \`node trex-artifacts/unique-suffix-fallback-01-before.mjs\` in \`/home/user/repo\` with exit code 0; it records the selected sibling lock path, Node’s MODULE\_NOT\_FOUND search paths, and validator acceptance, confirming the defect.

   <a href="https://app.greptile.com/trex/runs/19129302/artifacts?artifact=93888cb1-5226-41c1-84c1-ec05189053df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: scripts/generate-coding-agent-shrinkwrap.mjs
   Line: 287-294

   Comment:
   **Unique-suffix resolution accepts unreachable dependencies**

   After checking Node-style ancestor locations, `resolveExternalDependency` accepts a uniquely named package anywhere in the lockfile. A dependency nested beneath an unrelated sibling is therefore treated as satisfying a consumer's dependency even though Node cannot resolve it from that consumer. The shrinkwrap validation can approve a published dependency graph that fails at runtime with `MODULE_NOT_FOUND`. Restrict resolution to the consumer's ancestor `node_modules` chain and add a regression case with the dependency nested under an unrelated sibling.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Shrinkwrap validator accepts dependencies reachable only through an unrelated sibling**

   - **Bug**
     - A package map where `node_modules/consumer` depends on `target`, but the only `target` is at `node_modules/unrelated/node_modules/target`, is accepted by `validateShrinkwrap`. In the real fixture, Node resolution from `consumer` fails with `MODULE_NOT_FOUND`.
   - **Cause**
     - After checking Node-style ancestor candidates, `resolveExternalDependency` scans all lockfile paths for a unique `node_modules/<package>` suffix and returns it without verifying that it is on the consumer’s ancestor chain (`scripts/generate-coding-agent-shrinkwrap.mjs:287-294`). `validateShrinkwrap` uses that resolver to determine dependency presence (`:382-401`).
   - **Fix**
     - Remove the global unique-suffix fallback for dependency resolution, or restrict any fallback to paths reachable by Node’s ancestor `node_modules` lookup from `fromLockPath`. Add a regression test using a consumer and an unrelated sibling-nested dependency.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/generate-coding-agent-shrinkwrap.mjs:287-294
**Unique-suffix resolution accepts unreachable dependencies**

After checking Node-style ancestor locations, `resolveExternalDependency` accepts a uniquely named package anywhere in the lockfile. A dependency nested beneath an unrelated sibling is therefore treated as satisfying a consumer's dependency even though Node cannot resolve it from that consumer. The shrinkwrap validation can approve a published dependency graph that fails at runtime with `MODULE_NOT_FOUND`. Restrict resolution to the consumer's ancestor `node_modules` chain and add a regression case with the dependency nested under an unrelated sibling.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): consolidate Dependabot upda..."](https://github.com/bastani-inc/atomic/commit/222ef9f6011b3b1ae16ac019b4c55c62afc0d6c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53818334)</sub>

<!-- /greptile_comment -->