### PR TITLE
docs(changelog): 0.9.14-alpha.2 release notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.14-alpha.2] - 2026-08-17
+
 ### Added
 
 - Two new unbound viewport actions, `tui.altScreen.lineUp` and `tui.altScreen.lineDown`, scroll the transcript by a single line ([#2385](https://github.com/bastani-inc/atomic/issues/2385)).
@@ -24,6 +26,7 @@
 - Changed the built-in xAI default and the shipped xAI and OpenRouter workflow and subagent fallback chains from Grok 4.5 to Grok 4.6, and refreshed model-selection guidance from the latest DeepSWE v1.1 and Artificial Analysis v4.1.1 results.
 
 ### Fixed
+
 - Updated the Z.AI and Z.AI Coding Plan defaults to the catalog-valid `glm-5.3` model; direct GLM-5.3 chains use `:high`, while OpenRouter and Baseten remain documented provider-specific exceptions because their catalogs do not expose GLM-5.3 ([#2459](https://github.com/bastani-inc/atomic/issues/2459)).
 
 - Hardened hashline edits against unsafe integer anchors and oversized numeric ranges (inclusive ranges are capped at 100,000 lines before expansion), preserved hunk-looking `+TEXT` rows as literal payloads with a parser warning, omitted the synthetic terminal-newline row consistently across whole-file, truncated, and selector reads for LF and CRLF text while retaining genuine blank lines, and kept copied read output's original terminal-newline state when writing it back. Bare CR line-ending compatibility behavior is unchanged.

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.14-alpha.2] - 2026-08-17
+
 ### Added
 
 - Agent frontmatter accepts YAML array-form `tools` — flow sequences (`tools: [read, bash]`) and block sequences (`tools:` followed by `- read` lines) — as well as the comma-separated string form, and both spellings produce the same tool set. Frontmatter parses through the same YAML-backed parser Atomic exports, so legal multi-line flow sequences and zero-indent block lists work, and sequence values where a scalar belongs are ignored rather than stringified.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.14-alpha.2] - 2026-08-17
+
 ### Breaking Changes
 
 - `open-claude-design` removes the `max_refinements` input, the `approved_for_export` and `refinements_completed` outputs, and the `<artifact_dir>/feedback/` feedback artifact. A run now performs one `generate-1`, an optional live review, and export; callers must stop supplying, reading, or expecting those fields and artifacts ([#2401](https://github.com/bastani-inc/atomic/issues/2401)).

--- a/test/unit/pi-0.84.2-docs-contract.test.ts
+++ b/test/unit/pi-0.84.2-docs-contract.test.ts
@@ -7,7 +7,7 @@ import { moduleDir } from "../helpers/runtime.js";
 /**
  * L21 doc contract for the pi 0.84.2 migration: the docs must describe every
  * door the stack shipped, must never offer a renderer mode Atomic deleted, and
- * the [Unreleased] changelog sections must carry the user-visible outcome of
+ * the [0.9.14-alpha.2] changelog sections must carry the user-visible outcome of
  * L1–L20. A broken link between shipped behavior and shipped docs is exactly
  * the regression this suite exists to catch.
  */
@@ -240,9 +240,9 @@ describe("pi 0.84.2 docs contract — every shipped door is documented", () => {
 });
 
 describe("pi 0.84.2 docs contract — changelog covers L1–L20", () => {
-	test("coding-agent [Unreleased] Added carries every shipped feature", () => {
-		const unreleased = changelogSection(packageFile("coding-agent", "CHANGELOG.md"), "Unreleased");
-		const added = changelogSubsection(unreleased, "Added");
+	test("coding-agent [0.9.14-alpha.2] Added carries every shipped feature", () => {
+		const released = changelogSection(packageFile("coding-agent", "CHANGELOG.md"), "0.9.14-alpha.2");
+		const added = changelogSubsection(released, "Added");
 		for (const needle of [
 			"`fullscreenExitOutput`",
 			"`defaultTools`",
@@ -253,27 +253,27 @@ describe("pi 0.84.2 docs contract — changelog covers L1–L20", () => {
 			"`SessionNameState`",
 			"`getSessionNameState()`",
 		]) {
-			assert.ok(added.includes(needle), `[Unreleased] Added must mention ${needle}`);
+			assert.ok(added.includes(needle), `[0.9.14-alpha.2] Added must mention ${needle}`);
 		}
 		// A new export is new public surface, not a fix: it belongs under Added.
-		const fixed = changelogSubsection(unreleased, "Fixed");
+		const fixed = changelogSubsection(released, "Fixed");
 		assert.ok(!fixed.includes("`getSessionNameState()`"), "new SDK exports belong under ### Added");
 	});
 
-	test("coding-agent [Unreleased] Changed carries the pi 0.84.2 adoption and the Theme constructor change", () => {
-		const unreleased = changelogSection(packageFile("coding-agent", "CHANGELOG.md"), "Unreleased");
-		const changed = changelogSubsection(unreleased, "Changed");
+	test("coding-agent [0.9.14-alpha.2] Changed carries the pi 0.84.2 adoption and the Theme constructor change", () => {
+		const released = changelogSection(packageFile("coding-agent", "CHANGELOG.md"), "0.9.14-alpha.2");
+		const changed = changelogSubsection(released, "Changed");
 		assert.match(changed, /Adopted the pi 0\.84\.2 runtime/u);
 		// §5.3: the Theme constructor signature change is a public-API change and
 		// belongs under ### Changed, not ### Added.
 		assert.match(changed, /`Theme` constructor/u);
-		const added = changelogSubsection(unreleased, "Added");
+		const added = changelogSubsection(released, "Added");
 		assert.ok(!added.includes("`Theme` constructor"), "the Theme constructor change belongs under ### Changed");
 	});
 
-	test("coding-agent [Unreleased] Fixed carries the shared core defects and fullscreen repairs", () => {
-		const unreleased = changelogSection(packageFile("coding-agent", "CHANGELOG.md"), "Unreleased");
-		const fixed = changelogSubsection(unreleased, "Fixed");
+	test("coding-agent [0.9.14-alpha.2] Fixed carries the shared core defects and fullscreen repairs", () => {
+		const released = changelogSection(packageFile("coding-agent", "CHANGELOG.md"), "0.9.14-alpha.2");
+		const fixed = changelogSubsection(released, "Fixed");
 		for (const needle of [
 			"`message_update`",
 			"`usage`",
@@ -285,31 +285,35 @@ describe("pi 0.84.2 docs contract — changelog covers L1–L20", () => {
 			"#7963",
 			"never-named",
 		]) {
-			assert.ok(fixed.includes(needle), `[Unreleased] Fixed must mention ${needle}`);
+			assert.ok(fixed.includes(needle), `[0.9.14-alpha.2] Fixed must mention ${needle}`);
 		}
 	});
 
-	test("workflows [Unreleased] records removal of stage-chat search", () => {
-		const unreleased = changelogSection(packageFile("workflows", "CHANGELOG.md"), "Unreleased");
-		assert.match(unreleased, /Removed find-in-stage-chat/u);
-		assert.doesNotMatch(unreleased, /Added search inside attached workflow stage chats/u);
+	test("workflows [0.9.14-alpha.2] records removal of stage-chat search", () => {
+		const released = changelogSection(packageFile("workflows", "CHANGELOG.md"), "0.9.14-alpha.2");
+		assert.match(released, /Removed find-in-stage-chat/u);
+		assert.doesNotMatch(released, /Added search inside attached workflow stage chats/u);
 	});
 
-	test("subagents [Unreleased] carries the pi 0.84.2 parity fixes", () => {
-		const unreleased = changelogSection(packageFile("subagents", "CHANGELOG.md"), "Unreleased");
-		assert.match(unreleased, /array-form `tools`/u);
-		assert.match(unreleased, /thinking level/u);
+	test("subagents [0.9.14-alpha.2] carries the pi 0.84.2 parity fixes", () => {
+		const released = changelogSection(packageFile("subagents", "CHANGELOG.md"), "0.9.14-alpha.2");
+		assert.match(released, /array-form `tools`/u);
+		assert.match(released, /thinking level/u);
 	});
 
 	test("released changelog sections still carry their original headings", () => {
 		// The full released-section freeze is enforced against git tags by
-		// test/unit/changelog.test.ts; this pins the lighter invariant that L21
-		// inserted its entries only inside [Unreleased] and reordered nothing.
+		// test/unit/changelog.test.ts; this pins descending heading order after
+		// the 0.9.14-alpha.2 notes left [Unreleased].
 		const changelog = packageFile("coding-agent", "CHANGELOG.md");
 		const unreleasedAt = changelog.indexOf("## [Unreleased]");
+		const alpha2At = changelog.indexOf("## [0.9.14-alpha.2]");
 		const alphaAt = changelog.indexOf("## [0.9.14-alpha.1]");
 		const stableAt = changelog.indexOf("## [0.9.13]");
-		assert.ok(unreleasedAt !== -1 && alphaAt !== -1 && stableAt !== -1);
-		assert.ok(unreleasedAt < alphaAt && alphaAt < stableAt, "released sections stay in descending version order");
+		assert.ok(unreleasedAt !== -1 && alpha2At !== -1 && alphaAt !== -1 && stableAt !== -1);
+		assert.ok(
+			unreleasedAt < alpha2At && alpha2At < alphaAt && alphaAt < stableAt,
+			"released sections stay in descending version order",
+		);
 	});
 });


### PR DESCRIPTION
## Summary

Release notes for the `0.9.14-alpha.2` prerelease. The accumulated `[Unreleased]` entries in `packages/coding-agent`, `packages/subagents`, and `packages/workflows` move under a `## [0.9.14-alpha.2] - 2026-08-17` heading.

The pi 0.84.2 changelog contract now reads that version section instead of `[Unreleased]`, so the same feature, change, and fix pins still hold after the notes leave Unreleased.

## Changes

- `packages/coding-agent/CHANGELOG.md` — pi 0.84.2 adoption, new settings and SDK surface, hashline and fullscreen repairs, and the transcript-search / ADHD-mode removals.
- `packages/subagents/CHANGELOG.md` — YAML array-form `tools`, source-qualified skill selectors, thinking-level inheritance, and GLM-5.3 fallbacks.
- `packages/workflows/CHANGELOG.md` — `open-claude-design` review-loop break, `ctx.tool` operator card, Impeccable 4.1.1, session-scoped run survival, and DBOS registration diagnostics.
- `test/unit/pi-0.84.2-docs-contract.test.ts` — retarget L1–L20 changelog assertions to `[0.9.14-alpha.2]`.

## Versionless base

No version stamping here. Every `packages/*/package.json`, the `@bastani/atomic-natives` pin, `packages/natives/native/index.js`, `Cargo.toml`, and `Cargo.lock` stay at the `0.0.0` placeholder. `scripts/cut-release.ts` materializes `0.9.14-alpha.2` on the detached `Release 0.9.14-alpha.2` commit after this merges.

## Notes

- Local validation: `bunx vitest --run --project unit test/unit/changelog.test.ts test/unit/package-metadata.test.ts test/unit/pi-0.84.2-docs-contract.test.ts` (43 passed). Pre-commit `npm run check` and `npm run test:unit` passed. Pre-push `npm run test:integration` and `npm run test:ci-contracts` passed.
- An unrelated local scratch file, `.atomic/workflows/p0-2462-stacked-fix.ts`, fails root typecheck when present. It is untracked and is not in this PR.
- Two integration tests (`coding-agent-built-cli-assets`, `cut-release-npm-preflight --allow-new`) failed once under hook load and passed on a standalone retry. They were not changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789595376&installation_model_id=10562&pr_number=2483&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2483&signature=867b6cb60e133bd746c9df09bf24c1b266c9d15bb2829f88e8a40107ee52cd73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change moves the accumulated release notes for coding-agent, subagents, and workflows into dated `0.9.14-alpha.2` sections and retargets the pi 0.84.2 documentation contract to those released sections. The released notes preserve their prior content, leave `Unreleased` empty, and retain descending release-heading order.

The focused changelog, package-metadata, and pi documentation-contract suite passed all 43 tests. A comparison with the parent revision also confirmed that all promoted entries and subsection content were retained across the three changelogs.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the change is limited to release-note placement and corresponding documentation-contract expectations, and the focused validation passed.

No defects were found. Validation confirmed the released changelog content, empty Unreleased sections, release ordering, and the applicable documentation contracts.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran bunx vitest for the specified unit tests and confirmed all 43 tests passed.
- Compared the parent revision with the current revision to verify promoted changelog entries and subsection content were preserved, Unreleased is empty, and each new release section precedes older releases.
- Ran git diff --check HEAD^ HEAD and verified there are no whitespace errors.
- Validated the pi 0.84.2 docs contract, including released-section content checks and coding-agent heading order; the after-check confirms released content is preserved aside from a blank-line formatting in coding-agent, and the commit added a blank line within ### Fixed with no content change.

<a href="https://app.greptile.com/trex/runs/19287407/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): add 0.9.14-alpha.2 rele..."](https://github.com/bastani-inc/atomic/commit/c742929bfe65a07641d05c15ff19f8b67738a1f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54140240)</sub>

<!-- /greptile_comment -->