### PR TITLE
docs(specs): LLM-as-a-Verifier adoption program — umbrella + 6 child specs

### DIFF
--- a/research/docs/2026-08-17-llm-verifier-adoption-scan.md
+++ b/research/docs/2026-08-17-llm-verifier-adoption-scan.md
@@ -1,0 +1,97 @@
+# LLM-as-a-Verifier adoption — consolidated scan (issues, reference repo, code ground truth)
+
+**Date:** 2026-08-17
+**Sources:** GitHub issues bastani-inc/atomic #2487–#2491, #2493, #2494, #2212; reference repo [llm-as-a-verifier/llm-as-a-verifier](https://github.com/llm-as-a-verifier/llm-as-a-verifier) (arXiv:2607.05391, v0.2.0); local code inspection at commit `9d0a69da0e` (main).
+**Supersedes:** the archived evidence sections of closed issues #2254–#2261 remain the paper-citation reference; this scan adds the 0.2.0 engineering layer and the code ground truth for spec-writing.
+
+## 1. The issue set and its dependency DAG
+
+| Issue | Title (short) | Depends on |
+|---|---|---|
+| #2487 | shared `criteria.md` rubric format, per-criterion scoring, mean+veto aggregation | — |
+| #2493 | prefix-cache-aware verifier prompts + warm-first fan-out | #2487 (shapes its prompt builders) |
+| #2488 | tournament → soft-scored selection (graded scores, K repeats w/ slot swap, Bradley–Terry, PPT) | #2487 |
+| #2489 | trajectory progress-scoring primitive with skeptical calibration | #2487 |
+| #2490 | goal/ralph graded review signals: targeted re-verification + convergence trends | #2487, #2489 |
+| #2491 | docs: verification-scaling guidance for custom-workflow authors | phase 1 independent; phase 2 trails each ship |
+| #2494 | verifier call/token usage + cache-hit rate in verification ledgers | none hard; annotates ledgers #2488 rewrites |
+| #2212 | per-run time/token budgets with resumable `budget_exceeded` outcome | duration slice independent; token slice wants #2494's usage reducer |
+
+The graph forks at #2487 (both #2488 and #2489 depend on it, not on each other) and rejoins at #2490.
+
+## 2. Decisions already made (owner: flora131)
+
+1. **No logprobs.** #2260 closed: Atomic providers expose no token logprobs; the K-sample Monte-Carlo average is the accepted substitute for the paper's Eq. 3.1 expectation (~16× call cost for K=16 parity).
+2. **In-place upgrade of `tournament`,** not a new select-best-of-n workflow (#2488 header).
+3. **Progress score is never a kill switch** (#2489): monitoring + escalate-to-human only; measured VOC separation is +0.079.
+4. **`stop_review_loop` stays authoritative** for goal/ralph (#2490): graded signals inform, never approve/terminate.
+5. **Parse failures are indeterminate re-asks, never counted votes** (#2487/#2488) and **never durably checkpointed as scores** (#2488 comment; mirrors reference `on_error="tie"` being run-local, never cached).
+6. **Budget exhaustion reports `budget_exceeded`** as a returned status on the `blocked` exit rail, joining `RETURNED_BLOCKED_STATUSES` beside `auth_blocked`, resumable by construction (#2212 amendment). `WorkflowExitStatus` union unchanged.
+7. **Compatibility posture (spec-phase decision): breaking changes allowed freely.** The verification builtins are treated as pre-1.0 internals; the "output contract preserved or versioned deliberately" clauses in #2487/#2488 are relaxed by owner decision. Existing outputs are documented as current state, not constraints.
+8. **Delivery shape (spec-phase decision):** one linear gh-stack per cluster in its own worktree; every PR < 500 changed lines; each PR body carries an Evidence section (acceptance-criteria checklist, exact commands, trimmed real output, diff stat).
+9. **Budget shape (spec-phase decision, codex prior art):** `WorkflowBudget { maxDurationMs, maxTokens, maxCost, warnAtPercent }`, every field defaulting to `0` = unbudgeted; declared at config, definition (`workflow({ budget })`), and per-run via the workflow tool, resolved **later-wins per-field** (run > definition > config, overrides may widen/narrow/disable). `maxTokens` charges **uncached input + output** — openai/codex's goal-budget formula (`goal_token_delta_for_usage` in `codex-rs/ext/goal/src/accounting.rs`: `(input − cached_input) + output`; cache reads free, cache writes uncounted); cache-heavy spend is governed by `maxCost` (USD from `usage.cost`) instead of inflating the token meter. Exhaustion is a **soft landing**: one-time wrap-up injection to the frontier stage (codex `budget_limit.md` pattern; delivered once per run per budget), then stop with system-owned `budget_exceeded`. Accounting mechanics from codex: monotone saturating deltas, serialized single-accountant charging, baselines surviving durable resume. Codex's rollout budget (`core/src/rollout_budget.rs`, weighted units output×1.0 + uncached_input×0.1, escalating reminders) noted but not adopted — `maxCost` covers the price-shaped need.
+
+## 3. Reference-repo technique inventory → adoption mapping
+
+| Technique (reference location) | Paper/measured evidence | Adopting issue |
+|---|---|---|
+| `criteria.md` format: ground-truth note, `### Name {#id}` sections, comment stripping, id slugging (`llm_verifier/prompts.py`, `criteria/TEMPLATE.md`) | — | #2487 |
+| Per-criterion scoring in separate calls | compound rubrics latch on salient factor; best single criterion 76.4% vs 3-ensemble 78.3% (§4.3) | #2487 |
+| Mean aggregation + explicit veto, never unanimity AND | false-accept degrades `(1−p)^K` (#2255 derivation) | #2487 |
+| Anchored 20-point scale (letters A–T; integers 1–20 in prompt-template form) | granularity scaling | #2487 (shared constants) |
+| Graded pairwise scores → Bradley–Terry soft wins `σ(R_a−R_b)`; win mass `w`, count `c`, rank by `w/c` (`pivot_tournament.py`) | discrete judges tie 26.7% at K=1 | #2488 |
+| K repeats with A/B slot swap within each pair | positional bias cancels within pair; variance O(1/K); 74.7%→77.5% K=1→16 | #2488, #2490 |
+| PPT: random-Hamiltonian ring pass (slot bias cancels around ring), top-k pivots by ring mean, non-pivot×pivot + pivot×pivot rounds; `N + k(N−k) + C(k,2)` budget | O(Nk) vs O(N²); bo3 86.5%±1.1 vs pass@1 79.4 (oracle 92.1); bo5 88.0%±0.6 vs 78.7 (96.6) | #2488 |
+| Directed-comparison cache keyed `(criterion, task, a, b, rep)`; failures scored tie run-locally, never cached | resume/replay identical comparisons | #2488 (ctx.tool durability + seeded PRNG) |
+| Progress scoring over trajectory prefixes; skeptical calibration (trust output not narration; effort ≠ progress; declarations = zero evidence; scores may plateau/decrease) (`llm_verifier/progress.py`) | success/failure VOC separation +0.079 | #2489 |
+| **Batched multi-checkpoint scoring**: one call scores ALL checkpoints → O(K) cost regardless of length; online `ProgressTracker` = one call/step/repeat, prefix-only | — | #2489 (scope comment) |
+| Interior-checkpoint default `2..T-1` | — | #2489 (scope comment) |
+| Prefix-cache prompt layout: shared head (task, trajectories, scale), criterion strictly at tail; docstring makes ordering an invariant (`build_prompt`) | hit rate 5.2%→78.4%, ~3.4× fewer uncached input tokens | #2493 |
+| Warm-first scheduling: one request per distinct prefix to completion, then fan out (`score_directed_pairs` warm/rest phases) | same measurement | #2493 |
+| Token accounting: per-call input/cached-input/output/reasoning, measured hit rate, phase deltas via snapshot subtraction; cached comparisons add nothing (`TokenUsage`) | "measured rather than assumed" | #2494 |
+| Self-verification: same model judges its own rollouts, still +7.1/+9.3 over pass@1 | bo3/bo5 table above | #2491 (guidance) |
+| Cheap operating points: bo3 = `pivots=1, K=2`; bo5 same shape (`scripts/run_bo3.py`) | — | #2488 defaults, #2491 |
+| Multimodal image inputs on every entry point | — | deliberately deferred (no atomic verification builtin consumes screenshots) |
+| TurboAgent provider proxy | — | rejected: atomic owns fan-out at the workflow layer |
+
+## 4. Code ground truth (file:line, main @ `9d0a69da0e`)
+
+### Tournament (rewritten by #2488, prompts reshaped by #2493)
+- `packages/workflows/builtin/tournament-runner.ts` (194 lines): binary `winner: "first"|"second"` schema at 17–21; single-elimination bracket loop at 103–163 — one binary call eliminates a loser forever; orientation parity trick `(round+index)%2` at 111/137; judge fan-out via `ctx.parallel` at 130; `bracket.json` written at 166–167; outputs at 184–193 (`result`, `winner`, `winner_artifact_path`, `result_path`, `attempt_artifact_paths`, `judge_artifact_paths`, `bracket_path`, `artifact_dir`).
+- `packages/workflows/builtin/tournament-prompts.ts`: `renderPairwiseJudgePrompt` leads with pair-specific `candidates` section (37–42), rubric mid-prompt (44–49) — no two judge calls share a usable prompt prefix (the #2493 anti-pattern). Candidate bodies arrive via `reads` (runner 126), i.e. after the prompt — invisible to prefix caching.
+- `tournament.ts` (39 lines) + `tournament.d.ts` — definition wrapper + declared outputs.
+
+### Adversarial verification (rewired by #2487)
+- `packages/workflows/builtin/adversarial-verification-runner.ts`: hardcoded rubric written inline to `rubric.md`; `verifierSchema` = binary pass/fail verdict + `blocking_findings`; `INVALID_VERIFIER_REPORT` substitutes a fail verdict for an unparseable report — the #2255-inherited bug where a parse failure becomes a substantive objection under the unanimity gate.
+- `adversarial-verification.ts` (29 lines) + prompts + `.d.ts`.
+
+### Goal/ralph (consumed by #2490)
+- `packages/workflows/builtin/goal-schemas.ts` (82 lines): `confidence_score` per finding and `overall_confidence_score` at 7/71 — collected, then ignored by the gate; compound boolean "patch is correct/incorrect" at 66–69.
+- `packages/workflows/builtin/review-convergence.ts` (229 lines): `findingBlocksClosure` at 91–101 reads only `objective_alignment` + `priority`; a 0.51-confidence finding blocks with the authority of a 0.99 one.
+- `packages/workflows/builtin/ralph-review-gate.ts` (102 lines): 3–26 documents why `stop_review_loop` stays authoritative (self-referential acceptance criteria deadlocked runs). Hard guards: parse failures and `reviewer_error` never approve.
+
+### Progress-scoring consumers (#2489)
+- `packages/workflows/builtin/loop-until-done*.ts` (~36-line definition + runner + prompts): iteration ledger, `done: boolean` stop bit.
+- `packages/subagents/src/runs/shared/subagent-control.ts` (223 lines): wall-clock attention thresholds (`activeNoticeAfterMs`, `needsAttentionAfterMs`) — the proxies #2489 supplements (never replaces).
+
+### Usage telemetry (consumed by #2494, #2212)
+- `packages/workflows/src/shared/authoring-contract-stage.ts:84–98`: `WorkflowModelUsage { input?, output?, cacheRead?, cacheWrite?, cost?, turns? }`; `WorkflowModelAttempt.usage` carries it. Populated since #2197 closed. `WorkflowTaskResult.modelAttempts` (398–) exposes it per judge/verifier task.
+- `packages/workflows/src/durable/dbos-envelope.ts` `isModelUsage` validates the six keys.
+- #2197's measured run: 96.1% cache reads (457.8M of 476.4M tokens) — drives #2212 open question 3 (count all four counters).
+
+### Budget substrate (#2212)
+- `packages/workflows/src/shared/timing.ts` `elapsedRunMs(run, now)`: subtracts pause intervals, adds `accumulatedDurationMs` — the duration meter, already correct.
+- `packages/workflows/src/shared/returned-run-status.ts:5`: `RETURNED_BLOCKED_STATUSES = {"blocked","needs_human","incomplete","auth_blocked","active"}`; `isReturnedResumableBlockedWorkflowStatus` excludes only plain `blocked`. `budget_exceeded` joins here.
+- `packages/workflows/src/shared/authoring-contract-stage.ts:34`: `WorkflowExitStatus = "completed"|"skipped"|"cancelled"|"blocked"|"failed"` — unchanged by decision 6.
+- `maxDepth` config precedent: `WORKFLOW_CONFIG_DEFAULTS` → validation in `extension/config-file-loader.ts` → `WorkflowEffectiveConfig`.
+
+### Repo delivery constraints
+- `packages/workflows` ships raw `.ts`, `.js` import specifiers, **no build step** (AGENTS.md, EXTREMELY_IMPORTANT block).
+- Tests: root vitest projects (`npm run test:unit`), `node:assert/strict` style, 30 s shared per-test budget, no `--timeout` restating; load-sensitive tests must derive assertions from named constants.
+- Checks: `npm run check` = biome + `tsc --noEmit` + coding-agent `tsgo` pass + shrinkwrap check.
+- Existing unit suites touching this area: `test/unit/builtin-workflows-tournament-loop.test.ts`, `test/unit/builtin-workflows-adversarial-generate.test.ts`, `test/unit/review-convergence-closure.test.ts`.
+- Worktree convention: sibling dirs `../atomic-<topic>` (34 active worktrees observed). `gh-stack` v0.1.0 installed; stacks are strictly linear (one parent, one child); repo has stacked PRs enabled (existing usage observed).
+
+## 5. Estimates (session consensus)
+
+#2487 ≈ 1.5–2.5 d · #2488 ≈ 3–4 d · #2489 ≈ 1.5–2 d · #2490 ≈ 2–3 d · #2491 ≈ 0.5 d up front + trailing · #2493 ≈ 1 d · #2494 ≈ 0.5–1 d · #2212 duration ≈ 1–1.5 d, token ≈ 1 d. Program total ≈ 11.5–16 focused days human-equivalent; compressed by per-slice autonomous workflows.

--- a/specs/2026-08-17-goal-graded-signals.md
+++ b/specs/2026-08-17-goal-graded-signals.md
@@ -1,0 +1,183 @@
+# Goal/Ralph Graded Review Signals (Slices V9–V10) — Child Spec
+
+| Document Metadata      | Details                                                                 |
+| ---------------------- | ----------------------------------------------------------------------- |
+| Author(s)              | flora131 (with Claude Fable 5)                                          |
+| Status                 | In Review (RFC) — all open questions resolved 2026-08-17                |
+| Team / Owner           | flora131                                                                |
+| Created / Last Updated | 2026-08-17                                                              |
+| Parent                 | `specs/2026-08-17-llm-verifier-adoption-program.md` (umbrella)          |
+| Depends on             | `specs/2026-08-17-verification-criteria-module.md` (V1 scale/criteria) · `specs/2026-08-17-progress-scoring.md` (V7 `classify_trend`) · `specs/2026-08-17-tournament-soft-selection.md` (V6 `fold_usage`) |
+| Issues                 | #2490 (+ #2494's goal/ralph ledger scope, deferred here from V6)        |
+| Research               | `research/docs/2026-08-17-llm-verifier-adoption-scan.md` §3, §4         |
+| Slices                 | V9 `verifier/goal-reverify` · V10 `verifier/goal-convergence`           |
+
+## 1. Executive Summary
+
+The goal/ralph review loops collect graded signals and then discard them at the decision point: reviewers emit `confidence_score` per finding and `overall_confidence_score` (`goal-schemas.ts:7,71`), but `findingBlocksClosure` (`review-convergence.ts:91-101`) reads only alignment and priority — a finding held at 0.51 confidence blocks a repair round with the same authority as one held at 0.99, and each reviewer evaluates once (K=1) exactly where a single noisy finding costs a full repair round. This spec adds two contained upgrades. **V9 — `reverify_finding`**: before a *low-confidence, single-reviewer, demotable* blocking finding triggers repair, K fresh-context verifiers re-score it on the shared 1–20 scale; the mean confirms or demotes, spending the K-repeat budget only on disputed findings. **V10 — convergence evidence**: per-round scalars (unresolved blocking count, mean finding confidence, fraction proven, verifier usage) recorded in the goal/ralph ledgers, classified by V7's `classify_trend`, feeding `needs_human` escalation *before* turn exhaustion — plus reviewer calibration alignment and audit-only per-criterion scores. The prime directive is inherited unchanged: **`stop_review_loop` stays the sole approval authority; parse failures and `reviewer_error` never approve; nothing here approves or terminates anything.**
+
+## 2. Context and Motivation
+
+### 2.1 Current State (verified gaps, with the guards that must survive)
+
+- **Gap 1 — graded signals discarded:** `findingBlocksClosure` ignores `confidence_score` entirely. The schema collects it (`goal-schemas.ts:7`); no code path reads it.
+- **Gap 2 — K=1 everywhere:** one evaluation per reviewer per round; the paper's repeated-evaluation axis (74.7%→77.5%, K=1→16; variance O(1/K)) is unused where a noisy finding is most expensive.
+- **Gap 3 — no convergence magnitude:** the loop runs until the boolean flips or `max_turns`/`max_loops` exhausts. A loop re-litigating identical findings for 6 turns and one steadily closing them are indistinguishable until exhaustion.
+- **Hard guards that stay (from `ralph-review-gate.ts:3-26` and `review-convergence.ts`):** `stop_review_loop` is authoritative (self-referential acceptance criteria deadlocked runs; that fix is history, not up for renegotiation); parse failures and `reviewer_error` never approve; missing alignment/priority **blocks** (ambiguity never silently approves); `required_by_objective` blocks at ANY priority — "severity labels alone never dismiss work the literal contract requires."
+
+### 2.2 The Problem
+
+Naive fixes would weaken the guards: demoting any low-confidence finding lets re-verification dismiss literal-contract work; skipping re-verification entirely wastes a full repair round on hallucinated nits. The design threads the needle: re-verification applies exactly where the guards permit doubt, and everything else becomes evidence rather than authority.
+
+## 3. Goals and Non-Goals
+
+### 3.1 Functional Goals
+
+- [ ] `reverify_finding`: K fresh-context re-scores of eligible low-confidence blocking findings; mean decides Confirmed | Demoted; demotions carry full audit evidence in the ledger.
+- [ ] Eligibility (Q1–Q3 resolved): blocking ∧ single-reviewer ∧ `confidence_score < 0.7`. All alignment classes are demotable, but `required_by_objective` carries a **stricter bar**: demotion requires mean < 6 (clearly refuted) with all K repeats valid; the standard class demotes below mean 10. Corroborated (≥2-reviewer) findings are never eligible.
+- [ ] Per-round convergence scalars in the goal ledger and ralph loop state; V7 `classify_trend` over the series; flat/regressing trend cited as evidence in `needs_human` escalation before exhaustion.
+- [ ] goal/ralph ledger rounds gain `usage` blocks via V6 `fold_usage` (the #2494 scope deferred here).
+- [ ] Reviewer prompts adopt the paper's calibration rules where missing (observed output over narration; agent declarations are zero evidence).
+- [ ] Reviewer schema gains optional, audit-only per-criterion graded scores beside the authoritative compound boolean.
+
+### 3.2 Non-Goals (the guards, restated as refusals)
+
+- [ ] `stop_review_loop` semantics unchanged; **all existing gate tests pass unmodified.**
+- [ ] Re-verification NEVER approves a round, NEVER touches `stop_review_loop`, NEVER deletes a finding — it demotes blocking→non-blocking with evidence, only within eligibility.
+- [ ] The convergence trend NEVER approves and NEVER terminates; it is escalation evidence only (V7 containment inherited).
+- [ ] Parse failures anywhere in re-verification are indeterminate re-asks (V2 rule) — a re-verifier that fails to parse contributes nothing and can never demote by default.
+- [ ] NO reduction of reviewer count or rounds; K-repeats spend *additional* budget on disputed findings only.
+
+## 4. Proposed Solution (High-Level Design)
+
+### 4.1 The Re-Verification Gate (V9)
+
+```mermaid
+flowchart TB
+    classDef det fill:#48bb78,stroke:#38a169,color:#fff,font-weight:600
+    classDef stage fill:#667eea,stroke:#5a67d8,color:#fff
+    classDef guard fill:#e53e3e,stroke:#c53030,color:#fff,font-weight:600
+
+    R["review round findings"] --> CONS["consolidateFindingsBatch<br>(existing, unchanged)"]:::det
+    CONS --> BLK["unresolved blocking findings"]:::det
+    BLK --> ELIG{"eligible for re-verification?<br>single-reviewer ∧ demotable class<br>∧ confidence < threshold"}:::det
+    ELIG -->|no — guard-protected| REPAIR["repair round<br>(exactly as today)"]:::stage
+    ELIG -->|yes| RV["reverify_finding<br>K fresh-context verifiers<br>1–20: 'is this finding real and blocking?'"]:::stage
+    RV --> MEAN{"mean ≥ confirm threshold?"}:::det
+    MEAN -->|yes| REPAIR
+    MEAN -->|no| DEM["Demoted: non-blocking,<br>audit evidence in ledger"]:::det
+    DEM -.-> NOTE["never deleted; never approves;<br>stop_review_loop untouched"]:::guard
+```
+
+If demotion empties the blocking set, the round proceeds exactly as a round that never had blocking findings — **through the existing gate**, which still requires `stop_review_loop` from the reviewers. Re-verification can save a repair round; it cannot mint an approval.
+
+### 4.2 The Door Set at a Glance
+
+> `reverify_finding` · `record_convergence` · (imports: `classify_trend`, `fold_usage`, `VERIFICATION_SCALE`)
+
+Read alone: disputed findings get a second opinion under rules that protect the contract; every round's shape is recorded and classified; and the authorities that already existed are the only authorities that remain.
+
+## 5. Detailed Design
+
+### 5.1 The Doors
+
+```ts
+// V9 — packages/workflows/builtin/goal-reverify.ts
+
+reverify_finding(ctx, input: {
+  finding: ConsolidatedFinding;           // from consolidateFindingsBatch
+  context: { objective: string; candidateRefs: readonly string[] };
+  repeats?: number;                       // K, default 3 (Q2 resolved)
+}): Promise<ReverifyResult>
+// ReverifyResult = { verdict: "confirmed" | "demoted";
+//                    meanScore: number;                 // 1–20
+//                    perRepeat: (number | null)[];      // null = invalid re-ask exhausted
+//                    evidence: readonly string[] }
+// Stage question (fresh context, code_location + candidate refs in reads,
+// V3 prompt layout): "Assess this specific finding against the code it cites:
+// is it a real, objective-relevant, currently-unresolved blocker?" 1–20.
+// Guarantee (Q1/Q2 resolved — two-tier demotion):
+//   standard classes: "demoted" when mean < 10 over valid repeats AND
+//     ≥ ceil(K/2) repeats are valid — borderline-or-above stays blocking;
+//   required_by_objective: "demoted" ONLY when mean < 6 (clearly refuted)
+//     AND all K repeats are valid — the contract guard bends only to an
+//     unanimous-quorum, unambiguous refutation; any invalid repeat confirms.
+// Anything less (parse failures, missing quorum) is "confirmed" — doubt
+// defaults to blocking, mirroring the gate's ambiguity-never-approves rule.
+// Refusal BY CONSTRUCTION: eligibility is checked by the CALLER via
+// is_reverifiable before this door is reachable; the door itself re-checks
+// and throws on an ineligible finding — belt and suspenders.
+
+is_reverifiable(finding: ConsolidatedFinding, threshold: number): boolean
+// Pure. Encodes eligibility (Q1–Q3 resolved): blocking ∧ confidence <
+// threshold (0.7) ∧ single-reviewer (corroborated findings never eligible) ∧
+// alignment is not beyond/contradicts (those never block anyway). The
+// required_by_objective class passes eligibility but is flagged so
+// reverify_finding applies the stricter demotion bar.
+
+// V10 — packages/workflows/builtin/goal-convergence.ts
+
+record_convergence(round: {
+  unresolvedBlockingCount: number;
+  meanFindingConfidence: number | null;   // null when no findings
+  fractionProven: number;                 // requirements_traceability proven share
+  demotions: number;                      // V9 activity this round
+  usage: UsageTotals;                     // V6 fold over the round's stages
+}): ConvergenceEntry
+// Appended per round to the goal ledger / ralph loop state. Pure shaping —
+// the ledger write stays where ledger writes live today.
+// classify_trend (V7 import) runs over the unresolvedBlockingCount and
+// fractionProven series; a flat/regressing classification is attached to
+// needs_human escalation evidence ("3 rounds, same 4 blockers, confidence
+// falling") — and to nothing else.
+```
+
+**Per-door rubric audit:**
+
+| Door | (1) Joint | (2) One sentence | (3) Honest | (5) Every exit | (6) Refusals |
+|---|---|---|---|---|---|
+| `reverify_finding` | ✅ "re-verify the finding" | ✅ K re-scores decide confirmed-or-demoted for one disputed finding | ✅ re-verifies; cannot approve, delete, or stop | invalid repeats → confirmed (doubt blocks); quorum miss → confirmed | ineligible finding throws; demotion without evidence unrepresentable (result carries perRepeat + evidence) |
+| `record_convergence` | ✅ | ✅ shapes one round's scalars into one ledger entry | ✅ records, never decides | no-findings round → null confidence, defined | no authority to reach: output feeds ledgers and escalation text only |
+
+### 5.2 Calibration + criterion scores (V10)
+
+- **Calibration:** goal/ralph reviewer prompts gain the missing rules — trust observed output over narration; agent declarations ("done", "all tests pass") are zero evidence — phrased locally per prompt (a reviewer sees its prompt, not the paper). No rule that exists today is removed.
+- **Criterion scores (audit-only):** `reviewDecisionSchema` gains optional `criterion_scores?: [{criterion_id, score: 1..20}]` beside `overall_correctness`. The compound boolean remains the authoritative signal the gate reads; the graded scores are ledger evidence (and future analysis fodder). Breaking posture covers the schema addition; gate code does not read the new field — enforced by the existing-gate-tests-unmodified goal.
+
+### 5.3 Ralph parity
+
+Ralph's loop state gains the same `ConvergenceEntry` series and the same escalation evidence; `ralph-review-gate.ts` logic is untouched (its file-level contract comment is the spec's non-goal, quoted). Re-verification applies to ralph's consolidated findings through the same `is_reverifiable` door.
+
+## 6. Alternatives Considered
+
+| Option | Pros | Cons | Rejection |
+|---|---|---|---|
+| Confidence-weighted blocking (a 0.51 finding blocks "half") | no re-verification cost | ambiguity-never-approves guard dies; unauditable fractional authority | guards are non-negotiable |
+| Re-verify whole reviews (K× reviewers) | uniform variance reduction | K× cost on every round; #2490 explicitly targets the budget at disputed findings only | issue decision |
+| Demote by original reviewer's own confidence alone | zero extra calls | self-reported confidence demoting own finding = the narration bias this program exists to kill | calibration violation |
+| Trend auto-stops a non-converging loop | saves turns | violates #2489/#2490 containment; needs_human exists for exactly this | forbidden |
+
+## 7. Cross-Cutting Concerns
+
+- **Trust:** no new approval path exists. The diff's most dangerous line is the one that filters a demoted finding out of the blocking set — it is reachable only through `reverify_finding`'s evidence-carrying result, and the round still faces the unchanged gate.
+- **Cost:** re-verification spends `K × (eligible findings)` calls per round — zero when reviewers are confident or corroborated. Convergence recording is free (arithmetic over data already in hand). Usage blocks make both visible (V6).
+- **Compatibility:** breaking posture; schema addition + ledger reshape in CHANGELOG. Existing gate tests unmodified is a *hard* acceptance criterion (#2490).
+
+## 8. Test Plan
+
+- **V9** — `review-convergence-closure` suite **unmodified and green** (the guard proof), plus new fixtures: eligibility table (`is_reverifiable` × alignment classes, corroboration, thresholds); demotion path (low mean → demoted, evidence recorded, blocking set shrinks); doubt-defaults-to-blocking (invalid repeats, quorum miss → confirmed); ineligible-finding throw; demotion-empties-set → round still requires `stop_review_loop` (no auto-approve).
+- **V10** — goal ledger suite: `ConvergenceEntry` per round; series classified; `needs_human` escalation text cites trend evidence; usage block present; gate reads nothing new (assert `findingBlocksClosure` call sites unchanged).
+- **Interactive verification:**
+  1. Fixture round with one 0.4-confidence single-reviewer `consistent_with_objective` P2 finding + stubbed re-verifiers scoring 5,6,4 → demoted; ledger shows verdict, scores, evidence; repair round skipped; gate still waits on `stop_review_loop`.
+  2. Same finding held by two reviewers → not eligible; repair round proceeds (corroboration guard observable).
+  3. Same finding `required_by_objective`, stubbed re-verifiers scoring 5,5,5 → demoted (below 6, all valid); scoring 8,8,8 → confirmed (below-10 would demote a standard finding, but the contract bar holds); scoring 5,5,invalid → confirmed (unanimous-quorum rule observable).
+  4. Six-round fixture with identical unresolved counts → trend flat; escalation report cites "6 rounds, no convergence" before `max_turns`.
+- `npm run check` green per slice; Evidence protocol per umbrella §5.3.
+
+## 9. Open Questions / Unresolved Issues
+
+All resolved with the owner, 2026-08-17:
+
+- [x] **Q1 — Demotable classes:** all alignments demotable — **owner override of the drafted recommendation** — with a stricter bar for `required_by_objective`: mean < 6 and all K repeats valid (vs mean < 10 with majority quorum for standard classes). Rationale: fabricated contract claims are catchable, and the two-tier bar keeps the guard's spirit — the contract yields only to unanimous, unambiguous refutation.
+- [x] **Q2 — Threshold + K:** re-verify below `confidence_score < 0.7`; K=3; standard confirm threshold mean ≥ 10.
+- [x] **Q3 — Corroboration:** findings merged from ≥2 reviewers are never eligible; they go straight to repair.

--- a/specs/2026-08-17-llm-verifier-adoption-program.md
+++ b/specs/2026-08-17-llm-verifier-adoption-program.md
@@ -1,0 +1,250 @@
+# LLM-as-a-Verifier Adoption Program — Umbrella Spec (Worktrees, Stacks, Slices, Evidence)
+
+| Document Metadata      | Details                                                         |
+| ---------------------- | --------------------------------------------------------------- |
+| Author(s)              | flora131 (with Claude Fable 5)                                  |
+| Status                 | In Review (RFC) — all open questions resolved 2026-08-17        |
+| Team / Owner           | flora131                                                        |
+| Created / Last Updated | 2026-08-17                                                      |
+| Compatibility posture  | **Breaking changes allowed freely** (owner decision; see §7.2)  |
+| Research               | `research/docs/2026-08-17-llm-verifier-adoption-scan.md`        |
+| Child specs            | §5.4 index (authored per-cluster after this spec is approved)   |
+
+## 1. Executive Summary
+
+Eight issues (#2487–#2491, #2493, #2494, #2212) adopt the LLM-as-a-Verifier verification-scaling results into atomic's workflow builtins: graded per-criterion scoring replaces binary verdicts, Bradley–Terry soft selection replaces knockout brackets, trajectory progress curves replace wall-clock-only stall detection, verifier cost becomes measured, and runs gain enforceable budgets. This umbrella spec defines the **delivery machinery**: two git worktrees, two linear gh-stacks plus standalone PRs, fourteen implementation slices each under 500 changed lines, a per-PR Evidence protocol, and per-slice autonomous implementation via child workflows with deterministic verification gates. The program's door set at a glance: `parse_rubric`, `score_criterion`, `decide_verification`, `select_best`, `score_progress`, `classify_trend`, `reverify_finding`, `fold_usage`, `warm_first_fan_out`, `enforce_budget` ⚠. Two doors guard dangerous effects: `decide_verification` (the only path to an accept) and `enforce_budget` (the only path to `budget_exceeded`).
+
+## 2. Context and Motivation
+
+### 2.1 Current State
+
+See research §4 for exact file:line citations. The leaking doors today:
+
+- **`winner: "first" | "second"`** (`tournament-runner.ts:17-21`) — a binary door that cannot distinguish 51/49 from 99/1; the knockout bracket (103–163) makes one noisy call an irreversible elimination.
+- **`INVALID_VERIFIER_REPORT`** (`adversarial-verification-runner.ts`) — a parse failure is silently converted into a substantive fail vote; the unanimity gate then treats it as an objection. A dishonest door: its name says "report," its behavior is "veto."
+- **`findingBlocksClosure`** (`review-convergence.ts:91-101`) — reads only `objective_alignment` + `priority`; the `confidence_score` the schema collects is discarded at the decision point.
+- **No cost door at all** — verifier spend is unmeasured (`modelAttempts[].usage` exists but is folded nowhere), and no run has a ceiling (`#2212`).
+
+### 2.2 The Problem
+
+The statistical machinery (criteria decomposition, K repeats, soft selection, progress curves) multiplies verifier calls 3–16×. Shipping it without the engineering layer (prefix-cache prompt layout, warm-first scheduling, measured cost, budgets) makes it unaffordable; shipping it as one giant change makes it unreviewable. The delivery constraint is therefore structural: **every reviewable unit < 500 changed lines, every unit carrying its own evidence, every unit leaving the repo green.**
+
+## 3. Goals and Non-Goals
+
+### 3.1 Functional Goals
+
+- [ ] All 8 issues implemented, each acceptance criterion either proven in a PR Evidence section or explicitly amended on the issue first.
+- [ ] Two worktrees, two linear stacks (Stack V: verifier cluster; Stack B: budgets), standalone PRs for the independent docs slice.
+- [ ] Every PR < 500 changed **source** lines (tests uncapped but reported; docs-only slices exempt — Q3 resolved).
+- [ ] Every PR body carries the Evidence protocol (§5.3).
+- [ ] Every slice implemented autonomously by a child workflow whose verification gates run the same commands the Evidence section reports.
+- [ ] `npm run check` and the affected vitest suites green at every stack layer, not just at the top.
+
+### 3.2 Non-Goals (Out of Scope)
+
+- [ ] NOT porting token-logprob extraction (#2260 closed; K-sample averaging is the accepted operating point).
+- [ ] NOT building a select-best-of-n workflow separate from `tournament` (#2488 decision).
+- [ ] NOT letting any progress/trend signal terminate a run (#2489 hard constraint) — `classify_trend` refuses to be a kill switch by construction: it returns evidence, never an action.
+- [ ] NOT recomputing goal/ralph approval from findings arrays (#2490; `stop_review_loop` remains the sole approval door).
+- [ ] NOT multimodal verification inputs, NOT a TurboAgent-style provider proxy (research §3, deliberately deferred/rejected).
+- [ ] NOT changing the `WorkflowExitStatus` union (#2212 amendment: `budget_exceeded` is a returned status on the `blocked` rail).
+- [ ] NOT adding a build step to `packages/workflows` (raw `.ts` ships; hard repo constraint).
+
+## 4. Proposed Solution (High-Level Design)
+
+### 4.1 Delivery Topology
+
+```mermaid
+%%{init: {'theme':'base'}}%%
+flowchart TB
+    classDef wt fill:#4a90e2,stroke:#357abd,color:#fff,font-weight:600
+    classDef pr fill:#667eea,stroke:#5a67d8,color:#fff
+    classDef solo fill:#48bb78,stroke:#38a169,color:#fff
+
+    subgraph WTV["worktree ../atomic-verifier-stack — Stack V (linear, bottom→top)"]
+        direction TB
+        V1["V1 criteria-module (#2487a)"]:::pr --> V2["V2 adversarial-mean-veto (#2487b)"]:::pr
+        V2 --> V3["V3 prefix-cache-prompts (#2493)"]:::pr
+        V3 --> V4["V4 selection-math (#2488a)"]:::pr
+        V4 --> V5["V5 tournament-runner (#2488b)"]:::pr
+        V5 --> V6["V6 cost-ledger (#2494)"]:::pr
+        V6 --> V7["V7 progress-scoring (#2489a)"]:::pr
+        V7 --> V8["V8 progress-consumers (#2489b)"]:::pr
+        V8 --> V9["V9 goal-reverify (#2490a)"]:::pr
+        V9 --> V10["V10 goal-convergence (#2490b)"]:::pr
+        V10 --> V11["V11 docs-primitives (#2491 ph.2)"]:::pr
+    end
+
+    subgraph WTB["worktree ../atomic-budgets-stack — Stack B (linear)"]
+        direction TB
+        B1["B1 budget-config+reducer (#2212a)"]:::pr --> B2["B2 duration-enforcement (#2212b)"]:::pr
+        B2 --> B3["B3 token-budget (#2212c)"]:::pr
+    end
+
+    D1["standalone PR: docs-patterns (#2491 ph.1)"]:::solo
+
+    MAIN[(main)] --> WTV
+    MAIN --> WTB
+    MAIN --> D1
+```
+
+Rationale for the linearization (decided): gh-stack stacks are strictly linear; the real fork at #2487 is flattened into one stack because a single stack needs zero merge choreography, tells one reviewable story, and works while nothing is merged. The false edges introduced (V3→V4, V6→V7) cost nothing but ordering. Stack B is independent (different files, different concern) and runs concurrently. B3 consumes the usage-fold helper V6 creates — the one cross-stack edge: **B3 waits for V6 to merge to main** (Q2 resolved); B1/B2 proceed immediately in parallel.
+
+### 4.2 Slice Table (the 500-line budgets)
+
+| Slice | Branch | Issue | Content | Budget (src) | Test anchor |
+|---|---|---|---|---|---|
+| V1 | `verifier/criteria-module` | #2487 | `verification-criteria.ts`: `parse_rubric`, normalizer, `{#id}` slugging/dedup, comment stripping, shared 1–20 scale constants, mean+veto `decide_verification` helpers | ~400 | new `verification-criteria` unit suite |
+| V2 | `verifier/adversarial-mean-veto` | #2487 | adversarial-verification: per-criterion verifier calls, mean-vs-threshold gate with unconditional-veto path, parse failure → indeterminate re-ask (deletes `INVALID_VERIFIER_REPORT`) | ~350 | `builtin-workflows-adversarial-generate` |
+| V3 | `verifier/prefix-cache-prompts` | #2493 | shared-head/varying-tail prompt builders (candidate bodies inlined, 32 KiB bound + `reads` fallback), warm-first fan-out helper, ordering-invariant test, generate-and-filter judge adopts the builder (rider) | ~350 | new prompt-layout suite |
+| V4 | `verifier/selection-math` | #2488 | pure module: seeded PRNG, `ring_cycle`, `bradley_terry`, accumulate w/c, pivot selection, K-repeat slot-swap bookkeeping, `select_best` | ~400 | new deterministic math suite (no model calls) |
+| V5 | `verifier/tournament-runner` | #2488 | runner rewrite: graded per-criterion judge schema, PPT rounds via V4, comparisons ledger replaces bracket.json, ranking outputs, `.d.ts` | ~500 ⚠ tight | `builtin-workflows-tournament-loop` |
+| V6 | `verifier/cost-ledger` | #2494 | `fold_usage` aggregation helper + usage blocks in comparisons ledger, adversarial report, goal/ralph ledgers | ~250 | new usage-fold suite |
+| V7 | `verifier/progress-scoring` | #2489 | `score_progress` (calibration prompt builder, batched multi-checkpoint extraction, K repeats) + `classify_trend` (hysteresis) | ~400 | new progress suite (fixtures, no model calls) |
+| V8 | `verifier/progress-consumers` | #2489 | loop-until-done ledger curve + stop-report inclusion; subagent attention input beside wall-clock signals | ~250 | loop suite + subagents attention suite |
+| V9 | `verifier/goal-reverify` | #2490 | `reverify_finding`: low-confidence blocking findings re-scored K× fresh-context; mean decides blocking/demoted | ~350 | `review-convergence-closure` + new fixtures |
+| V10 | `verifier/goal-convergence` | #2490 | per-round convergence scalars in goal/ralph ledgers, trend → `needs_human` evidence, calibration prompt alignment | ~350 | goal ledger suite |
+| V11 | `verifier/docs-primitives` | #2491 | primitive-specific doc updates (workflows.md pattern sections, README table) | docs-only | n/a (docs) |
+| B1 | `budgets/config-reducer` | #2212 | `WorkflowBudget { maxDurationMs, maxTokens, maxCost, warnAtPercent }` (all default 0 = unbudgeted), 3-layer later-wins-per-field resolution (run > definition > config), pure budget reducer, `budget_exceeded` in `RETURNED_BLOCKED_STATUSES`, validation (0 valid; negatives/non-finite rejected) | ~400 | new budget-reducer table tests |
+| B2 | `budgets/duration-enforcement` | #2212 | checkpoint enforcement (stage/tool boundaries, resume path), one-time wrap-up injection then stop (codex `budget_limit.md` pattern), warn-once notice, status surface, R1–R2/R5–R7/R9–R10/R13–R14 | ~400 | new enforcement suite |
+| B3 | `budgets/token-cost-budget` | #2212 | run-tree usage aggregation via `fold_usage` (from V6); `maxTokens` = uncached input + output (codex goal formula); `maxCost` = USD from `usage.cost`; delta accounting w/ double-charge guard (R3–R4, R8, R11–R12) | ~350 | extend enforcement suite |
+| D1 | `verifier/docs-patterns` | #2491 | pattern-level guidance in docs/workflows.md + README (no primitive refs) | docs-only | n/a |
+
+### 4.3 Autonomous Execution Model
+
+Each slice runs as **one child implementation workflow** (goal-shaped: implement → fresh-context review → repair loop) launched in the stack worktree with the slice branch checked out, receiving: the child spec section for that slice, the research doc path, the slice's acceptance checklist, and the line budget as a `<keepContext>`-tagged constraint. Deterministic `ctx.tool` gates run: `npm run check`, the slice's test anchor via targeted vitest, and `git diff --stat` against the budget. The workflow stops at implementation acceptance; **PR submission is the separated final action** (Q5 resolved): on evidence-green, `gh stack submit --auto` runs automatically to create/refresh **draft** PRs; marking ready (`--open`) and merging (`gh stack merge … --yes`) remain operator-only. Stack hygiene (rebase-upstack after mid-stack changes) is operator-side, per the gh-stack skill. If V5 exceeds its budget despite the V4 extraction, the pre-authorized V5a/V5b split applies (Q6 resolved): V5a = runner core (PPT orchestration, judge schema), V5b = prompts + comparisons ledger + `.d.ts`.
+
+### 4.4 The Door Set at a Glance (Stranger-Across-Time View)
+
+> `parse_rubric` · `score_criterion` · `decide_verification` ⚠ · `select_best` · `score_progress` · `classify_trend` · `reverify_finding` · `fold_usage` · `warm_first_fan_out` · `enforce_budget` ⚠
+
+Read alone: rubrics are parsed once by one parser; every judgment is per-criterion; acceptance has exactly one door and that door knows the difference between a failing report and an unreadable one; selection ranks rather than eliminates; progress is scored and classified but never acted on autonomously; cost is folded where decisions are audited; fan-out warms its cache first; and exactly one door can stop a run for spending too much — resumably.
+
+## 5. Detailed Design
+
+### 5.1 Program-Level Door Contracts
+
+Full typed contracts live in the child specs; the umbrella fixes the guarantees and refusals that cross slice boundaries:
+
+```
+parse_rubric(markdown: string): Result<Criteria, RubricError>
+// Guarantee: returns normalized criteria with unique ids or a named parse error.
+// Refuses: empty descriptions; duplicate ids (deduped deterministically, recorded).
+// RubricError = EmptyCriterion | NoCriteria | MalformedSection
+
+decide_verification(reports: CriterionReport[]): Accept | Repair(findings) | Indeterminate(reask)
+// Guarantee: mean-vs-threshold with an unconditional veto path; an unparseable
+// report is Indeterminate and can ONLY trigger a re-ask — it is unrepresentable
+// as a counted vote (CriterionReport can only be constructed from a schema-valid
+// structured output). ⚠ The single door to an accept in adversarial-verification.
+
+select_best(pool: Candidate[], score: DirectedScore, seed: Seed): Ranking
+// Guarantee: full mean-preference ranking via ring + pivot rounds; deterministic
+// under (pool, seed); no candidate is ever eliminated by a single comparison.
+// Refuses: re-scoring an already-scored directed pair (cache identity).
+
+score_progress(prefix: Steps, checkpoints: CheckpointSet, k: Repeats): Curve
+classify_trend(curve: Curve): { trend: Rising|Flat|Regressing, evidence: Curve }
+// Guarantee: classification with hysteresis; returns evidence only.
+// Refusal BY TYPE: no consumer receives an action — there is no "kill" variant
+// to construct. Wall-clock signals are supplemented, never removed.
+
+reverify_finding(finding: BlockingFinding, k: Repeats): Confirmed | Demoted
+// Guarantee: K fresh-context re-scores; the mean decides. Consumes the K budget
+// only for findings below the confidence threshold. Never touches stop_review_loop.
+
+fold_usage(results: WorkflowTaskResult[]): UsageTotals   // absent fields = 0;
+// replayed/cached results contribute nothing; derives cache_hit_rate.
+
+warm_first_fan_out(steps: JudgeStep[]): results
+// Guarantee: exactly one in-flight call per distinct prompt prefix until that
+// prefix has completed once; then unrestricted fan-out.
+
+enforce_budget(run: RunMeters, budget: EffectiveBudget): Continue | Warn | Exhausted ⚠
+// EffectiveBudget = per-field later-wins resolution of run > definition > config;
+// each of {maxDurationMs, maxTokens (uncached input+output), maxCost (USD)}
+// disabled at 0. Guarantee: checked only at stage/tool boundaries; Exhausted
+// delivers a one-time wrap-up injection to the frontier stage, then stops with
+// returned status `budget_exceeded` (blocked rail, resumable), naming budget/
+// reading/ceiling/frontier and carrying the wrap-up summary. Refuses: the status
+// is system-owned — no stage, tool, or model output can construct it; resume
+// never mints fresh meters; deltas are charged once (serialized accounting).
+```
+
+**Per-door rubric audit** is performed in each child spec (§5.1 of each); the two ⚠ doors additionally satisfy rubric #8 here: an accept in adversarial-verification is reachable only through `decide_verification`; `budget_exceeded` is producible only by `enforce_budget`.
+
+### 5.2 Stack Mechanics (operator doors)
+
+- Create: `git worktree add ../atomic-verifier-stack -b verifier/criteria-module main`, then `gh stack init verifier/criteria-module` and `gh stack add <branch>` per slice (always positional args; `git config rerere.enabled true`, `remote.pushDefault origin` — repo has 5 remotes).
+- Submit checkpoints: `gh stack submit --auto` (draft PRs), `--open` when a layer's evidence is complete.
+- Mid-stack repair: navigate down, commit, `gh stack rebase --upstack`.
+- Merge: `gh stack merge <pr> --yes` bottom-up as reviews approve; `gh stack sync --prune` after.
+
+### 5.3 The Evidence Protocol (every PR body)
+
+```markdown
+## Evidence
+### Acceptance criteria (from #NNNN, this slice's subset)
+- [x] criterion … — proven by <test name / command>
+### Commands
+$ npm run check            → exit 0 (trimmed tail pasted)
+$ npx vitest --run --project unit -t "<anchor>"  → N passed (summary pasted)
+### Size
+$ git diff --stat <base>..HEAD → X files, +A −B (cap: 500 source lines; tests uncapped, reported; docs exempt)
+### Spec
+specs/2026-08-17-<child>.md §<n>; research: research/docs/2026-08-17-llm-verifier-adoption-scan.md
+```
+
+CI green is necessary but not sufficient; the pasted output is the reviewable artifact. A slice whose acceptance criterion is amended (posture change) links the amending issue comment instead.
+
+### 5.4 Child Spec Index (authored next, one per cluster)
+
+| Spec file (planned) | Covers | Slices |
+|---|---|---|
+| `specs/2026-08-17-verification-criteria-module.md` | #2487 + #2493 | V1–V3 |
+| `specs/2026-08-17-tournament-soft-selection.md` | #2488 + #2494 | V4–V6 |
+| `specs/2026-08-17-progress-scoring.md` | #2489 | V7–V8 |
+| `specs/2026-08-17-goal-graded-signals.md` | #2490 | V9–V10 |
+| `specs/2026-08-17-verifier-docs.md` | #2491 | D1, V11 |
+| `specs/2026-08-17-run-budgets.md` | #2212 | B1–B3 |
+
+Each child spec is a full create-spec document (doors with typed contracts + rubric audit, data model, test plan, interactive verification) whose §Test Plan commands are byte-identical to the Evidence commands its slices will paste.
+
+## 6. Alternatives Considered
+
+| Option | Pros | Cons | Reason for rejection |
+|---|---|---|---|
+| Foundation stack (V1–V3) merges first, then parallel stacks for #2488/#2489 | true dependency edges, real parallelism | gated on review/merge latency of foundation; 3 worktrees + merge choreography | Selected topology (one linear stack) trades false edges for zero choreography — decided in Q&A |
+| One PR per issue (8 PRs) | fewer PRs | #2488 alone ≫ 500 lines; unreviewable | violates the 500-line constraint |
+| #2494 standalone from main | independent landing | edits `bracket.json`/ledgers that V5 rewrites → guaranteed conflict under breaking-allowed | **Rejected (Q1):** placed as V6, after the rewrite it annotates |
+| Fully autonomous including merges | max speed | removes the human review gate the stack exists to serve | **Rejected (Q5):** auto-submit drafts; ready + merge stay human |
+
+## 7. Cross-Cutting Concerns
+
+### 7.1 Security and Trust
+
+- The two ⚠ doors are the only trust-bearing chokepoints introduced: `decide_verification` (what gets called verified) and `enforce_budget` (what stops a run). Both make their central refusal unrepresentable (unparseable report ≠ vote; `budget_exceeded` unconstructible by any stage or model output).
+- Implementation workflows receive worktree paths and branch names as `<keepContext>`-tagged identifiers so compaction cannot re-target them.
+
+### 7.2 Backwards Compatibility
+
+**Posture: breaking changes allowed freely** (owner decision, this session). Consequences, recorded as current-state documentation rather than constraints: `tournament` outputs (`winner`, `bracket_path`, …) may be reshaped into ranking/ledger outputs; `adversarial-verification`'s report schema may change; `.d.ts` files updated to the new shapes in the same slice. The "output contract preserved" clauses in #2487/#2488 are superseded — **both issues amended by comment before implementation starts** (Q4 resolved). CHANGELOG entries mark every user-visible break under `### Breaking Changes`.
+
+## 8. Test Plan
+
+- **Per-slice**: the slice table's test anchor + `npm run check`, run by the implementation workflow as `ctx.tool` gates AND pasted as Evidence. New suites are deterministic (fixtures, seeded PRNG, no model calls) per the issues' acceptance criteria.
+- **Per-layer stack invariant**: after any `rebase --upstack`, re-run the anchors of every layer above the change before re-submitting.
+- **Program-level interactive verification** (executable by a human or agent, per child spec): e.g. run the tournament builtin on a 3-candidate fixture pool with a fixed seed twice → identical comparisons ledger; feed an unparseable judge fixture → observe re-ask, not a vote; run a budgeted workflow past its duration ceiling → `budget_exceeded`, resume with raised budget → completion.
+- **Suite discipline**: 30 s shared budget, no `--timeout` flags, load-tolerant assertions from named constants (repo policy).
+
+## 9. Open Questions / Unresolved Issues
+
+All resolved with the owner, 2026-08-17:
+
+- [x] **Q1 — #2494 placement:** V6, inside Stack V, sequenced after the tournament-runner rewrite it annotates.
+- [x] **Q2 — B3 cross-stack edge:** B3 waits for V6 to merge to main; B1/B2 proceed in parallel immediately.
+- [x] **Q3 — 500-line accounting:** cap counts source only; tests uncapped but reported in the Evidence diff stat; docs-only slices (D1, V11) exempt.
+- [x] **Q4 — issue amendments:** #2487 and #2488 amended by comment recording the breaking-allowed posture, linking this spec, before implementation starts.
+- [x] **Q5 — human gates:** evidence-green slices auto-run `gh stack submit --auto` (draft PRs); marking ready and merging are operator-only.
+- [x] **Q6 — V5 overflow:** V5a/V5b split pre-authorized (runner core / prompts+ledger+`.d.ts`); implementing workflow may apply it without a new decision.
+- [x] **Q7 — D1 timing:** the pattern-level docs PR lands now, as a standalone PR from main, before Stack V starts.

--- a/specs/2026-08-17-progress-scoring.md
+++ b/specs/2026-08-17-progress-scoring.md
@@ -1,0 +1,170 @@
+# Trajectory Progress Scoring + Trend Classification (Slices V7–V8) — Child Spec
+
+| Document Metadata      | Details                                                                 |
+| ---------------------- | ----------------------------------------------------------------------- |
+| Author(s)              | flora131 (with Claude Fable 5)                                          |
+| Status                 | In Review (RFC) — all open questions resolved 2026-08-17                |
+| Team / Owner           | flora131                                                                |
+| Created / Last Updated | 2026-08-17                                                              |
+| Parent                 | `specs/2026-08-17-llm-verifier-adoption-program.md` (umbrella)          |
+| Depends on             | `specs/2026-08-17-verification-criteria-module.md` (V1 scale)           |
+| Issues                 | #2489 (+ its batched-scoring scope comment); #2200 noted as substrate   |
+| Research               | `research/docs/2026-08-17-llm-verifier-adoption-scan.md` §3, §4         |
+| Slices                 | V7 `verifier/progress-scoring` · V8 `verifier/progress-consumers`       |
+
+## 1. Executive Summary
+
+Stall detection today is wall-clock arithmetic: `loop-until-done` has a `done` boolean and iteration caps; subagent control has `activeNoticeAfterMs`/`needsAttentionAfterMs`. None of them can see the difference between a run grinding toward completion and a run confidently rebuilding the wrong thing at full speed. This spec adds a trajectory progress signal: a cheap model stage scores "would the CURRENT state satisfy the acceptance criteria?" on the shared 1–20 scale under the paper's skeptical calibration (trust observed output, not narration; effort is not progress; declarations are zero evidence; scores may plateau or fall), and a deterministic **`classify_trend`** door turns score series into rising/flat/regressing with hysteresis — *flat is the stall signal* (the paper's failed run is low and flat, not descending). Two doors carry the change: **`score_progress`** (batched: one call scores every checkpoint, so a retrospective curve costs O(K) calls regardless of trajectory length) and **`classify_trend`** (returns evidence only — a kill action is unrepresentable in its type). The measured VOC separation is +0.079: useful for prioritization, nowhere near strong enough to act autonomously, and the design enforces that.
+
+## 2. Context and Motivation
+
+### 2.1 Current State
+
+- `loop-until-done` (builtin, ~36-line definition + runner): iteration ledger records what happened; `done: boolean` is the only progress representation. A loop re-litigating the same failure for 6 iterations and one steadily closing gaps look identical until exhaustion.
+- `packages/subagents/src/runs/shared/subagent-control.ts` (223 lines): attention escalation keyed to wall-clock (`activeNoticeAfterMs`, `needsAttentionAfterMs`) and failed-tool counts — proxies that measure *time and motion*, not state quality. #2258's finding stands: wall-clock proxies cannot distinguish productive long runs from stuck ones.
+- No calibration discipline anywhere: nothing instructs an evaluator that "all tests pass!" in prose is zero evidence.
+
+### 2.2 The Problem
+
+The signal exists in the paper with known limits (+0.079 VOC separation, plateau-not-descend failure signature). The design problem is entirely about *containment*: exposing a useful monitoring magnitude without ever letting it fail, block, or kill a run — while keeping the cost at O(K) calls per scoring event.
+
+## 3. Goals and Non-Goals
+
+### 3.1 Functional Goals
+
+- [ ] Calibration prompt builder with the paper's skeptical rules, verbatim in spirit (research §3).
+- [ ] Batched multi-checkpoint scoring: one model call scores all N checkpoints of a finished prefix (O(K) calls per curve); per-prefix scoring for live monitoring (one call per repeat per event).
+- [ ] Deterministic `classify_trend` with hysteresis; named-constant thresholds; fixture-tested.
+- [ ] `loop-until-done`: per-iteration progress score in the ledger; stop/exhaustion report includes curve + trend.
+- [ ] Subagent attention: trend consumed as a prioritization input **beside** the wall-clock signals (Q3 resolved: pure helper + injected score series; no model calls inside the subagents runtime).
+- [ ] Checkpoint default: interior steps `2..T−1` (reference parity; endpoints carry no information).
+
+### 3.2 Non-Goals (Out of Scope — the refusals ARE the design)
+
+- [ ] The score/trend NEVER terminates, fails, or blocks a run — there is no code path from `classify_trend` to any stop door (#2489 hard constraint; enforced by type: the classifier returns `{trend, evidence}` and no consumer accepts an action from it).
+- [ ] NO wall-clock heuristic is removed or weakened.
+- [ ] NOT goal/ralph round-convergence trends — that is V10's (#2490), which imports `classify_trend` from here.
+- [ ] NOT an autonomous resample/abandon mechanism (the reference `ProgressTracker` docstring suggests early abandonment; atomic deliberately does not adopt it).
+- [ ] NOT letter scales or logprob expectation (V1 scale, schema-validated integers).
+
+## 4. Proposed Solution (High-Level Design)
+
+### 4.1 Signal Flow
+
+```mermaid
+flowchart LR
+    classDef det fill:#48bb78,stroke:#38a169,color:#fff,font-weight:600
+    classDef stage fill:#667eea,stroke:#5a67d8,color:#fff
+    classDef sink fill:#718096,stroke:#4a5568,color:#fff
+
+    PREFIX["trajectory prefix<br>(iteration summaries / steps)"] --> PROMPT["build_progress_prompt<br>(skeptical calibration)"]:::det
+    PROMPT --> SCORE["score_progress<br>model stage × K repeats<br>one call scores ALL checkpoints"]:::stage
+    SCORE --> CURVE["curve: mean over K<br>per checkpoint"]:::det
+    CURVE --> TREND["classify_trend<br>(hysteresis)"]:::det
+    TREND --> L["loop-until-done ledger<br>+ stop report"]:::sink
+    TREND --> S["subagent attention<br>prioritization input"]:::sink
+    TREND -.->|"NEVER"| KILL["✗ stop/fail/kill"]
+```
+
+### 4.2 The Door Set at a Glance
+
+> `build_progress_prompt` · `score_progress` · `classify_trend`
+
+Read alone: a calibrated question is built, a state is scored against acceptance criteria, and a series is classified into a trend that is evidence for humans and prioritizers — nothing else. No door in this set can end anything.
+
+## 5. Detailed Design
+
+### 5.1 The Doors (V7 — `packages/workflows/builtin/progress-scoring.ts`)
+
+```ts
+build_progress_prompt(input: {
+  problem: string;                       // task / acceptance criteria
+  steps: readonly string[];              // numbered agent steps (action + observed output)
+  checkpoints: readonly number[];        // 1-indexed; default interior 2..T−1
+}): string
+// Guarantee: a neutral prompt that never reveals eventual success/failure;
+// carries the calibration rules verbatim: trust observed output over narration;
+// effort/step count is not progress; agent declarations ("done!", "all tests
+// pass") are ZERO evidence; scores need not rise — wrong approaches plateau,
+// regressions decrease. Scale: VERIFICATION_SCALE 1..20 oriented as
+// "1 = certainly would not satisfy the acceptance criteria … 20 = verified
+// satisfaction with observed output". Head/tail layout per V3 (steps in the
+// shared head; checkpoint list at the tail) so K repeats share a prefix.
+
+score_progress(ctx, input: {
+  problem: string; steps: readonly string[];
+  checkpoints?: readonly number[];       // default interior
+  repeats?: number;                      // K, default 1 (Q1 resolved; hysteresis absorbs single-sample noise)
+}): Promise<ProgressCurve>
+// ProgressCurve = { checkpoints: number[]; scores: number[];   // mean over K
+//                   perRepeat: (number | null)[][] }           // null = invalid
+// Guarantee: O(repeats) model calls total — ONE call per repeat scores every
+// checkpoint (schema: { scores: [{ checkpoint, score: 1..20 }] }). An invalid
+// repeat contributes nothing (never a fabricated midpoint); a checkpoint with
+// zero valid repeats is null in the curve, never invented.
+// Refuses: checkpoints outside 1..T throw; scoring an empty prefix throws.
+
+classify_trend(series: readonly number[], config?: TrendConfig): TrendResult
+// TrendConfig  = { window: number; riseDelta: number; fallDelta: number }
+//                (named defaults: window 3, ±1.5 on the 1..20 scale)
+// TrendResult  = { trend: "rising" | "flat" | "regressing";
+//                  evidence: { series, window, delta } }
+// Guarantee: pure and deterministic; hysteresis — the trend changes only when
+// the windowed delta crosses riseDelta/fallDelta, so a single noisy score
+// cannot flip it. Short series (< window+1) are "flat" by definition.
+// Refusal BY TYPE: TrendResult carries no action. There is no "kill",
+// "stop", or "escalate" variant to construct; consumers that escalate do so
+// under their own authority citing the evidence.
+```
+
+**Per-door rubric audit:**
+
+| Door | (1) Joint | (2) One sentence | (3) Honest | (5) Every exit | (6) Refusals |
+|---|---|---|---|---|---|
+| `build_progress_prompt` | ✅ | ✅ builds the calibrated question | ✅ never scores | n/a (pure) | success/failure of the trajectory unrepresentable in the prompt |
+| `score_progress` | ✅ "score the progress" | ✅ scores the current state against acceptance criteria | ✅ scores, never judges done-ness for the loop | invalid repeat → null, never a midpoint | out-of-range checkpoint throws; empty prefix throws |
+| `classify_trend` | ✅ | ✅ classifies a series into one trend with evidence | ✅ classifies, never acts | short series → flat, stated | action unrepresentable in the return type |
+
+### 5.2 V8 — Consumers
+
+**loop-until-done:** after each iteration, one `score_progress` call over the **iteration-summary prefix** — the ledger's own per-iteration records (Q2 resolved) — appends `{iteration, score, trend}` to the existing ledger. The loop's stop condition is **unchanged** — `done` and the iteration cap decide, exactly as today. The stop/exhaustion report gains the curve and final trend ("iterations 4–7 flat at ~6/20" is the human-readable stall evidence). Cost: K calls per iteration (default 1), documented.
+
+**Subagent attention (`subagent-control.ts`):** the trend becomes a prioritization input beside `activeNoticeAfterMs`/`needsAttentionAfterMs` — a regressing/flat-low trend can *raise* attention priority; it can never itself mark a run failed or suppress a wall-clock signal. Shape (Q3 resolved): `classify_trend` is duplicated as a tiny pure helper in `packages/subagents` (or the score series arrives via the existing control-config surface); orchestrators that already score pass the series in; the subagents runtime schedules **no model calls** of its own.
+
+### 5.3 Data Model
+
+- Ledger entry (loop): `{ iteration, progress: { score, perRepeat, trend, window } }` — additive to the existing iteration record.
+- Stop report: `progress_curve: number[]`, `final_trend`, plus the calibration disclaimer line ("monitoring signal; VOC separation +0.079; never authoritative").
+
+## 6. Alternatives Considered
+
+| Option | Pros | Cons | Rejection |
+|---|---|---|---|
+| One call per checkpoint | simpler extraction | O(N·K) calls; the scope comment exists precisely because this cost profile kills retrospective scoring | batched is reference parity |
+| Score the full transcript | maximum fidelity | token-explosive; loop ledgers already summarize; V3 caching helps but cannot fix O(transcript) growth per iteration | Q2 decides representation |
+| Trend gates the loop (auto-stop on regressing) | "smart" loops | violates the #2489 hard constraint; +0.079 separation is prioritization-grade, not decision-grade | forbidden by design |
+| EWMA/slope-fitting classifier | statistically fancier | hysteresis-on-windowed-delta is explainable in one sentence and table-testable; fancier stats invite tuning theater | keep it inspectable |
+
+## 7. Cross-Cutting Concerns
+
+- **Containment (trust):** the only door with authority anywhere near this signal is human escalation, and it cites evidence rather than receiving commands. Tests assert no consumer code path mutates run status from a `TrendResult`.
+- **Cost:** loop scoring is K calls/iteration; a 10-iteration loop at K=1 adds 10 cheap calls. The prompt reuses V3 layout so repeats share a prefix.
+- **Cross-package boundary:** `progress-scoring.ts` lives in `packages/workflows/builtin`; `subagent-control.ts` lives in `packages/subagents`. Resolved (Q3): the classifier is pure and tiny — duplicated helper in subagents, kept honest by mirrored table tests in both packages.
+
+## 8. Test Plan
+
+- **V7** — `npx vitest --run --project unit -t "progress-scoring"`: prompt fixtures (calibration rules present; no success leakage; checkpoint list at tail; head byte-identical across K repeats); extraction fixtures (valid, partial-invalid → nulls, fully-invalid repeat dropped); `classify_trend` table tests (rising/flat/regressing boundaries at named constants, hysteresis under alternating noise, short-series flat, the paper's low-and-flat failure signature classified flat not regressing).
+- **V8** — loop suite: stubbed scorer → ledger entries present, stop report carries curve + trend, `done`/cap behavior byte-identical with scoring disabled vs enabled (proving non-interference); subagents attention suite: trend input raises priority, never sets failure, wall-clock signals unaffected.
+- **Interactive verification:**
+  1. Feed the two bundled-style trajectories (success/failure fixtures) through `score_progress` with a stub returning the paper's curves → success classifies rising, failure classifies flat — not regressing.
+  2. Run loop-until-done on a fixture task with scoring enabled and disabled → identical stop decisions; enabled run's report shows the curve.
+  3. Grep the diff for any call path from `TrendResult` into `ctx.exit`/status mutation → none (the refusal, made executable).
+- `npm run check` green per slice; Evidence protocol per umbrella §5.3.
+
+## 9. Open Questions / Unresolved Issues
+
+All resolved with the owner, 2026-08-17:
+
+- [x] **Q1 — Default K:** 1; configurable per loop; hysteresis absorbs single-sample noise.
+- [x] **Q2 — Representation:** iteration-summary prefix (the ledger's own records; bounded growth, observation-grounded).
+- [x] **Q3 — Subagent shape:** minimal — pure `classify_trend` helper duplicated in `packages/subagents` (mirrored table tests keep the two honest), score series injected via the existing control-config surface; no model calls inside the subagents runtime.

--- a/specs/2026-08-17-run-budgets.md
+++ b/specs/2026-08-17-run-budgets.md
@@ -1,0 +1,195 @@
+# Per-Run Budgets with Resumable `budget_exceeded` (Slices B1–B3) — Child Spec
+
+| Document Metadata      | Details                                                                 |
+| ---------------------- | ----------------------------------------------------------------------- |
+| Author(s)              | flora131 (with Claude Fable 5)                                          |
+| Status                 | In Review (RFC) — all open questions resolved 2026-08-17                |
+| Team / Owner           | flora131                                                                |
+| Created / Last Updated | 2026-08-17                                                              |
+| Parent                 | `specs/2026-08-17-llm-verifier-adoption-program.md` (umbrella; Stack B, independent track) |
+| Depends on             | V6 `fold_usage` merged to main (B3 only; B1–B2 independent)             |
+| Issues                 | #2212 (body is authoritative for requirements R1–R14)                   |
+| Research               | `research/docs/2026-08-17-llm-verifier-adoption-scan.md` §2 (decisions 6, 9), §4; prior art: openai/codex `ext/goal/accounting.rs`, `core/rollout_budget.rs`, `budget_limit.md` |
+| Slices                 | B1 `budgets/config-reducer` · B2 `budgets/duration-enforcement` · B3 `budgets/token-cost-budget` |
+
+## 1. Executive Summary
+
+Workflow runs have no ceiling: a loop with a bad stop condition burns hours and dollars until a human notices. This spec implements #2212 as three slices on an independent stack. **B1** builds the pure core: `WorkflowBudget { maxDurationMs, maxTokens, maxCost, warnAtPercent }` (every field `0` = unbudgeted), three-layer later-wins-per-field resolution (run override > definition > config default), the budget reducer, `budget_exceeded` joining `RETURNED_BLOCKED_STATUSES` beside `auth_blocked` — resumable by construction, `WorkflowExitStatus` untouched. **B2** wires enforcement at stage/tool boundaries (never mid-stream) with the codex soft landing: one wrap-up injection to the frontier stage, then stop with the full report (budget, reading, ceiling, frontier, wrap-up summary). **B3** adds the token meter (codex's goal formula: uncached input + output — cache-heavy spend is `maxCost`'s job at true price) and the cost meter, folded across the whole run tree via V6's `fold_usage`, with monotone saturating deltas and a single-accountant guard. One dangerous door: **`enforce_budget`** ⚠ — the only producer of `budget_exceeded`, system-owned, unconstructible by any stage or model output.
+
+## 2. Context and Motivation
+
+Condensed from #2212 (the issue body carries the full argument): the duration meter already exists and is correct (`elapsedRunMs`: pauses excluded, `accumulatedDurationMs` carried); the `blocked` exit rail and the resumable-returned-status distinction already exist (`returned-run-status.ts:5` — `auth_blocked` is the precedent); usage telemetry is populated since #2197; `maxDepth` is the config-plumbing template. What is missing is purely the budget layer itself — and the honest outcome shape, decided in the issue amendments: not `failed` (nothing went wrong), not plain `blocked` (nothing needs diagnosing), but `budget_exceeded` (one known decision: raise and resume, or accept).
+
+## 3. Goals and Non-Goals
+
+### 3.1 Functional Goals
+
+Requirements R1–R14 in #2212 are the authoritative list; this spec maps them to slices: B1 owns R1, R8, R13 (+ status vocabulary); B2 owns R2, R5, R6, R7, R9, R10, R14 (duration meter, checkpoints, soft landing, warn-once, no-budget-no-change); B3 owns R3, R4, R11, R12 (token/cost aggregation, resume carry, independence, status surface completion — duration state surfaces in B2, meters complete in B3).
+
+### 3.2 Non-Goals
+
+- [ ] NOT a new `WorkflowExitStatus` member (issue amendment; blocked rail + returned status).
+- [ ] NOT mid-stream abortion of model calls (R5; boundaries only — spent work is banked).
+- [ ] NOT counting cache reads/writes in `maxTokens` (codex formula; `maxCost` governs them at true price — issue OQ3 resolved).
+- [ ] NOT settable/clearable by any stage, tool, or model output (R6; codex `update_goal` refusal, made structural).
+- [ ] NOT a `maxStages`/`maxToolCalls` budget unless Q3 says otherwise (issue OQ4).
+- [ ] NOT weakening any existing stop mechanism (`max_turns`, `max_loops`, iteration caps all stay).
+
+## 4. Proposed Solution (High-Level Design)
+
+### 4.1 Enforcement Flow
+
+```mermaid
+flowchart TB
+    classDef det fill:#48bb78,stroke:#38a169,color:#fff,font-weight:600
+    classDef stage fill:#667eea,stroke:#5a67d8,color:#fff
+    classDef term fill:#e53e3e,stroke:#c53030,color:#fff,font-weight:600
+
+    CFG["config default"] --> RES["resolve_budget<br>later wins per-field<br>run > definition > config"]:::det
+    DEF["workflow({ budget })"] --> RES
+    RUN["workflow tool run override"] --> RES
+    RES --> EB["EffectiveBudget<br>(0 = dimension off)"]:::det
+    B["stage/tool boundary"] --> METER["meter_run<br>duration: elapsedRunMs<br>tokens: Σ(input+output)<br>cost: Σ usage.cost<br>(saturating deltas, one accountant)"]:::det
+    METER --> ENF{"enforce_budget ⚠"}:::det
+    EB --> ENF
+    ENF -->|Continue| B
+    ENF -->|"Warn (once per budget)"| NOTICE["lifecycle notice"]:::det --> B
+    ENF -->|Exhausted| WRAP["one-time wrap-up injection<br>to frontier stage (codex budget_limit.md)"]:::stage
+    WRAP --> STOP["stop: blocked rail,<br>returned status budget_exceeded<br>+ report + wrap-up summary"]:::term
+    STOP -.->|"workflow resume<br>with raised budget"| B
+```
+
+### 4.2 The Door Set at a Glance
+
+> `resolve_budget` · `meter_run` · `enforce_budget` ⚠
+
+Read alone: three declarations become one effective budget by a rule a reader can hold in one sentence; the run's spend is metered once, tree-wide, without double-charging; and exactly one door can stop a run for spending too much — after letting it say goodbye, and never for good.
+
+## 5. Detailed Design
+
+### 5.1 The Doors
+
+```ts
+// B1 — pure core (packages/workflows/src/shared/budget.ts or sibling)
+
+interface WorkflowBudget {
+  readonly maxDurationMs?: number;   // integer ms; 0 = off (default)
+  readonly maxTokens?: number;       // integer; uncached input + output; 0 = off
+  readonly maxCost?: number;         // USD; 0 = off
+  readonly warnAtPercent?: number;   // default 80
+}
+
+resolve_budget(layers: { config?: WorkflowBudget; definition?: WorkflowBudget;
+                          run?: WorkflowBudget }): EffectiveBudget
+// Guarantee: later wins PER FIELD (run > definition > config); unset fields
+// fall through; every field defaults to 0 = unbudgeted. An operator override
+// may widen, narrow, or disable any dimension (R8).
+// Validation (R13, maxDepth pattern): negative, non-finite, or (ms/tokens)
+// non-integer values are config errors; 0 is valid-and-off.
+// Refusal BY TYPE: EffectiveBudget is the only currency enforce_budget
+// accepts, and resolve_budget is its only constructor — there is no way to
+// smuggle an unresolved or unvalidated budget to the enforcement door.
+
+meter_run(tree: RunUsageTree, now: number): RunMeters
+// RunMeters = { durationMs, tokens, cost, perCounter: {input, output,
+//               cacheRead, cacheWrite} }   // all four REPORTED; two charged
+// Guarantee (R2–R4): duration = elapsedRunMs semantics (pauses out,
+// accumulated in); tokens = Σ (usage.input + usage.output) and cost =
+// Σ usage.cost over every WorkflowModelAttempt in the run tree, nested
+// ctx.workflow children and retries included, via fold_usage (V6).
+// Mechanics (R14, codex parity): monotone saturating deltas against a
+// persisted baseline; a single-accountant guard so concurrent stage
+// completions cannot double-charge; baselines survive durable resume (R3 —
+// a resumed run never gets fresh meters).
+
+// B2 — enforcement (foreground executor boundary hooks)
+
+enforce_budget(meters: RunMeters, budget: EffectiveBudget): Continue | Warn | Exhausted ⚠
+// Guarantee (R5–R7, R9): evaluated ONLY at deterministic checkpoints —
+// before stage dispatch, before a ctx.tool node, after either completes, and
+// on the durable-resume path. Warn fires once per run per budget dimension
+// (lifecycle notice machinery). Exhausted triggers, in order:
+//   1. one-time wrap-up injection to the frontier stage — codex
+//      budget_limit.md shape: budget exhausted; stop substantive work;
+//      summarize progress, remaining work, blockers; leave a next step.
+//      Delivered at most once per run per budget (R14). Wrap-up scope (Q2
+//      resolved): the frontier stage finishes its CURRENT turn with the
+//      injection appended — one turn, no new stages; spend recorded as
+//      wrapUpUsage in the exhaustion report.
+//   2. stop on the blocked exit rail with returned status budget_exceeded
+//      (resumable: `workflow resume` with a raised budget continues from the
+//      frontier), reporting {dimension, reading, ceiling, frontier stage,
+//      wrap-up summary} (R7).
+// Refusals: the status is SYSTEM-OWNED — no stage/tool/model output path can
+// construct, set, or clear it (R6); a no-budget run takes a zero-cost early
+// return (R10, behavior identical to today); concurrent top-level runs meter
+// independently (R11).
+```
+
+**Per-door rubric audit:**
+
+| Door | (1) Joint | (2) One sentence | (3) Honest | (5) Every exit | (6) Refusals | (8) Chokepoint |
+|---|---|---|---|---|---|---|
+| `resolve_budget` | ✅ | ✅ three layers → one effective budget, later wins per field | ✅ resolves, never enforces | invalid values → config error at load, not at exhaustion | unvalidated budget unreachable by type | sole `EffectiveBudget` constructor |
+| `meter_run` | ✅ | ✅ one tree-wide reading per boundary | ✅ meters, never judges | absent usage → zeros; replayed checkpoints → no delta | double-charge structurally excluded (baseline + single accountant) | n/a |
+| `enforce_budget` ⚠ | ✅ "enforce the budget" | ✅ maps meters × budget to continue, warn-once, or soft-landed stop | ✅ the stop is named for exactly what happened | resume → carried baselines; repeat exhaustion → no second wrap-up | status unconstructible elsewhere; stream abortion impossible (no mid-stream call site) | ✅ sole producer of `budget_exceeded` |
+
+### 5.2 Config & tool plumbing (B1/B2)
+
+- `workflows.budget` default: `WORKFLOW_CONFIG_DEFAULTS` → validation in `extension/config-file-loader.ts` → `WorkflowEffectiveConfig` (the `maxDepth` route, exactly).
+- Definition: `workflow({ budget: {...} })` — authoring-contract field, validated at discovery.
+- Run override: `budget` parameter on the workflow tool's `run` action; schema mirrors `WorkflowBudget`; documented in the tool description and `docs/workflows.md`.
+- `workflow status` surfaces per-dimension readings/ceilings/percent (R12), in summary verbosity (#2195 alignment).
+
+
+### 5.2b Child-scoped budgets (Q1 resolved: children may narrow)
+
+A nested `ctx.workflow(...)` invocation MAY declare its own `budget`. Semantics:
+
+- **Additional constraint, not a fork of authority.** The child's meters cover only its subtree; the parent's tree-wide meters are unaffected and still include all child spend. A child ceiling wider than the parent's remaining budget is legal and simply never trips first — widening is meaningless by construction, so no cross-layer validation is needed.
+- **Child exhaustion soft-lands the subtree only:** the child's frontier stage gets the one-turn wrap-up, the child run ends with returned status `budget_exceeded`, and the **parent continues**, receiving that result at the child boundary to handle like any other child outcome (repair, skip, escalate, or stop by its own logic).
+- **Which trips first:** every boundary checks child scope and root scope; when both exhaust at the same boundary, the **root wins** (subtree wrap-up is subsumed by the run's).
+- **Resolution within the child:** the child's declared budget is layer-resolved like any definition budget (a run-level override does not reach into child declarations).
+- Meter mechanics: per-scope baselines in `meter_run` (a scope is the root or a child-subtree boundary node); the single-accountant guard covers all scopes.
+### 5.3 Slice mapping
+
+| Slice | Contents | Budget (src) |
+|---|---|---|
+| B1 | types, `resolve_budget`, validation, `budget_exceeded` in `RETURNED_BLOCKED_STATUSES`, config/definition/tool plumbing | ~400 |
+| B2 | boundary hooks, duration metering, warn-once notices, wrap-up injection (current-turn bound), stop + report, status surface, resume carry for duration, child-scope enforcement + subtree soft-landing | ~450 |
+| B3 | `meter_run` token/cost via `fold_usage`, per-scope baselines + single accountant, resume carry for tokens/cost, R11 independence tests, child-subtree metering | ~400 |
+
+## 6. Alternatives Considered
+
+Consolidated in #2212's resolved open questions (1: status shape; 3: token counting) and the umbrella's Q&A; not restated. One addition:
+
+| Option | Pros | Cons | Rejection |
+|---|---|---|---|
+| Enforce inside stages (inject "stop now" mid-turn) | tighter ceilings | aborts paid-for work; violates R5; codex rollout budget aborts at turn boundaries for the same reason | boundaries only |
+| Skip the wrap-up (hard stop) | zero spend past ceiling | the raise-or-accept decision loses its context; codex measured this trade and kept the soft landing | owner decision, session record |
+
+## 7. Cross-Cutting Concerns
+
+- **Honesty at the ceiling:** the wrap-up turn itself spends tokens after exhaustion. Bounded by Q2's answer, reported in the exhaustion record (`wrapUpUsage`), and never repeated (R14).
+- **Cross-stack dependency:** B3 imports `fold_usage` from V6 (merged to main first — umbrella Q2). B1/B2 have no Stack V dependency.
+- **Docs:** tool description + `docs/workflows.md` budget section + CHANGELOG (`### Added`) ride each slice.
+
+## 8. Test Plan
+
+- **B1** — budget-reducer table tests: per-field later-wins across all 8 layer-presence combinations; 0-disables; validation matrix (negative/non-finite/non-integer rejected, 0 accepted); status vocabulary (`budget_exceeded` ∈ `RETURNED_BLOCKED_STATUSES`, `isReturnedResumableBlockedWorkflowStatus("budget_exceeded") === true`).
+- **B2** — enforcement suite (stub clock): no-budget run → zero enforcement calls observable (R10); warn fires exactly once per dimension under repeated boundaries (R9); exhaustion at a boundary → wrap-up delivered once → stop with full report (R6/R7/R14); paused time never charges (R2); resume carries elapsed (R3-duration); repeat exhaustion after resume without raise → immediate stop, **no second wrap-up**.
+- **B3** — metering suite: tree aggregation fixtures (nested children, retries) charging input+output only, all four counters reported (R4); cost summation; delta monotonicity under out-of-order completions; single-accountant under simulated concurrency (R14); two concurrent runs meter independently (R11); resume carries token/cost baselines (R3).
+- **Interactive verification:**
+  1. Run a fixture workflow with `budget: { maxDurationMs: 1 }` → run stops `budget_exceeded`; report names duration, reading, ceiling, frontier; wrap-up summary present.
+  2. `workflow resume` with a raised run-override budget → run completes; total elapsed reflects both sessions.
+  3. Same workflow, no budget anywhere → byte-identical behavior to pre-B1 (R10, observable).
+  4. `workflow status` during a budgeted run → per-dimension readings and percent.
+- `npm run check` green per slice; Evidence protocol per umbrella §5.3.
+
+## 9. Open Questions / Unresolved Issues
+
+All resolved with the owner, 2026-08-17:
+
+- [x] **Q1 — Child budgets:** children may declare their own budget — **owner override of the drafted recommendation** — as an additional subtree-scoped constraint (§5.2b): parent meters unaffected, child exhaustion soft-lands only the subtree and surfaces as the child's `budget_exceeded` result, root wins simultaneous exhaustion. B2/B3 budgets raised to ~450/~400 for the scope work. Resolves #2212 OQ2.
+- [x] **Q2 — Wrap-up bound:** current turn only; no new stages; `wrapUpUsage` recorded in the exhaustion report.
+- [x] **Q3 — Third dimension:** out of scope for v1; revisit `maxStages`/`maxToolCalls` with a motivating incident. Resolves #2212 OQ4.

--- a/specs/2026-08-17-tournament-soft-selection.md
+++ b/specs/2026-08-17-tournament-soft-selection.md
@@ -1,0 +1,195 @@
+# Tournament Soft-Scored Selection + Cost Ledger (Slices V4–V6) — Child Spec
+
+| Document Metadata      | Details                                                                 |
+| ---------------------- | ----------------------------------------------------------------------- |
+| Author(s)              | flora131 (with Claude Fable 5)                                          |
+| Status                 | In Review (RFC) — all open questions resolved 2026-08-17                |
+| Team / Owner           | flora131                                                                |
+| Created / Last Updated | 2026-08-17                                                              |
+| Parent                 | `specs/2026-08-17-llm-verifier-adoption-program.md` (umbrella; posture: breaking allowed) |
+| Depends on             | `specs/2026-08-17-verification-criteria-module.md` (V1 scale/criteria, V3 prompt builder + warm-first) |
+| Issues                 | #2488 (soft-scored tournament), #2494 (verifier cost ledger)            |
+| Research               | `research/docs/2026-08-17-llm-verifier-adoption-scan.md` §3, §4         |
+| Slices                 | V4 `verifier/selection-math` · V5 `verifier/tournament-runner` (V5a/V5b split pre-authorized) · V6 `verifier/cost-ledger` |
+
+## 1. Executive Summary
+
+The tournament builtin currently eliminates a candidate forever on one binary judge call (`winner: "first"|"second"`, knockout bracket). This spec replaces it with the Probabilistic Pivot Tournament: judges emit graded per-criterion scores for both slots, each directed comparison repeats K times with A/B slot swap, scores become soft wins via Bradley–Terry, and the full pool is ranked by count-normalized mean preference — no elimination, `N + k(N−k) + C(k,2)` comparisons instead of a bracket. Three slices: **V4** is pure deterministic math (`plan_comparisons`, `soft_win`, `rank_candidates` — table-tested, seeded, no model calls); **V5** rewrites the runner on top of V4 + the V1 scale + the V3 prompt builder and warm-first scheduler, replacing `bracket.json` with a comparisons ledger; **V6** adds `fold_usage` so every verification ledger reports measured calls, tokens, and cache-hit rate — the proof mechanism for V3's optimization and the shared reducer #2212's token budget will import. Dangerous doors: none new — selection ranks; it never destroys.
+
+## 2. Context and Motivation
+
+### 2.1 Current State (leaking doors)
+
+- `tournament-runner.ts:17-21` — `judgeDecisionSchema` is binary; 51/49 and 99/1 are indistinguishable; discrete judges tie on 26.7% of comparisons at K=1 (paper).
+- `tournament-runner.ts:103-163` — single-elimination loop: `next.push(winner)` drops the loser permanently on one call; a bye (105) advances unjudged.
+- `tournament-runner.ts:111,137` — one orientation per match with a parity trick (`(round+index)%2`): positional bias cancels only *across* matches on average, never *within* a pair.
+- `tournament-runner.ts:166-167` — `bracket.json` records matches, not evidence: no scores, no orientations, no repeats, no cost.
+- No usage measurement anywhere: `modelAttempts[].usage` (populated since #2197) is folded by nobody (#2494).
+
+### 2.2 The Problem
+
+Selection quality is capped by judgment noise that the architecture amplifies (knockout) instead of averaging (soft wins). Fixing it multiplies judge calls by `criteria × K`, which is affordable only on top of V3's cache layout — and honest only if V6 measures what it actually cost.
+
+## 3. Goals and Non-Goals
+
+### 3.1 Functional Goals
+
+- [ ] Deterministic selection math: identical `(n, pivots, K, seed)` → identical comparison schedule, orientations, and ranking math, on every platform.
+- [ ] Judges score both slots per criterion on the shared 1–20 scale; a parse failure is an indeterminate re-ask, never a counted comparison (V2 rule), and never durably persisted as a score.
+- [ ] No knockout: every candidate is ranked; a single noisy judgment shifts a mean, never eliminates.
+- [ ] Slot swap *within* each directed comparison (odd repeats swap A/B; scores recorded back in candidate order).
+- [ ] Comparisons ledger replaces `bracket.json`: every score, orientation, repeat, criterion, soft win, plus per-phase usage (V6).
+- [ ] `fold_usage` helper importable by #2212 (B3) and consumed by tournament + adversarial ledgers.
+- [ ] Heterogeneous candidate pools via an optional ordered model list (round-robin across attempt slots), assignment recorded in the ledger, honest caveat documented (Q3 resolved: ships in V5b).
+
+### 3.2 Non-Goals (Out of Scope)
+
+- [ ] NOT a new workflow: this is the in-place upgrade of `tournament` (#2488 decision).
+- [ ] NOT logprob rewards (#2260 closed): K-sample averaging is the operating point.
+- [ ] NOT re-scoring already-scored directed pairs: within a run, the schedule is deduplicated; across resume, durable stage replay returns checkpointed results.
+- [ ] NOT enforcement of any budget (V6 measures; #2212 enforces).
+- [ ] NOT goal/ralph ledger usage blocks (Q4 resolved: they land in V10, where those ledgers are already reshaped).
+
+## 4. Proposed Solution (High-Level Design)
+
+### 4.1 Selection Flow
+
+```mermaid
+flowchart TB
+    classDef det fill:#48bb78,stroke:#38a169,color:#fff,font-weight:600
+    classDef stage fill:#667eea,stroke:#5a67d8,color:#fff
+
+    A["attempts × N<br>(optional per-slot model round-robin)"]:::stage --> PLAN["plan_comparisons(n, pivots, K, seed)<br>ring pass → pivot selection → pivot rounds<br>deterministic, deduplicated"]:::det
+    PLAN --> J["score_pair stages<br>(pair, criterion, rep, orientation)<br>via build_scoring_prompt + warm_first_fan_out"]:::stage
+    J --> ACC["soft_win σ(R_a−R_b) → accumulate w/c"]:::det
+    ACC --> PIV{"pivots selected?<br>(after ring pass)"}:::det
+    PIV -->|no| PLAN2["pivot rounds"]:::det --> J
+    PIV -->|yes| RANK["rank_candidates: w_i/c_i descending"]:::det
+    RANK --> LEDGER["comparisons.json<br>(scores, orientations, reps, usage)"]:::det
+    LEDGER --> RED["reducer stage: report winner + ranking"]:::stage
+```
+
+Two model touchpoints (judges, reducer); everything between is pure TypeScript.
+
+### 4.2 The Door Set at a Glance
+
+> `plan_comparisons` · `score_pair` · `soft_win` · `rank_candidates` · `fold_usage`
+
+Read alone: the schedule is planned once, deterministically; judging scores pairs; scores become soft wins; ranking is arithmetic over accumulated preference; and cost is folded where the decision is audited. Nothing eliminates, so nothing is irreversible.
+
+## 5. Detailed Design
+
+### 5.1 The Doors (V4 — `packages/workflows/builtin/selection-math.ts`)
+
+```ts
+// — Pure, dependency-free, seeded. Reference parity: llm_verifier/pivot_tournament.py —
+
+seeded_rng(seed: number): () => number
+// Guarantee: deterministic float sequence in [0,1) (mulberry32-class); identical
+// across platforms/runtimes. The ONLY randomness source in selection.
+
+plan_comparisons(input: { n: number; pivots: number; repeats: number; seed: number }):
+  ComparisonPlan
+// ComparisonPlan = {
+//   ring: DirectedPair[];              // N adjacent pairs of a seeded Hamiltonian
+//                                      // cycle — every candidate once per slot
+//   pivotRounds: (pivots: number[]) => DirectedPair[];  // non-pivot×pivot + pivot×pivot,
+//                                      // minus pairs already in the ring (dedup)
+//   jobs: (pairs) => ScoringJob[];     // × criteria × repeats; odd rep swaps slots
+// }
+// ScoringJob = { a, b, criterionId, rep, swapped }   // prefix key = (a-slot, b-slot)
+// Guarantee: identical input → identical plan; total directed pairs ≤
+// N + k(N−k) + C(k,2); no pair scheduled twice.
+// Refuses: n < 2; pivots < 1; repeats < 1 (constructor-validated).
+
+soft_win(scoreA: number, scoreB: number): number
+// Guarantee: p(a≻b) = σ(normalize(scoreA) − normalize(scoreB)) where
+// normalize maps VERIFICATION_SCALE 1..20 → [0,1] (reference operates on [0,1]
+// rewards; raw 1–20 differences would saturate the sigmoid).
+
+accumulate(prefs: { a, b, p }[], w: number[], c: number[]): void
+// w[a]+=p, c[a]+=1, w[b]+=1−p, c[b]+=1 — reference accumulate() parity.
+
+select_pivots(w: number[], c: number[], k: number): number[]
+// Top-k by mean preference w_i/c_i; ties broken by lower index (deterministic).
+
+rank_candidates(w: number[], c: number[]): Ranking
+// Guarantee: full ordering by w_i/c_i descending, ties by index; exposes the
+// per-candidate mean preference. No candidate is absent from the ranking.
+```
+
+**Per-door rubric audit:**
+
+| Door | (1) Joint | (2) One sentence | (3) Honest | (5) Every exit | (6) Refusals |
+|---|---|---|---|---|---|
+| `plan_comparisons` | ✅ "plan the comparisons" | ✅ one deterministic schedule per input | ✅ plans, never scores | invalid n/k/K throw at construction | double-scheduling a pair unrepresentable (dedup by key) |
+| `soft_win` | ✅ | ✅ maps two scores to one preference | ✅ never returns a verdict | equal scores → exactly 0.5 | out-of-scale scores impossible (CriterionScore schema, V1) |
+| `rank_candidates` | ✅ | ✅ orders all candidates by mean preference | ✅ ranks, never eliminates | c_i = 0 → defined (0 preference, last) | dropping a candidate unrepresentable (output length = n) |
+
+### 5.2 V5 — tournament runner rewrite
+
+**Inputs** (existing + new; `.d.ts` updated): `prompt`, `num_attempts` (2–8, default 4), `max_concurrency` (unchanged) + `n_evaluations` (K, default **2**), `pivots` (default **1** — the bo3 preset; 2 documented as the accuracy upgrade), `seed` (optional, default **0**), `criteria` (V1 record/markdown; default: the 3 judge criteria decomposed from the current rubric), `models` (optional ordered list, round-robin across attempt slots; ships in V5b). (Q1–Q3 resolved.)
+
+**Judge stage (`score_pair`):** one stage per `ScoringJob` — one criterion, both slots, schema `{ criterion_id, score_a: 1..20, score_b: 1..20, evidence[] }` (V1 scale schema). Prompt via V3 `build_scoring_prompt`: head = task + both candidate bodies in slot order + scale; tail = criterion. `swapped` jobs present candidates in reversed slots; scores are recorded back in candidate order. Scheduled via `warm_first_fan_out` (a swapped orientation is a distinct prefix — both get warmed). Parse failure → one re-ask; still invalid → the job is recorded `{invalid: true}` and **excluded** (its rep contributes nothing; `directed_reward` averages over valid entries; a fully-invalid pair defaults both rewards to 0.5 — reference parity — and is flagged in the ledger).
+
+**Rounds:** ring jobs first → `accumulate` → `select_pivots` → pivot-round jobs → `accumulate` into the same w/c → `rank_candidates`. Byes no longer exist (no bracket).
+
+**Ledger** (`comparisons.json`, replaces `bracket.json`): `{ task, seed, params {n, pivots, K, criteria}, comparisons: [{a, b, criterion_id, rep, swapped, score_a, score_b, p_ab, invalid?}], w[], c[], ranking: [{label, meanPreference}], budget: {planned, executed}, usage (V6, per phase: attempts/ring/pivots/reducer), model_assignment? }`.
+
+**Outputs** (breaking allowed; names kept where they cost nothing): `result`, `winner` (= ranking[0]), `winner_artifact_path`, `result_path`, `attempt_artifact_paths`, `artifact_dir` retained; `judge_artifact_paths` → per-job artifacts; `bracket_path` → `comparisons_path`; new `ranking` (labels + mean preferences), `seed`. Reducer stage reports winner + full ranking + notable disagreements from the ledger.
+
+**V5a/V5b split (pre-authorized):** V5a = runner core (plan execution, accumulation, ranking, ledger); V5b = judge prompts, `.d.ts`, reducer report, `models` round-robin.
+
+### 5.3 V6 — `fold_usage` and ledger usage blocks (#2494)
+
+```ts
+fold_usage(results: readonly WorkflowTaskResult[]): UsageTotals
+// UsageTotals = { calls, input, output, cacheRead, cacheWrite, cost, turns,
+//                 cacheHitRate }   // cacheRead / (input + cacheRead); absent fields = 0
+// Guarantee: pure fold over modelAttempts[].usage including retried attempts;
+// results without usage contribute zeros. Deterministic, fixture-tested.
+```
+
+- Home: `packages/workflows/builtin/verification-usage.ts` — importable later by #2212 B3 (run-tree meter) without pulling tournament code.
+- Consumers in this slice: tournament ledger (per phase + total) and adversarial-verification round summaries (`verification-summary-<round>.json` gains `usage`). goal/ralph ledger blocks land in V10 (Q4 resolved).
+- Durable-replay honesty: ledger writes happen once per phase in run code; a durable-resumed run replays the checkpointed write rather than re-folding, so replayed rounds add nothing (umbrella/reference parity: "comparisons served from cache add nothing").
+
+### 5.4 Cost at defaults (stated, not hidden)
+
+Per round with N=4: directed pairs = `4 + k(4−k) + C(k,2)`; judge calls = pairs × criteria × K. The Q1 decision fixes the default point; the ledger's `budget` block records planned vs executed for every run.
+
+## 6. Alternatives Considered
+
+| Option | Pros | Cons | Rejection |
+|---|---|---|---|
+| Keep knockout, add graded scores | smaller diff | one noisy call still eliminates permanently — the core defect | defeats #2488 |
+| Full round-robin O(N²) | max information | cost quadratic; PPT reaches comparable selection at O(Nk) | reference result |
+| Global usage counter (reference `USAGE` style) | matches reference | process-global state in a workflow runtime with concurrent runs; atomic already has per-result usage | fold per result-set instead |
+| Raw 1–20 differences into sigmoid | no normalize step | σ(19) ≈ 1.0 — saturates; soft wins collapse to hard wins | normalize to [0,1] first |
+
+## 7. Cross-Cutting Concerns
+
+- **Determinism & resume:** the schedule is a pure function of `(n, pivots, K, seed)`; stage names derive from `ScoringJob` identity (`judge-<a>-<b>-<criterion>-r<rep>`), so durable replay reattaches checkpointed results to identical jobs and call order is stable.
+- **Compatibility:** breaking posture; `bracket_path` removal and ledger reshape recorded in CHANGELOG `### Breaking Changes`; retained output names documented as unchanged.
+- **Trust:** no new irreversible doors. The winner is arithmetic over the ledger; anyone can recompute the ranking from `comparisons.json` alone.
+
+## 8. Test Plan
+
+- **V4** — `npx vitest --run --project unit -t "selection-math"`: seeded RNG cross-platform vectors; ring cycle = valid Hamiltonian adjacency (every candidate once per slot); plan determinism (same input twice → deep-equal plans); dedup (ring ∩ pivot pairs never double-scheduled); swap bookkeeping (odd reps swapped, recorded in candidate order); BT accumulation w/c invariants (Σc = 2 × comparisons); pivot tie-break by index; ranking length = n always; budget formula `N + k(N−k) + C(k,2)` upper bound.
+- **V5** — `builtin-workflows-tournament-loop` updated: stubbed judges → ledger complete (every job present or `invalid`-flagged); invalid job excluded from means and never persisted as a score; fully-invalid pair → 0.5/0.5 flagged; ranking recomputable from ledger (test recomputes and compares); retained outputs present; fixed seed twice → identical ledgers.
+- **V6** — new usage-fold suite: fixtures for absent usage → zeros, retries summed, hit-rate derivation, empty set → all-zero totals.
+- **Interactive verification:**
+  1. Run tournament on a 3-candidate fixture with `seed: 7` twice → byte-identical `comparisons.json` (modulo usage/timing fields).
+  2. Recompute `w/c` from the ledger by hand for one candidate → matches `ranking` entry.
+  3. Corrupt one judge fixture → ledger shows `invalid: true` for that job, rep count for that pair reduced by one, no score fabricated.
+  4. Inspect `usage.cacheHitRate` across ring phase with V3 active vs a control with shuffled prompt order → the V3 claim is now a measured number.
+- `npm run check` green per slice; Evidence protocol per umbrella §5.3.
+
+## 9. Open Questions / Unresolved Issues
+
+All resolved with the owner, 2026-08-17:
+
+- [x] **Q1 — Operating point:** defaults `pivots=1, n_evaluations=2, C=3` (the measured bo3 preset; 42 judge calls/round at N=4). `pivots=2` documented as the accuracy upgrade; the ledger's `budget` block records planned vs executed either way.
+- [x] **Q2 — Seed:** optional input, default `0`; schedules fully reproducible across runs.
+- [x] **Q3 — Heterogeneous pool:** ships in V5b — ordered `models` list, round-robin per attempt slot, assignment in the ledger, caveat documented (diversity is a bet on the selector).
+- [x] **Q4 — goal/ralph usage blocks:** deferred to V10; V6 touches only tournament + adversarial. #2494 completes across V6+V10, noted on the issue when V6 lands.

--- a/specs/2026-08-17-verification-criteria-module.md
+++ b/specs/2026-08-17-verification-criteria-module.md
@@ -1,0 +1,216 @@
+# Verification Criteria Module + Prefix-Cache Prompts (Slices V1–V3) — Child Spec
+
+| Document Metadata      | Details                                                                 |
+| ---------------------- | ----------------------------------------------------------------------- |
+| Author(s)              | flora131 (with Claude Fable 5)                                          |
+| Status                 | In Review (RFC) — all open questions resolved 2026-08-17                |
+| Team / Owner           | flora131                                                                |
+| Created / Last Updated | 2026-08-17                                                              |
+| Parent                 | `specs/2026-08-17-llm-verifier-adoption-program.md` (umbrella; posture: breaking allowed) |
+| Issues                 | #2487 (criteria + aggregation), #2493 (prefix-cache prompts)            |
+| Research               | `research/docs/2026-08-17-llm-verifier-adoption-scan.md` §3, §4         |
+| Slices                 | V1 `verifier/criteria-module` · V2 `verifier/adversarial-mean-veto` · V3 `verifier/prefix-cache-prompts` |
+
+## 1. Executive Summary
+
+This spec defines the foundation of Stack V: one shared rubric primitive (`packages/workflows/builtin/verification-criteria.ts`) that every verification builtin consumes, the rewiring of `adversarial-verification` from a binary unanimity gate to per-criterion graded scoring with mean+veto aggregation, and the prompt/scheduling layer that makes the multiplied verifier calls affordable. Three doors carry the change: **`parse_rubric`** (one canonical `criteria.md` parser, mirroring the reference implementation), **`decide_verification`** ⚠ (the single deterministic door to an accept — an unparseable verifier report is *unrepresentable* as a vote, killing the inherited #2255 bug at the type level), and **`warm_first_fan_out`** (one warm call per distinct prompt prefix before fanning out, paired with shared-head/varying-tail prompt layout; reference-measured 5.2%→78.4% cache-hit improvement). Everything is deterministic and unit-testable without model calls except the verifier stages themselves.
+
+## 2. Context and Motivation
+
+### 2.1 Current State (leaking doors)
+
+- `adversarial-verification-runner.ts:8-12` — `verifierSchema` collapses a verifier's judgment to binary `pass|fail`. §4.3 of the paper: compound binary rubrics latch onto the most salient factor.
+- `adversarial-verification-runner.ts:45-49,74,77-78` — **the inherited bug**: an unparseable report is replaced by `INVALID_VERIFIER_REPORT` (a substantive fail vote written to the artifact), and `allVerifiersPassed` requires `validReports.length === verifier_count`, so a parse failure blocks acceptance exactly like a real objection. The door named "report" behaves as "veto."
+- `adversarial-verification-runner.ts:54` — the rubric is a hardcoded 5-bullet list written to `rubric.md`; no caller can supply criteria.
+- `adversarial-verification-runner.ts:89-94` — unanimity AND: false-accept protection degrades as `(1−p)^K` but false-*reject* grows as `1−(1−p)^K` (#2255 derivation); the reducer's accept is overridden by one noisy fail.
+- `tournament-prompts.ts:37-42` + `adversarial-verification-prompts.ts` `renderVerifierPrompt` — pair/candidate-specific content leads every prompt; criterion/rubric text sits mid-prompt; candidate bodies arrive via `reads` (after the prompt). No two sibling verifier calls share a usable prompt prefix.
+
+### 2.2 The Problem
+
+Per-criterion scoring multiplies verifier invocations by criteria count, and #2488/#2490 add K repeats on top. The statistical upgrade is unaffordable without the prompt-layout and scheduling changes, and unsound without the aggregation fix — so V1–V3 ship as one dependency chain: types and parser first, the consumer rewire second, the cost layer third.
+
+## 3. Goals and Non-Goals
+
+### 3.1 Functional Goals
+
+- [ ] One canonical `criteria.md` parser + normalizer with reference-parity semantics (`{#id}` anchors, slugging, dedup, comment stripping, empty-description rejection).
+- [ ] Shared anchored 1–20 scale constants used by every downstream slice (V4–V10).
+- [ ] `adversarial-verification` accepts caller-supplied criteria, scores each criterion in a separate verifier invocation, and gates on mean-vs-threshold with an unconditional veto path.
+- [ ] Parse failures become bounded re-asks; they can never be counted as votes and are never durably persisted as scores.
+- [ ] Scoring prompt builders emit byte-identical shared heads across sibling calls, varying only at the tail; fan-outs warm one call per distinct prefix first.
+- [ ] Cost knob documented: `criteria.length × verifier_count` invocations per round.
+
+### 3.2 Non-Goals (Out of Scope)
+
+- [ ] NOT porting the letter-scale/logprob machinery (A–T letters exist for logprob extraction; atomic uses schema-validated integers 1–20).
+- [ ] NOT changing tournament or goal/ralph consumers here (V5, V9–V10 consume this module).
+- [ ] NOT preserving the existing `adversarial-verification` output contract (umbrella posture: breaking allowed; `.d.ts` updated in V2).
+- [ ] NOT promising a cache-hit rate: the prompt layout creates the *conditions* for provider prefix caching; the measurement lands with V6 (`fold_usage` cache-read evidence).
+- [ ] NOT adding a build step to `packages/workflows`.
+
+## 4. Proposed Solution (High-Level Design)
+
+### 4.1 Architecture
+
+```mermaid
+flowchart TB
+    classDef mod fill:#4a90e2,stroke:#357abd,color:#fff,font-weight:600
+    classDef stage fill:#667eea,stroke:#5a67d8,color:#fff
+    classDef det fill:#48bb78,stroke:#38a169,color:#fff,font-weight:600
+
+    RUBRIC["criteria input<br>(record | markdown | default)"] --> PARSE["parse_rubric /<br>normalize_criteria"]:::mod
+    PARSE --> HEAD["build shared prompt head<br>(task + candidate body + scale)"]:::mod
+    HEAD --> WARM["warm_first_fan_out"]:::mod
+    WARM --> S1["score_criterion × (C × verifier_count)<br>model stages, schema-validated"]:::stage
+    S1 --> DECIDE{"decide_verification ⚠<br>deterministic"}:::det
+    DECIDE -->|Accept| DONE[approved]
+    DECIDE -->|"Repair(findings)"| CONS["consolidate-findings stage<br>(model, repair guidance only)"]:::stage --> REPAIR[repair stage] --> WARM
+    DECIDE -->|"Indeterminate(reask)"| REASK["bounded re-ask<br>(same stage config, fresh context)"]:::stage --> DECIDE
+```
+
+The **acceptance decision moves out of the model reducer into deterministic code** (Q1 resolved). The old reducer stage survives with a smaller, honest job: consolidating confirmed findings into repair guidance.
+
+### 4.2 The Door Set at a Glance
+
+> `parse_rubric` · `normalize_criteria` · `select_criteria` · `score_criterion` · `decide_verification` ⚠ · `build_scoring_prompt` · `warm_first_fan_out`
+
+Read alone: rubrics have one parser and one normal form; every score is one criterion in one call; acceptance has exactly one deterministic door; prompts are built for cache sharing; fan-out warms before it floods.
+
+## 5. Detailed Design
+
+### 5.1 The Doors (V1 — `packages/workflows/builtin/verification-criteria.ts`)
+
+```ts
+// — Types. A Criterion is the unit of judgment; a CriterionScore can only —
+// — be constructed from a schema-valid structured output.                 —
+
+interface Criterion { readonly id: string; readonly name: string; readonly description: string }
+interface Criteria { readonly groundTruthNote: string; readonly criteria: readonly Criterion[] }
+
+parse_rubric(markdown: string): Criteria                                   // throws RubricError
+// Guarantee: returns normalized criteria with unique ids in file order.
+// Semantics (reference parity, llm_verifier/prompts.py):
+//   `# title` ignored · `## Ground Truth Note` optional, first wins ·
+//   `## Criteria` section owns `### Name {#id}` headings · HTML comments
+//   stripped before parsing (author notes never reach a verifier) ·
+//   id slug: lowercase, alnum→underscore, ≤40 chars, fallback "criterion" ·
+//   duplicate ids deduped _2, _3, … in encounter order.
+// RubricError (named): NoCriteria | EmptyCriterion(ids)
+// Refuses: a criterion without a body (empty description is an error, not a
+// silent skip) — a rubric line a verifier cannot score with is a lie.
+
+normalize_criteria(input: Record<string,string> | readonly string[] | readonly CriterionInput[]): readonly Criterion[]
+// Guarantee: one canonical {id,name,description}[] from any accepted shape;
+// same slug/dedup rules; empty description throws. (Reference parity.)
+
+select_criteria(criteria: readonly Criterion[], ids?: readonly string[]): readonly Criterion[]
+// Guarantee: subset+order by ids; unknown id throws (never silently drops).
+
+// — The scale. One definition, shared by V4–V10. —
+VERIFICATION_SCALE: {
+  readonly min: 1; readonly max: 20;
+  readonly anchors: string;   // "1 = certainly fails … 10 = borderline … 20 = verified correct"
+  readonly schema: TSchema;   // Type.Integer({ minimum: 1, maximum: 20 })
+}
+
+// — Scoring artifact. The only way to mint one is a schema-valid report. —
+interface CriterionScore {
+  readonly criterionId: string;
+  readonly score: number;                     // 1..20, schema-enforced
+  readonly evidence: readonly string[];
+  readonly findings: readonly Finding[];
+}
+interface Finding { readonly finding: string; readonly severity: "veto" | "blocking" | "note" }
+
+// — The chokepoint. —
+decide_verification(
+  round: { scores: readonly CriterionScore[]; invalidCount: number; expectedCount: number },
+  policy: { acceptMean: number; quorumFraction: number },
+): Accept | Repair | Indeterminate
+// Accept        = { kind: "accept"; mean: number }
+// Repair        = { kind: "repair"; mean: number; findings: Finding[] }   // confirmed findings only
+// Indeterminate = { kind: "indeterminate"; missing: number }              // re-ask, never a vote
+// Guarantee: Accept iff quorum holds AND mean(scores) ≥ acceptMean AND no
+// severity:"veto" finding exists; any veto finding forces Repair regardless
+// of mean; a round below quorum (valid < ceil(expected × quorumFraction))
+// is Indeterminate. ⚠ The single door to an accept; pure and table-testable.
+// Refusal BY TYPE: `invalidCount` is metadata — there is no constructor that
+// turns an unparseable report into a CriterionScore, so a parse failure
+// cannot lower (or raise) the mean. The #2255 bug is unrepresentable.
+```
+
+**Per-door rubric audit:**
+
+| Door | (1) Joint | (2) One sentence | (3) Honest name | (5) Every exit | (6) Refusals real | (8) Chokepoint |
+|---|---|---|---|---|---|---|
+| `parse_rubric` | ✅ "parse the rubric" | ✅ returns normalized criteria or a named error | ✅ parses, never invents | empty body → `EmptyCriterion`, not a skip | unparseable rubric cannot produce criteria | n/a |
+| `decide_verification` ⚠ | ✅ "decide the verification" | ✅ "maps one round of scores to exactly one of accept/repair/indeterminate" | ✅ decides, never re-scores | below quorum → Indeterminate; veto → Repair even at mean 20 | invalid report unconstructible as a score | ✅ sole accept path in V2 |
+| `warm_first_fan_out` | ✅ scheduling joint | ✅ "runs one call per distinct prefix to completion before releasing the rest" | ✅ | a warm-phase failure still releases its group (no deadlock) | grouping key is caller-supplied, not inferred | n/a |
+
+### 5.2 V2 — adversarial-verification rewire
+
+**Inputs** (breaking, `.d.ts` updated): `task`, `verifier_count`, `max_repairs` (unchanged) + new optional `criteria` (record `{name: description}` or `criteria.md` markdown string; default: 3 criteria decomposed from the existing rubric — `task_fit`, `evidence`, `completeness`) + `accept_mean` (default **14**; 10 = borderline on the shared scale) + `reask_limit` (default 1). (Q2 resolved.)
+
+**Fan-out shape:** per round, `criteria.length × verifier_count` stages, each scoring **one criterion** with schema = `{ criterion_id, score (VERIFICATION_SCALE.schema), evidence, findings[{finding, severity}] }`, `context: "fresh"`, `failFast: false`. Reports persist per stage as today (schema-shaped JSON artifacts) — but an invalid report persists as `{ "invalid": true, "stage": … }`, never as a substitute verdict, and is **never durably recorded as a score** (umbrella decision; reference `on_error="tie"` parity).
+
+**Round logic:**
+1. Collect valid `CriterionScore`s; invalid/missing → one bounded re-ask wave (`reask_limit`, same stage config, fresh context).
+2. `decide_verification(round, policy)`:
+   - **Accept** → done; `approved: true`.
+   - **Repair** → consolidate-findings stage (the old reducer, renamed job: merge confirmed findings into actionable repair guidance; it CANNOT flip the decision) → repair stage → next round. `max_repairs` bound unchanged; exhaustion → not approved, remaining work preserved verbatim.
+   - **Indeterminate** (still below quorum after re-asks) → the round repeats once; a second Indeterminate ends the run not-approved with the quorum failure as evidence (never silent acceptance, never a fabricated fail vote).
+3. Outputs: `approved`, `mean_score`, per-criterion score table path, `repairs_completed`, `candidate_path`, `review_report_path`, `remaining_work` — reshaped freely under the breaking posture.
+
+### 5.3 V3 — prefix-cache prompt layout + warm-first scheduling
+
+**Layout invariant** (documented in the module, reference-docstring parity): a scoring-family prompt is `SHARED HEAD ‖ VARYING TAIL`.
+- **Head** (byte-identical across the family): task statement, ground-truth note, candidate body/bodies **inlined** (bound: **32 KiB per candidate**, a named tested constant; any oversized candidate flips the whole family to `reads` so sibling heads stay byte-identical — Q3 resolved), scale anchors.
+- **Tail** (only per-call variation): criterion name+description, output-format instruction.
+- `build_scoring_prompt(head: SharedHead, criterion: Criterion): string` — the only prompt constructor V2 (and later V5) may use; a unit test asserts two sibling prompts share a byte-identical head and differ only after it.
+- **Rider (Q4 resolved):** the `generate-and-filter` judge prompt adopts `build_scoring_prompt` in this slice (~50 src lines) — the third consumer proves the builder API before V5 lands on it.
+
+**`warm_first_fan_out(ctx, steps, prefixKeyOf, options)`:** partition steps by prefix key; phase 1 runs one step per distinct key (bounded concurrency); phase 2 releases the rest at full concurrency. A phase-1 failure releases its group anyway (`failFast: false` families) — warming is an optimization, never a gate. Slot-swapped orientations (V5) are distinct keys by construction.
+
+### 5.4 Data Model
+
+- `criteria.md` format: as §5.1 semantics; `criteria/TEMPLATE.md`-style docs land in D1/V11, not here.
+- Score artifact (per stage): `verification-<round>-<criterion>-<k>.json` = the `CriterionScore` or `{invalid: true}` marker.
+- Round summary: `verification-summary-<round>.json` = `{ scores[], mean, invalidCount, decision }` — the auditable input to `decide_verification`, plus (from V6) a usage block.
+
+## 6. Alternatives Considered
+
+| Option | Pros | Cons | Rejection |
+|---|---|---|---|
+| Keep model reducer as decision-maker, show mean as evidence | no behavior change to reducer | acceptance stays non-deterministic; the chokepoint has two doors | fails rubric #8; Q1 confirms the split |
+| One verifier call scores all criteria at once | C× fewer calls | recreates the compound-rubric failure (§4.3: salient-factor latch) — the exact thing #2487 removes | defeats the purpose |
+| Letters A–T like the reference | prompt parity | letters exist only for logprob extraction; atomic has schemas and no logprobs | integers 1–20, schema-enforced |
+| Count invalid reports as fail votes (status quo) | "safe" bias | provably wrong: converts infrastructure noise into substantive objections; degrades as verifier_count grows | the bug this spec deletes |
+
+## 7. Cross-Cutting Concerns
+
+- **Trust:** `decide_verification` is pure TypeScript — the accept path is auditable from the round summary alone. No model output can mint a `CriterionScore` without passing the schema.
+- **Compatibility:** breaking allowed (umbrella §7.2); V2 updates `adversarial-verification.d.ts` and `packages/workflows/CHANGELOG.md` (`### Breaking Changes`) in-slice.
+- **Cost:** stated in docs + `.d.ts` comments: default criteria triple per-round calls; `reask_limit` adds at most `invalid × reask_limit` calls; V3 exists to make the multiplied input tokens mostly cache reads.
+
+## 8. Test Plan
+
+Commands are the Evidence commands (umbrella §5.3):
+
+- **V1** — `npx vitest --run --project unit -t "verification-criteria"`: table tests for parser (section layout, `{#id}`, slug/dedup incl. 40-char truncation, comment stripping, empty-description rejection, no-criteria rejection), normalizer (record/array/dict shapes, error cases), `select_criteria` unknown-id throw, and `decide_verification` (mean threshold boundary, veto overrides mean=20, quorum boundary at `ceil(expected × fraction)`, invalidCount never shifts mean).
+- **V2** — existing `builtin-workflows-adversarial-generate` suite updated: fixture run with stubbed stages → per-criterion artifacts, re-ask on invalid fixture (never a vote), repair on veto finding, quorum-failure ends not-approved.
+- **V3** — new prompt-layout suite: byte-identical-head assertion; warm/rest partition determinism; warm-failure releases group.
+- **Interactive verification** (human or agent):
+  1. `printf '## Criteria\n### Correct {#c}\nIs it correct?\n' | <preview helper>` → 1 criterion, id `c` (parser door observable at the boundary).
+  2. Run adversarial-verification on a trivial fixture task with `verifier_count: 2`, default criteria → round summary shows `C×2` scores, a mean, and a deterministic decision.
+  3. Corrupt one verifier fixture to emit prose instead of structured output → artifact shows `{invalid: true}`, summary `invalidCount: 1`, decision unchanged in kind (re-ask happened, no fail vote).
+  4. Inject a `severity: "veto"` finding with all scores 20 → decision is Repair, not Accept.
+- Per-slice: `npm run check` green; suite discipline per umbrella §8.
+
+## 9. Open Questions / Unresolved Issues
+
+All resolved with the owner, 2026-08-17:
+
+- [x] **Q1 — Accept owner:** `decide_verification` decides deterministically; the reducer stage is demoted to findings-consolidator for repair prompts and cannot flip the decision.
+- [x] **Q2 — Defaults:** 3 criteria (`task_fit`, `evidence`, `completeness`) decomposed from the current rubric; `accept_mean: 14`.
+- [x] **Q3 — Inline bound:** 32 KiB per candidate body, named constant; oversized flips the whole family to `reads` to keep heads identical.
+- [x] **Q4 — generate-and-filter judge:** rider in V3 (~50 src lines) adopting `build_scoring_prompt`.

--- a/specs/2026-08-17-verifier-docs.md
+++ b/specs/2026-08-17-verifier-docs.md
@@ -1,0 +1,75 @@
+# Verification-Scaling Authoring Guidance (Slices D1, V11) — Child Spec
+
+| Document Metadata      | Details                                                                 |
+| ---------------------- | ----------------------------------------------------------------------- |
+| Author(s)              | flora131 (with Claude Fable 5)                                          |
+| Status                 | In Review (RFC) — all open questions resolved 2026-08-17                |
+| Team / Owner           | flora131                                                                |
+| Created / Last Updated | 2026-08-17                                                              |
+| Parent                 | `specs/2026-08-17-llm-verifier-adoption-program.md` (umbrella)          |
+| Issues                 | #2491 (+ its self-verification / operating-points comment)              |
+| Research               | `research/docs/2026-08-17-llm-verifier-adoption-scan.md` §3              |
+| Slices                 | D1 `verifier/docs-patterns` (now, standalone from main) · V11 `verifier/docs-primitives` (top of Stack V) |
+| Targets                | `packages/coding-agent/docs/workflows.md` (starter patterns) · `packages/workflows/README.md` (pattern table) |
+
+## 1. Executive Summary
+
+Custom-workflow authors write judge stages, verifier fan-outs, and bounded loops today, guided by starter patterns that predate the LLM-as-a-Verifier findings. This spec lands the findings **inside the existing pattern flow** — never as a detached essay — in two phases. **D1 (now):** pattern-level guidance that names no unshipped primitive: graded scores over binary verdicts, K repeats with slot swap, criteria decomposition with mean+veto (never unanimity AND), progress magnitude beside the stop bit, pool diversity as an oracle-ceiling bet, the no-logprobs cost constraint, and the self-verification finding (a same-model judge captures most of the selection headroom). **V11 (top of Stack V):** primitive references — inputs, defaults, ledger formats — added to the same sections as each builtin ships. Acceptance is citation fidelity: every number matches the paper, every default matches the shipped code.
+
+## 2. Context and Motivation
+
+`docs/workflows.md` (5,258 lines) documents Tournament, Adversarial verification, Generate-and-filter, and Loop until done as starter patterns; `packages/workflows/README.md` (915 lines) carries the pattern table. Neither says anything about judge-stage design: an author following them today writes a binary `winner` schema (the exact anti-pattern V5 deletes), a unanimity gate (V2's), and a loop with no progress signal (V8's). The findings exist, the numbers are published, and the builtins are being upgraded — the guidance layer is the missing piece, and its pattern-level half has no code dependency at all.
+
+## 3. Goals and Non-Goals
+
+### 3.1 Functional Goals (D1)
+
+- [ ] Each existing starter pattern gains its verification-scaling guidance **in place**: Tournament → graded per-criterion scores, BT preference from score gaps, K repeats with A/B swap, the 26.7%-tie-at-K=1 number; Adversarial verification → criteria decomposition, mean+veto, the `1−(1−p)^K` false-reject argument; Generate-and-filter → same judge guidance; Loop until done → progress magnitude, flat-is-the-stall-signal, never-a-kill-switch.
+- [ ] Cross-cutting subsection (one, short, linked from the patterns — not a freestanding essay): the anchored 1–20 scale; the no-logprobs constraint (K-sample averaging at ~16× cost for K=1-logprob parity); pool diversity (oracle 92.1% vs pass@1 83.1%, and the counter-caveat that a chance-level selector makes diversity worse); self-verification (same-model judge: 86.5%/88.0% vs 79.4%/78.7% pass@1); cheap operating points (bo3 `pivots=1, K=2`, bo5).
+- [ ] README pattern-table rows annotated where guidance changes what an author should write.
+- [ ] Every cited number traceable to research §3 (which cites the paper).
+
+### 3.2 Functional Goals (V11)
+
+- [ ] Primitive references land in the same sections: criteria module usage + `criteria.md` format (after V1–V2), warm-first/prefix layout guidance (after V3), tournament inputs/defaults/ledger (after V5–V6), progress scoring + trend (after V7–V8), goal/ralph re-verification + convergence (after V9–V10). One docs slice at the top of the stack, checked against shipped defaults.
+
+### 3.3 Non-Goals
+
+- [ ] NOT documenting unshipped primitives in D1 (D1 must be true if Stack V never lands).
+- [ ] NOT a research-paper summary or appendix; guidance lives where an author's eyes already are.
+- [ ] NOT reformatting either file beyond the touched sections (no repo-wide docs churn).
+- [ ] NOT changelog entries for D1 (docs guidance is not shipped-package behavior; V11's primitive references ride the same slices' CHANGELOG entries already required by V1–V10 — no doubles).
+
+## 4. Design
+
+### 4.1 Placement map (the "door set" of a docs change is where readers enter)
+
+| Reader entry point | D1 adds | V11 adds |
+|---|---|---|
+| workflows.md § Tournament pattern | graded-scores/K-swap/BT guidance + numbers | inputs (`pivots`, `n_evaluations`, `seed`, `criteria`, `models`), bo3 default, `comparisons.json` |
+| workflows.md § Adversarial verification | criteria decomposition, mean+veto, false-reject math | `criteria` input, `accept_mean: 14`, re-ask semantics, round summary format |
+| workflows.md § Generate-and-filter | judge guidance (same as tournament's) | criteria-module usage |
+| workflows.md § Loop until done | progress magnitude, flat = stall, containment rule | ledger `progress` entries, K default 1, trend in stop reports |
+| workflows.md § new short subsection "Verification scaling" | scale, no-logprobs constraint, diversity/oracle, self-verification, operating points | links to primitive sections |
+| README.md pattern table | one-line guidance deltas per row | updated row descriptions as behavior ships |
+
+### 4.2 Fidelity rules
+
+- Numbers appear with their benchmark context (e.g., "Terminal-Bench 2.1 self-verification") — never naked percentages.
+- Every V11 default is copied from the shipped code the same slice can see, not from this spec (the spec may drift; the code cannot).
+- The containment sentences (trend never kills; `stop_review_loop` stays authoritative) appear wherever the corresponding signal is documented — the docs must not advertise authority the primitives refuse.
+
+## 5. Test Plan
+
+Docs slices carry evidence too (umbrella Evidence protocol, docs-exempt from the line cap but not from proof):
+
+- **D1:** Evidence section lists each edited section with an anchor link; a reviewer (or agent) checks every cited number against research §3's table — the checklist is enumerated in the PR body. `npm run check` still runs (markdown touches nothing, but the gate is uniform).
+- **V11:** same, plus a defaults cross-check: for each documented default, the Evidence section quotes the shipped source line (`tournament.ts` input schema, etc.).
+- **Interactive verification:** a stranger-across-time test, made executable — an agent is given only the edited Tournament section and asked to draft a judge-stage schema; the draft must use graded per-criterion integer scores, not a binary winner. **Required before D1 goes ready-for-review** (Q2 resolved); prompt-level check, not a CI test.
+
+## 6. Open Questions / Unresolved Issues
+
+All resolved with the owner, 2026-08-17:
+
+- [x] **Q1 — Home:** a short "Verification scaling" subsection inside workflows.md's starter-patterns chapter, linked from each pattern.
+- [x] **Q2 — D1 review:** human review **plus** the executable stranger-test before marking ready — the test result is pasted in D1's Evidence section.


### PR DESCRIPTION
## Summary

Spec hierarchy for the LLM-as-a-Verifier adoption program (#2487–#2491, #2493, #2494) and the run-budget track (#2212). Docs only — no code changes.

- **Research corpus:** `research/docs/2026-08-17-llm-verifier-adoption-scan.md` — technique→issue mapping, file:line ground truth at `9d0a69da0e`, and the decision log (including the codex-derived budget shape).
- **Umbrella:** `specs/2026-08-17-llm-verifier-adoption-program.md` — delivery topology (2 worktrees, 2 linear gh-stacks + standalone docs PR, 17 slices each < 500 source lines), per-PR Evidence protocol, autonomous per-slice execution model. All 7 topology questions resolved.
- **Six child specs** (V1–V11, D1, B1–B3), each In Review with all open questions resolved; owner overrides recorded in-spec where decisions diverged from drafted recommendations (breaking-changes posture; all-classes demotable with two-tier bar; child-scoped budgets).

## Review notes

- §4.2 (umbrella slice table) and §5.1 of each child spec (door contracts) are the load-bearing sections.
- Issue sync already done: posture amendments on #2487/#2488; #2212 body reflects the budget shape and resolved open questions.

## Evidence

Docs-only change; `npm run check` unaffected (no source touched). Slice implementation PRs will carry the full Evidence protocol these specs define.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789621079&installation_model_id=10562&pr_number=2495&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2495&signature=9f4e7ee48f1b36532d7c62797f66beadfb33d17d3be6ed23ac20a3f22ab6b62c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This documentation change defines proposed contracts for workflow run budgets, usage metering, progress scoring, and trend classification. Focused checks demonstrated two contract failures: cache-inclusive provider input can be counted against an uncached-input budget, and a required null checkpoint cannot be represented by or passed through the declared scoring APIs.

The specifications should be corrected before they are used as implementation contracts.

## T-Rex validation blocked

- Tool: the executed cache-accounting harness returned artifact paths without the required labels, and the nullable-checkpoint harness returned no uploaded artifact reference. The executed results therefore cannot be attached as valid proof entries.

<h3>Confidence Score: 3/5</h3>

Not safe to treat as implementation-ready until the budget normalization and nullable-checkpoint contracts are made consistent.

Two independent, reproducible non-security contract failures remain: one produces incorrect token readings for cache-inclusive providers, and one leaves an explicitly required scoring result unrepresentable by the declared API.

**Files Needing Attention:** `specs/2026-08-17-run-budgets.md` needs a canonical cache-normalization rule; `specs/2026-08-17-progress-scoring.md` needs a consistent nullable score and trend-classification contract.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding and referenced the review comment for details.
- T-Rex executed the cache-contract verification and captured exact evidence of an overcharge, concluding the verdict was confirmed.
- T-Rex produced a second proof for another posted P1 finding and referenced the review comment for details.
- T-Rex ran the requested verification again, but the local artifact references were not uploaded.

<a href="https://app.greptile.com/trex/runs/19340570/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Token meter formula conflicts with the uncached-input policy**

   - **Bug**
     - `specs/2026-08-17-run-budgets.md:93-103` specifies `tokens = Σ (usage.input + usage.output)`, but the document states that `maxTokens` charges uncached input plus output and excludes cache reads/writes. For providers whose `input` includes cached prompt tokens and whose `cacheRead` exposes that cached partition, the specified formula charges cached tokens.
   - **Cause**
     - The meter declaration neither subtracts `usage.cacheRead` from a cache-inclusive `usage.input` nor defines a normalized-uncached meaning for `usage.input` before summation.
   - **Fix**
     - Define a canonical usage invariant before metering, or specify `tokens = Σ ((usage.input - usage.cacheRead) + usage.output)` for cache-inclusive provider input totals, with validation/clamping semantics for missing or inconsistent counters.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
specs/2026-08-17-run-budgets.md:93-99
**Cache-inclusive input is charged as uncached usage**

`maxTokens` is defined as uncached input plus output, but the meter requires `Σ (usage.input + usage.output)` without defining whether `usage.input` has already been normalized. Providers that include cached prompt tokens in both `input` and `cacheRead` will therefore charge those cached tokens toward the budget. Define a canonical normalized input field or explicitly subtract cache-read tokens, including behavior for absent or inconsistent cache counters, before enforcing the token budget.

### Issue 2
specs/2026-08-17-progress-scoring.md:99-107
**Null checkpoints cannot be represented or classified**

A checkpoint with zero valid repeats is required to be `null`, but `ProgressCurve.scores` is declared as `number[]`. Widening it to represent the required value then makes it incompatible with `classify_trend(series: readonly number[])`, leaving consumers without a specified way to preserve checkpoint alignment and classify incomplete curves. Define null handling consistently across the curve and trend API, or specify a normalization step before trend classification.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(specs): LLM-as-a-Verifier adoption ..."](https://github.com/bastani-inc/atomic/commit/0c57f732dc15edfcbca68065b42615a38e67b084) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54238541)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->