### PR TITLE
docs(changelog): 0.9.14-alpha.3 release notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.14-alpha.3] - 2026-08-17
+
 ### Changed
 
 - Documented built-in workflow and subagent Grok 4.6 fallbacks as `xai/grok-4.6:xhigh` and `github-copilot/grok-4.6:xhigh`.

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.14-alpha.3] - 2026-08-17
+
 ### Changed
 
 - MCP OAuth now opens the authorization URL from WSL when the Linux working directory is not reachable from Windows.

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.14-alpha.3] - 2026-08-17
+
 ### Changed
 
 - Raised every built-in subagent Grok 4.6 fallback from `xai/grok-4.6:high` to `xai/grok-4.6:xhigh` and added the matching `github-copilot/grok-4.6:xhigh` twin immediately after each xAI id.

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.14-alpha.3] - 2026-08-17
+
 ### Fixed
 
 - `fetch_content` PDF extraction no longer throws `TypeError: Math.sumPrecise is not a function` on Node runtimes without that builtin.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.14-alpha.3] - 2026-08-17
+
 ### Changed
 
 - Raised built-in Goal, Ralph, and open-claude-design Grok 4.6 fallbacks from `xai/grok-4.6:high` to `xai/grok-4.6:xhigh` and added the matching `github-copilot/grok-4.6:xhigh` twin immediately after each xAI id.


### PR DESCRIPTION
## Summary

Release notes for the `0.9.14-alpha.3` prerelease. The accumulated `[Unreleased]` entries in `packages/coding-agent`, `packages/mcp`, `packages/subagents`, `packages/web-access`, and `packages/workflows` move under a `## [0.9.14-alpha.3] - 2026-08-17` heading.

## Changes

- `packages/coding-agent/CHANGELOG.md` — Grok 4.6 `xhigh` fallbacks, idempotent `/workflow resume` recovery, WSL MCP OAuth launch, `ask_user_question` readiness-gate answers, batched parallel hashline edits, and Node PDF extraction.
- `packages/mcp/CHANGELOG.md` — MCP OAuth browser launch from WSL when the Linux working directory is not reachable from Windows.
- `packages/subagents/CHANGELOG.md` — built-in subagent Grok 4.6 fallbacks raised to `xai/grok-4.6:xhigh` with matching Copilot twins.
- `packages/web-access/CHANGELOG.md` — `fetch_content` PDF extraction no longer requires `Math.sumPrecise`.
- `packages/workflows/CHANGELOG.md` — Goal/Ralph/open-claude-design Grok 4.6 `xhigh` fallbacks, readiness-gate custom text, and graph-viewer overlay mounting for `ask_user_question`.

## Versionless base

No version stamping here. Every `packages/*/package.json`, the `@bastani/atomic-natives` pin, `packages/natives/native/index.js`, `Cargo.toml`, and `Cargo.lock` stay at the `0.0.0` placeholder. `scripts/cut-release.ts` materializes `0.9.14-alpha.3` on the detached `Release 0.9.14-alpha.3` commit after this merges.

## Notes

- Local validation: `bunx vitest --run --project unit test/unit/changelog.test.ts test/unit/package-metadata.test.ts test/unit/pi-0.84.2-docs-contract.test.ts` (43 passed). Pre-commit `npm run check` and `npm run test:unit` passed. Pre-push `npm run test:integration` and `npm run test:ci-contracts` passed.
- Diff is changelog-only. Intercom and natives had empty `[Unreleased]` sections and were left unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789626225&installation_model_id=10562&pr_number=2497&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2497&signature=1cb164e4232591464edeccb4cb33a8abfbd16321c7e0be2720221607038d69a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds `0.9.14-alpha.3` release sections dated 2026-08-17 to the coding-agent, MCP, subagents, web-access, and workflows changelogs while preserving their `Unreleased` sections. The release-note contract was checked on both the parent and reviewed commits: all 43 targeted tests passed in each case, and the new alpha.3 sections are not locally tagged immutable releases.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the documentation-only update preserves the changelog release contract.

The targeted suite passed all 43 checks before and after the update, covering prerelease parsing, package metadata, documentation contracts, and immutable tagged changelog sections.

**Files Needing Attention:** No files require follow-up.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the release-contract suite against the baseline parent commit and verified the test set passed.
- Ran the release-contract suite against the reviewed commit and verified the test set passed.
- Validated that the reviewed commit adds only the five changelog sections and does not introduce a locally tagged immutable release section.

<a href="https://app.greptile.com/trex/runs/19349003/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): add 0.9.14-alpha.3 rele..."](https://github.com/bastani-inc/atomic/commit/06280d6ffeecc47c3c2ca99ddf03d8cc7b179399) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54258292)</sub>

<!-- /greptile_comment -->