### PR TITLE
feat(workflows): verification-criteria module — parser, scale, mean+veto gate (V1, #2487)

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added a shared `verification-criteria` module (`parse_rubric`, `normalize_criteria`, `select_criteria`, `VERIFICATION_SCALE`, `decide_verification`) so verification builtins can score one criterion at a time on an anchored 1–20 scale and accept only when a quorum mean clears the threshold with no veto finding. Unparseable reports cannot become scores and cannot shift the mean ([#2487](https://github.com/bastani-inc/atomic/issues/2487)).
+
 ### Fixed
 
 - Opened `ctx.tool` detail now matches the main-chat tool block: `Box(1,1)` inner padding, a blank row under the `$` header, full-width alignment with the orchestrator bars, unpainted canvas above and below the card, host `toolTitle`/`toolOutput` colors, a dim `ctrl+o Expand` hint, and second-resolution `Took`/`Elapsed` timing.

--- a/packages/workflows/builtin/verification-criteria.ts
+++ b/packages/workflows/builtin/verification-criteria.ts
@@ -267,3 +267,54 @@ export const VERIFICATION_SCALE: {
   anchors: "1 = certainly fails … 10 = borderline … 20 = verified correct",
   schema: Type.Integer({ minimum: 1, maximum: 20 }),
 };
+
+export type Accept = { readonly kind: "accept"; readonly mean: number };
+export type Repair = { readonly kind: "repair"; readonly mean: number; readonly findings: readonly Finding[] };
+export type Indeterminate = { readonly kind: "indeterminate"; readonly missing: number };
+export type VerificationDecision = Accept | Repair | Indeterminate;
+
+export type VerificationRound = {
+  readonly scores: readonly CriterionScore[];
+  readonly invalidCount: number;
+  readonly expectedCount: number;
+};
+
+export type VerificationPolicy = {
+  readonly acceptMean: number;
+  readonly quorumFraction: number;
+};
+
+function mean_score(scores: readonly CriterionScore[]): number {
+  if (scores.length === 0) return 0;
+  let total = 0;
+  for (const item of scores) total += item.score;
+  return total / scores.length;
+}
+
+/**
+ * Map one round of schema-valid scores to accept / repair / indeterminate.
+ *
+ * Accept iff quorum holds AND mean ≥ acceptMean AND no `severity: "veto"`
+ * finding exists. Any veto forces Repair regardless of mean. Below quorum
+ * (`valid < ceil(expected × quorumFraction)`) is Indeterminate.
+ *
+ * `invalidCount` is metadata only: there is no constructor that turns an
+ * unparseable report into a CriterionScore, so a parse failure cannot shift
+ * the mean.
+ */
+export function decide_verification(round: VerificationRound, policy: VerificationPolicy): VerificationDecision {
+  // `invalidCount` is intentionally unread. It cannot enter the mean.
+  const { scores, expectedCount } = round;
+  const valid = scores.length;
+  const quorumNeeded = Math.ceil(expectedCount * policy.quorumFraction);
+  if (valid < quorumNeeded) {
+    return { kind: "indeterminate", missing: Math.max(0, expectedCount - valid) };
+  }
+
+  const mean = mean_score(scores);
+  const findings = scores.flatMap((item) => item.findings);
+  if (findings.some((item) => item.severity === "veto") || mean < policy.acceptMean) {
+    return { kind: "repair", mean, findings };
+  }
+  return { kind: "accept", mean };
+}

--- a/packages/workflows/builtin/verification-criteria.ts
+++ b/packages/workflows/builtin/verification-criteria.ts
@@ -173,6 +173,89 @@ export function parse_rubric(markdown: string): Criteria {
   return { groundTruthNote, criteria };
 }
 
+function isRecord(value: object): value is Record<string, string> {
+  return Object.values(value).every((entry) => typeof entry === "string");
+}
+
+function isOptionalString(value: object, key: "id" | "name" | "description"): boolean {
+  if (!(key in value)) return true;
+  return typeof (value as CriterionInput)[key] === "string";
+}
+
+function isCriterionInput(value: object): value is CriterionInput {
+  return isOptionalString(value, "id") && isOptionalString(value, "name") && isOptionalString(value, "description");
+}
+
+function normalize_one(raw: string | CriterionInput, index: number, seen: Set<string>): Criterion {
+  const cidRaw = typeof raw === "string" ? "" : String(raw.id ?? "");
+  const nameRaw = typeof raw === "string" ? raw : String(raw.name ?? "");
+  const desc = typeof raw === "string" ? raw : String(raw.description ?? "");
+  if (desc.length === 0) {
+    throw new EmptyCriterion([cidRaw || nameRaw || String(index)]);
+  }
+  const name = nameRaw || cidRaw || slug_id(desc);
+  const id = dedup_id(cidRaw || slug_id(name), seen);
+  return criterion(id, name, desc);
+}
+
+/**
+ * Canonicalize any accepted criteria shape into `{id,name,description}[]`.
+ *
+ * Same slug/dedup rules as `parse_rubric`. Empty descriptions throw
+ * `EmptyCriterion`; an empty collection throws `NoCriteria`.
+ */
+export function normalize_criteria(
+  input: Record<string, string> | readonly string[] | readonly CriterionInput[],
+): readonly Criterion[] {
+  if (input === null || typeof input !== "object") {
+    throw new TypeError(`criteria must be a record, string[], or CriterionInput[], got ${typeof input}`);
+  }
+
+  const rawItems: Array<string | CriterionInput> = [];
+  if (Array.isArray(input)) {
+    for (const [index, raw] of input.entries()) {
+      if (typeof raw === "string") {
+        rawItems.push(raw);
+        continue;
+      }
+      if (isCriterionInput(raw)) {
+        rawItems.push(raw);
+        continue;
+      }
+      throw new TypeError(`criteria[${index}] must be a string or CriterionInput`);
+    }
+  } else if (isRecord(input)) {
+    for (const [name, description] of Object.entries(input)) {
+      rawItems.push({ name, description });
+    }
+  } else {
+    throw new TypeError("criteria record values must be strings");
+  }
+
+  const seen = new Set<string>();
+  const out = rawItems.map((raw, index) => normalize_one(raw, index, seen));
+  if (out.length === 0) {
+    throw new NoCriteria("criteria is empty");
+  }
+  return out;
+}
+
+/**
+ * Return the subset of `criteria` in `ids` order.
+ *
+ * Omitted `ids` returns every criterion in the original order. An unknown id
+ * throws — nothing is silently dropped.
+ */
+export function select_criteria(criteria: readonly Criterion[], ids?: readonly string[]): readonly Criterion[] {
+  if (ids === undefined) return criteria;
+  const byId = new Map(criteria.map((item) => [item.id, item]));
+  const missing = ids.filter((id) => !byId.has(id));
+  if (missing.length > 0) {
+    throw new Error(`criteria not found: ${missing.join(", ")}`);
+  }
+  return ids.map((id) => byId.get(id)!);
+}
+
 export const VERIFICATION_SCALE: {
   readonly min: 1;
   readonly max: 20;

--- a/packages/workflows/builtin/verification-criteria.ts
+++ b/packages/workflows/builtin/verification-criteria.ts
@@ -1,0 +1,186 @@
+/**
+ * Shared verification rubric primitive.
+ *
+ * Doors: `parse_rubric`, `normalize_criteria`, `select_criteria`,
+ * `decide_verification`. A CriterionScore can only exist as a schema-valid
+ * structured report — an unparseable verifier output is unrepresentable as a
+ * vote, so it cannot shift the mean.
+ */
+import { Type, type TSchema } from "typebox";
+
+export interface Criterion {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+}
+
+export interface Criteria {
+  readonly groundTruthNote: string;
+  readonly criteria: readonly Criterion[];
+}
+
+export interface CriterionInput {
+  readonly id?: string;
+  readonly name?: string;
+  readonly description?: string;
+}
+
+export interface Finding {
+  readonly finding: string;
+  readonly severity: "veto" | "blocking" | "note";
+}
+
+export interface CriterionScore {
+  readonly criterionId: string;
+  readonly score: number;
+  readonly evidence: readonly string[];
+  readonly findings: readonly Finding[];
+}
+
+export type RubricErrorCode = "NoCriteria" | "EmptyCriterion";
+
+export class RubricError extends Error {
+  readonly code: RubricErrorCode;
+
+  constructor(message: string, code: RubricErrorCode) {
+    super(message);
+    this.name = code;
+    this.code = code;
+  }
+}
+
+export class NoCriteria extends RubricError {
+  constructor(message = "no criteria found — check the `## Criteria` section and its `### Name {#id}` headings") {
+    super(message, "NoCriteria");
+    this.name = "NoCriteria";
+  }
+}
+
+export class EmptyCriterion extends RubricError {
+  readonly ids: readonly string[];
+
+  constructor(ids: readonly string[]) {
+    super(`criteria have empty instructions: ${ids.join(", ")}`, "EmptyCriterion");
+    this.name = "EmptyCriterion";
+    this.ids = ids;
+  }
+}
+
+const CRITERION_ID_ANCHOR = /^(.*?)\s*\{#([A-Za-z0-9_-]+)\}\s*$/;
+const HTML_COMMENT = /<!--.*?-->/gs;
+const SLUG_MAX_LENGTH = 40;
+
+function slug_id(text: string): string {
+  const slug = text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return slug.slice(0, SLUG_MAX_LENGTH).replace(/_+$/g, "") || "criterion";
+}
+
+function dedup_id(cid: string, seen: Set<string>): string {
+  let out = cid;
+  let n = 1;
+  while (seen.has(out)) {
+    n += 1;
+    out = `${cid}_${n}`;
+  }
+  seen.add(out);
+  return out;
+}
+
+function criterion(id: string, name: string, description: string): Criterion {
+  return { id, name, description };
+}
+
+/**
+ * Parse a `criteria.md` document into normalized criteria.
+ *
+ * `# title` is ignored. `## Ground Truth Note` is optional; the first section
+ * wins. `## Criteria` owns `### Name {#id}` headings. HTML comments are stripped
+ * before parse. Ids slug to lowercase alnum/underscore, ≤40 chars, fallback
+ * `"criterion"`, with encounter-order `_2` / `_3` dedup.
+ *
+ * @throws {NoCriteria} when the Criteria section yields no headings
+ * @throws {EmptyCriterion} when any criterion has an empty body
+ */
+export function parse_rubric(markdown: string): Criteria {
+  const lines = markdown.replace(HTML_COMMENT, "").split(/\r?\n/);
+
+  let groundTruthNote = "";
+  let seenGroundTruth = false;
+  const criteria: Criterion[] = [];
+  const seen = new Set<string>();
+
+  let section: "ground_truth" | "criteria" | null = null;
+  let currentName: string | null = null;
+  let currentId: string | null = null;
+  let buf: string[] = [];
+
+  const flush = (): void => {
+    const text = buf.join("\n").trim();
+    buf = [];
+    if (section === "ground_truth") {
+      if (!seenGroundTruth) {
+        groundTruthNote = text;
+        seenGroundTruth = true;
+      }
+      return;
+    }
+    if (currentName === null || currentId === null) return;
+    criteria.push(criterion(currentId, currentName, text));
+    currentName = null;
+    currentId = null;
+  };
+
+  for (const line of lines) {
+    if (line.startsWith("## ") && !line.startsWith("### ")) {
+      flush();
+      const heading = line.slice(3).trim().toLowerCase();
+      if (heading.includes("ground truth")) {
+        section = "ground_truth";
+      } else if (heading.includes("criteri")) {
+        section = "criteria";
+      } else {
+        section = null;
+      }
+      continue;
+    }
+    if (line.startsWith("### ") && section === "criteria") {
+      flush();
+      const heading = line.slice(4).trim();
+      const anchored = CRITERION_ID_ANCHOR.exec(heading);
+      const name = anchored ? anchored[1]!.trim() : heading;
+      const rawId = anchored ? anchored[2]!.trim() : slug_id(heading);
+      currentName = name;
+      currentId = dedup_id(rawId, seen);
+      continue;
+    }
+    if (line.startsWith("# ")) {
+      continue;
+    }
+    buf.push(line);
+  }
+  flush();
+
+  if (criteria.length === 0) {
+    throw new NoCriteria();
+  }
+  const empty = criteria.filter((item) => item.description.length === 0).map((item) => item.id);
+  if (empty.length > 0) {
+    throw new EmptyCriterion(empty);
+  }
+  return { groundTruthNote, criteria };
+}
+
+export const VERIFICATION_SCALE: {
+  readonly min: 1;
+  readonly max: 20;
+  readonly anchors: string;
+  readonly schema: TSchema;
+} = {
+  min: 1,
+  max: 20,
+  anchors: "1 = certainly fails … 10 = borderline … 20 = verified correct",
+  schema: Type.Integer({ minimum: 1, maximum: 20 }),
+};

--- a/packages/workflows/builtin/verification-criteria.ts
+++ b/packages/workflows/builtin/verification-criteria.ts
@@ -67,7 +67,6 @@ export class EmptyCriterion extends RubricError {
 }
 
 const CRITERION_ID_ANCHOR = /^(.*?)\s*\{#([A-Za-z0-9_-]+)\}\s*$/;
-const HTML_COMMENT = /<!--.*?-->/gs;
 const SLUG_MAX_LENGTH = 40;
 
 function slug_id(text: string): string {
@@ -93,6 +92,17 @@ function criterion(id: string, name: string, description: string): Criterion {
   return { id, name, description };
 }
 
+function strip_html_comments(markdown: string): string {
+  let sanitized = markdown;
+  while (true) {
+    const opener = sanitized.indexOf("<!--");
+    if (opener === -1) return sanitized;
+    const closer = sanitized.indexOf("-->", opener + 4);
+    if (closer === -1) return sanitized.slice(0, opener);
+    sanitized = sanitized.slice(0, opener) + sanitized.slice(closer + 3);
+  }
+}
+
 /**
  * Parse a `criteria.md` document into normalized criteria.
  *
@@ -105,7 +115,7 @@ function criterion(id: string, name: string, description: string): Criterion {
  * @throws {EmptyCriterion} when any criterion has an empty body
  */
 export function parse_rubric(markdown: string): Criteria {
-  const lines = markdown.replace(HTML_COMMENT, "").split(/\r?\n/);
+  const lines = strip_html_comments(markdown).split(/\r?\n/);
 
   let groundTruthNote = "";
   let seenGroundTruth = false;

--- a/test/unit/verification-criteria.test.ts
+++ b/test/unit/verification-criteria.test.ts
@@ -1,0 +1,392 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+	type Criterion,
+	type CriterionScore,
+	decide_verification,
+	EmptyCriterion,
+	type Finding,
+	NoCriteria,
+	normalize_criteria,
+	parse_rubric,
+	select_criteria,
+	VERIFICATION_SCALE,
+} from "../../packages/workflows/builtin/verification-criteria.js";
+
+function score(overrides: Partial<CriterionScore> = {}): CriterionScore {
+	return {
+		criterionId: "c",
+		score: 14,
+		evidence: ["observed"],
+		findings: [],
+		...overrides,
+	};
+}
+
+function finding(severity: Finding["severity"], text = `${severity} finding`): Finding {
+	return { finding: text, severity };
+}
+
+describe("verification-criteria", () => {
+	describe("parse_rubric", () => {
+		test("parses section layout, ignores # title, and keeps the first ground-truth note", () => {
+			const parsed = parse_rubric(`# Title ignored
+
+## Ground Truth Note
+
+Trust the logs.
+
+## Ground Truth Note
+
+This second note must not win.
+
+## Other
+
+### Not A Criterion
+
+outside the Criteria section
+
+## Criteria
+
+### Correct {#c}
+
+Is it correct?
+
+### Completeness
+
+Does it cover every requirement?
+`);
+			assert.equal(parsed.groundTruthNote, "Trust the logs.");
+			assert.deepEqual(
+				parsed.criteria.map((item) => ({ id: item.id, name: item.name, description: item.description })),
+				[
+					{ id: "c", name: "Correct", description: "Is it correct?" },
+					{
+						id: "completeness",
+						name: "Completeness",
+						description: "Does it cover every requirement?",
+					},
+				],
+			);
+		});
+
+		test("accepts a ## Criterion heading (reference 'criteri' match) and CRLF line endings", () => {
+			const parsed = parse_rubric("## Criterion\r\n### Correct {#c}\r\nIs it correct?\r\n");
+			assert.equal(parsed.criteria.length, 1);
+			assert.equal(parsed.criteria[0]?.id, "c");
+			assert.equal(parsed.criteria[0]?.description, "Is it correct?");
+			assert.equal(parsed.groundTruthNote, "");
+		});
+
+		const slugCases: ReadonlyArray<{
+			readonly name: string;
+			readonly heading: string;
+			readonly id: string;
+			readonly display: string;
+		}> = [
+			{
+				name: "explicit {#id} is not slugged",
+				heading: "### Empirical Verification {#My-ID}",
+				id: "My-ID",
+				display: "Empirical Verification",
+			},
+			{
+				name: "name is slugged when no anchor is present",
+				heading: "### Final Answer Correctness",
+				id: "final_answer_correctness",
+				display: "Final Answer Correctness",
+			},
+			{
+				name: "40-char truncation strips a trailing underscore",
+				heading: "### This Is A Very Long Criterion Name That Exceeds Forty",
+				id: "this_is_a_very_long_criterion_name_that",
+				display: "This Is A Very Long Criterion Name That Exceeds Forty",
+			},
+			{
+				name: "punctuation-only heading falls back to criterion",
+				heading: "### ???",
+				id: "criterion",
+				display: "???",
+			},
+		];
+
+		for (const example of slugCases) {
+			test(example.name, () => {
+				const parsed = parse_rubric(`## Criteria\n${example.heading}\nbody\n`);
+				assert.equal(parsed.criteria[0]?.id, example.id);
+				assert.equal(parsed.criteria[0]?.name, example.display);
+			});
+		}
+
+		test("dedups duplicate ids with _2 and _3 in encounter order", () => {
+			const parsed = parse_rubric(`## Criteria
+### Same
+one
+
+### Same
+two
+
+### Same {#same}
+three
+`);
+			assert.deepEqual(
+				parsed.criteria.map((item) => item.id),
+				["same", "same_2", "same_3"],
+			);
+		});
+
+		test("strips HTML comments before parse so commented headings never become criteria", () => {
+			const parsed = parse_rubric(`## Criteria
+<!--
+### Fake {#fake}
+this is an author note
+-->
+### Real {#real}
+<!-- inline -->visible
+`);
+			assert.equal(parsed.criteria.length, 1);
+			assert.equal(parsed.criteria[0]?.id, "real");
+			assert.equal(parsed.criteria[0]?.description, "visible");
+		});
+
+		test("rejects an empty criterion body instead of skipping it", () => {
+			assert.throws(
+				() =>
+					parse_rubric(`## Criteria
+### Empty {#e}
+
+### Good {#g}
+body
+`),
+				(error: unknown) => {
+					assert.ok(error instanceof EmptyCriterion);
+					assert.equal(error.name, "EmptyCriterion");
+					assert.deepEqual(error.ids, ["e"]);
+					return true;
+				},
+			);
+		});
+
+		const noCriteriaCases = [
+			["empty document", ""],
+			["title only", "# Title\n"],
+			["ground-truth only", "## Ground Truth Note\nDo not trust narration.\n"],
+			["headings outside Criteria", "### Orphan\nbody\n"],
+		] as const;
+
+		for (const [name, markdown] of noCriteriaCases) {
+			test(`rejects ${name} with NoCriteria`, () => {
+				assert.throws(() => parse_rubric(markdown), NoCriteria);
+			});
+		}
+	});
+
+	describe("normalize_criteria", () => {
+		test("normalizes a name→description record", () => {
+			assert.deepEqual(
+				normalize_criteria({
+					"Root cause": "Did the agent fix the real cause?",
+					Verification: "Did the agent confirm the fix?",
+				}),
+				[
+					{
+						id: "root_cause",
+						name: "Root cause",
+						description: "Did the agent fix the real cause?",
+					},
+					{
+						id: "verification",
+						name: "Verification",
+						description: "Did the agent confirm the fix?",
+					},
+				],
+			);
+		});
+
+		test("normalizes a string[] using each string as name and description", () => {
+			assert.deepEqual(normalize_criteria(["Did the agent solve the task?"]), [
+				{
+					id: "did_the_agent_solve_the_task",
+					name: "Did the agent solve the task?",
+					description: "Did the agent solve the task?",
+				},
+			]);
+		});
+
+		test("normalizes CriterionInput[] and slugs missing ids", () => {
+			assert.deepEqual(
+				normalize_criteria([
+					{ id: "task_fit", name: "Task fit", description: "Does it solve the asked task?" },
+					{ name: "Evidence", description: "Is every claim evidenced?" },
+				]),
+				[
+					{ id: "task_fit", name: "Task fit", description: "Does it solve the asked task?" },
+					{ id: "evidence", name: "Evidence", description: "Is every claim evidenced?" },
+				],
+			);
+		});
+
+		test("derives a name from id or description slug and dedups colliding ids", () => {
+			assert.deepEqual(
+				normalize_criteria([{ id: "fit", description: "Fits the task." }, { description: "Fits the task." }]),
+				[
+					{ id: "fit", name: "fit", description: "Fits the task." },
+					{ id: "fits_the_task", name: "fits_the_task", description: "Fits the task." },
+				],
+			);
+		});
+
+		test("applies 40-char slug truncation to record keys", () => {
+			const longName = "This Is A Very Long Criterion Name That Exceeds Forty";
+			const [item] = normalize_criteria({ [longName]: "body" });
+			assert.equal(item?.id, "this_is_a_very_long_criterion_name_that");
+		});
+
+		test("throws EmptyCriterion when a description is missing", () => {
+			assert.throws(
+				() => normalize_criteria([{ name: "Gap" }]),
+				(error: unknown) => {
+					assert.ok(error instanceof EmptyCriterion);
+					assert.deepEqual(error.ids, ["Gap"]);
+					return true;
+				},
+			);
+			assert.throws(() => normalize_criteria({ Gap: "" }), EmptyCriterion);
+			assert.throws(() => normalize_criteria([""]), EmptyCriterion);
+		});
+
+		test("throws NoCriteria when the collection is empty", () => {
+			assert.throws(() => normalize_criteria({}), NoCriteria);
+			assert.throws(() => normalize_criteria([]), NoCriteria);
+		});
+
+		test("throws TypeError for a non-string array entry", () => {
+			assert.throws(() => normalize_criteria([1 as unknown as string]), TypeError);
+		});
+	});
+
+	describe("select_criteria", () => {
+		const pool: readonly Criterion[] = [
+			{ id: "a", name: "A", description: "first" },
+			{ id: "b", name: "B", description: "second" },
+			{ id: "c", name: "C", description: "third" },
+		];
+
+		test("returns every criterion in file order when ids are omitted", () => {
+			assert.deepEqual(select_criteria(pool), pool);
+		});
+
+		test("subsets and reorders by the given ids", () => {
+			assert.deepEqual(
+				select_criteria(pool, ["c", "a"]).map((item) => item.id),
+				["c", "a"],
+			);
+		});
+
+		test("throws on an unknown id instead of dropping it", () => {
+			assert.throws(() => select_criteria(pool, ["a", "missing", "also"]), /criteria not found: missing, also/);
+		});
+	});
+
+	describe("VERIFICATION_SCALE", () => {
+		test("is the shared anchored 1–20 integer scale", () => {
+			assert.equal(VERIFICATION_SCALE.min, 1);
+			assert.equal(VERIFICATION_SCALE.max, 20);
+			assert.equal(VERIFICATION_SCALE.anchors, "1 = certainly fails … 10 = borderline … 20 = verified correct");
+			const schema = VERIFICATION_SCALE.schema as {
+				readonly type: string;
+				readonly minimum: number;
+				readonly maximum: number;
+			};
+			assert.equal(schema.type, "integer");
+			assert.equal(schema.minimum, 1);
+			assert.equal(schema.maximum, 20);
+		});
+	});
+
+	describe("decide_verification", () => {
+		const policy = { acceptMean: 14, quorumFraction: 0.8 };
+
+		test("accepts at the mean threshold boundary and repairs just below it", () => {
+			const atThreshold = decide_verification(
+				{ scores: [score({ score: 14 }), score({ score: 14 })], invalidCount: 0, expectedCount: 2 },
+				policy,
+			);
+			assert.deepEqual(atThreshold, { kind: "accept", mean: 14 });
+
+			const below = decide_verification(
+				{ scores: [score({ score: 14 }), score({ score: 13 })], invalidCount: 0, expectedCount: 2 },
+				policy,
+			);
+			assert.equal(below.kind, "repair");
+			if (below.kind === "repair") {
+				assert.equal(below.mean, 13.5);
+				assert.deepEqual(below.findings, []);
+			}
+		});
+
+		test("a veto finding forces Repair even when every score is 20", () => {
+			const veto = finding("veto", "security hole");
+			const decision = decide_verification(
+				{
+					scores: [score({ score: 20, findings: [veto] }), score({ score: 20, findings: [finding("note")] })],
+					invalidCount: 0,
+					expectedCount: 2,
+				},
+				policy,
+			);
+			assert.equal(decision.kind, "repair");
+			if (decision.kind === "repair") {
+				assert.equal(decision.mean, 20);
+				assert.deepEqual(decision.findings, [veto, finding("note")]);
+			}
+		});
+
+		test("blocking and note findings do not veto a passing mean", () => {
+			const decision = decide_verification(
+				{
+					scores: [score({ score: 16, findings: [finding("blocking"), finding("note")] })],
+					invalidCount: 0,
+					expectedCount: 1,
+				},
+				policy,
+			);
+			assert.deepEqual(decision, { kind: "accept", mean: 16 });
+		});
+
+		const quorumCases: ReadonlyArray<{
+			readonly name: string;
+			readonly expected: number;
+			readonly fraction: number;
+			readonly valid: number;
+			readonly kind: "accept" | "indeterminate";
+		}> = [
+			{ name: "holds at ceil(10 × 0.8) = 8", expected: 10, fraction: 0.8, valid: 8, kind: "accept" },
+			{ name: "fails at 7 of ceil(10 × 0.8) = 8", expected: 10, fraction: 0.8, valid: 7, kind: "indeterminate" },
+			{ name: "holds at ceil(5 × 0.5) = 3", expected: 5, fraction: 0.5, valid: 3, kind: "accept" },
+			{ name: "fails at 2 of ceil(5 × 0.5) = 3", expected: 5, fraction: 0.5, valid: 2, kind: "indeterminate" },
+		];
+
+		for (const example of quorumCases) {
+			test(`quorum ${example.name}`, () => {
+				const scores = Array.from({ length: example.valid }, () => score({ score: 20 }));
+				const decision = decide_verification(
+					{ scores, invalidCount: example.expected - example.valid, expectedCount: example.expected },
+					{ acceptMean: 14, quorumFraction: example.fraction },
+				);
+				assert.equal(decision.kind, example.kind);
+				if (decision.kind === "indeterminate") {
+					assert.equal(decision.missing, example.expected - example.valid);
+				}
+			});
+		}
+
+		test("invalidCount is metadata and never shifts the mean or the decision", () => {
+			const scores = [score({ score: 18 }), score({ score: 16 })];
+			const withNone = decide_verification({ scores, invalidCount: 0, expectedCount: 2 }, policy);
+			const withMany = decide_verification({ scores, invalidCount: 99, expectedCount: 2 }, policy);
+			assert.deepEqual(withNone, { kind: "accept", mean: 17 });
+			assert.deepEqual(withMany, withNone);
+		});
+	});
+});

--- a/test/unit/verification-criteria.test.ts
+++ b/test/unit/verification-criteria.test.ts
@@ -149,6 +149,26 @@ this is an author note
 			assert.equal(parsed.criteria[0]?.description, "visible");
 		});
 
+		test("drops a trailing unterminated HTML comment", () => {
+			const parsed = parse_rubric(`## Criteria
+### Real {#real}
+visible
+<!-- unfinished author note
+### Fake {#fake}
+hidden
+`);
+			assert.deepEqual(parsed.criteria, [{ id: "real", name: "Real", description: "visible" }]);
+		});
+
+		test("strips HTML comment openers revealed by an earlier removal", () => {
+			const parsed = parse_rubric(`## Criteria
+### Real {#real}
+visible
+<!<!-- inner -->--hidden
+`);
+			assert.equal(parsed.criteria[0]?.description, "visible");
+		});
+
 		test("rejects an empty criterion body instead of skipping it", () => {
 			assert.throws(
 				() =>


### PR DESCRIPTION
## Summary

V1 of #2487: a shared `verification-criteria` module that every later verification slice can import. Rubrics parse once, scores are schema-valid integers on a shared 1–20 scale, and `decide_verification` is the only accept door. An unparseable report cannot become a `CriterionScore` and cannot shift the mean.

Does not rewire `adversarial-verification` (V2) and does not add prompt builders or warm-first fan-out (V3).

## Changes

- `parse_rubric`: `criteria.md` parser with optional first-wins `## Ground Truth Note`, `## Criteria` / `### Name {#id}` headings, HTML-comment stripping, lowercase-alnum-underscore slugs ≤40 chars, `_2`/`_3` dedup, and named `NoCriteria` / `EmptyCriterion` errors
- `normalize_criteria`: record, `string[]`, and `CriterionInput[]` shapes with the same slug/dedup rules
- `select_criteria`: subset + order by ids; unknown id throws
- `VERIFICATION_SCALE`: anchored 1–20 `Type.Integer` schema
- `decide_verification`: Accept iff quorum ∧ mean ≥ acceptMean ∧ no `severity: "veto"` finding; veto → Repair even at mean 20; below `ceil(expected × quorumFraction)` → Indeterminate; `invalidCount` is metadata only

## Evidence

### Acceptance criteria (from #2487, this slice's subset)

- [x] Parser unit tests: section layout, `{#id}` anchors, id dedup, comment stripping, empty-description rejection — proven by `test/unit/verification-criteria.test.ts` (`npx vitest --run --project unit -t "verification-criteria"`, 33 passed)
- [x] Shared module in `packages/workflows/builtin/verification-criteria.ts`: format parser, normalizer, aggregation helpers (`parse_rubric`, `normalize_criteria`, `select_criteria`, `decide_verification`, `VERIFICATION_SCALE`)
- [x] Mean aggregation with an unconditional veto path — proven by `decide_verification` table tests (threshold boundary, veto overrides mean=20, quorum at `ceil(expected × fraction)`, `invalidCount` never shifts the mean)
- [x] Unparseable reports cannot become scores — `CriterionScore` has no invalid/parse-failure constructor; `invalidCount` is unread metadata
- [x] No build step added to `packages/workflows` (raw `.ts`, `.js` import specifiers)
- [x] `npm run check` green
- [x] `packages/workflows/CHANGELOG.md` `[Unreleased]` `### Added` updated
- [ ] adversarial-verification per-criterion reports / mean+veto rewire — **V2**, out of this slice
- [ ] `packages/coding-agent/docs` primitive docs — **V11**, out of this slice

### Commands

```
$ npm run check
Checked 2536 files in 5s. No fixes applied.

> typecheck
> tsc --noEmit && npm --workspace=@bastani/atomic run typecheck

> @bastani/atomic@0.0.0 typecheck
> tsgo -p tsconfig.build.json --noEmit

> check:shrinkwrap
> node scripts/generate-coding-agent-shrinkwrap.mjs --check

packages/coding-agent/npm-shrinkwrap.json is up to date.
→ exit 0
```

```
$ npx vitest --run --project unit -t "verification-criteria"
 Test Files  1 passed | 670 skipped (671)
      Tests  33 passed | 6559 skipped (6592)
   Duration  796.94s (transform 19.96s, setup 697.19s, import 33.66s, tests 8ms, environment 47ms)
→ 33 passed
```

### Size

```
$ git diff --stat main...HEAD
 packages/workflows/CHANGELOG.md                    |   4 +
 .../workflows/builtin/verification-criteria.ts     | 320 +++++++++++++++++
 test/unit/verification-criteria.test.ts            | 392 +++++++++++++++++++++
 3 files changed, 716 insertions(+)
```

Source only (`verification-criteria.ts`): **320** insertions (cap: 500 source lines). Tests uncapped (392). Changelog docs-exempt (4).

### Spec

`specs/2026-08-17-verification-criteria-module.md` §5.1; research: `research/docs/2026-08-17-llm-verifier-adoption-scan.md` §3–§4.

Related: #2487

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789638725&installation_model_id=10562&pr_number=2501&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2501&signature=424a6cab88302a171a37690784badf1c55d16de03474dd1c6d7989031dd60b64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds shared helpers for parsing verification rubrics, normalizing and selecting criteria, and aggregating verifier decisions with quorum, mean, and veto handling. Focused runtime checks confirmed that deduplicated generated IDs can exceed the documented 40-character canonical format and that a non-finite score can approve a verification round.

Merge safety: not safe to merge until score validation prevents invalid numeric values from producing acceptance. The identifier truncation issue should also be corrected to preserve the documented ID contract.

<h3>Confidence Score: 4/5</h3>

The new decision helper can return acceptance for an invalid score, so the change is not safe to merge as written.

There is one independent P1 non-security finding and one P2 finding. Under the required scoring table, one non-security P1 produces a score of 4; the P2 finding does not further change the score.

**Files Needing Attention:** packages/workflows/builtin/verification-criteria.ts needs score validation in decide_verification and suffix-aware truncation in dedup_id.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P2 finding by running a focused 40-character criterion-ID collision validation.
- T-Rex captured the observed output from the existing criterion-ID collision validation to support the P2 proof.
- T-Rex produced a proof for the posted P1 finding, validating the NaN verification decision reproduction.
- T-Rex captured the NaN verification decision execution output to accompany the P1 proof.

<a href="https://app.greptile.com/trex/runs/19640002/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/workflows/builtin/verification-criteria.ts:85
**Deduplication suffix exceeds the canonical ID limit**

When two criteria generate the same 40-character slug, `dedup_id` appends `_2` to the already-truncated base ID. The second identifier is therefore 42 characters long, contradicting the documented canonical maximum of 40 characters and making these criteria incompatible with consumers that enforce that format. Reserve room for the suffix when constructing deduplicated IDs.

### Issue 2
packages/workflows/builtin/verification-criteria.ts:325
**Non-finite scores bypass the verification threshold**

`decide_verification` trusts the runtime `score` value instead of enforcing the declared 1–20 integer scale. A `NaN` score makes `mean < acceptMean` evaluate to `false`, so a full-quorum round with no veto returns `accept` with a `NaN` mean. Validate scores as finite schema-valid integers before aggregation, or treat invalid values as unavailable rather than allowing them to approve verification.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/bastani-inc/atomic/commit/af136121fb3ec2a19732ebaa17a7417524d0f05c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54836476)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->