### PR TITLE
feat(web-access): make search curator UI opt-in

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Bundled `web_search` no longer opens the curator confirmation UI by default. Persist `"workflow": "summary-review"` in web-search config or run `/curator on` to opt in.
+
+### Removed
+
+- The `workflow` parameter on bundled `web_search`. Models cannot select the curator per call.
+
 ## [0.9.14-alpha.3] - 2026-08-17
 
 ### Changed

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- The interactive search curator is now opt-in. `web_search` returns raw results unless you set `"workflow": "summary-review"` in web-search config or run `/curator on`.
+
+### Removed
+
+- The `workflow` parameter on `web_search`. The curator is no longer selectable per tool call; enable it with web-search config or `/curator`.
+
 ## [0.9.14-alpha.3] - 2026-08-17
 
 ### Fixed

--- a/packages/web-access/README.md
+++ b/packages/web-access/README.md
@@ -78,7 +78,7 @@ For batch search/fetch calls, partial success remains usable and retains item-le
 
 ### web_search
 
-Search the web via Exa, Perplexity AI, or Gemini. Returns a synthesized answer with source citations.
+Search the web via Exa, Perplexity AI, or Gemini. Returns a synthesized answer with source citations. The curator UI is off by default; enable it with `/curator on` or `"workflow": "summary-review"` in config.
 
 ```typescript
 web_search({ query: "rust async programming" })
@@ -87,8 +87,6 @@ web_search({ query: "latest news", numResults: 10, recencyFilter: "week" })
 web_search({ query: "...", domainFilter: ["github.com"] })
 web_search({ query: "...", provider: "exa" })
 web_search({ query: "...", includeContent: true })
-web_search({ queries: ["query 1", "query 2"], workflow: "none" })
-web_search({ queries: ["query 1", "query 2"], workflow: "summary-review" })
 ```
 
 | Parameter | Description |
@@ -99,7 +97,6 @@ web_search({ queries: ["query 1", "query 2"], workflow: "summary-review" })
 | `domainFilter` | Limit to domains (prefix with `-` to exclude) |
 | `provider` | `auto` (default), `exa`, `perplexity`, or `gemini` |
 | `includeContent` | Fetch full page content from sources in background |
-| `workflow` | `none` (skip curator) or `summary-review` (auto-generate summary draft after search completion, default) |
 
 ### code_search
 
@@ -227,7 +224,7 @@ Toggle or configure the curator workflow at runtime.
 /curator summary-review     # explicit workflow
 ```
 
-Persists to `~/.pi/web-search.json` and takes effect on the next `web_search` call. When disabled, `web_search` returns raw results without opening the curator window.
+Persists to `~/.pi/web-search.json` and takes effect on the next `web_search` call. The curator is off by default. When disabled, `web_search` returns raw results without opening the curator window.
 
 ### /search
 
@@ -287,7 +284,7 @@ All config lives in `~/.pi/web-search.json`. Every field is optional.
 }
 ```
 
-`EXA_API_KEY`, `GEMINI_API_KEY`, and `PERPLEXITY_API_KEY` env vars take precedence over config file values. `provider` sets the default search provider: `"exa"`, `"perplexity"`, or `"gemini"`. This is also updated automatically when you change the provider in the curator UI. `workflow` sets the default curator mode: `"summary-review"` (default, opens curator with auto-generated summary draft) or `"none"` (raw results, no curator). Overridden per-call via the `workflow` parameter on `web_search`, or toggled at runtime with `/curator`. `chromeProfile` overrides the Chromium profile directory used for Gemini Web cookie lookup. `allowBrowserCookies` enables Chromium cookie extraction for Gemini Web; it defaults to `false` to avoid surprise macOS Keychain prompts. You can also set `PI_ALLOW_BROWSER_COOKIES=1`. `searchModel` overrides the Gemini API model used by `web_search` without changing URL, YouTube, or video extraction defaults. `summaryModel` sets the default model used for generating summary drafts in the curator UI (e.g. `"anthropic/claude-haiku-4-5"` or `"openai-codex/gpt-5.3-codex-spark"`). Only models available in your model registry are eligible; if the configured model is unavailable, the default falls back to the built-in preference list. `curatorTimeoutSeconds` controls the initial curator idle timeout (default `20`, max `600`); users can still adjust the timer in the curator UI.
+`EXA_API_KEY`, `GEMINI_API_KEY`, and `PERPLEXITY_API_KEY` env vars take precedence over config file values. `provider` sets the default search provider: `"exa"`, `"perplexity"`, or `"gemini"`. This is also updated automatically when you change the provider in the curator UI. `workflow` sets the curator mode: `"none"` (default, raw results, no curator) or `"summary-review"` (opens curator with auto-generated summary draft). Enable it in this file or toggle at runtime with `/curator`. `chromeProfile` overrides the Chromium profile directory used for Gemini Web cookie lookup. `allowBrowserCookies` enables Chromium cookie extraction for Gemini Web; it defaults to `false` to avoid surprise macOS Keychain prompts. You can also set `PI_ALLOW_BROWSER_COOKIES=1`. `searchModel` overrides the Gemini API model used by `web_search` without changing URL, YouTube, or video extraction defaults. `summaryModel` sets the default model used for generating summary drafts in the curator UI (e.g. `"anthropic/claude-haiku-4-5"` or `"openai-codex/gpt-5.3-codex-spark"`). Only models available in your model registry are eligible; if the configured model is unavailable, the default falls back to the built-in preference list. `curatorTimeoutSeconds` controls the initial curator idle timeout (default `20`, max `600`); users can still adjust the timer in the curator UI.
 
 ### Shortcuts
 

--- a/packages/web-access/index.ts
+++ b/packages/web-access/index.ts
@@ -320,7 +320,7 @@ export default function webAccess(pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "web_search",
 		label: "Web Search",
-		description: "Search the web using Perplexity AI, Exa, or Gemini. Returns an AI-synthesized answer with source citations. For comprehensive research, prefer queries (plural) with 2-4 varied angles over a single query — each query gets its own synthesized answer, so varying phrasing and scope gives much broader coverage. When includeContent is true, full page content is fetched in the background. Searches auto-open the interactive browser curator and stream results live; set workflow to \"none\" to skip curation. Provider auto-selects: Exa (direct API with key, MCP fallback without), else Perplexity (needs key), else Gemini API (needs key), else Gemini Web (needs a supported Chromium-based browser login).",
+		description: "Search the web using Perplexity AI, Exa, or Gemini. Returns an AI-synthesized answer with source citations. For comprehensive research, prefer queries (plural) with 2-4 varied angles over a single query — each query gets its own synthesized answer, so varying phrasing and scope gives much broader coverage. When includeContent is true, full page content is fetched in the background. Searches return raw results by default. Enable the interactive browser curator with /curator on or by setting workflow to \"summary-review\" in web-search config. Provider auto-selects: Exa (direct API with key, MCP fallback without), else Perplexity (needs key), else Gemini API (needs key), else Gemini Web (needs a supported Chromium-based browser login).",
 		promptSnippet: "Use for web research questions. Prefer {queries:[...]} with 2-4 varied angles over a single query for broader coverage.",
 		parameters: Type.Object({
 			query: Type.Optional(Type.String({ description: "Single search query. For research tasks, prefer 'queries' with multiple varied angles instead." })),
@@ -330,7 +330,6 @@ export default function webAccess(pi: ExtensionAPI) {
 			recencyFilter: Type.Optional(Type.String({ enum: ["day", "week", "month", "year"], description: "Filter by recency" })),
 			domainFilter: Type.Optional(Type.Array(Type.String(), { description: "Limit to domains (prefix with - to exclude)" })),
 			provider: Type.Optional(Type.String({ enum: ["auto", "perplexity", "gemini", "exa"], description: "Search provider (default: auto)" })),
-			workflow: Type.Optional(Type.String({ enum: ["none", "summary-review"], description: "Search workflow mode: none = no curator, summary-review = open curator with auto summary draft (default)" })),
 		}),
 		execute: (...args) => executeHeavyTool(loadHeavy, "web_search", args),
 		renderResult: (...args) => renderHeavyToolResult(loadedHeavy?.heavy ?? null, "web_search", args),

--- a/packages/web-access/web-search-config.ts
+++ b/packages/web-access/web-search-config.ts
@@ -33,8 +33,8 @@ export interface ProviderAvailability {
 	gemini: boolean;
 }
 
-export type WebSearchWorkflow = "none" | "summary-review";
-export type CuratorWorkflow = "summary-review";
+export type { CuratorWorkflow, WebSearchWorkflow } from "./web-search-workflow.js";
+export { resolveWorkflow } from "./web-search-workflow.js";
 
 export interface CuratorBootstrap {
 	availableProviders: ProviderAvailability;
@@ -97,12 +97,6 @@ function normalizeCuratorTimeoutSeconds(value: unknown): number | undefined {
 	const normalized = Math.floor(value);
 	if (normalized < 1) return undefined;
 	return Math.min(normalized, MAX_CURATOR_TIMEOUT_SECONDS);
-}
-
-export function resolveWorkflow(input: unknown, hasUI: boolean): WebSearchWorkflow {
-	if (!hasUI) return "none";
-	if (typeof input === "string" && input.trim().toLowerCase() === "none") return "none";
-	return "summary-review";
 }
 
 export function normalizeQueryList(queryList: unknown[]): string[] {

--- a/packages/web-access/web-search-tool.ts
+++ b/packages/web-access/web-search-tool.ts
@@ -32,7 +32,7 @@ export function registerWebSearchTool(pi: ExtensionAPI, deps: RegisterWebSearchT
 		name: "web_search",
 		label: "Web Search",
 		description:
-			`Search the web using Perplexity AI, Exa, or Gemini. Returns an AI-synthesized answer with source citations. For comprehensive research, prefer queries (plural) with 2-4 varied angles over a single query — each query gets its own synthesized answer, so varying phrasing and scope gives much broader coverage. When includeContent is true, full page content is fetched in the background. Searches auto-open the interactive browser curator and stream results live; set workflow to "none" to skip curation. Provider auto-selects: Exa (direct API with key, MCP fallback without), else Perplexity (needs key), else Gemini API (needs key), else Gemini Web (needs a supported Chromium-based browser login).`,
+			`Search the web using Perplexity AI, Exa, or Gemini. Returns an AI-synthesized answer with source citations. For comprehensive research, prefer queries (plural) with 2-4 varied angles over a single query — each query gets its own synthesized answer, so varying phrasing and scope gives much broader coverage. When includeContent is true, full page content is fetched in the background. Searches return raw results by default. Enable the interactive browser curator with /curator on or by setting workflow to "summary-review" in web-search config. Provider auto-selects: Exa (direct API with key, MCP fallback without), else Perplexity (needs key), else Gemini API (needs key), else Gemini Web (needs a supported Chromium-based browser login).`,
 		promptSnippet:
 			"Use for web research questions. Prefer {queries:[...]} with 2-4 varied angles over a single query for broader coverage.",
 		parameters: Type.Object({
@@ -47,11 +47,6 @@ export function registerWebSearchTool(pi: ExtensionAPI, deps: RegisterWebSearchT
 			provider: Type.Optional(
 				StringEnum(["auto", "perplexity", "gemini", "exa"], { description: "Search provider (default: auto)" }),
 			),
-			workflow: Type.Optional(
-				StringEnum(["none", "summary-review"], {
-					description: "Search workflow mode: none = no curator, summary-review = open curator with auto summary draft (default)",
-				}),
-			),
 		}),
 
 		async execute(_toolCallId, params, signal, onUpdate, ctx) {
@@ -60,7 +55,7 @@ export function registerWebSearchTool(pi: ExtensionAPI, deps: RegisterWebSearchT
 				: (params.query !== undefined ? [params.query] : []);
 			const queryList = normalizeQueryList(rawQueryList);
 			const configWorkflow = loadConfigForExtensionInit().workflow;
-			const workflow = resolveWorkflow(params.workflow ?? configWorkflow, ctx?.hasUI !== false);
+			const workflow = resolveWorkflow(configWorkflow, ctx?.hasUI !== false);
 			const shouldCurate = workflow !== "none";
 
 			if (queryList.length === 0) {

--- a/packages/web-access/web-search-workflow.ts
+++ b/packages/web-access/web-search-workflow.ts
@@ -1,0 +1,10 @@
+export type WebSearchWorkflow = "none" | "summary-review";
+export type CuratorWorkflow = "summary-review";
+
+export function resolveWorkflow(input: unknown, hasUI: boolean): WebSearchWorkflow {
+	if (!hasUI) return "none";
+	if (typeof input === "string" && input.trim().toLowerCase() === "summary-review") {
+		return "summary-review";
+	}
+	return "none";
+}

--- a/test/unit/web-search-resolve-workflow.test.ts
+++ b/test/unit/web-search-resolve-workflow.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { resolveWorkflow } from "../../packages/web-access/web-search-workflow.js";
+
+test("resolveWorkflow defaults to none without an explicit summary-review opt-in", () => {
+	assert.equal(resolveWorkflow(undefined, true), "none");
+	assert.equal(resolveWorkflow(undefined, false), "none");
+	assert.equal(resolveWorkflow("none", true), "none");
+	assert.equal(resolveWorkflow("NONE", true), "none");
+	assert.equal(resolveWorkflow("", true), "none");
+	assert.equal(resolveWorkflow("result-review", true), "none");
+	assert.equal(resolveWorkflow(1, true), "none");
+});
+
+test("resolveWorkflow enables the curator only for explicit summary-review when a UI is present", () => {
+	assert.equal(resolveWorkflow("summary-review", true), "summary-review");
+	assert.equal(resolveWorkflow("  Summary-Review  ", true), "summary-review");
+	assert.equal(resolveWorkflow("summary-review", false), "none");
+});


### PR DESCRIPTION
## Summary

`web_search` no longer opens the interactive curator confirmation UI by default. Most users do not want that panel, so it is now opt-in through user config rather than a tool argument.

## Changes

- Default `resolveWorkflow()` to `"none"` unless config or `/curator` explicitly asks for `"summary-review"`.
- Remove the `workflow` parameter from the `web_search` tool so models cannot open the curator per call.
- Keep `/curator on`, `/websearch`, and `"workflow": "summary-review"` in web-search config as the opt-in path.
- Update tool descriptions, README, and changelogs to match.
- Add unit coverage for the default and the explicit config opt-in.

## Breaking Changes

Interactive sessions that previously auto-opened the curator now get raw results unless they opt in with one of:

- `"workflow": "summary-review"` in web-search config
- `/curator on`

`web_search({ workflow: "summary-review" })` is no longer a tool option. `/websearch` still opens the curator directly.

## Notes

Worktree: `/Users/tonystark/Documents/projects/atomic-web-search-curator-opt-in`

Verified locally: `npm run check`, `npm run test:unit`, `npm run test:integration`, and `npm run test:ci-contracts`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789664753&installation_model_id=10562&pr_number=2508&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2508&signature=558b937b930d4aa1ef6c72afeb23933ad7db9ee8409f0b4e2e3b107d4c9d91ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes the web-search curator opt-in through persisted configuration or curator commands, while searches return raw results by default. The legacy configuration path does not activate the curator in the running session: after `/curator on` writes the Atomic configuration, searches still return raw results until restart. This should be fixed before merge.

<h3>Confidence Score: 4/5</h3>

Not merge-safe until enabling the curator reliably affects users running from the supported legacy configuration.

There is one verified non-security P1 finding, which maps to a score of 4 under the required scoring table.

**Files Needing Attention:** packages/web-access/web-search-config.ts needs the persisted configuration read path to be refreshed after `/curator on`; packages/web-access/web-search-tool.ts consumes the stale workflow at lines 57-58.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and linked it to the review comment for details.
- An isolated curator reproduction script was executed to reproduce the finding in a controlled environment.
- The legacy-only configuration output was reviewed to verify the environment configuration used during reproduction.
- The curator enable failure output was reviewed to understand enablement steps and any issues encountered.

<a href="https://app.greptile.com/trex/runs/19438051/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/web-access/web-search-tool.ts:57-58
**Legacy config pins stale workflow**

When Atomic starts with only the supported legacy `~/.pi/web-search.json`, `/curator on` writes `workflow: "summary-review"` to `~/.atomic/web-search.json`, but this process continues loading workflow from the legacy file. `web_search` therefore keeps selecting raw results rather than opening the curator until Atomic is restarted. Resolve the readable config path for each load, or invalidate/update the legacy read-path selection after saving the Atomic config.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web-access): make search curator UI..."](https://github.com/bastani-inc/atomic/commit/e8e5b491c41b0c2431c885203ea15a4c6ddafb95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54438712)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->