### PR TITLE
docs(changelog): 0.9.14-alpha.4 release notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.14-alpha.4] - 2026-08-18
+
 ### Changed
 
 - Bundled `web_search` no longer opens the curator confirmation UI by default. Persist `"workflow": "summary-review"` in web-search config or run `/curator on` to opt in.

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.14-alpha.4] - 2026-08-18
+
 ### Changed
 
 - The interactive search curator is now opt-in. `web_search` returns raw results unless you set `"workflow": "summary-review"` in web-search config or run `/curator on`.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.14-alpha.4] - 2026-08-18
+
 ### Fixed
 
 - Opened `ctx.tool` detail now matches the main-chat tool block: `Box(1,1)` inner padding, a blank row under the `$` header, full-width alignment with the orchestrator bars, unpainted canvas above and below the card, host `toolTitle`/`toolOutput` colors, a dim `ctrl+o Expand` hint, and second-resolution `Took`/`Elapsed` timing.


### PR DESCRIPTION
## Summary

Release notes for the `0.9.14-alpha.4` prerelease. The accumulated `[Unreleased]` entries in `packages/coding-agent`, `packages/web-access`, and `packages/workflows` move under a `## [0.9.14-alpha.4] - 2026-08-18` heading.

## Changes

- `packages/coding-agent/CHANGELOG.md` — bundled `web_search` curator UI is now opt-in via web-search config or `/curator on`; the per-call `workflow` parameter is removed.
- `packages/web-access/CHANGELOG.md` — interactive search curator is opt-in; `web_search` returns raw results unless `"workflow": "summary-review"` is set or `/curator on` is run; the per-call `workflow` parameter is removed.
- `packages/workflows/CHANGELOG.md` — opened `ctx.tool` detail matches the main-chat tool block (padding, header spacing, orchestrator-bar alignment, host tool colors, expand hint, and second-resolution timing).

## Versionless base

No version stamping here. Every `packages/*/package.json`, the `@bastani/atomic-natives` pin, `packages/natives/native/index.js`, `Cargo.toml`, and `Cargo.lock` stay at the `0.0.0` placeholder. `scripts/cut-release.ts` materializes `0.9.14-alpha.4` on the detached `Release 0.9.14-alpha.4` commit after this merges.

## Notes

- Local validation: `bunx vitest --run --project unit test/unit/changelog.test.ts test/unit/package-metadata.test.ts test/unit/pi-0.84.2-docs-contract.test.ts` (43 passed). Pre-commit `npm run check` and `npm run test:unit` passed. Pre-push `npm run test:integration` and `npm run test:ci-contracts` passed.
- Diff is changelog-only. Intercom, MCP, natives, and subagents had empty `[Unreleased]` sections and were left unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789665884&installation_model_id=10562&pr_number=2509&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2509&signature=893e198c980081bced18c2fb5be712f8572298a2bcb1fb198e8fdc9dfd24db15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `0.9.14-alpha.4` release notes to the coding-agent, web-access, and workflows changelogs while preserving their empty `Unreleased` sections. A possible changelog-contract regression was disproved: the focused changelog and package-metadata checks passed both before and after the change, including immutable released-section checks for all three updated changelogs. No defects were found.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the release-note-only update preserves changelog and package metadata contracts.

No review findings remain. The focused checks passed before and after the release-note changes, covering changelog parsing, release ordering, tagged-section immutability, and shared package-version consistency.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the baseline by running the focused release-contract tests at HEAD^, confirming 23/23 contracts passed.
- Validated the post-change state by running the focused release-contract tests at HEAD, confirming 23/23 contracts passed and that the three changed changelogs' immutable released-tail checks are included.
- Verified the repository diff shows only the three changelog files changed, and that package manifests remain versionless and their consistency contract passes.
- Checked the focused release-contract runner exit status and reviewed the runner source to confirm the test run completed cleanly.
- Reviewed the Focused Vitest configuration source to ensure tests are scoped correctly for contract validation.

<a href="https://app.greptile.com/trex/runs/19441430/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): add 0.9.14-alpha.4 rele..."](https://github.com/bastani-inc/atomic/commit/8e78d3c68a2abe67f53770f63bd8bc0af9557345) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54444867)</sub>

<!-- /greptile_comment -->