### PR TITLE
feat(workflows): prefix-cache prompt layout + warm-first fan-out (V3, #2493)

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - Added a shared `verification-criteria` module (`parse_rubric`, `normalize_criteria`, `select_criteria`, `VERIFICATION_SCALE`, `decide_verification`) so verification builtins can score one criterion at a time on an anchored 1–20 scale and accept only when a quorum mean clears the threshold with no veto finding. Unparseable reports cannot become scores and cannot shift the mean ([#2487](https://github.com/bastani-inc/atomic/issues/2487)).
+- Added prefix-cache-aware verification prompts with a byte-identical shared head, UTF-8 bounded candidate inlining with whole-family read fallback, and warm-first verifier fan-out scheduling that preserves input order while releasing later phases after warm failures ([#2493](https://github.com/bastani-inc/atomic/issues/2493)).
 
 ### Fixed
 

--- a/packages/workflows/builtin/adversarial-verification-runner.ts
+++ b/packages/workflows/builtin/adversarial-verification-runner.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { Type, type Static } from "typebox";
 import type { WorkflowRunContext, WorkflowSerializableValue } from "../src/shared/types.js";
 import { renderReducerPrompt, renderRepairPrompt, renderVerifierPrompt, renderWorkerPrompt } from "./adversarial-verification-prompts.js";
+import { warm_first_fan_out } from "./verification-prompts.js";
 import { stableArtifactRoot } from "./pattern-artifact-root.js";
 
 const verifierSchema = Type.Object({
@@ -60,13 +61,18 @@ export async function runAdversarialVerification(ctx: WorkflowRunContext<Inputs>
   let decision: ReducerDecision = { decision: "reject", rationale: "No valid reducer decision was produced.", remaining_work: ["Reducer did not return a valid structured decision."] };
   for (;;) {
     verifierArtifactPaths = Array.from({ length: ctx.inputs.verifier_count }, (_, index) => join(root, `verification-${repairsCompleted}-${index + 1}.json`));
-    const reports = await ctx.parallel(verifierArtifactPaths.map((_, index) => ({
-      name: `verifier-${repairsCompleted}-${index + 1}`,
-      prompt: renderVerifierPrompt(ctx.inputs.task, candidatePath, rubricPath),
-      context: "fresh" as const,
-      reads: [candidatePath, rubricPath],
-      schema: verifierSchema,
-    })), { concurrency: Math.min(ctx.inputs.verifier_count, 4), failFast: false });
+	const verifierPrompt = renderVerifierPrompt(ctx.inputs.task, candidatePath, rubricPath);
+	const verifierSteps = verifierArtifactPaths.map((_, index) => ({
+		name: `verifier-${repairsCompleted}-${index + 1}`,
+		prompt: verifierPrompt,
+		context: "fresh" as const,
+		reads: [candidatePath, rubricPath],
+		schema: verifierSchema,
+	}));
+	const reports = await warm_first_fan_out(ctx, verifierSteps, () => verifierPrompt, {
+		concurrency: Math.min(ctx.inputs.verifier_count, 4),
+		failFast: false,
+	});
     // Verifier reports are inter-stage data: the reducer reads schema-shaped
     // JSON from these paths, so the runner persists the structured decisions
     // itself rather than routing them through the stage artifact channel.

--- a/packages/workflows/builtin/generate-and-filter-prompts.ts
+++ b/packages/workflows/builtin/generate-and-filter-prompts.ts
@@ -1,3 +1,6 @@
+import type { ScoringCandidate } from "./verification-prompts.js";
+import { build_scoring_prompt } from "./verification-prompts.js";
+
 const GROUNDED_REPORTING = "Before reporting progress, audit each claim against a tool result from this session. Report only work you can point to evidence for; say so explicitly when something is unverified.";
 const READABLE_REPORT = "Lead with the outcome. Keep facts, decisions, caveats, and next steps; drop background and repetition. Use complete, readable sentences rather than compressed fragments.";
 
@@ -9,10 +12,26 @@ export function renderFilterPrompt(task: string, candidatePaths: readonly string
   return `<artifacts>\nRead every candidate: ${candidatePaths.join(", ")}\n</artifacts>\n\n<role>\nYou deduplicate and filter independently generated candidates.\n</role>\n\n<rubric>\nFirst collapse substantively equivalent candidates. Then score fit to the task, feasibility, evidence, distinctiveness, and risk. Near-duplicates must not gain weight by repetition. Record every discarded candidate and a concrete reason.\n</rubric>\n\n<success_criteria>\nAt most ${shortlistSize} strongest distinct candidates remain, ranked by the rubric, and every discarded candidate has a concrete reason.\n</success_criteria>\n\n<stop_rules>\nStop after every candidate is shortlisted once or recorded as discarded.\n</stop_rules>\n\n<output_format>\nCall structured_output with shortlist (candidate artifact paths in ranked order) and discarded entries containing path and a concise, criteria-based reason.\n</output_format>\n\n<objective>\nSelect at most ${shortlistSize} strongest candidates for: ${task}\n</objective>`;
 }
 
-export function renderJudgePrompt(task: string, filterPath: string, shortlistSize: number): string {
-  return `<artifacts>\nRead the filter report at ${filterPath} and every candidate path it references.\n</artifacts>\n\n<role>\nYou independently judge the filtered shortlist against the explicit rubric.\n</role>\n\n<rubric>\nCheck task fit, feasibility, evidence, distinctiveness, and material risk. Do not restore a duplicate merely because it is phrased differently.\n</rubric>\n\n<success_criteria>\nAt most ${shortlistSize} distinct candidate paths are ranked by rubric-grounded evidence.\n</success_criteria>\n\n<stop_rules>\nStop after evaluating every filtered candidate and ranking the qualifying paths.\n</stop_rules>\n\n<output_format>\nCall structured_output with shortlist and a concise, criteria-based rationale in complete sentences.\n</output_format>\n\n<objective>\nRank the candidates that best satisfy: ${task}\n</objective>`;
+export function renderJudgePrompt(
+	task: string,
+	filterPath: string,
+	shortlistSize: number,
+	candidates: readonly ScoringCandidate[] = [],
+): string {
+	return build_scoring_prompt(
+		{
+			task: `Rank at most ${shortlistSize} distinct candidate paths for: ${task}.`,
+			groundTruthNote: `Read the filter report at ${filterPath} and every candidate path it references before judging.`,
+			candidates,
+			outputFormat: "Call structured_output with shortlist (candidate paths in ranked order) and rationale (a concise, criteria-based explanation).",
+		},
+		{
+			id: "filtered_shortlist",
+			name: "Filtered shortlist",
+			description: "Check task fit, feasibility, evidence, distinctiveness, and material risk; do not restore a duplicate merely because it is phrased differently.",
+		},
+	);
 }
-
 export function renderFinalShortlistPrompt(task: string, decisionPath: string): string {
   return `<artifact>\nRead the authoritative selection at ${decisionPath}; follow its order and do not add candidates.\n</artifact>\n\n<role>\nYou present a concise, actionable final shortlist so the reader can choose the next evaluation without reading the selection session.\n</role>\n\n<success_criteria>\nEvery selected candidate appears once in authoritative order with its differentiator, evidence, tradeoffs, and recommended next evaluation.\n</success_criteria>\n\n<stop_rules>\nStop after presenting every selected candidate once; do not add or reorder candidates.\n</stop_rules>\n\n<output_format>\nRanked markdown shortlist with candidate path, differentiator, evidence, tradeoffs, and recommended next evaluation. ${READABLE_REPORT}\n${GROUNDED_REPORTING}\n</output_format>\n\n<objective>\nSummarize the selected candidates for: ${task}\n</objective>`;
 }

--- a/packages/workflows/builtin/generate-and-filter-prompts.ts
+++ b/packages/workflows/builtin/generate-and-filter-prompts.ts
@@ -1,8 +1,13 @@
-import type { ScoringCandidate } from "./verification-prompts.js";
-import { build_scoring_prompt } from "./verification-prompts.js";
+import type { ScoringCandidate, SharedHead } from "./verification-prompts.js";
+import { build_scoring_prompt, scoring_prompt_reads } from "./verification-prompts.js";
 
 const GROUNDED_REPORTING = "Before reporting progress, audit each claim against a tool result from this session. Report only work you can point to evidence for; say so explicitly when something is unverified.";
 const READABLE_REPORT = "Lead with the outcome. Keep facts, decisions, caveats, and next steps; drop background and repetition. Use complete, readable sentences rather than compressed fragments.";
+
+export interface RenderedJudgePrompt {
+	readonly prompt: string;
+	readonly reads: readonly string[];
+}
 
 export function renderGeneratorPrompt(task: string, ordinal: number): string {
   return `<role>\nYou independently generate candidate ${ordinal}; do not imitate or assume other candidates.\n</role>\n\n<success_criteria>\nOne distinct, concrete candidate states its value, constraints, risks, and how it can be evaluated.\n</success_criteria>\n\n<stop_rules>\nStop after one self-contained, evaluable candidate; do not add alternatives.\n</stop_rules>\n\n<output_format>\nA candidate artifact with title, proposal, criteria-based rationale, risks, and evaluation evidence. ${READABLE_REPORT}\n${GROUNDED_REPORTING}\n</output_format>\n\n<objective>\n${task}\n</objective>`;
@@ -17,20 +22,19 @@ export function renderJudgePrompt(
 	filterPath: string,
 	shortlistSize: number,
 	candidates: readonly ScoringCandidate[] = [],
-): string {
-	return build_scoring_prompt(
-		{
-			task: `Rank at most ${shortlistSize} distinct candidate paths for: ${task}.`,
-			groundTruthNote: `Read the filter report at ${filterPath} and every candidate path it references before judging.`,
-			candidates,
-			outputFormat: "Call structured_output with shortlist (candidate paths in ranked order) and rationale (a concise, criteria-based explanation).",
-		},
-		{
-			id: "filtered_shortlist",
-			name: "Filtered shortlist",
-			description: "Check task fit, feasibility, evidence, distinctiveness, and material risk; do not restore a duplicate merely because it is phrased differently.",
-		},
-	);
+): RenderedJudgePrompt {
+	const head: SharedHead = {
+		task: `Rank at most ${shortlistSize} distinct candidate paths for: ${task}.`,
+		groundTruthNote: `Read the filter report at ${filterPath} and every candidate path it references before judging.`,
+		candidates,
+		outputFormat: "Call structured_output with shortlist (candidate paths in ranked order) and rationale (a concise, criteria-based explanation).",
+	};
+	const prompt = build_scoring_prompt(head, {
+		id: "filtered_shortlist",
+		name: "Filtered shortlist",
+		description: "Check task fit, feasibility, evidence, distinctiveness, and material risk; do not restore a duplicate merely because it is phrased differently.",
+	});
+	return { prompt, reads: [filterPath, ...scoring_prompt_reads(head)] };
 }
 export function renderFinalShortlistPrompt(task: string, decisionPath: string): string {
   return `<artifact>\nRead the authoritative selection at ${decisionPath}; follow its order and do not add candidates.\n</artifact>\n\n<role>\nYou present a concise, actionable final shortlist so the reader can choose the next evaluation without reading the selection session.\n</role>\n\n<success_criteria>\nEvery selected candidate appears once in authoritative order with its differentiator, evidence, tradeoffs, and recommended next evaluation.\n</success_criteria>\n\n<stop_rules>\nStop after presenting every selected candidate once; do not add or reorder candidates.\n</stop_rules>\n\n<output_format>\nRanked markdown shortlist with candidate path, differentiator, evidence, tradeoffs, and recommended next evaluation. ${READABLE_REPORT}\n${GROUNDED_REPORTING}\n</output_format>\n\n<objective>\nSummarize the selected candidates for: ${task}\n</objective>`;

--- a/packages/workflows/builtin/generate-and-filter-runner.ts
+++ b/packages/workflows/builtin/generate-and-filter-runner.ts
@@ -1,4 +1,4 @@
-import { writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { Type, type Static } from "typebox";
 import type { WorkflowRunContext, WorkflowSerializableValue } from "../src/shared/types.js";
@@ -61,19 +61,22 @@ export async function runGenerateAndFilter(ctx: WorkflowRunContext<Inputs>): Pro
   let shortlist = filteredShortlist.length > 0 ? filteredShortlist : fallbackShortlist;
   let judgePath: string | null = null;
   let decisionPath = filterPath;
-  if (ctx.inputs.use_judge) {
-    judgePath = join(root, "judge.json");
-    const judged = await ctx.task("judge", {
-      prompt: renderJudgePrompt(ctx.inputs.prompt, filterPath, shortlistLimit), context: "fresh",
-      reads: [filterPath, ...shortlist], schema: judgeSchema,
-    });
-    const judgedDecision = judgeDecision(judged.structured);
-    // Same inter-stage contract as the filter report above.
-    await writeFile(judgePath, `${JSON.stringify(judgedDecision ?? { shortlist: [], rationale: "Judge stage produced no valid structured decision." }, null, 2)}\n`);
-    const judgedShortlist = selectCandidates(judgedDecision?.shortlist ?? []);
-    shortlist = judgedShortlist.length > 0 ? judgedShortlist : shortlist;
-    decisionPath = judgePath;
-  }
+	if (ctx.inputs.use_judge) {
+		judgePath = join(root, "judge.json");
+		const judgeCandidates = await Promise.all(
+			shortlist.map(async (path) => ({ path, body: await readFile(path, "utf8") })),
+		);
+		const judged = await ctx.task("judge", {
+			prompt: renderJudgePrompt(ctx.inputs.prompt, filterPath, shortlistLimit, judgeCandidates), context: "fresh",
+			reads: [filterPath, ...shortlist], schema: judgeSchema,
+		});
+		const judgedDecision = judgeDecision(judged.structured);
+		// Same inter-stage contract as the filter report above.
+		await writeFile(judgePath, `${JSON.stringify(judgedDecision ?? { shortlist: [], rationale: "Judge stage produced no valid structured decision." }, null, 2)}\n`);
+		const judgedShortlist = selectCandidates(judgedDecision?.shortlist ?? []);
+		shortlist = judgedShortlist.length > 0 ? judgedShortlist : shortlist;
+		decisionPath = judgePath;
+	}
   const finalPath = join(root, "shortlist.md");
   const finalShortlist = await ctx.task("final-shortlist", {
     prompt: renderFinalShortlistPrompt(ctx.inputs.prompt, decisionPath), context: "fresh",

--- a/packages/workflows/builtin/generate-and-filter-runner.ts
+++ b/packages/workflows/builtin/generate-and-filter-runner.ts
@@ -66,9 +66,10 @@ export async function runGenerateAndFilter(ctx: WorkflowRunContext<Inputs>): Pro
 		const judgeCandidates = await Promise.all(
 			shortlist.map(async (path) => ({ path, body: await readFile(path, "utf8") })),
 		);
+		const judgePrompt = renderJudgePrompt(ctx.inputs.prompt, filterPath, shortlistLimit, judgeCandidates);
 		const judged = await ctx.task("judge", {
-			prompt: renderJudgePrompt(ctx.inputs.prompt, filterPath, shortlistLimit, judgeCandidates), context: "fresh",
-			reads: [filterPath, ...shortlist], schema: judgeSchema,
+			prompt: judgePrompt.prompt, context: "fresh",
+			reads: judgePrompt.reads, schema: judgeSchema,
 		});
 		const judgedDecision = judgeDecision(judged.structured);
 		// Same inter-stage contract as the filter report above.

--- a/packages/workflows/builtin/verification-prompts.ts
+++ b/packages/workflows/builtin/verification-prompts.ts
@@ -7,6 +7,10 @@
  * The tail contains only the criterion name and description plus the output
  * format instruction. Keeping this ordering invariant means sibling criteria
  * can share the provider's cached prefix byte-for-byte.
+ *
+ * A pathless candidate is valid while the whole family is inline. If any body
+ * exceeds the inline bound, every candidate must provide its caller-bound path;
+ * this layer refuses the family rather than inventing a read path.
  */
 import type {
 	WorkflowParallelOptions,
@@ -21,6 +25,11 @@ import { VERIFICATION_SCALE } from "./verification-criteria.js";
 export const MAX_INLINE_CANDIDATE_BYTES = 32 * 1024;
 
 export interface ScoringCandidate {
+	/**
+	 * Optional only while every candidate body is inline. An oversized family
+	 * requires a caller-bound path for every candidate; paths are preserved
+	 * verbatim and are never synthesized.
+	 */
 	readonly path?: string;
 	readonly body: string;
 }
@@ -50,14 +59,27 @@ function inlineCandidates(head: SharedHead): boolean {
 	);
 }
 
-function candidateSection(head: SharedHead, inline: boolean): string {
+function fallbackReadPaths(head: SharedHead): readonly string[] | undefined {
+	if (inlineCandidates(head)) return undefined;
+	const paths: string[] = [];
+	for (const [index, candidate] of head.candidates.entries()) {
+		if (candidate.path === undefined) {
+			throw new TypeError(
+				`Oversized candidate family requires a caller-bound path for every candidate; candidate ${index + 1} has no path.`,
+			);
+		}
+		paths.push(candidate.path);
+	}
+	return paths;
+}
+
+function candidateSection(head: SharedHead, readPaths: readonly string[] | undefined): string {
 	return head.candidates
 		.map((candidate, index) => {
-			if (inline) {
+			if (readPaths === undefined) {
 				return `<candidate index="${index + 1}">\n${candidate.body}\n</candidate>`;
 			}
-			const source = candidate.path ?? `candidate-${index + 1}`;
-			return `<candidate index="${index + 1}" source="read">\nRead candidate from ${source}.\n</candidate>`;
+			return `<candidate index="${index + 1}" source="read">\nRead candidate from ${readPaths[index]!}.\n</candidate>`;
 		})
 		.join("\n");
 }
@@ -66,11 +88,11 @@ function candidateSection(head: SharedHead, inline: boolean): string {
  * Return candidate paths required by the read fallback.
  *
  * The whole family switches together: either every body is in the shared head,
- * or every candidate is named as a read. Order and duplicate paths are kept.
+ * or every candidate is named as a caller-provided read. Order and duplicate
+ * paths are kept; an oversized pathless family throws instead of guessing.
  */
 export function scoring_prompt_reads(head: SharedHead): readonly string[] {
-	if (inlineCandidates(head)) return [];
-	return head.candidates.map((candidate, index) => candidate.path ?? `candidate-${index + 1}`);
+	return fallbackReadPaths(head) ?? [];
 }
 
 /**
@@ -80,7 +102,7 @@ export function scoring_prompt_reads(head: SharedHead): readonly string[] {
  * family, preserving the same head for every sibling criterion.
  */
 export function build_scoring_prompt(head: SharedHead, criterion: Criterion): string {
-	const inline = inlineCandidates(head);
+	const readPaths = fallbackReadPaths(head);
 	const sharedHead = [
 		"<scoring_head>",
 		"<task_statement>",
@@ -90,7 +112,7 @@ export function build_scoring_prompt(head: SharedHead, criterion: Criterion): st
 		head.groundTruthNote,
 		"</ground_truth_note>",
 		"<candidates>",
-		candidateSection(head, inline),
+		candidateSection(head, readPaths),
 		"</candidates>",
 		"<scale_anchors>",
 		head.scaleAnchors ?? VERIFICATION_SCALE.anchors,
@@ -106,6 +128,14 @@ export function build_scoring_prompt(head: SharedHead, criterion: Criterion): st
 		"</output_format>",
 	].join("\n");
 	return `${sharedHead}\n\n${varyingTail}`;
+}
+
+function boundedConcurrency(
+	stepCount: number,
+	phaseCap: number | undefined,
+	inheritedCap: number | undefined,
+): number {
+	return Math.min(stepCount, phaseCap ?? stepCount, inheritedCap ?? stepCount);
 }
 
 /**
@@ -133,6 +163,7 @@ export async function warm_first_fan_out<K>(
 	}
 
 	const { warmConcurrency, ...parallelOptions } = options;
+	const inheritedConcurrency = parallelOptions.concurrency;
 	const resultsByIndex = new Map<number, WorkflowTaskResult>();
 	let warmFailure: Error | undefined;
 	if (warmIndices.length > 0) {
@@ -140,7 +171,11 @@ export async function warm_first_fan_out<K>(
 		try {
 			const warmResults = await ctx.parallel(warmSteps, {
 				...parallelOptions,
-				concurrency: warmConcurrency ?? Math.min(warmSteps.length, DEFAULT_WARM_CONCURRENCY),
+				concurrency: boundedConcurrency(
+					warmSteps.length,
+					warmConcurrency ?? DEFAULT_WARM_CONCURRENCY,
+					inheritedConcurrency,
+				),
 				failFast: false,
 			});
 			for (const [resultIndex, result] of warmResults.entries()) {
@@ -156,7 +191,7 @@ export async function warm_first_fan_out<K>(
 		const restSteps = restIndices.map((index) => steps[index]!);
 		const restResults = await ctx.parallel(restSteps, {
 			...parallelOptions,
-			concurrency: restSteps.length,
+			concurrency: boundedConcurrency(restSteps.length, undefined, inheritedConcurrency),
 		});
 		for (const [resultIndex, result] of restResults.entries()) {
 			const originalIndex = restIndices[resultIndex];

--- a/packages/workflows/builtin/verification-prompts.ts
+++ b/packages/workflows/builtin/verification-prompts.ts
@@ -1,0 +1,171 @@
+/**
+ * Prefix-cache-aware verification prompts and warm-first fan-out.
+ *
+ * A scoring-family prompt is always `SHARED HEAD ‖ VARYING TAIL`: the head
+ * contains the task statement, ground-truth note, candidate bodies (or read
+ * references when the family is too large), and scale anchors, in that order.
+ * The tail contains only the criterion name and description plus the output
+ * format instruction. Keeping this ordering invariant means sibling criteria
+ * can share the provider's cached prefix byte-for-byte.
+ */
+import type {
+	WorkflowParallelOptions,
+	WorkflowRunContext,
+	WorkflowTaskResult,
+	WorkflowTaskStep,
+} from "../src/shared/types.js";
+import type { Criterion } from "./verification-criteria.js";
+import { VERIFICATION_SCALE } from "./verification-criteria.js";
+
+/** Maximum UTF-8 byte length of one candidate body eligible for inlining. */
+export const MAX_INLINE_CANDIDATE_BYTES = 32 * 1024;
+
+export interface ScoringCandidate {
+	readonly path?: string;
+	readonly body: string;
+}
+
+export interface SharedHead {
+	readonly task: string;
+	readonly groundTruthNote: string;
+	readonly candidates: readonly ScoringCandidate[];
+	readonly scaleAnchors?: string;
+	readonly outputFormat?: string;
+}
+
+export interface WarmFirstFanOutOptions extends WorkflowParallelOptions {
+	/** Maximum number of distinct prefixes warmed at once. */
+	readonly warmConcurrency?: number;
+}
+
+export type WarmFirstFanOutContext = Pick<WorkflowRunContext, "parallel">;
+
+const DEFAULT_WARM_CONCURRENCY = 4;
+const DEFAULT_OUTPUT_FORMAT =
+	"Call structured_output with criterion_id, score (1–20), evidence, and findings containing finding and severity.";
+
+function inlineCandidates(head: SharedHead): boolean {
+	return head.candidates.every(
+		(candidate) => Buffer.byteLength(candidate.body, "utf8") <= MAX_INLINE_CANDIDATE_BYTES,
+	);
+}
+
+function candidateSection(head: SharedHead, inline: boolean): string {
+	return head.candidates
+		.map((candidate, index) => {
+			if (inline) {
+				return `<candidate index="${index + 1}">\n${candidate.body}\n</candidate>`;
+			}
+			const source = candidate.path ?? `candidate-${index + 1}`;
+			return `<candidate index="${index + 1}" source="read">\nRead candidate from ${source}.\n</candidate>`;
+		})
+		.join("\n");
+}
+
+/**
+ * Return candidate paths required by the read fallback.
+ *
+ * The whole family switches together: either every body is in the shared head,
+ * or every candidate is named as a read. Order and duplicate paths are kept.
+ */
+export function scoring_prompt_reads(head: SharedHead): readonly string[] {
+	if (inlineCandidates(head)) return [];
+	return head.candidates.map((candidate, index) => candidate.path ?? `candidate-${index + 1}`);
+}
+
+/**
+ * Build one scoring prompt with a byte-identical shared head and criterion tail.
+ * Candidate bodies are measured in UTF-8 bytes, not JavaScript code units. If
+ * any body exceeds `MAX_INLINE_CANDIDATE_BYTES`, no body is inlined for the
+ * family, preserving the same head for every sibling criterion.
+ */
+export function build_scoring_prompt(head: SharedHead, criterion: Criterion): string {
+	const inline = inlineCandidates(head);
+	const sharedHead = [
+		"<scoring_head>",
+		"<task_statement>",
+		head.task,
+		"</task_statement>",
+		"<ground_truth_note>",
+		head.groundTruthNote,
+		"</ground_truth_note>",
+		"<candidates>",
+		candidateSection(head, inline),
+		"</candidates>",
+		"<scale_anchors>",
+		head.scaleAnchors ?? VERIFICATION_SCALE.anchors,
+		"</scale_anchors>",
+	].join("\n");
+	const varyingTail = [
+		"<criterion>",
+		`<name>${criterion.name}</name>`,
+		`<description>${criterion.description}</description>`,
+		"</criterion>",
+		"<output_format>",
+		head.outputFormat ?? DEFAULT_OUTPUT_FORMAT,
+		"</output_format>",
+	].join("\n");
+	return `${sharedHead}\n\n${varyingTail}`;
+}
+
+/**
+ * Run one warm step per prefix, then release the remaining steps. Prefix keys
+ * are caller-owned; first-seen order is deterministic. Warm failures are
+ * observed without fail-fast, and the second phase is always attempted before
+ * the warm error is rethrown. Successful results are returned in input order.
+ */
+export async function warm_first_fan_out<K>(
+	ctx: WarmFirstFanOutContext,
+	steps: readonly WorkflowTaskStep[],
+	prefixKeyOf: (step: WorkflowTaskStep, index: number) => K,
+	options: WarmFirstFanOutOptions = {},
+): Promise<WorkflowTaskResult[]> {
+	const warmIndices: number[] = [];
+	const restIndices: number[] = [];
+	const seen = new Set<K>();
+	for (const [index, step] of steps.entries()) {
+		const prefixKey = prefixKeyOf(step, index);
+		if (seen.has(prefixKey)) restIndices.push(index);
+		else {
+			seen.add(prefixKey);
+			warmIndices.push(index);
+		}
+	}
+
+	const { warmConcurrency, ...parallelOptions } = options;
+	const resultsByIndex = new Map<number, WorkflowTaskResult>();
+	let warmFailure: Error | undefined;
+	if (warmIndices.length > 0) {
+		const warmSteps = warmIndices.map((index) => steps[index]!);
+		try {
+			const warmResults = await ctx.parallel(warmSteps, {
+				...parallelOptions,
+				concurrency: warmConcurrency ?? Math.min(warmSteps.length, DEFAULT_WARM_CONCURRENCY),
+				failFast: false,
+			});
+			for (const [resultIndex, result] of warmResults.entries()) {
+				const originalIndex = warmIndices[resultIndex];
+				if (originalIndex !== undefined) resultsByIndex.set(originalIndex, result);
+			}
+		} catch (error) {
+			warmFailure = error instanceof Error ? error : new Error(String(error));
+		}
+	}
+
+	if (restIndices.length > 0) {
+		const restSteps = restIndices.map((index) => steps[index]!);
+		const restResults = await ctx.parallel(restSteps, {
+			...parallelOptions,
+			concurrency: restSteps.length,
+		});
+		for (const [resultIndex, result] of restResults.entries()) {
+			const originalIndex = restIndices[resultIndex];
+			if (originalIndex !== undefined) resultsByIndex.set(originalIndex, result);
+		}
+	}
+
+	if (warmFailure !== undefined) throw warmFailure;
+	return steps
+		.map((_, index) => resultsByIndex.get(index))
+		.filter((result): result is WorkflowTaskResult => result !== undefined);
+}

--- a/test/unit/builtin-workflows-adversarial-generate.test.ts
+++ b/test/unit/builtin-workflows-adversarial-generate.test.ts
@@ -6,6 +6,8 @@ import { join } from "node:path";
 import { test } from "vitest";
 import adversarialVerification from "../../packages/workflows/builtin/adversarial-verification.js";
 import generateAndFilter from "../../packages/workflows/builtin/generate-and-filter.js";
+import { MAX_INLINE_CANDIDATE_BYTES } from "../../packages/workflows/builtin/verification-prompts.js";
+import type { WorkflowTaskOptions } from "../../packages/workflows/src/shared/types.js";
 import {
 	assertOutputTypes,
 	assertWorkflowDefinition,
@@ -28,6 +30,12 @@ async function withTempCwd<T>(run: (cwd: string) => Promise<T>): Promise<T> {
 function assignCwd<T extends object>(ctx: T, cwd: string): T {
 	Object.defineProperty(ctx, "cwd", { value: cwd, enumerable: true });
 	return ctx;
+}
+
+function shortlistFromFilter(options: WorkflowTaskOptions): string[] {
+	const filterPath = readPaths(options).find((path) => path.endsWith("filter.json"));
+	if (filterPath === undefined) return [];
+	return (JSON.parse(readFileSync(filterPath, "utf8")) as { shortlist: string[] }).shortlist;
 }
 
 test("adversarial-verification declares bounded composable contracts", () => {
@@ -157,7 +165,7 @@ test("generate-and-filter declares bounded composable contracts", () => {
 	});
 });
 
-test("generate-and-filter fans out, dedupes, optionally judges, and finalizes artifact shortlist", async () => {
+test("generate-and-filter prompt-layout rider inlines small candidates without duplicate reads", async () => {
 	await withTempCwd(async (cwd) => {
 		const ctx = assignCwd(
 			makeMockCtx(
@@ -173,7 +181,7 @@ test("generate-and-filter fans out, dedupes, optionally judges, and finalizes ar
 								})
 							: name === "judge"
 								? JSON.stringify({
-										shortlist: readPaths(options).filter((path) => path.includes("candidate-")),
+										shortlist: shortlistFromFilter(options),
 										rationale: "ranked",
 									})
 								: undefined,
@@ -204,11 +212,14 @@ test("generate-and-filter fans out, dedupes, optionally judges, and finalizes ar
 		assert.ok(
 			readPaths(ctx.calls.taskOptions["dedupe-and-filter"]?.[0]).some((path) => path.endsWith("manifest.json")),
 		);
-		assert.ok(readPaths(ctx.calls.taskOptions.judge?.[0]).some((path) => path.endsWith("filter.json")));
+		assert.deepEqual(readPaths(ctx.calls.taskOptions.judge?.[0]), [result.filter_path]);
 		const judgePrompt = ctx.calls.prompts.judge?.[0] ?? "";
 		assert.match(judgePrompt, /<scoring_head>/);
 		assert.match(judgePrompt, /<criterion>/);
 		assert.match(judgePrompt, /<scale_anchors>/);
+		assert.match(judgePrompt, /\[mock-task:generate-1\]/);
+		assert.match(judgePrompt, /\[mock-task:generate-2\]/);
+		assert.doesNotMatch(judgePrompt, /\[mock-task:generate-3\]/);
 		assert.ok(readPaths(ctx.calls.taskOptions["final-shortlist"]?.[0]).some((path) => path.endsWith("judge.json")));
 		const filterReport = JSON.parse(readFileSync(result.filter_path, "utf8")) as {
 			shortlist: string[];
@@ -223,6 +234,43 @@ test("generate-and-filter fans out, dedupes, optionally judges, and finalizes ar
 		};
 		assert.ok(judgeReport.shortlist.every((path) => path.includes("candidate-")));
 		assert.equal(judgeReport.rationale, "ranked");
+	});
+});
+
+test("generate-and-filter prompt-layout rider reads every candidate when one is oversized", async () => {
+	await withTempCwd(async (cwd) => {
+		const oversizedBody = "é".repeat(Math.floor(MAX_INLINE_CANDIDATE_BYTES / 2) + 1);
+		const ctx = assignCwd(
+			makeMockCtx(
+				{ prompt: "generate options", num_candidates: 2, shortlist_size: 2, use_judge: true, max_concurrency: 2 },
+				{
+					task: (name, options) => {
+						if (name === "generate-1") return "small candidate body";
+						if (name === "generate-2") return oversizedBody;
+						if (name === "dedupe-and-filter") {
+							return JSON.stringify({
+								shortlist: readPaths(options).filter((path) => path.endsWith(".md")),
+								discarded: [],
+							});
+						}
+						if (name === "judge") {
+							return JSON.stringify({ shortlist: shortlistFromFilter(options), rationale: "ranked" });
+						}
+						return undefined;
+					},
+				},
+			),
+			cwd,
+		);
+		const result = await generateAndFilter.run(ctx);
+		const judgePrompt = ctx.calls.prompts.judge?.[0] ?? "";
+		assert.doesNotMatch(judgePrompt, /small candidate body/);
+		assert.equal(judgePrompt.includes("é"), false);
+		assert.match(judgePrompt, /source="read"/);
+		assert.deepEqual(readPaths(ctx.calls.taskOptions.judge?.[0]), [
+			result.filter_path,
+			...result.candidate_artifact_paths,
+		]);
 	});
 });
 

--- a/test/unit/builtin-workflows-adversarial-generate.test.ts
+++ b/test/unit/builtin-workflows-adversarial-generate.test.ts
@@ -71,8 +71,8 @@ test("adversarial-verification uses fresh evidence verifiers and accepts only th
 		const result = await adversarialVerification.run(ctx);
 		assert.equal(result.approved, true);
 		assert.equal(result.repairs_completed, 0);
-		assert.deepEqual(ctx.calls.parallel, [["verifier-0-1", "verifier-0-2"]]);
-		for (const name of ctx.calls.parallel[0]!) {
+		assert.deepEqual(ctx.calls.parallel, [["verifier-0-1"], ["verifier-0-2"]]);
+		for (const name of ctx.calls.parallel.flat()) {
 			const options = ctx.calls.taskOptions[name]?.[0];
 			assert.equal(options?.context, "fresh");
 			assert.ok(readPaths(options).some((path) => path.endsWith("candidate.md")));
@@ -205,6 +205,10 @@ test("generate-and-filter fans out, dedupes, optionally judges, and finalizes ar
 			readPaths(ctx.calls.taskOptions["dedupe-and-filter"]?.[0]).some((path) => path.endsWith("manifest.json")),
 		);
 		assert.ok(readPaths(ctx.calls.taskOptions.judge?.[0]).some((path) => path.endsWith("filter.json")));
+		const judgePrompt = ctx.calls.prompts.judge?.[0] ?? "";
+		assert.match(judgePrompt, /<scoring_head>/);
+		assert.match(judgePrompt, /<criterion>/);
+		assert.match(judgePrompt, /<scale_anchors>/);
 		assert.ok(readPaths(ctx.calls.taskOptions["final-shortlist"]?.[0]).some((path) => path.endsWith("judge.json")));
 		const filterReport = JSON.parse(readFileSync(result.filter_path, "utf8")) as {
 			shortlist: string[];

--- a/test/unit/verification-prompt-layout.test.ts
+++ b/test/unit/verification-prompt-layout.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+	build_scoring_prompt,
+	MAX_INLINE_CANDIDATE_BYTES,
+	type SharedHead,
+	scoring_prompt_reads,
+	warm_first_fan_out,
+} from "../../packages/workflows/builtin/verification-prompts.js";
+import type {
+	WorkflowParallelOptions,
+	WorkflowTaskResult,
+	WorkflowTaskStep,
+} from "../../packages/workflows/src/shared/types.js";
+
+const criterionA = { id: "correctness", name: "Correctness", description: "The candidate is correct." };
+const criterionB = { id: "evidence", name: "Evidence", description: "The candidate cites evidence." };
+
+function result(name: string): WorkflowTaskResult {
+	return { name, stageName: name, text: name };
+}
+
+function steps(...names: string[]): WorkflowTaskStep[] {
+	return names.map((name) => ({ name, prompt: name.slice(0, 1) }));
+}
+
+describe("prompt-layout", () => {
+	test("keeps the shared head byte-identical while only the criterion tail varies", () => {
+		assert.equal(MAX_INLINE_CANDIDATE_BYTES, 32 * 1024);
+		const head: SharedHead = {
+			task: "Complete the task.",
+			groundTruthNote: "The checked fixture is authoritative.",
+			candidates: [
+				{ path: "first.md", body: "first candidate α" },
+				{ path: "second.md", body: "second candidate β" },
+			],
+		};
+		const promptA = build_scoring_prompt(head, criterionA);
+		const promptB = build_scoring_prompt(head, criterionB);
+		const marker = "\n\n<criterion>\n";
+		const [headA, tailA] = promptA.split(marker);
+		const [headB, tailB] = promptB.split(marker);
+		assert.notEqual(headA, undefined);
+		assert.notEqual(tailA, undefined);
+		assert.equal(headA, headB);
+		assert.match(tailA!, /<name>Correctness<\/name>/);
+		assert.match(tailB!, /<name>Evidence<\/name>/);
+		assert.ok(promptA.indexOf("<task_statement>") < promptA.indexOf("<ground_truth_note>"));
+		assert.ok(promptA.indexOf("<ground_truth_note>") < promptA.indexOf("<candidates>"));
+		assert.ok(promptA.indexOf("<candidates>") < promptA.indexOf("<scale_anchors>"));
+		assert.ok(promptA.indexOf("<scale_anchors>") < promptA.indexOf(marker));
+		assert.match(headA!, /first candidate α/);
+		assert.match(headA!, /second candidate β/);
+		assert.equal(scoring_prompt_reads(head).length, 0);
+	});
+
+	test("flips every candidate to reads when one UTF-8 body exceeds the bound", () => {
+		const oversizedBody = "é".repeat(Math.floor(MAX_INLINE_CANDIDATE_BYTES / 2) + 1);
+		assert.ok(Buffer.byteLength(oversizedBody, "utf8") > MAX_INLINE_CANDIDATE_BYTES);
+		const head: SharedHead = {
+			task: "Review the candidates.",
+			groundTruthNote: "Use the supplied artifacts.",
+			candidates: [
+				{ path: "small.md", body: "small body" },
+				{ path: "large.md", body: oversizedBody },
+				{ path: "small.md", body: "duplicate path stays ordered" },
+			],
+		};
+		const promptA = build_scoring_prompt(head, criterionA);
+		const promptB = build_scoring_prompt(head, criterionB);
+		const marker = "\n\n<criterion>\n";
+		assert.equal(promptA.slice(0, promptA.indexOf(marker)), promptB.slice(0, promptB.indexOf(marker)));
+		assert.doesNotMatch(promptA, /small body/);
+		assert.doesNotMatch(promptA, /duplicate path stays ordered/);
+		assert.doesNotMatch(promptA, /é/);
+		assert.match(promptA, /Read candidate from small\.md/);
+		assert.match(promptA, /Read candidate from large\.md/);
+		assert.deepEqual(scoring_prompt_reads(head), ["small.md", "large.md", "small.md"]);
+	});
+
+	test("partitions warm and rest phases deterministically and preserves original result order", async () => {
+		const calls: string[][] = [];
+		const options: WorkflowParallelOptions[] = [];
+		const ctx = {
+			parallel: async (phase: readonly WorkflowTaskStep[], phaseOptions: WorkflowParallelOptions = {}) => {
+				calls.push(phase.map((step) => step.name));
+				options.push(phaseOptions);
+				return phase.map((step) => result(step.name));
+			},
+		};
+		const input = steps("a-1", "a-2", "b-1", "b-2");
+		const output = await warm_first_fan_out(ctx, input, (step) => step.prompt, { warmConcurrency: 2 });
+		assert.deepEqual(calls, [
+			["a-1", "b-1"],
+			["a-2", "b-2"],
+		]);
+		assert.equal(options[0]?.concurrency, 2);
+		assert.equal(options[0]?.failFast, false);
+		assert.equal(options[1]?.concurrency, 2);
+		assert.deepEqual(
+			output.map((item) => item.name),
+			["a-1", "a-2", "b-1", "b-2"],
+		);
+
+		const repeatCalls: string[][] = [];
+		const repeatCtx = {
+			parallel: async (phase: readonly WorkflowTaskStep[]) => {
+				repeatCalls.push(phase.map((step) => step.name));
+				return phase.map((step) => result(step.name));
+			},
+		};
+		await warm_first_fan_out(repeatCtx, input, (step) => step.prompt, { warmConcurrency: 2 });
+		assert.deepEqual(repeatCalls, calls);
+	});
+
+	test("releases the rest phase after a warm-phase failure", async () => {
+		const calls: string[][] = [];
+		let phaseNumber = 0;
+		const ctx = {
+			parallel: async (phase: readonly WorkflowTaskStep[]) => {
+				calls.push(phase.map((step) => step.name));
+				phaseNumber += 1;
+				if (phaseNumber === 1) throw new Error("warm failed");
+				return phase.map((step) => result(step.name));
+			},
+		};
+		await assert.rejects(
+			warm_first_fan_out(ctx, steps("a-1", "a-2", "b-1"), (step) => step.prompt, { warmConcurrency: 2 }),
+			/warm failed/,
+		);
+		assert.deepEqual(calls, [["a-1", "b-1"], ["a-2"]]);
+	});
+});

--- a/test/unit/verification-prompt-layout.test.ts
+++ b/test/unit/verification-prompt-layout.test.ts
@@ -78,6 +78,39 @@ describe("prompt-layout", () => {
 		assert.deepEqual(scoring_prompt_reads(head), ["small.md", "large.md", "small.md"]);
 	});
 
+	test("keeps pathless and exact-boundary bodies inline", () => {
+		const exactBody = "x".repeat(MAX_INLINE_CANDIDATE_BYTES);
+		assert.equal(Buffer.byteLength(exactBody, "utf8"), MAX_INLINE_CANDIDATE_BYTES);
+		const head: SharedHead = {
+			task: "Review the exact boundary.",
+			groundTruthNote: "The body is caller-provided.",
+			candidates: [{ body: "pathless small body" }, { body: exactBody }],
+		};
+		const prompt = build_scoring_prompt(head, criterionA);
+		assert.match(prompt, /pathless small body/);
+		assert.ok(prompt.includes(exactBody));
+		assert.deepEqual(scoring_prompt_reads(head), []);
+	});
+
+	test("rejects an oversized family when any candidate lacks a caller-bound path", () => {
+		const oversizedBody = "é".repeat(Math.floor(MAX_INLINE_CANDIDATE_BYTES / 2) + 1);
+		const head: SharedHead = {
+			task: "Review the fallback.",
+			groundTruthNote: "Every read must be caller-bound.",
+			candidates: [{ body: "pathless sibling" }, { path: "large.md", body: oversizedBody }],
+		};
+		assert.throws(
+			() => build_scoring_prompt(head, criterionA),
+			(error: unknown) => {
+				assert.ok(error instanceof TypeError);
+				assert.match(error.message, /caller-bound path for every candidate/);
+				assert.doesNotMatch(error.message, /candidate-1/);
+				return true;
+			},
+		);
+		assert.throws(() => scoring_prompt_reads(head), /caller-bound path for every candidate/);
+	});
+
 	test("partitions warm and rest phases deterministically and preserves original result order", async () => {
 		const calls: string[][] = [];
 		const options: WorkflowParallelOptions[] = [];
@@ -111,6 +144,38 @@ describe("prompt-layout", () => {
 		};
 		await warm_first_fan_out(repeatCtx, input, (step) => step.prompt, { warmConcurrency: 2 });
 		assert.deepEqual(repeatCalls, calls);
+	});
+
+	test("honors inherited concurrency in both phases and uses the tighter cap", async () => {
+		const inheritedOptions: WorkflowParallelOptions[] = [];
+		const inheritedContext = {
+			parallel: async (phase: readonly WorkflowTaskStep[], phaseOptions: WorkflowParallelOptions = {}) => {
+				inheritedOptions.push(phaseOptions);
+				return phase.map((step) => result(step.name));
+			},
+		};
+		const input = steps("a-1", "a-2", "b-1", "b-2", "c-1", "c-2");
+		await warm_first_fan_out(inheritedContext, input, (step) => step.prompt, { concurrency: 1 });
+		assert.deepEqual(
+			inheritedOptions.map((phase) => phase.concurrency),
+			[1, 1],
+		);
+
+		const tighterOptions: WorkflowParallelOptions[] = [];
+		const tighterContext = {
+			parallel: async (phase: readonly WorkflowTaskStep[], phaseOptions: WorkflowParallelOptions = {}) => {
+				tighterOptions.push(phaseOptions);
+				return phase.map((step) => result(step.name));
+			},
+		};
+		await warm_first_fan_out(tighterContext, steps("a-1", "a-2", "b-1", "b-2", "c-1", "c-2"), (step) => step.prompt, {
+			warmConcurrency: 3,
+			concurrency: 2,
+		});
+		assert.deepEqual(
+			tighterOptions.map((phase) => phase.concurrency),
+			[2, 2],
+		);
 	});
 
 	test("releases the rest phase after a warm-phase failure", async () => {


### PR DESCRIPTION
## Summary

Slice **V3** of the LLM-as-a-Verifier adoption program (`specs/2026-08-17-verification-criteria-module.md` §5.3): the prefix-cache prompt layout and warm-first fan-out scheduling layer.

- **`packages/workflows/builtin/verification-prompts.ts`** (new): `build_scoring_prompt(head, criterion)` enforcing the SHARED HEAD ‖ VARYING TAIL invariant — task, ground-truth note, candidate bodies, and scale anchors in a byte-identical head; only the criterion + output instruction in the tail. Candidates inline under the named `MAX_INLINE_CANDIDATE_BYTES` (32 KiB, UTF-8); one oversized candidate flips the **whole family** to `reads` so sibling heads stay byte-identical. `warm_first_fan_out(ctx, steps, prefixKeyOf, options)`: one step per distinct prefix key completes first (populating the provider cache), then the rest flood at full concurrency; a warm-phase failure still releases its group.
- **Rider (Q4)**: the generate-and-filter judge prompt adopts `build_scoring_prompt`.
- Adversarial-verification wiring is minimal by design — the full rewire is V2 (parallel branch); reconciliation lands at V6 as planned.

Base: `verifier/criteria-module` (V1, #2504). Stack: V1 → **V3** → V4 → V5 → V6.

## Evidence

Produced by an implement→review→repair goal run (2 turns, approved by completion/evidence/risk reviewers on the final checkout):

- `npm run check` — green (includes the coding-agent tsgo `erasableSyntaxOnly` pass)
- `npx vitest --run --project unit -t "prompt-layout"` — green: byte-identical sibling heads (order indices verified), exact 32,768-byte boundary kept inline, one oversized UTF-8 body flips the family to reads with ordered duplicate reads preserved, deterministic warm/rest partition, warm-failure releases its group
- Size cap: **288 changed source lines** (< 500; cap applies to `packages/**`; tests uncapped: 519 total insertions)
- Independent reviewer probe confirmed the module docstring states the ordering invariant and `build_scoring_prompt` returns a raw string
- CHANGELOG: `packages/workflows/CHANGELOG.md` under `## [Unreleased]` ### Added

Spec contract: `specs/2026-08-17-verification-criteria-module.md` §5.3 (Q3: 32 KiB inline bound; Q4: G&F rider included).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789666997&installation_model_id=10562&pr_number=2510&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2510&signature=e5da63caf0794af2fdf3872251f859435a88d4fe68d1e8a37ec77e508dc49c14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds prefix-cache-aware scoring prompt layouts, warm-first verifier scheduling, and adopts the scoring layout for generate-and-filter judging. Execution confirmed that model-generated response text can break out of the intended prompt data section and place replacement ranking instructions ahead of the legitimate judge criteria, allowing shortlist selection to be influenced by untrusted content.

<h3>Confidence Score: 3/5</h3>

Do not merge until model-generated response text is represented as data that cannot terminate or extend the judge prompt's instruction structure.

An executable reproduction exercised the affected prompt builder with adversarial closing tags and ranking directives, directly observing those directives before the legitimate judge prompt tail. The focused normal-layout tests passed but do not cover hostile response content.

**Files Needing Attention:** packages/workflows/builtin/verification-prompts.ts needs an injection-resistant encoding or transport for inline response bodies, along with adversarial prompt-boundary coverage.

<details open><summary><h3>Security Review</h3></summary>

The scoring prompt builder has a prompt-injection integrity issue. Untrusted model-generated response text can close XML-like prompt sections and add ranking or output directives before the intended judge instructions.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and attached artifacts detailing adversarial prompt-boundary reproduction and focused prompt layout results.
- T-Rex published a second finding-comment-proof validating the same P1 finding.
- T-Rex performed a general-contract-validation-proof showing how the adversarial injection can distort the judge prompt structure and shortlist instruction ordering, and noted that reproduction sources and test outputs were uploaded.
- T-Rex organized and linked the related artifacts to the findings so reviewers can inspect the adversarial prompt-boundary evidence.

<a href="https://app.greptile.com/trex/runs/19640009/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Candidate bodies can close the judge prompt's candidate section and inject ranking instructions**

   - **Bug**
     - At `packages/workflows/builtin/verification-prompts.ts:80`, an inline model-generated candidate body is inserted verbatim between `<candidate>` tags. A body containing `</candidate>`, `</candidates>`, and a new `<criterion>`/`<output_format>` closes the enclosing candidate region and places injected judge instructions before the legitimate criterion tail.
   - **Cause**
     - `candidate.body` is concatenated directly into an XML-like prompt format without escaping, encoding, or an injection-resistant representation.
   - **Fix**
     - Encode candidate bodies before interpolation (for example, a robust serialized/quoted representation with explicit instruction that it is untrusted data), or use an unambiguous delimiter/structured transport that cannot be terminated by candidate-controlled text; add an adversarial regression test with closing tags and injected criterion/output instructions.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/workflows/builtin/verification-prompts.ts:80
**Candidate content can override judge instructions**

`candidate.body` is concatenated directly into the XML-like scoring prompt. A model-generated body containing `</candidate>` and `</candidates>` can close the enclosing data section and place a controlled `<criterion>` or `<output_format>` before the legitimate judge instructions. Encode candidate text or use an injection-resistant representation before interpolation, and add a regression case with closing tags plus injected ranking directives.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(workflows): honor V3 fan-out and rea..."](https://github.com/bastani-inc/atomic/commit/4d84b6c3d41cfd39d77f4b22a974cb068ca17264) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54836493)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->