### PR TITLE
fix(rpc): preserve queue control lane semantics

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Queue-control RPC frames now remain reachable during long-running prompts, and failed remote queue clears restore host-queued messages ([#2516](https://github.com/bastani-inc/atomic/issues/2516)).
+
 ## [0.9.14-alpha.4] - 2026-08-18
 
 ### Changed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Queue-control RPC frames now remain reachable during long-running prompts, and failed remote queue clears restore host-queued messages ([#2516](https://github.com/bastani-inc/atomic/issues/2516)).
+- Queue-control RPC frames now remain reachable during long-running prompts. A failed remote `clear_queue` restores host-queued messages only when no later `queue_update` has already supplied engine truth, including an empty queue ([#2516](https://github.com/bastani-inc/atomic/issues/2516)).
 
 ## [0.9.14-alpha.4] - 2026-08-18
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Queue-control RPC frames now remain reachable during long-running prompts. A failed remote `clear_queue` restores host-queued messages only when no later `queue_update` has already supplied engine truth, including an empty queue ([#2516](https://github.com/bastani-inc/atomic/issues/2516)).
+- Queue-control RPC frames now remain reachable during long-running prompts. When all overlapping remote `clear_queue` calls fail, Atomic restores the pre-clear host queue only if no later `queue_update` has supplied engine truth, including an empty queue ([#2516](https://github.com/bastani-inc/atomic/issues/2516)).
 
 ## [0.9.14-alpha.4] - 2026-08-18
 

--- a/packages/coding-agent/src/modes/interactive-engine/isolated-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive-engine/isolated-runtime.ts
@@ -408,7 +408,15 @@ export class IsolatedInteractiveRuntime extends AgentSessionRuntime {
 					const queued = { steering: [...this.steeringMessages], followUp: [...this.followUpMessages] };
 					this.steeringMessages = [];
 					this.followUpMessages = [];
-					this.dispatchBestEffort("clear queue", this.client.requestInternal({ type: "clear_queue" }));
+					const clearRequest = this.client.requestInternal({ type: "clear_queue" });
+					this.dispatchBestEffort(
+						"clear queue",
+						clearRequest.catch((error: Error) => {
+							this.steeringMessages = [...queued.steering, ...this.steeringMessages];
+							this.followUpMessages = [...queued.followUp, ...this.followUpMessages];
+							throw error;
+						}),
+					);
 					return queued;
 				},
 			},

--- a/packages/coding-agent/src/modes/interactive-engine/isolated-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive-engine/isolated-runtime.ts
@@ -22,6 +22,16 @@ import type { EngineKeybindingState, InteractiveEngineCommand, InteractiveEngine
 import { RemoteCommandCatalog, type RemoteCommandsListener } from "./remote-command-catalog.ts";
 import { RemoteModelCatalog } from "./remote-model-catalog.ts";
 import { RemoteQueuePause } from "./remote-queue-pause.js";
+
+type QueueSnapshot = { steering: string[]; followUp: string[] };
+
+type PendingQueueClear = {
+	snapshot: QueueSnapshot;
+	queueUpdateGeneration: number;
+	count: number;
+	succeeded: boolean;
+};
+
 /**
  * Owns Atomic's local interactive host facade and child-process engine.
  *
@@ -38,13 +48,10 @@ export class IsolatedInteractiveRuntime extends AgentSessionRuntime {
 	private readonly activeBashRequestIds = new Map<string | symbol, string>();
 	private steeringMessages: string[] = [];
 	private followUpMessages: string[] = [];
-	/**
-	 * Bumped by every authoritative queue_update and every optimistic local
-	 * clear. A failed clear_queue restores its snapshot only while the
-	 * generation it captured is still current, so neither an engine update nor
-	 * a newer clear can be overwritten by a stale rollback.
-	 */
-	private queueGeneration = 0;
+	/** Bumped by every authoritative queue_update. */
+	private queueUpdateGeneration = 0;
+	/** Clears started before the next queue_update share one rollback snapshot. */
+	private pendingQueueClear: PendingQueueClear | undefined;
 	private engineCallbackActive = false;
 	private readonly queuePause: RemoteQueuePause;
 	private autoCompactionEnabled = true;
@@ -412,27 +419,29 @@ export class IsolatedInteractiveRuntime extends AgentSessionRuntime {
 			clearQueue: {
 				configurable: true,
 				value: () => {
-					const queued = { steering: [...this.steeringMessages], followUp: [...this.followUpMessages] };
-					this.queueGeneration += 1;
-					const generation = this.queueGeneration;
+					const queued: QueueSnapshot = {
+						steering: [...this.steeringMessages],
+						followUp: [...this.followUpMessages],
+					};
+					const pendingClear = this.pendingQueueClear ?? {
+						snapshot: queued,
+						queueUpdateGeneration: this.queueUpdateGeneration,
+						count: 0,
+						succeeded: false,
+					};
+					this.pendingQueueClear = pendingClear;
+					pendingClear.count += 1;
 					this.steeringMessages = [];
 					this.followUpMessages = [];
-					const clearRequest = this.client.requestInternal({ type: "clear_queue" });
 					this.dispatchBestEffort(
 						"clear queue",
-						clearRequest.catch((error: Error) => {
-							// A later queue_update is engine truth, including an empty one, and a
-							// later overlapping clear owns a newer snapshot. Array length cannot
-							// stand in for either: an authoritative empty update looks like "no
-							// update arrived" and would resurrect messages the engine removed,
-							// while concurrent rollbacks would make the result depend on rejection
-							// order. Restore only while this clear's generation is still current.
-							if (this.queueGeneration === generation) {
-								this.steeringMessages = [...queued.steering];
-								this.followUpMessages = [...queued.followUp];
-							}
-							throw error;
-						}),
+						this.client.requestInternal({ type: "clear_queue" }).then(
+							() => this.settleQueueClear(pendingClear, true),
+							(error: Error) => {
+								this.settleQueueClear(pendingClear, false);
+								throw error;
+							},
+						),
 					);
 					return queued;
 				},
@@ -542,6 +551,20 @@ export class IsolatedInteractiveRuntime extends AgentSessionRuntime {
 		});
 	}
 
+	private settleQueueClear(pendingClear: PendingQueueClear, succeeded: boolean): void {
+		if (this.pendingQueueClear !== pendingClear) return;
+
+		pendingClear.count -= 1;
+		pendingClear.succeeded ||= succeeded;
+		if (pendingClear.count > 0) return;
+
+		this.pendingQueueClear = undefined;
+		if (pendingClear.succeeded || this.queueUpdateGeneration !== pendingClear.queueUpdateGeneration) return;
+
+		this.steeringMessages = [...pendingClear.snapshot.steering];
+		this.followUpMessages = [...pendingClear.snapshot.followUp];
+	}
+
 	private resetUnpersistedSessionView(): void {
 		const session = super.session;
 		const manager = SessionManager.create(session.sessionManager.getCwd(), session.sessionManager.getSessionDir());
@@ -594,7 +617,8 @@ export class IsolatedInteractiveRuntime extends AgentSessionRuntime {
 				this.compactionReason = undefined;
 				break;
 			case "queue_update":
-				this.queueGeneration += 1;
+				this.queueUpdateGeneration += 1;
+				this.pendingQueueClear = undefined;
 				this.steeringMessages = [...event.steering];
 				this.followUpMessages = [...event.followUp];
 				break;

--- a/packages/coding-agent/src/modes/interactive-engine/isolated-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive-engine/isolated-runtime.ts
@@ -38,6 +38,7 @@ export class IsolatedInteractiveRuntime extends AgentSessionRuntime {
 	private readonly activeBashRequestIds = new Map<string | symbol, string>();
 	private steeringMessages: string[] = [];
 	private followUpMessages: string[] = [];
+	private queueUpdateGeneration = 0;
 	private engineCallbackActive = false;
 	private readonly queuePause: RemoteQueuePause;
 	private autoCompactionEnabled = true;
@@ -406,17 +407,21 @@ export class IsolatedInteractiveRuntime extends AgentSessionRuntime {
 				configurable: true,
 				value: () => {
 					const queued = { steering: [...this.steeringMessages], followUp: [...this.followUpMessages] };
+					const generation = this.queueUpdateGeneration;
 					this.steeringMessages = [];
 					this.followUpMessages = [];
 					const clearRequest = this.client.requestInternal({ type: "clear_queue" });
 					this.dispatchBestEffort(
 						"clear queue",
 						clearRequest.catch((error: Error) => {
-							// A queue_update replaces both arrays with the engine's authoritative queue.
-							// A non-empty array is already engine truth, so prepending the snapshot would
-							// duplicate it. Restore only an array that is still empty after the failed clear.
-							if (this.steeringMessages.length === 0) this.steeringMessages = [...queued.steering];
-							if (this.followUpMessages.length === 0) this.followUpMessages = [...queued.followUp];
+							// A later queue_update is engine truth, including an empty one. Length
+							// cannot stand in for that: an authoritative empty update looks like
+							// "no update arrived" and would restore messages the engine already
+							// removed. Restore the snapshot only when no update followed this clear.
+							if (this.queueUpdateGeneration === generation) {
+								this.steeringMessages = [...queued.steering];
+								this.followUpMessages = [...queued.followUp];
+							}
 							throw error;
 						}),
 					);
@@ -580,6 +585,7 @@ export class IsolatedInteractiveRuntime extends AgentSessionRuntime {
 				this.compactionReason = undefined;
 				break;
 			case "queue_update":
+				this.queueUpdateGeneration += 1;
 				this.steeringMessages = [...event.steering];
 				this.followUpMessages = [...event.followUp];
 				break;

--- a/packages/coding-agent/src/modes/interactive-engine/isolated-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive-engine/isolated-runtime.ts
@@ -412,8 +412,11 @@ export class IsolatedInteractiveRuntime extends AgentSessionRuntime {
 					this.dispatchBestEffort(
 						"clear queue",
 						clearRequest.catch((error: Error) => {
-							this.steeringMessages = [...queued.steering, ...this.steeringMessages];
-							this.followUpMessages = [...queued.followUp, ...this.followUpMessages];
+							// A queue_update replaces both arrays with the engine's authoritative queue.
+							// A non-empty array is already engine truth, so prepending the snapshot would
+							// duplicate it. Restore only an array that is still empty after the failed clear.
+							if (this.steeringMessages.length === 0) this.steeringMessages = [...queued.steering];
+							if (this.followUpMessages.length === 0) this.followUpMessages = [...queued.followUp];
 							throw error;
 						}),
 					);

--- a/packages/coding-agent/src/modes/interactive-engine/isolated-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive-engine/isolated-runtime.ts
@@ -38,7 +38,13 @@ export class IsolatedInteractiveRuntime extends AgentSessionRuntime {
 	private readonly activeBashRequestIds = new Map<string | symbol, string>();
 	private steeringMessages: string[] = [];
 	private followUpMessages: string[] = [];
-	private queueUpdateGeneration = 0;
+	/**
+	 * Bumped by every authoritative queue_update and every optimistic local
+	 * clear. A failed clear_queue restores its snapshot only while the
+	 * generation it captured is still current, so neither an engine update nor
+	 * a newer clear can be overwritten by a stale rollback.
+	 */
+	private queueGeneration = 0;
 	private engineCallbackActive = false;
 	private readonly queuePause: RemoteQueuePause;
 	private autoCompactionEnabled = true;
@@ -407,18 +413,21 @@ export class IsolatedInteractiveRuntime extends AgentSessionRuntime {
 				configurable: true,
 				value: () => {
 					const queued = { steering: [...this.steeringMessages], followUp: [...this.followUpMessages] };
-					const generation = this.queueUpdateGeneration;
+					this.queueGeneration += 1;
+					const generation = this.queueGeneration;
 					this.steeringMessages = [];
 					this.followUpMessages = [];
 					const clearRequest = this.client.requestInternal({ type: "clear_queue" });
 					this.dispatchBestEffort(
 						"clear queue",
 						clearRequest.catch((error: Error) => {
-							// A later queue_update is engine truth, including an empty one. Length
-							// cannot stand in for that: an authoritative empty update looks like
-							// "no update arrived" and would restore messages the engine already
-							// removed. Restore the snapshot only when no update followed this clear.
-							if (this.queueUpdateGeneration === generation) {
+							// A later queue_update is engine truth, including an empty one, and a
+							// later overlapping clear owns a newer snapshot. Array length cannot
+							// stand in for either: an authoritative empty update looks like "no
+							// update arrived" and would resurrect messages the engine removed,
+							// while concurrent rollbacks would make the result depend on rejection
+							// order. Restore only while this clear's generation is still current.
+							if (this.queueGeneration === generation) {
 								this.steeringMessages = [...queued.steering];
 								this.followUpMessages = [...queued.followUp];
 							}
@@ -585,7 +594,7 @@ export class IsolatedInteractiveRuntime extends AgentSessionRuntime {
 				this.compactionReason = undefined;
 				break;
 			case "queue_update":
-				this.queueUpdateGeneration += 1;
+				this.queueGeneration += 1;
 				this.steeringMessages = [...event.steering];
 				this.followUpMessages = [...event.followUp];
 				break;

--- a/packages/coding-agent/src/modes/interactive-engine/isolated-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive-engine/isolated-runtime.ts
@@ -86,6 +86,7 @@ export class IsolatedInteractiveRuntime extends AgentSessionRuntime {
 				this.streaming = false;
 				this.compacting = false;
 				this.compactionReason = undefined;
+				this.pendingQueueClear = undefined;
 				this.engineCallbackActive = false;
 				this.health.markCooperativeAbortSettled();
 			},

--- a/packages/coding-agent/src/modes/rpc/rpc-input-scheduler.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-input-scheduler.ts
@@ -8,6 +8,8 @@ const INTERRUPT_COMMANDS: ReadonlySet<string> = new Set([
 	"abort_retry",
 	"abort_bash",
 	"pause_queued_messages",
+	"resume_queued_messages",
+	"clear_queue",
 ]);
 const CONCURRENT_COMMANDS: ReadonlySet<string> = new Set(["bash", "user_bash", "refresh_models"]);
 
@@ -23,9 +25,9 @@ export function isRpcExtensionUIResponse(value: unknown): value is RpcExtensionU
 }
 
 /**
- * Control frames must remain reachable while an ordinary RPC command is
- * pending. Interrupts cancel that command, while host responses can unblock UI
- * work awaited by it. Everything else stays on the ordered command lane.
+ * pending. Interrupts cancel or adjust queued work for that command, while
+ * host responses can unblock UI work awaited by it. Everything else stays on
+ * the ordered command lane.
  */
 export function isConcurrentRpcControlLine(line: string): boolean {
 	if (parseInteractiveEngineCommand(line)) return true;

--- a/packages/coding-agent/src/modes/rpc/rpc-input-scheduler.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-input-scheduler.ts
@@ -25,6 +25,7 @@ export function isRpcExtensionUIResponse(value: unknown): value is RpcExtensionU
 }
 
 /**
+ * Control frames must remain reachable while an ordinary RPC command is
  * pending. Interrupts cancel or adjust queued work for that command, while
  * host responses can unblock UI work awaited by it. Everything else stays on
  * the ordered command lane.

--- a/test/unit/isolated-runtime-clear-queue.test.ts
+++ b/test/unit/isolated-runtime-clear-queue.test.ts
@@ -144,3 +144,23 @@ test("clearQueue adopts disjoint authoritative engine queues after a failed remo
 		harness.cleanup();
 	}
 });
+
+test("clearQueue keeps an authoritative empty queue_update when the remote clear fails", async () => {
+	const harness = await createHarness();
+	try {
+		const probe = createClearQueueClient();
+		const runtime = await createRuntime(harness, probe.client);
+		const session = runtime.session;
+		probe.emit({ type: "queue_update", steering: ["before steer"], followUp: ["before follow-up"] });
+
+		session.clearQueue();
+		probe.emit({ type: "queue_update", steering: [], followUp: [] });
+		probe.reject(new Error("engine unavailable"));
+		await settleRejectedClear();
+
+		assert.deepEqual(session.getSteeringMessages(), []);
+		assert.deepEqual(session.getFollowUpMessages(), []);
+	} finally {
+		harness.cleanup();
+	}
+});

--- a/test/unit/isolated-runtime-clear-queue.test.ts
+++ b/test/unit/isolated-runtime-clear-queue.test.ts
@@ -18,8 +18,7 @@ function servicesFor(harness: Harness) {
 
 function createClearQueueClient() {
 	let eventListener: ((event: RpcEvent) => void) | undefined;
-	const clearRequest = Promise.withResolvers<void>();
-	let clearCalls = 0;
+	const clearRequests: PromiseWithResolvers<void>[] = [];
 	const client = {
 		onEvent(listener: (event: RpcEvent) => void) {
 			eventListener = listener;
@@ -30,8 +29,9 @@ function createClearQueueClient() {
 		onGenerationEnded: () => () => {},
 		requestInternal<T>(command: { type: string }): Promise<T> {
 			if (command.type === "clear_queue") {
-				clearCalls += 1;
-				return clearRequest.promise as Promise<T>;
+				const request = Promise.withResolvers<void>();
+				clearRequests.push(request);
+				return request.promise as Promise<T>;
 			}
 			return Promise.resolve(undefined as T);
 		},
@@ -43,11 +43,13 @@ function createClearQueueClient() {
 		emit(event: RpcEvent): void {
 			eventListener?.(event);
 		},
-		reject(error: Error): void {
-			clearRequest.reject(error);
+		reject(error: Error, index = 0): void {
+			const request = clearRequests[index];
+			if (request === undefined) throw new Error(`no clear_queue request at index ${index}`);
+			request.reject(error);
 		},
 		get clearCalls(): number {
-			return clearCalls;
+			return clearRequests.length;
 		},
 	};
 }
@@ -156,6 +158,55 @@ test("clearQueue keeps an authoritative empty queue_update when the remote clear
 		session.clearQueue();
 		probe.emit({ type: "queue_update", steering: [], followUp: [] });
 		probe.reject(new Error("engine unavailable"));
+		await settleRejectedClear();
+
+		assert.deepEqual(session.getSteeringMessages(), []);
+		assert.deepEqual(session.getFollowUpMessages(), []);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test("an older failed clear cannot overwrite a newer clear's state", async () => {
+	const harness = await createHarness();
+	try {
+		const probe = createClearQueueClient();
+		const runtime = await createRuntime(harness, probe.client);
+		const session = runtime.session;
+		probe.emit({ type: "queue_update", steering: ["before steer"], followUp: ["before follow-up"] });
+
+		assert.deepEqual(session.clearQueue(), { steering: ["before steer"], followUp: ["before follow-up"] });
+		assert.deepEqual(session.clearQueue(), { steering: [], followUp: [] });
+		assert.equal(probe.clearCalls, 2);
+
+		probe.reject(new Error("engine unavailable"), 0);
+		await settleRejectedClear();
+		assert.deepEqual(session.getSteeringMessages(), []);
+		assert.deepEqual(session.getFollowUpMessages(), []);
+
+		probe.reject(new Error("engine unavailable"), 1);
+		await settleRejectedClear();
+		assert.deepEqual(session.getSteeringMessages(), []);
+		assert.deepEqual(session.getFollowUpMessages(), []);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test("overlapping failed clears settle identically when rejected newest-first", async () => {
+	const harness = await createHarness();
+	try {
+		const probe = createClearQueueClient();
+		const runtime = await createRuntime(harness, probe.client);
+		const session = runtime.session;
+		probe.emit({ type: "queue_update", steering: ["before steer"], followUp: ["before follow-up"] });
+
+		session.clearQueue();
+		session.clearQueue();
+
+		probe.reject(new Error("engine unavailable"), 1);
+		await settleRejectedClear();
+		probe.reject(new Error("engine unavailable"), 0);
 		await settleRejectedClear();
 
 		assert.deepEqual(session.getSteeringMessages(), []);

--- a/test/unit/isolated-runtime-clear-queue.test.ts
+++ b/test/unit/isolated-runtime-clear-queue.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { AgentSessionRuntime } from "../../packages/coding-agent/src/core/agent-session-runtime.ts";
+import { IsolatedInteractiveRuntime } from "../../packages/coding-agent/src/modes/interactive-engine/isolated-runtime.ts";
+import type { RpcEvent } from "../../packages/coding-agent/src/modes/rpc/rpc-types.ts";
+import { createHarness, type Harness } from "../../packages/coding-agent/test/suite/harness.ts";
+
+function servicesFor(harness: Harness) {
+	return {
+		cwd: harness.tempDir,
+		agentDir: harness.tempDir,
+		modelRuntime: harness.session.modelRuntime,
+		settingsManager: harness.settingsManager,
+		resourceLoader: harness.session.resourceLoader,
+		diagnostics: [],
+	};
+}
+
+function createClearQueueClient() {
+	let eventListener: ((event: RpcEvent) => void) | undefined;
+	const clearRequest = Promise.withResolvers<void>();
+	let clearCalls = 0;
+	const client = {
+		onEvent(listener: (event: RpcEvent) => void) {
+			eventListener = listener;
+			return () => {
+				if (eventListener === listener) eventListener = undefined;
+			};
+		},
+		onGenerationEnded: () => () => {},
+		requestInternal<T>(command: { type: string }): Promise<T> {
+			if (command.type === "clear_queue") {
+				clearCalls += 1;
+				return clearRequest.promise as Promise<T>;
+			}
+			return Promise.resolve(undefined as T);
+		},
+		stop: async () => {},
+		restart: async () => {},
+	};
+	return {
+		client,
+		emit(event: RpcEvent): void {
+			eventListener?.(event);
+		},
+		reject(error: Error): void {
+			clearRequest.reject(error);
+		},
+		get clearCalls(): number {
+			return clearCalls;
+		},
+	};
+}
+
+async function createRuntime(
+	harness: Harness,
+	client: ReturnType<typeof createClearQueueClient>["client"],
+): Promise<IsolatedInteractiveRuntime> {
+	const localRuntime = new AgentSessionRuntime(harness.session, servicesFor(harness), async () => {
+		throw new Error("unused runtime factory");
+	});
+	return new IsolatedInteractiveRuntime(
+		localRuntime,
+		async () => {
+			throw new Error("unused isolated runtime factory");
+		},
+		client as never,
+	);
+}
+
+test("clearQueue restores its snapshot before messages admitted after the local clear", async () => {
+	const harness = await createHarness();
+	try {
+		const probe = createClearQueueClient();
+		const runtime = await createRuntime(harness, probe.client);
+		const session = runtime.session;
+		probe.emit({ type: "queue_update", steering: ["before steer"], followUp: ["before follow-up"] });
+
+		const returned = session.clearQueue();
+		assert.deepEqual(returned, { steering: ["before steer"], followUp: ["before follow-up"] });
+		assert.deepEqual(session.getSteeringMessages(), []);
+		assert.deepEqual(session.getFollowUpMessages(), []);
+		assert.equal(probe.clearCalls, 1);
+
+		probe.emit({ type: "queue_update", steering: ["admitted steer"], followUp: ["admitted follow-up"] });
+		probe.reject(new Error("engine unavailable"));
+		await Promise.resolve();
+		await Promise.resolve();
+
+		assert.deepEqual(session.getSteeringMessages(), ["before steer", "admitted steer"]);
+		assert.deepEqual(session.getFollowUpMessages(), ["before follow-up", "admitted follow-up"]);
+	} finally {
+		harness.cleanup();
+	}
+});

--- a/test/unit/isolated-runtime-clear-queue.test.ts
+++ b/test/unit/isolated-runtime-clear-queue.test.ts
@@ -167,7 +167,7 @@ test("clearQueue keeps an authoritative empty queue_update when the remote clear
 	}
 });
 
-test("an older failed clear cannot overwrite a newer clear's state", async () => {
+test("overlapping failed clears restore the original queue when rejected oldest-first", async () => {
 	const harness = await createHarness();
 	try {
 		const probe = createClearQueueClient();
@@ -186,14 +186,14 @@ test("an older failed clear cannot overwrite a newer clear's state", async () =>
 
 		probe.reject(new Error("engine unavailable"), 1);
 		await settleRejectedClear();
-		assert.deepEqual(session.getSteeringMessages(), []);
-		assert.deepEqual(session.getFollowUpMessages(), []);
+		assert.deepEqual(session.getSteeringMessages(), ["before steer"]);
+		assert.deepEqual(session.getFollowUpMessages(), ["before follow-up"]);
 	} finally {
 		harness.cleanup();
 	}
 });
 
-test("overlapping failed clears settle identically when rejected newest-first", async () => {
+test("overlapping failed clears restore the original queue when rejected newest-first", async () => {
 	const harness = await createHarness();
 	try {
 		const probe = createClearQueueClient();
@@ -209,8 +209,8 @@ test("overlapping failed clears settle identically when rejected newest-first", 
 		probe.reject(new Error("engine unavailable"), 0);
 		await settleRejectedClear();
 
-		assert.deepEqual(session.getSteeringMessages(), []);
-		assert.deepEqual(session.getFollowUpMessages(), []);
+		assert.deepEqual(session.getSteeringMessages(), ["before steer"]);
+		assert.deepEqual(session.getFollowUpMessages(), ["before follow-up"]);
 	} finally {
 		harness.cleanup();
 	}

--- a/test/unit/isolated-runtime-clear-queue.test.ts
+++ b/test/unit/isolated-runtime-clear-queue.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { AgentSessionRuntime } from "../../packages/coding-agent/src/core/agent-session-runtime.ts";
+import type { InteractiveEngineGenerationEnded } from "../../packages/coding-agent/src/modes/interactive-engine/engine-generation.ts";
 import { IsolatedInteractiveRuntime } from "../../packages/coding-agent/src/modes/interactive-engine/isolated-runtime.ts";
 import type { RpcEvent } from "../../packages/coding-agent/src/modes/rpc/rpc-types.ts";
 import { createHarness, type Harness } from "../../packages/coding-agent/test/suite/harness.ts";
@@ -18,6 +19,7 @@ function servicesFor(harness: Harness) {
 
 function createClearQueueClient() {
 	let eventListener: ((event: RpcEvent) => void) | undefined;
+	let generationEndedListener: ((event: InteractiveEngineGenerationEnded) => void) | undefined;
 	const clearRequests: PromiseWithResolvers<void>[] = [];
 	const client = {
 		onEvent(listener: (event: RpcEvent) => void) {
@@ -26,7 +28,12 @@ function createClearQueueClient() {
 				if (eventListener === listener) eventListener = undefined;
 			};
 		},
-		onGenerationEnded: () => () => {},
+		onGenerationEnded(listener: (event: InteractiveEngineGenerationEnded) => void) {
+			generationEndedListener = listener;
+			return () => {
+				if (generationEndedListener === listener) generationEndedListener = undefined;
+			};
+		},
 		requestInternal<T>(command: { type: string }): Promise<T> {
 			if (command.type === "clear_queue") {
 				const request = Promise.withResolvers<void>();
@@ -42,6 +49,9 @@ function createClearQueueClient() {
 		client,
 		emit(event: RpcEvent): void {
 			eventListener?.(event);
+		},
+		emitGenerationEnded(event: InteractiveEngineGenerationEnded): void {
+			generationEndedListener?.(event);
 		},
 		reject(error: Error, index = 0): void {
 			const request = clearRequests[index];
@@ -211,6 +221,31 @@ test("overlapping failed clears restore the original queue when rejected newest-
 
 		assert.deepEqual(session.getSteeringMessages(), ["before steer"]);
 		assert.deepEqual(session.getFollowUpMessages(), ["before follow-up"]);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test("clearQueue does not restore a retired engine's queue after replacement", async () => {
+	const harness = await createHarness();
+	try {
+		const probe = createClearQueueClient();
+		const runtime = await createRuntime(harness, probe.client);
+		const session = runtime.session;
+		probe.emit({ type: "queue_update", steering: ["before steer"], followUp: ["before follow-up"] });
+
+		session.clearQueue();
+		probe.emitGenerationEnded({
+			generation: 1,
+			error: new Error("engine replaced"),
+			kind: "explicit-stop",
+			expected: true,
+		});
+		probe.reject(new Error("engine unavailable"));
+		await settleRejectedClear();
+
+		assert.deepEqual(session.getSteeringMessages(), []);
+		assert.deepEqual(session.getFollowUpMessages(), []);
 	} finally {
 		harness.cleanup();
 	}

--- a/test/unit/isolated-runtime-clear-queue.test.ts
+++ b/test/unit/isolated-runtime-clear-queue.test.ts
@@ -68,7 +68,12 @@ async function createRuntime(
 	);
 }
 
-test("clearQueue restores its snapshot before messages admitted after the local clear", async () => {
+async function settleRejectedClear(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+test("clearQueue keeps authoritative superset queues without duplicating the failed snapshot", async () => {
 	const harness = await createHarness();
 	try {
 		const probe = createClearQueueClient();
@@ -82,13 +87,59 @@ test("clearQueue restores its snapshot before messages admitted after the local 
 		assert.deepEqual(session.getFollowUpMessages(), []);
 		assert.equal(probe.clearCalls, 1);
 
+		probe.emit({
+			type: "queue_update",
+			steering: ["before steer", "new steer"],
+			followUp: ["before follow-up", "new follow-up"],
+		});
+		probe.reject(new Error("engine unavailable"));
+		await settleRejectedClear();
+
+		assert.deepEqual(session.getSteeringMessages(), ["before steer", "new steer"]);
+		assert.deepEqual(session.getFollowUpMessages(), ["before follow-up", "new follow-up"]);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test("clearQueue restores both snapshots when the remote clear fails before any engine update", async () => {
+	const harness = await createHarness();
+	try {
+		const probe = createClearQueueClient();
+		const runtime = await createRuntime(harness, probe.client);
+		const session = runtime.session;
+		probe.emit({ type: "queue_update", steering: ["before steer"], followUp: ["before follow-up"] });
+
+		const returned = session.clearQueue();
+		assert.deepEqual(returned, { steering: ["before steer"], followUp: ["before follow-up"] });
+		assert.deepEqual(session.getSteeringMessages(), []);
+		assert.deepEqual(session.getFollowUpMessages(), []);
+
+		probe.reject(new Error("engine unavailable"));
+		await settleRejectedClear();
+
+		assert.deepEqual(session.getSteeringMessages(), ["before steer"]);
+		assert.deepEqual(session.getFollowUpMessages(), ["before follow-up"]);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test("clearQueue adopts disjoint authoritative engine queues after a failed remote clear", async () => {
+	const harness = await createHarness();
+	try {
+		const probe = createClearQueueClient();
+		const runtime = await createRuntime(harness, probe.client);
+		const session = runtime.session;
+		probe.emit({ type: "queue_update", steering: ["before steer"], followUp: ["before follow-up"] });
+
+		session.clearQueue();
 		probe.emit({ type: "queue_update", steering: ["admitted steer"], followUp: ["admitted follow-up"] });
 		probe.reject(new Error("engine unavailable"));
-		await Promise.resolve();
-		await Promise.resolve();
+		await settleRejectedClear();
 
-		assert.deepEqual(session.getSteeringMessages(), ["before steer", "admitted steer"]);
-		assert.deepEqual(session.getFollowUpMessages(), ["before follow-up", "admitted follow-up"]);
+		assert.deepEqual(session.getSteeringMessages(), ["admitted steer"]);
+		assert.deepEqual(session.getFollowUpMessages(), ["admitted follow-up"]);
 	} finally {
 		harness.cleanup();
 	}

--- a/test/unit/rpc-input-scheduler.test.ts
+++ b/test/unit/rpc-input-scheduler.test.ts
@@ -77,6 +77,58 @@ test("pause_queued_messages reaches a running prompt before abort", async () => 
 	await sleep(0);
 });
 
+test("clear_queue reaches a running prompt without waiting for it to finish", async () => {
+	const prompt = deferred();
+	const clearHandled = deferred();
+	const calls: string[] = [];
+	const dispatch = createRpcInputScheduler(async (line) => {
+		const type = (JSON.parse(line) as { type: string }).type;
+		calls.push(`${type}:start`);
+		if (type === "prompt") await prompt.promise;
+		if (type === "clear_queue") clearHandled.resolve();
+		calls.push(`${type}:end`);
+	});
+
+	dispatch('{"type":"prompt"}');
+	dispatch('{"type":"clear_queue"}');
+	await Promise.race([
+		clearHandled.promise,
+		sleep(50).then(() => {
+			throw new Error("clear_queue remained queued behind prompt");
+		}),
+	]);
+	assert.deepEqual(calls, ["prompt:start", "clear_queue:start", "clear_queue:end"]);
+
+	prompt.resolve();
+	await sleep(0);
+});
+
+test("resume_queued_messages reaches a running prompt without waiting for it to finish", async () => {
+	const prompt = deferred();
+	const resumeHandled = deferred();
+	const calls: string[] = [];
+	const dispatch = createRpcInputScheduler(async (line) => {
+		const type = (JSON.parse(line) as { type: string }).type;
+		calls.push(`${type}:start`);
+		if (type === "prompt") await prompt.promise;
+		if (type === "resume_queued_messages") resumeHandled.resolve();
+		calls.push(`${type}:end`);
+	});
+
+	dispatch('{"type":"prompt"}');
+	dispatch('{"type":"resume_queued_messages"}');
+	await Promise.race([
+		resumeHandled.promise,
+		sleep(50).then(() => {
+			throw new Error("resume_queued_messages remained queued behind prompt");
+		}),
+	]);
+	assert.deepEqual(calls, ["prompt:start", "resume_queued_messages:start", "resume_queued_messages:end"]);
+
+	prompt.resolve();
+	await sleep(0);
+});
+
 test("ordinary RPC commands remain ordered while a command is running", async () => {
 	const compact = deferred();
 	const calls: string[] = [];
@@ -116,9 +168,18 @@ test("host protocol responses bypass a running RPC command", async () => {
 });
 
 test("only validated cancellation and host-control frames bypass the ordinary lane", () => {
-	for (const type of ["abort", "abort_compaction", "abort_retry", "abort_bash", "pause_queued_messages"]) {
+	for (const type of [
+		"abort",
+		"abort_compaction",
+		"abort_retry",
+		"abort_bash",
+		"pause_queued_messages",
+		"resume_queued_messages",
+		"clear_queue",
+	]) {
 		assert.equal(isConcurrentRpcControlLine(JSON.stringify({ type })), true, type);
 	}
+
 	assert.equal(isConcurrentRpcControlLine('{"type":"extension_ui_response","id":"ui-1","cancelled":true}'), true);
 	assert.equal(
 		isConcurrentRpcControlLine('{"type":"engine_custom_input","componentId":"ui-1","requestId":1,"data":"escape"}'),


### PR DESCRIPTION
## Summary
Fixes queue-control handling for issue #2516 by routing control requests through the interrupt lane and preserving authoritative queue state when remote clearing fails.

## Changes

- Route RPC queue controls through the interrupt lane so they are admitted ahead of ordinary queued work.
- Restore the host queue only when a failed `clear_queue` leaves it empty.
- Avoid duplicating entries when a `queue_update` already supplied the engine's authoritative queue.
- Add focused scheduler and isolated-runtime regression coverage.
- Update the coding-agent changelog.

## Notes

Focused tests, the package test suite, and `npm run check` pass. The standard push hook also ran the full suites; unrelated pre-existing environment/base failures remain in semver pin, workflow scope-guard, and native release publisher contract tests.

Closes #2516

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789687747&installation_model_id=10562&pr_number=2519&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2519&signature=f9691a24c9e15a6956f123ffa279b4dc5bfb3121dfe93555e303534537915e13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Queue clearing now reconciles local state with engine state across authoritative updates, overlapping requests, and engine replacement. The previously reported stale-empty-update rollback was disproved: an empty authoritative update remains empty after the request fails. The previously reported timing-dependent overlapping rollback and lost-original-queue behaviors were disproved in both failure orders. The previously reported retired-engine rollback was also disproved: a request from the replaced engine cannot restore its old queue snapshot.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains in the queue-clear reconciliation behavior.

No accepted blocking findings remain. Focused runtime checks exercised authoritative empty updates, overlapping failures in both settlement orders, mixed success and failure, and rejection after engine replacement.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The runtime harness emitted an authoritative empty queue update after an optimistic clear and then rejected clear\_queue, leaving both steering and follow-up queues empty.
- Two overlapping clearQueue() calls with no later queue update were issued; in both oldest-first and newest-first orders, the queue stayed cleared until the final rejection and then restored the original messages, showing rollback behavior is independent of settlement order.
- The focused queue-clear recovery test completed with seven tests passing and demonstrated that replacement clears the pending rollback record so retired requests cannot restore old messages.
- A test of overlapping clear requests with no later update finished with empty host queues in both orders, confirming that one successful engine clear suppresses rollback of stale messages.
- The requested verification ran, but local artifact references were not uploaded.

<a href="https://app.greptile.com/trex/runs/19522213/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(rpc): invalidate clears from retired..."](https://github.com/bastani-inc/atomic/commit/8115519ca9221a56980a9111fb6285d1b8908844) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54573901)</sub>

<!-- /greptile_comment -->