### PR TITLE
fix/slash autosend package load

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Bare `/` and slash-command drafts typed while explicitly loaded extension and workflow packages finish loading now remain in the interactive editor until Enter is pressed.
+
 ## [0.9.14-alpha.4] - 2026-08-18
 
 ### Changed

--- a/packages/coding-agent/src/main-deferred-startup.ts
+++ b/packages/coding-agent/src/main-deferred-startup.ts
@@ -46,6 +46,10 @@ export interface ComputeStartupInputCaptureInput {
 export function computeStartupInputCaptureEnabled(input: ComputeStartupInputCaptureInput): boolean {
 	if (input.parsed.resume || input.parsed.session !== undefined) return false;
 	const hasTrustInputs = hasProjectTrustInputs(input.sessionCwd);
+	// Explicit extension and resource paths make startup slower without adding a
+	// pre-TUI stdin consumer, so their longer typing window makes capture more
+	// necessary. Ignore their counts here while computeDeferExtensions continues
+	// to use the real counts when deciding whether to defer the actual loading.
 	return (
 		input.deprecationWarningCount === 0 &&
 		computeDeferExtensions({
@@ -56,8 +60,8 @@ export function computeStartupInputCaptureEnabled(input: ComputeStartupInputCapt
 			listModels: input.parsed.listModels,
 			shouldResolveProjectTrust: input.parsed.projectTrustOverride === undefined && hasTrustInputs,
 			storedProjectTrust: hasTrustInputs ? input.projectTrustStore.get(input.sessionCwd) : null,
-			resolvedExtensionPathCount: input.resolvedExtensionPathCount,
-			resolvedResourcePathCount: input.resolvedResourcePathCount,
+			resolvedExtensionPathCount: 0,
+			resolvedResourcePathCount: 0,
 			hasSystemPromptInput:
 				input.parsed.systemPrompt !== undefined || (input.parsed.appendSystemPrompt?.length ?? 0) > 0,
 			unknownFlagCount: input.parsed.unknownFlags.size,

--- a/packages/coding-agent/test/fixtures/slash-autosend-extension-package/extension.ts
+++ b/packages/coding-agent/test/fixtures/slash-autosend-extension-package/extension.ts
@@ -1,0 +1,8 @@
+import type { ExtensionAPI } from "../../../src/core/extensions/types.ts";
+
+export default function slashAutosendFixtureExtension(pi: ExtensionAPI): void {
+	pi.registerCommand("foo", {
+		description: "Harmless slash auto-send regression fixture command",
+		handler: async () => {},
+	});
+}

--- a/packages/coding-agent/test/fixtures/slash-autosend-extension-package/extension.ts
+++ b/packages/coding-agent/test/fixtures/slash-autosend-extension-package/extension.ts
@@ -3,6 +3,8 @@ import type { ExtensionAPI } from "../../../src/core/extensions/types.ts";
 export default function slashAutosendFixtureExtension(pi: ExtensionAPI): void {
 	pi.registerCommand("foo", {
 		description: "Harmless slash auto-send regression fixture command",
-		handler: async () => {},
+		handler: async (_args, ctx) => {
+			ctx.ui.notify("Slash auto-send fixture command ran");
+		},
 	});
 }

--- a/packages/coding-agent/test/fixtures/slash-autosend-extension-package/package.json
+++ b/packages/coding-agent/test/fixtures/slash-autosend-extension-package/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "atomic-test-slash-autosend-extension",
+  "private": true,
+  "type": "module",
+  "atomic": {
+    "extensions": [
+      "./extension.ts"
+    ]
+  }
+}

--- a/packages/coding-agent/test/fixtures/slash-autosend-workflow-package/noop-workflow.ts
+++ b/packages/coding-agent/test/fixtures/slash-autosend-workflow-package/noop-workflow.ts
@@ -1,0 +1,9 @@
+import { workflow } from "@bastani/workflows";
+
+export default workflow({
+	name: "slash-autosend-noop",
+	description: "No-op workflow for slash auto-send regression coverage.",
+	inputs: {},
+	outputs: {},
+	run: async () => ({}),
+});

--- a/packages/coding-agent/test/fixtures/slash-autosend-workflow-package/package.json
+++ b/packages/coding-agent/test/fixtures/slash-autosend-workflow-package/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "atomic-test-slash-autosend-workflow",
+  "private": true,
+  "type": "module",
+  "atomic": {
+    "workflows": [
+      "./noop-workflow.ts"
+    ]
+  }
+}

--- a/packages/coding-agent/test/interactive-slash-draft-package-load.test.ts
+++ b/packages/coding-agent/test/interactive-slash-draft-package-load.test.ts
@@ -1,0 +1,305 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AutocompleteProvider } from "@earendil-works/pi-tui";
+import { Container } from "@earendil-works/pi-tui";
+import { afterAll, describe, test, vi } from "vitest";
+import type { AgentSessionRuntime } from "../src/core/agent-session-runtime.ts";
+import { createSyntheticSourceInfo } from "../src/core/source-info.ts";
+import { computeStartupInputCaptureEnabled } from "../src/main-deferred-startup.ts";
+import type { EarlyInputCapture } from "../src/main-early-input.ts";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+import type { InteractiveSubmission } from "../src/modes/interactive/interactive-submission.ts";
+import { onInteractiveEngineRemoteCommandsChanged } from "../src/modes/interactive-engine/extension-ui-bridge.ts";
+import { IsolatedInteractiveRuntime } from "../src/modes/interactive-engine/isolated-runtime.ts";
+import { RemoteCommandCatalog } from "../src/modes/interactive-engine/remote-command-catalog.ts";
+import type { RpcClient } from "../src/modes/rpc/rpc-client.ts";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const extensionPackagePath = join(testDir, "fixtures", "slash-autosend-extension-package");
+const workflowPackagePath = join(testDir, "fixtures", "slash-autosend-workflow-package");
+const fixturePackagePaths = [extensionPackagePath, workflowPackagePath] as const;
+const startupCaptureCwd = mkdtempSync(join(tmpdir(), "atomic-slash-autosend-capture-"));
+
+afterAll(() => {
+	rmSync(startupCaptureCwd, { recursive: true, force: true });
+});
+
+interface DraftEditor {
+	getText(): string;
+	setText(text: string): void;
+	setAutocompleteProvider(provider: AutocompleteProvider): void;
+}
+
+interface DraftProbeContext {
+	startupCookedInputRecovered: boolean;
+	pendingUserInputs: InteractiveSubmission[];
+	startupReplayInputs: string[];
+	startupReplayActiveInput?: string;
+	startupDraftText?: string;
+	inputHandlerReadyRecorded: boolean;
+	onInputCallback?: (submission: InteractiveSubmission) => void;
+	options: { startupInputCapture?: EarlyInputCapture; deferredModelScopePatterns?: string[] };
+	defaultEditor: DraftEditor & { onSubmit?: (text: string) => void | Promise<void> };
+	editor: DraftEditor;
+	ui: { requestRender(): void };
+	autocompleteProviderWrappers: Array<(provider: AutocompleteProvider) => AutocompleteProvider>;
+	autocompleteProvider?: AutocompleteProvider;
+	createBaseAutocompleteProvider(): AutocompleteProvider;
+	advanceStartupInputReplay(submittedText: string): void;
+	recoverCookedStartupInput(): boolean;
+	drainStartupReplayCommands(): Promise<void>;
+}
+
+interface DraftProbe {
+	context: DraftProbeContext;
+	inputPromise: Promise<InteractiveSubmission>;
+	userMessages: string[];
+	slashCommandExecutions: string[];
+	providerInstallations: number;
+}
+
+const interactivePrototype = InteractiveMode.prototype as unknown as {
+	getUserInput(this: DraftProbeContext): Promise<InteractiveSubmission>;
+	advanceStartupInputReplay(this: DraftProbeContext, submittedText: string): void;
+	recoverCookedStartupInput(this: DraftProbeContext): boolean;
+	drainStartupReplayCommands(this: DraftProbeContext): Promise<void>;
+	setupAutocompleteProvider(this: DraftProbeContext): void;
+	completeDeferredStartup(this: DeferredStartupProbeContext): Promise<void>;
+};
+
+const baseProvider: AutocompleteProvider = {
+	async getSuggestions() {
+		return null;
+	},
+	applyCompletion(lines, cursorLine, cursorCol) {
+		return { lines, cursorLine, cursorCol };
+	},
+};
+
+function fixturePackageCapture(projectTrustOverride: true | undefined): EarlyInputCapture | undefined {
+	const enabled = computeStartupInputCaptureEnabled({
+		appMode: "interactive",
+		stdinIsTTY: true,
+		parsed: {
+			help: false,
+			listModels: undefined,
+			projectTrustOverride,
+			systemPrompt: undefined,
+			appendSystemPrompt: [],
+			unknownFlags: new Map(),
+			provider: undefined,
+			model: undefined,
+			resume: false,
+			session: undefined,
+		},
+		sessionCwd: startupCaptureCwd,
+		projectTrustStore: { get: () => null },
+		resolvedExtensionPathCount: fixturePackagePaths.length,
+		resolvedResourcePathCount: 0,
+		deprecationWarningCount: 0,
+	});
+	return enabled ? { consume: () => ({ text: "", submissions: [] }) } : undefined;
+}
+
+function createDraftProbe(draft: string, projectTrustOverride: true | undefined): DraftProbe {
+	let text = draft;
+	let providerInstallations = 0;
+	const editor: DraftProbeContext["defaultEditor"] = {
+		getText: () => text,
+		setText: (next) => {
+			text = next;
+		},
+		setAutocompleteProvider: () => {
+			providerInstallations += 1;
+		},
+	};
+	const userMessages: string[] = [];
+	const slashCommandExecutions: string[] = [];
+	const context: DraftProbeContext = {
+		startupCookedInputRecovered: false,
+		pendingUserInputs: [],
+		startupReplayInputs: [],
+		inputHandlerReadyRecorded: true,
+		options: { startupInputCapture: fixturePackageCapture(projectTrustOverride) },
+		defaultEditor: editor,
+		editor,
+		ui: { requestRender: vi.fn() },
+		autocompleteProviderWrappers: [],
+		createBaseAutocompleteProvider: () => baseProvider,
+		advanceStartupInputReplay: interactivePrototype.advanceStartupInputReplay,
+		recoverCookedStartupInput: interactivePrototype.recoverCookedStartupInput,
+		drainStartupReplayCommands: interactivePrototype.drainStartupReplayCommands,
+	};
+	editor.onSubmit = async (submittedText) => {
+		if (submittedText === "/foo") slashCommandExecutions.push(submittedText);
+		else userMessages.push(submittedText);
+		context.advanceStartupInputReplay(submittedText);
+	};
+	return {
+		context,
+		inputPromise: interactivePrototype.getUserInput.call(context),
+		userMessages,
+		slashCommandExecutions,
+		get providerInstallations() {
+			return providerInstallations;
+		},
+	};
+}
+
+async function settleStartupRecovery(): Promise<void> {
+	for (let attempt = 0; attempt < 12; attempt += 1) {
+		await new Promise<void>((resolve) => setImmediate(resolve));
+	}
+}
+
+async function observeDraftAfterEvent(
+	draft: string,
+	projectTrustOverride: true | undefined,
+	event: (probe: DraftProbe) => Promise<void> | void,
+): Promise<{
+	editorText: string;
+	userMessages: string[];
+	slashCommandExecutions: string[];
+}> {
+	const probe = createDraftProbe(draft, projectTrustOverride);
+	await event(probe);
+	await settleStartupRecovery();
+	const observed = {
+		editorText: probe.context.editor.getText(),
+		userMessages: [...probe.userMessages],
+		slashCommandExecutions: [...probe.slashCommandExecutions],
+	};
+	probe.context.onInputCallback?.({ text: "cleanup", draft: "cleanup" });
+	await probe.inputPromise;
+	return observed;
+}
+
+interface DeferredStartupProbeContext extends DraftProbeContext {
+	deferredStartupPending: boolean;
+	promptTurnWorkingLoaderActive: boolean;
+	bindCurrentSessionExtensions(): Promise<void>;
+	session: {
+		reload(options: { reason: "startup" }): Promise<void>;
+		resourceLoader: { getThemes(): { themes: [] } };
+		extensionRunner: object;
+		modelRuntime: { getError(): undefined };
+	};
+	rebuildChatFromMessages(): void;
+	stopWorkingLoader(): void;
+	themeController: { applyFromSettings(): Promise<void> };
+	setupAutocompleteProvider(): void;
+	setupExtensionShortcuts(runner: object): void;
+	retryDeferredModelRestore(container: object): Promise<void>;
+	showLoadedResources(options: object): void;
+	maybeWarnAboutAnthropicSubscriptionAuth(model?: undefined, container?: object): Promise<void>;
+	showStartupNoticesIfNeeded(container: object): void;
+	updateAvailableProviderCount(): Promise<void>;
+	updateEditorBorderColor(): void;
+	showError(message: string): void;
+	startupNoticesContainer: object;
+	resourceDisclosureContainer: object;
+	chatContainer: Container;
+}
+
+function asDeferredStartupContext(probe: DraftProbe): DeferredStartupProbeContext {
+	return Object.assign(probe.context, {
+		deferredStartupPending: true,
+		promptTurnWorkingLoaderActive: false,
+		bindCurrentSessionExtensions: vi.fn(async () => {}),
+		session: {
+			reload: vi.fn(async () => {}),
+			resourceLoader: { getThemes: () => ({ themes: [] as [] }) },
+			extensionRunner: {},
+			modelRuntime: { getError: () => undefined },
+		},
+		rebuildChatFromMessages: vi.fn(),
+		stopWorkingLoader: vi.fn(),
+		themeController: { applyFromSettings: vi.fn(async () => {}) },
+		setupAutocompleteProvider: vi.fn(),
+		setupExtensionShortcuts: vi.fn(),
+		retryDeferredModelRestore: vi.fn(async () => {}),
+		showLoadedResources: vi.fn(),
+		maybeWarnAboutAnthropicSubscriptionAuth: vi.fn(async () => {}),
+		showStartupNoticesIfNeeded: vi.fn(),
+		updateAvailableProviderCount: vi.fn(async () => {}),
+		updateEditorBorderColor: vi.fn(),
+		showError: vi.fn(),
+		startupNoticesContainer: {},
+		resourceDisclosureContainer: {},
+		chatContainer: new Container(),
+	});
+}
+
+function assertDraftWasNotSent(
+	draft: string,
+	observed: { editorText: string; userMessages: string[]; slashCommandExecutions: string[] },
+): void {
+	assert.deepEqual(observed, {
+		editorText: draft,
+		userMessages: [],
+		slashCommandExecutions: [],
+	});
+}
+
+describe("interactive slash drafts while package commands become available", () => {
+	for (const { approval, projectTrustOverride } of [
+		{ approval: "with --approve", projectTrustOverride: true },
+		{ approval: "without --approve", projectTrustOverride: undefined },
+	] as const) {
+		describe(approval, () => {
+			for (const draft of ["/", "/foo"]) {
+				test(`keeps ${JSON.stringify(draft)} unsent when package and workflow loading finishes`, async () => {
+					const observed = await observeDraftAfterEvent(draft, projectTrustOverride, async (probe) => {
+						const context = asDeferredStartupContext(probe);
+						await interactivePrototype.completeDeferredStartup.call(context);
+						assert.equal(context.deferredStartupPending, false);
+					});
+					assertDraftWasNotSent(draft, observed);
+				});
+
+				test(`keeps ${JSON.stringify(draft)} unsent when the remote command catalog arrives`, async () => {
+					const observed = await observeDraftAfterEvent(draft, projectTrustOverride, async (probe) => {
+						const catalog = new RemoteCommandCatalog({
+							getCommands: async () => [
+								{
+									name: "foo",
+									description: "Fixture command",
+									source: "extension",
+									sourceInfo: createSyntheticSourceInfo(join(extensionPackagePath, "extension.ts"), {
+										source: extensionPackagePath,
+									}),
+								},
+							],
+						} as unknown as RpcClient);
+						const runtime = Object.create(IsolatedInteractiveRuntime.prototype) as IsolatedInteractiveRuntime;
+						Object.defineProperty(runtime, "onRemoteCommandsChanged", {
+							value: catalog.onChange.bind(catalog),
+						});
+						let catalogEvents = 0;
+						const unsubscribe = onInteractiveEngineRemoteCommandsChanged(runtime as AgentSessionRuntime, () => {
+							catalogEvents += 1;
+							interactivePrototype.setupAutocompleteProvider.call(probe.context);
+						});
+						catalog.refresh();
+						await new Promise<void>((resolve) => setImmediate(resolve));
+						unsubscribe();
+						assert.equal(catalogEvents, 1);
+						assert.equal(probe.providerInstallations, 1);
+					});
+					assertDraftWasNotSent(draft, observed);
+				});
+
+				test(`keeps ${JSON.stringify(draft)} unsent when autocomplete is rebuilt`, async () => {
+					const observed = await observeDraftAfterEvent(draft, projectTrustOverride, (probe) => {
+						interactivePrototype.setupAutocompleteProvider.call(probe.context);
+						assert.equal(probe.providerInstallations, 1);
+					});
+					assertDraftWasNotSent(draft, observed);
+				});
+			}
+		});
+	}
+});

--- a/packages/coding-agent/test/main-deferred-startup.test.ts
+++ b/packages/coding-agent/test/main-deferred-startup.test.ts
@@ -112,6 +112,48 @@ describe("computeStartupInputCaptureEnabled", () => {
 		}
 	});
 
+	it.each([
+		{
+			resource: "extension",
+			approval: "with --approve",
+			projectTrustOverride: true,
+			resolvedExtensionPathCount: 1,
+			resolvedResourcePathCount: 0,
+		},
+		{
+			resource: "extension",
+			approval: "without --approve",
+			projectTrustOverride: undefined,
+			resolvedExtensionPathCount: 1,
+			resolvedResourcePathCount: 0,
+		},
+		{
+			resource: "resource",
+			approval: "with --approve",
+			projectTrustOverride: true,
+			resolvedExtensionPathCount: 0,
+			resolvedResourcePathCount: 1,
+		},
+		{
+			resource: "resource",
+			approval: "without --approve",
+			projectTrustOverride: undefined,
+			resolvedExtensionPathCount: 0,
+			resolvedResourcePathCount: 1,
+		},
+	])("captures startup input with explicit $resource paths $approval", (testCase) => {
+		const input = baseStartupCaptureInput({
+			resolvedExtensionPathCount: testCase.resolvedExtensionPathCount,
+			resolvedResourcePathCount: testCase.resolvedResourcePathCount,
+		});
+		input.parsed.projectTrustOverride = testCase.projectTrustOverride;
+		try {
+			expect(computeStartupInputCaptureEnabled(input)).toBe(true);
+		} finally {
+			removeTempDir(input.sessionCwd);
+		}
+	});
+
 	it("does not start pre-session input capture for resume picker startup", () => {
 		const input = baseStartupCaptureInput();
 		input.parsed.resume = true;

--- a/test/unit/interactive-mode-startup-input.test.ts
+++ b/test/unit/interactive-mode-startup-input.test.ts
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AutocompleteProvider } from "@earendil-works/pi-tui";
+import { afterAll, describe, test } from "vitest";
+import { computeStartupInputCaptureEnabled } from "../../packages/coding-agent/src/main-deferred-startup.js";
+import type { EarlyInputCapture } from "../../packages/coding-agent/src/main-early-input.js";
+import { InteractiveMode } from "../../packages/coding-agent/src/modes/interactive/interactive-mode.js";
+import { seedStartupInput } from "../../packages/coding-agent/src/modes/interactive/interactive-mode-base.js";
+import type { InteractiveSubmission } from "../../packages/coding-agent/src/modes/interactive/interactive-submission.js";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const explicitPackagePaths = [
+	join(testDir, "../../packages/coding-agent/test/fixtures/slash-autosend-extension-package"),
+	join(testDir, "../../packages/coding-agent/test/fixtures/slash-autosend-workflow-package"),
+];
+const startupCwd = mkdtempSync(join(tmpdir(), "atomic-explicit-package-startup-"));
+
+afterAll(() => {
+	rmSync(startupCwd, { recursive: true, force: true });
+});
+
+interface DraftEditor {
+	onSubmit?: (text: string) => void | Promise<void>;
+	getText(): string;
+	setText(text: string): void;
+	setAutocompleteProvider(provider: AutocompleteProvider): void;
+}
+
+interface StartupInputContext {
+	startupCookedInputRecovered: boolean;
+	pendingUserInputs: InteractiveSubmission[];
+	startupReplayInputs: string[];
+	startupReplayActiveInput?: string;
+	startupDraftText?: string;
+	options: { startupInputCapture?: EarlyInputCapture };
+	defaultEditor: DraftEditor;
+	editor: DraftEditor;
+	ui: { requestRender(): void };
+	autocompleteProviderWrappers: Array<(provider: AutocompleteProvider) => AutocompleteProvider>;
+	autocompleteProvider?: AutocompleteProvider;
+	createBaseAutocompleteProvider(): AutocompleteProvider;
+	deliverStartupReplayPrompt(text: string): void;
+}
+
+const interactivePrototype = InteractiveMode.prototype as unknown as {
+	setupAutocompleteProvider(this: StartupInputContext): void;
+	recoverCookedStartupInput(this: StartupInputContext): boolean;
+	drainStartupReplayCommands(this: StartupInputContext): Promise<void>;
+	advanceStartupInputReplay(this: StartupInputContext, submittedText: string): void;
+};
+
+const baseProvider: AutocompleteProvider = {
+	async getSuggestions() {
+		return null;
+	},
+	applyCompletion(lines, cursorLine, cursorCol) {
+		return { lines, cursorLine, cursorCol };
+	},
+};
+
+function startupCaptureEnabledForExplicitPackages(): boolean {
+	return computeStartupInputCaptureEnabled({
+		appMode: "interactive",
+		stdinIsTTY: true,
+		parsed: {
+			help: false,
+			listModels: undefined,
+			projectTrustOverride: true,
+			systemPrompt: undefined,
+			appendSystemPrompt: [],
+			unknownFlags: new Map(),
+			provider: undefined,
+			model: undefined,
+			resume: false,
+			session: undefined,
+		},
+		sessionCwd: startupCwd,
+		projectTrustStore: { get: () => null },
+		resolvedExtensionPathCount: explicitPackagePaths.length,
+		resolvedResourcePathCount: 0,
+		deprecationWarningCount: 0,
+	});
+}
+
+function createStartupContext(
+	draft: string,
+	capture: EarlyInputCapture | undefined,
+): {
+	context: StartupInputContext;
+	providerInstallations: string[];
+	submitted: string[];
+} {
+	let editorText = "";
+	const providerInstallations: string[] = [];
+	const submitted: string[] = [];
+	const editor: DraftEditor = {
+		getText: () => editorText,
+		setText: (text) => {
+			editorText = text;
+		},
+		setAutocompleteProvider: () => {
+			providerInstallations.push(editorText);
+		},
+	};
+	const context: StartupInputContext = {
+		startupCookedInputRecovered: false,
+		pendingUserInputs: [],
+		startupReplayInputs: [],
+		options: { startupInputCapture: capture },
+		defaultEditor: editor,
+		editor,
+		ui: { requestRender: () => {} },
+		autocompleteProviderWrappers: [],
+		createBaseAutocompleteProvider: () => baseProvider,
+		deliverStartupReplayPrompt: (text) => {
+			context.pendingUserInputs.push({ text, draft: text });
+		},
+	};
+	editor.onSubmit = async (text) => {
+		submitted.push(text);
+		interactivePrototype.advanceStartupInputReplay.call(context, text);
+	};
+
+	if (capture) {
+		seedStartupInput(context.pendingUserInputs, editor, capture.consume());
+	} else {
+		// Without raw capture, terminal-cooked bytes eventually appear in the editor.
+		editor.setText(draft);
+	}
+	return { context, providerInstallations, submitted };
+}
+
+describe("interactive startup input with explicit packages", () => {
+	for (const draft of ["/", "/foo"]) {
+		test(`keeps ${JSON.stringify(draft)} as a draft when extension and workflow package loading finishes`, async () => {
+			const captureEnabled = startupCaptureEnabledForExplicitPackages();
+			assert.equal(captureEnabled, true, "explicit -e packages must keep raw startup input capture enabled");
+			const capture = captureEnabled ? { consume: () => ({ text: draft, submissions: [] }) } : undefined;
+			const { context, providerInstallations, submitted } = createStartupContext(draft, capture);
+
+			// Package completion publishes the new command catalog and rebuilds autocomplete.
+			interactivePrototype.setupAutocompleteProvider.call(context);
+			assert.equal(interactivePrototype.recoverCookedStartupInput.call(context), false);
+			await interactivePrototype.drainStartupReplayCommands.call(context);
+
+			assert.deepEqual(providerInstallations, [draft]);
+			assert.equal(context.editor.getText(), draft);
+			assert.deepEqual(submitted, []);
+			assert.deepEqual(context.pendingUserInputs, []);
+		});
+	}
+
+	test("auto-runs only Enter-terminated command-like startup input and restores the unfinished draft", async () => {
+		const draft = "/foo";
+		const capture: EarlyInputCapture = {
+			consume: () => ({ text: draft, submissions: ["/settings", "!pwd"] }),
+		};
+		const { context, submitted } = createStartupContext(draft, undefined);
+		seedStartupInput(
+			context.pendingUserInputs,
+			context.editor,
+			capture.consume(),
+			context.startupReplayInputs,
+			(text) => {
+				context.startupDraftText = text;
+			},
+			(text) => {
+				context.startupReplayActiveInput = text;
+			},
+		);
+
+		await interactivePrototype.drainStartupReplayCommands.call(context);
+
+		assert.deepEqual(submitted, ["/settings", "!pwd"]);
+		assert.equal(context.editor.getText(), draft);
+		assert.equal(context.startupReplayActiveInput, undefined);
+		assert.deepEqual(context.startupReplayInputs, []);
+		assert.deepEqual(context.pendingUserInputs, []);
+	});
+});


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789706329&installation_model_id=10562&pr_number=2525&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2525&signature=371c06db5cf7f53d572a14f34a1cc26e1198c0caf5d4954b18119d9e5fef86e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change keeps unfinished slash drafts in the editor while explicit extension and workflow packages load, and lets queue-control requests reach a running prompt. The examined queue-state concern was disproved: overlapping failed clear requests did not overwrite a later authoritative queue update in either completion order, and the focused queue-clear and RPC scheduler suites passed.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the focused checks of the changed interactive startup and queue-control behavior.

No publishable defects remain. Execution covered two overlapping clear requests, a later authoritative queue update, and both rejection orders; the authoritative steering and follow-up queues were retained in each case.

**Files Needing Attention:** No additional files need attention. The focused verification covered packages/coding-agent/src/modes/interactive-engine/isolated-runtime.ts and packages/coding-agent/src/modes/rpc/rpc-input-scheduler.ts.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused reproduction against the parent implementation with two overlapping queue-clear requests, a later authoritative queue update, and both oldest-first and newest-first rejected clear responses.
- Ran the same reproduction against the changed implementation together with the focused queue-clear and RPC scheduler suites.
- The later authoritative steering and follow-up queues remained intact in both response orders, and all 20 focused tests passed.
- Before: the parent implementation reproduction passed 2/2, preserving 'later' and 'later follow-up' after both rejection orders; After: the changed implementation plus focused suites passed 20/20.

<a href="https://app.greptile.com/trex/runs/19570161/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/bastani-inc/atomic/commit/f1d1336876f322199e2a7154282eb7adfc3b4293) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54692683)</sub>

<!-- /greptile_comment -->