### PR TITLE
fix/startup ctrl c quiet exit

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Interactive startup now exits quietly when Ctrl+C stops the engine during first-paint binding, without leaking expected in-flight RPC transport failures.
+
 ## [0.9.14-alpha.4] - 2026-08-18
 
 ### Changed

--- a/packages/coding-agent/src/modes/interactive-engine/isolated-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive-engine/isolated-runtime.ts
@@ -6,6 +6,7 @@ import type { ResourceOverlap } from "../../core/diagnostics.ts";
 import { SessionManager } from "../../core/session-manager.ts";
 import type { JsonAgentSessionEvent } from "../json-event.ts";
 import type { RpcClient } from "../rpc/rpc-client.ts";
+import { isRpcTransportFailure } from "../rpc/rpc-transport-error.ts";
 import type {
 	RpcAutocompleteItem,
 	RpcEvent,
@@ -46,6 +47,8 @@ export class IsolatedInteractiveRuntime extends AgentSessionRuntime {
 	private remoteSessionFile: string | undefined;
 	private readonly health: EngineHealthController;
 	private readonly remoteCommands: RemoteCommandCatalog;
+	private disposed = false;
+	private disposePromise: Promise<void> | undefined;
 	private readonly remoteModelCatalog: RemoteModelCatalog;
 	private resourceOverlaps: ResourceOverlap[] = [];
 
@@ -86,34 +89,40 @@ export class IsolatedInteractiveRuntime extends AgentSessionRuntime {
 		return session;
 	}
 	async initializeFromEngine(): Promise<void> {
-		const state = await this.client.getState();
-		const catalog = await this.client.requestInternal<RpcModelCatalog>({ type: "get_available_models" });
-		if (state.sessionFile && super.session.sessionManager.getSessionFile() !== state.sessionFile) {
-			await super.switchSession(state.sessionFile);
+		if (this.disposed) return;
+		try {
+			const state = await this.client.getState();
+			const catalog = await this.client.requestInternal<RpcModelCatalog>({ type: "get_available_models" });
+			if (state.sessionFile && super.session.sessionManager.getSessionFile() !== state.sessionFile) {
+				await super.switchSession(state.sessionFile);
+			}
+			const session = super.session;
+			this.remoteModelCatalog.apply(catalog);
+			this.remoteModelCatalog.patch(session);
+			(session.agent.state as { model?: Model<Api> }).model = state.model;
+			session.agent.state.thinkingLevel = state.thinkingLevel;
+			session.agent.steeringMode = state.steeringMode;
+			session.agent.followUpMode = state.followUpMode;
+			this.autoCompactionEnabled = state.autoCompactionEnabled;
+			this.resourceOverlaps = state.resourceOverlaps ?? [];
+			this.remoteSessionName = state.sessionName;
+			this.remoteSessionFile = state.sessionFile;
+			this.streaming = state.isStreaming;
+			this.compacting = state.isCompacting;
+			this.compactionReason = state.isCompacting ? state.compactionReason : undefined;
+			this.queuePause.synchronize(state.queuedMessagesPaused === true);
+			this.replaceModelFallback(state.modelFallbackMessage, state.modelFallbackReason);
+			this.refreshSessionView();
+			this.engineCallbackActive = false;
+			this.health.clearUnresponsive();
+			this.health.markCooperativeAbortSettled();
+			// Non-blocking refresh so isolated autocomplete lists engine-only extension
+			// commands after bind/restart/reload/new/resume/fork. See RemoteCommandCatalog.
+			this.remoteCommands.refresh();
+		} catch (error) {
+			if (this.disposed && isRpcTransportFailure(error)) return;
+			throw error;
 		}
-		const session = super.session;
-		this.remoteModelCatalog.apply(catalog);
-		this.remoteModelCatalog.patch(session);
-		(session.agent.state as { model?: Model<Api> }).model = state.model;
-		session.agent.state.thinkingLevel = state.thinkingLevel;
-		session.agent.steeringMode = state.steeringMode;
-		session.agent.followUpMode = state.followUpMode;
-		this.autoCompactionEnabled = state.autoCompactionEnabled;
-		this.resourceOverlaps = state.resourceOverlaps ?? [];
-		this.remoteSessionName = state.sessionName;
-		this.remoteSessionFile = state.sessionFile;
-		this.streaming = state.isStreaming;
-		this.compacting = state.isCompacting;
-		this.compactionReason = state.isCompacting ? state.compactionReason : undefined;
-		this.queuePause.synchronize(state.queuedMessagesPaused === true);
-		this.replaceModelFallback(state.modelFallbackMessage, state.modelFallbackReason);
-		this.refreshSessionView();
-		this.engineCallbackActive = false;
-		this.health.clearUnresponsive();
-		this.health.markCooperativeAbortSettled();
-		// Non-blocking refresh so isolated autocomplete lists engine-only extension
-		// commands after bind/restart/reload/new/resume/fork. See RemoteCommandCatalog.
-		this.remoteCommands.refresh();
 	}
 
 	override async loginOAuthProvider(provider: string, callbacks: AtomicOAuthLoginCallbacks) {
@@ -158,8 +167,13 @@ export class IsolatedInteractiveRuntime extends AgentSessionRuntime {
 		await this.client.requestInternal<void>({ type: "invoke_shortcut", key });
 	}
 
-	waitUntilBound(): Promise<void> {
-		return this.client.waitForInteractiveEngineBound();
+	async waitUntilBound(): Promise<void> {
+		try {
+			await this.client.waitForInteractiveEngineBound();
+		} catch (error) {
+			if (this.disposed && isRpcTransportFailure(error)) return;
+			throw error;
+		}
 	}
 	getEnginePid(): number | undefined {
 		return this.client.getEnginePid();
@@ -296,12 +310,15 @@ export class IsolatedInteractiveRuntime extends AgentSessionRuntime {
 	 */
 	protected override async settleActiveResponseBeforeTeardown(): Promise<void> {}
 
-	override async dispose(): Promise<void> {
-		// Joins any in-flight replacement: shutdown voids the client's restart
-		// permit and waits for the attempt, so nothing spawns after this returns.
-		await this.health.shutdown();
-		await this.client.stop();
-		await super.dispose();
+	override dispose(): Promise<void> {
+		if (this.disposePromise) return this.disposePromise;
+		this.disposed = true;
+		this.disposePromise = (async () => {
+			// EngineHealthController owns the one client stop and joins recovery.
+			await this.health.shutdown();
+			await super.dispose();
+		})();
+		return this.disposePromise;
 	}
 
 	private patchSession(session: AgentSession): void {

--- a/packages/coding-agent/src/modes/interactive-engine/isolated-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive-engine/isolated-runtime.ts
@@ -314,8 +314,11 @@ export class IsolatedInteractiveRuntime extends AgentSessionRuntime {
 		if (this.disposePromise) return this.disposePromise;
 		this.disposed = true;
 		this.disposePromise = (async () => {
-			// EngineHealthController owns the one client stop and joins recovery.
+			// EngineHealthController owns the first client stop and joins recovery.
 			await this.health.shutdown();
+			// A replacement may have spawned while shutdown joined recovery; the
+			// idempotent trailing stop closes that child before disposal returns.
+			await this.client.stop();
 			await super.dispose();
 		})();
 		return this.disposePromise;

--- a/packages/coding-agent/src/modes/interactive/interactive-startup.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-startup.ts
@@ -231,6 +231,7 @@ InteractiveModeBase.prototype.init = async function (this: InteractiveModeBase):
 	// Start UI before extension/session work; fd/rg readiness and git watching move after first paint.
 	this.ui.start();
 	await waitForInteractiveEngineBound(this.runtimeHost);
+	if (this.isShuttingDown) return;
 	recordTimeSinceReset("time-to-first-frame");
 	this.footerDataProvider.onBranchChange(() => {
 		this.ui.requestRender();
@@ -297,6 +298,7 @@ InteractiveModeBase.prototype.updateTerminalTitle = function (this: InteractiveM
 
 InteractiveModeBase.prototype.run = async function (this: InteractiveModeBase): Promise<void> {
 	await this.init();
+	if (this.isShuttingDown) return;
 
 	if (shouldRefreshCatalogsOnStartup()) void refreshCatalogsAfterTuiStartup(this);
 

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -84,6 +84,9 @@ export class RpcClient extends RpcClientApi {
 	private readonly pendingRequests = new RpcPendingRequests();
 	/** Bumped by every explicit stop; a restart holds a permit across its own stop. */
 	private restartRevision = 0;
+	private stopPromise: Promise<void> | undefined;
+	/** Keeps the explicit-stop fence armed while restart has no child between generations. */
+	private restartInFlight = 0;
 	private readonly terminalDrain = new RpcTerminalDrain();
 	private stdoutDrained: Promise<void> = Promise.resolve();
 	private requestId = 0;
@@ -112,6 +115,7 @@ export class RpcClient extends RpcClientApi {
 	}
 
 	async start(): Promise<void> {
+		if (this.stopPromise) await this.stopPromise;
 		if (this.process) {
 			throw new Error("Client already started");
 		}
@@ -189,9 +193,16 @@ export class RpcClient extends RpcClientApi {
 	 * Explicit stop. Voids any in-flight restart permit, so a replacement caught
 	 * between its own stop and start can never spawn after this returns.
 	 */
-	async stop(): Promise<void> {
+	stop(): Promise<void> {
+		if (this.stopPromise) return this.stopPromise;
+		if (!this.process && this.restartInFlight === 0) return Promise.resolve();
 		this.restartRevision += 1;
-		await this.stopCurrentGeneration();
+		if (!this.process) return Promise.resolve();
+		const stopPromise = this.stopCurrentGeneration().finally(() => {
+			if (this.stopPromise === stopPromise) this.stopPromise = undefined;
+		});
+		this.stopPromise = stopPromise;
+		return stopPromise;
 	}
 
 	/**
@@ -328,12 +339,17 @@ export class RpcClient extends RpcClientApi {
 	 * quietly, because callers go on to initialize against the new child.
 	 */
 	async restart(sessionFile: string | undefined): Promise<void> {
-		const permit = this.restartRevision;
-		await this.stopCurrentGeneration();
-		if (permit !== this.restartRevision) throw rpcTransportError(RESTART_CANCELLED_MESSAGE);
-		this.options = { ...this.options, args: restartCliArgs(this.options.args, sessionFile) };
-		await this.start();
-		await this.waitForInteractiveEngineBound();
+		this.restartInFlight += 1;
+		try {
+			const permit = this.restartRevision;
+			await this.stopCurrentGeneration();
+			if (permit !== this.restartRevision) throw rpcTransportError(RESTART_CANCELLED_MESSAGE);
+			this.options = { ...this.options, args: restartCliArgs(this.options.args, sessionFile) };
+			await this.start();
+			await this.waitForInteractiveEngineBound();
+		} finally {
+			this.restartInFlight -= 1;
+		}
 	}
 
 	async requestInternal<T>(command: RpcCommandBody): Promise<T> {

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -85,8 +85,6 @@ export class RpcClient extends RpcClientApi {
 	/** Bumped by every explicit stop; a restart holds a permit across its own stop. */
 	private restartRevision = 0;
 	private stopPromise: Promise<void> | undefined;
-	/** Keeps the explicit-stop fence armed while restart has no child between generations. */
-	private restartInFlight = 0;
 	private readonly terminalDrain = new RpcTerminalDrain();
 	private stdoutDrained: Promise<void> = Promise.resolve();
 	private requestId = 0;
@@ -194,9 +192,8 @@ export class RpcClient extends RpcClientApi {
 	 * between its own stop and start can never spawn after this returns.
 	 */
 	stop(): Promise<void> {
-		if (this.stopPromise) return this.stopPromise;
-		if (!this.process && this.restartInFlight === 0) return Promise.resolve();
 		this.restartRevision += 1;
+		if (this.stopPromise) return this.stopPromise;
 		if (!this.process) return Promise.resolve();
 		const stopPromise = this.stopCurrentGeneration().finally(() => {
 			if (this.stopPromise === stopPromise) this.stopPromise = undefined;
@@ -339,17 +336,12 @@ export class RpcClient extends RpcClientApi {
 	 * quietly, because callers go on to initialize against the new child.
 	 */
 	async restart(sessionFile: string | undefined): Promise<void> {
-		this.restartInFlight += 1;
-		try {
-			const permit = this.restartRevision;
-			await this.stopCurrentGeneration();
-			if (permit !== this.restartRevision) throw rpcTransportError(RESTART_CANCELLED_MESSAGE);
-			this.options = { ...this.options, args: restartCliArgs(this.options.args, sessionFile) };
-			await this.start();
-			await this.waitForInteractiveEngineBound();
-		} finally {
-			this.restartInFlight -= 1;
-		}
+		const permit = this.restartRevision;
+		await this.stopCurrentGeneration();
+		if (permit !== this.restartRevision) throw rpcTransportError(RESTART_CANCELLED_MESSAGE);
+		this.options = { ...this.options, args: restartCliArgs(this.options.args, sessionFile) };
+		await this.start();
+		await this.waitForInteractiveEngineBound();
 	}
 
 	async requestInternal<T>(command: RpcCommandBody): Promise<T> {

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -113,7 +113,6 @@ export class RpcClient extends RpcClientApi {
 	}
 
 	async start(): Promise<void> {
-		if (this.stopPromise) await this.stopPromise;
 		if (this.process) {
 			throw new Error("Client already started");
 		}
@@ -338,6 +337,9 @@ export class RpcClient extends RpcClientApi {
 	async restart(sessionFile: string | undefined): Promise<void> {
 		const permit = this.restartRevision;
 		await this.stopCurrentGeneration();
+		// Join an in-flight stop before the permit check: waiting after it would
+		// reopen the window this fence exists to close.
+		if (this.stopPromise) await this.stopPromise;
 		if (permit !== this.restartRevision) throw rpcTransportError(RESTART_CANCELLED_MESSAGE);
 		this.options = { ...this.options, args: restartCliArgs(this.options.args, sessionFile) };
 		await this.start();

--- a/packages/coding-agent/test/interactive-engine-shutdown.test.ts
+++ b/packages/coding-agent/test/interactive-engine-shutdown.test.ts
@@ -103,7 +103,11 @@ describe("isolated interactive startup shutdown", () => {
 			assert.strictEqual(firstDispose, secondDispose);
 			await firstDispose;
 			await startup;
-			assert.equal(stop.mock.calls.length, 1);
+			assert.equal(
+				stop.mock.calls.length,
+				2,
+				"shutdown requests the idempotent stop during health and trailing cleanup",
+			);
 		} finally {
 			harness.cleanup();
 		}
@@ -131,7 +135,11 @@ describe("isolated interactive startup shutdown", () => {
 			await Promise.resolve();
 			await runtime.dispose();
 			await startup;
-			assert.equal(stop.mock.calls.length, 1);
+			assert.equal(
+				stop.mock.calls.length,
+				2,
+				"shutdown requests the idempotent stop during health and trailing cleanup",
+			);
 		} finally {
 			harness.cleanup();
 		}
@@ -158,7 +166,11 @@ describe("isolated interactive startup shutdown", () => {
 			await waitForInteractiveEngineBound(runtime);
 			await runtime.dispose();
 			await Promise.resolve();
-			assert.equal(stop.mock.calls.length, 1);
+			assert.equal(
+				stop.mock.calls.length,
+				2,
+				"shutdown requests the idempotent stop during health and trailing cleanup",
+			);
 		} finally {
 			harness.cleanup();
 		}

--- a/packages/coding-agent/test/interactive-engine-shutdown.test.ts
+++ b/packages/coding-agent/test/interactive-engine-shutdown.test.ts
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, test, vi } from "vitest";
+import { AgentSessionRuntime } from "../src/core/agent-session-runtime.ts";
+import { waitForInteractiveEngineBound } from "../src/modes/interactive-engine/extension-ui-bridge.ts";
+import { IsolatedInteractiveRuntime } from "../src/modes/interactive-engine/isolated-runtime.ts";
+import { rpcTransportError } from "../src/modes/rpc/rpc-transport-error.ts";
+import type { RpcEvent, RpcModelCatalog, RpcSessionState, RpcSlashCommand } from "../src/modes/rpc/rpc-types.ts";
+import { createHarness, type Harness } from "./suite/harness.ts";
+
+interface Deferred<T> {
+	promise: Promise<T>;
+	resolve: (value: T | PromiseLike<T>) => void;
+	reject: (error: Error) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+	let resolve!: Deferred<T>["resolve"];
+	let reject!: Deferred<T>["reject"];
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = (error: Error) => rejectPromise(error);
+	});
+	return { promise, resolve, reject };
+}
+
+function servicesFor(harness: Harness) {
+	return {
+		cwd: harness.tempDir,
+		agentDir: harness.tempDir,
+		settingsManager: harness.settingsManager,
+		modelRegistry: harness.session.modelRegistry,
+		resourceLoader: harness.session.resourceLoader,
+	};
+}
+
+function createLocalRuntime(harness: Harness): AgentSessionRuntime {
+	return new AgentSessionRuntime(harness.session, servicesFor(harness) as never, async () => {
+		throw new Error("unused runtime factory");
+	});
+}
+
+function createState(): RpcSessionState {
+	return {
+		thinkingLevel: "off",
+		isStreaming: false,
+		isCompacting: false,
+		steeringMode: "all",
+		followUpMode: "all",
+		sessionId: "engine-session",
+		autoCompactionEnabled: true,
+		messageCount: 0,
+		pendingMessageCount: 0,
+		queuedMessagesPaused: false,
+	};
+}
+
+function createRuntime(
+	harness: Harness,
+	client: {
+		onEvent(listener: (event: RpcEvent) => void): () => void;
+		onGenerationEnded(listener: () => void): () => void;
+		waitForInteractiveEngineBound(): Promise<void>;
+		stop(): Promise<void>;
+		getState(): Promise<RpcSessionState>;
+		requestInternal<T>(command: { type: string }): Promise<T>;
+		getCommands(): Promise<readonly RpcSlashCommand[]>;
+	},
+): IsolatedInteractiveRuntime {
+	return new IsolatedInteractiveRuntime(
+		createLocalRuntime(harness),
+		async () => {
+			throw new Error("unused runtime factory");
+		},
+		client as never,
+	);
+}
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("isolated interactive startup shutdown", () => {
+	test("resolves a bind wait when explicit disposal rejects it", async () => {
+		const harness = await createHarness();
+		try {
+			const bound = deferred<void>();
+			const stop = vi.fn(async () => {
+				bound.reject(rpcTransportError("Agent process stopped"));
+			});
+			const runtime = createRuntime(harness, {
+				onEvent: () => () => {},
+				onGenerationEnded: () => () => {},
+				waitForInteractiveEngineBound: () => bound.promise,
+				stop,
+				getState: async () => createState(),
+				requestInternal: async <T>(_command: { type: string }) => undefined as T,
+				getCommands: async () => [],
+			});
+
+			const startup = waitForInteractiveEngineBound(runtime);
+			const firstDispose = runtime.dispose();
+			const secondDispose = runtime.dispose();
+
+			assert.strictEqual(firstDispose, secondDispose);
+			await firstDispose;
+			await startup;
+			assert.equal(stop.mock.calls.length, 1);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	test("handles an in-flight first-paint getState rejection during disposal", async () => {
+		const harness = await createHarness();
+		try {
+			const state = deferred<RpcSessionState>();
+			const stop = vi.fn(async () => {
+				state.reject(rpcTransportError("Agent process stopped"));
+			});
+			const runtime = createRuntime(harness, {
+				onEvent: () => () => {},
+				onGenerationEnded: () => () => {},
+				waitForInteractiveEngineBound: async () => {},
+				stop,
+				getState: () => state.promise,
+				requestInternal: async <T>(_command: { type: string }) => undefined as T,
+				getCommands: async () => [],
+			});
+
+			const startup = waitForInteractiveEngineBound(runtime);
+			await Promise.resolve();
+			await Promise.resolve();
+			await runtime.dispose();
+			await startup;
+			assert.equal(stop.mock.calls.length, 1);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	test("keeps remote command refresh rejection contained during explicit disposal", async () => {
+		const harness = await createHarness();
+		try {
+			const commands = deferred<never>();
+			const stop = vi.fn(async () => {
+				commands.reject(rpcTransportError("Agent process stopped"));
+			});
+			const runtime = createRuntime(harness, {
+				onEvent: () => () => {},
+				onGenerationEnded: () => () => {},
+				waitForInteractiveEngineBound: async () => {},
+				stop,
+				getState: async () => createState(),
+				requestInternal: async <T>(_command: { type: string }) =>
+					({ models: [], scopedModels: [] }) as RpcModelCatalog as T,
+				getCommands: () => commands.promise,
+			});
+
+			await waitForInteractiveEngineBound(runtime);
+			await runtime.dispose();
+			await Promise.resolve();
+			assert.equal(stop.mock.calls.length, 1);
+		} finally {
+			harness.cleanup();
+		}
+	});
+});

--- a/packages/coding-agent/test/rpc-client-process-exit.test.ts
+++ b/packages/coding-agent/test/rpc-client-process-exit.test.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -34,5 +35,21 @@ process.stdin.resume();
 		await client.start();
 
 		await expect(client.getCommands()).rejects.toThrow(/Agent process exited \(code=43 signal=null\)/);
+	});
+
+	test("shares concurrent stop teardown and makes repeat stop a no-op", async () => {
+		const client = new RpcClient({
+			cliPath: writeChildScript(`
+process.stdin.resume();
+`),
+		});
+
+		await client.start();
+		const firstStop = client.stop();
+		const secondStop = client.stop();
+
+		assert.strictEqual(firstStop, secondStop);
+		await firstStop;
+		await client.stop();
 	});
 });

--- a/test/unit/interactive-engine-shutdown-fence.test.ts
+++ b/test/unit/interactive-engine-shutdown-fence.test.ts
@@ -210,6 +210,7 @@ serialTest(
 				() => undefined,
 				(error: unknown) => error,
 			);
+			await sleep(5);
 			const secondStop = client.stop();
 			assert.strictEqual(secondStop, firstStop, "concurrent stops must share the teardown");
 

--- a/test/unit/interactive-engine-shutdown-fence.test.ts
+++ b/test/unit/interactive-engine-shutdown-fence.test.ts
@@ -10,11 +10,14 @@
 import assert from "node:assert/strict";
 import { join } from "node:path";
 import { test } from "vitest";
+import { AgentSessionRuntime } from "../../packages/coding-agent/src/core/agent-session-runtime.ts";
 import type { ActivityWatchdogDiagnostic } from "../../packages/coding-agent/src/modes/interactive-engine/activity-watchdog.ts";
 import type { InteractiveEngineGenerationEnded } from "../../packages/coding-agent/src/modes/interactive-engine/engine-generation.ts";
 import { EngineHealthController } from "../../packages/coding-agent/src/modes/interactive-engine/engine-health.ts";
+import { IsolatedInteractiveRuntime } from "../../packages/coding-agent/src/modes/interactive-engine/isolated-runtime.ts";
 import { RpcClient } from "../../packages/coding-agent/src/modes/rpc/rpc-client.ts";
 import { RESTART_CANCELLED_MESSAGE } from "../../packages/coding-agent/src/modes/rpc/rpc-command-timeouts.ts";
+import { createHarness, type Harness } from "../../packages/coding-agent/test/suite/harness.ts";
 import { bunExecutable, moduleDir, sleep } from "../helpers/runtime.js";
 
 const serialTest = process.platform === "win32" ? test.sequential.skip : test.sequential;
@@ -35,6 +38,49 @@ function ended(): InteractiveEngineGenerationEnded {
 		kind: "exit",
 		expected: false,
 	};
+}
+
+function createBlockingClient(): RpcClient {
+	return new RpcClient({
+		cliPath: join(moduleDir(import.meta.url), "../../packages/coding-agent/src/cli.ts"),
+		cwd: join(moduleDir(import.meta.url), "../.."),
+		runtimeExecutable: bunExecutable(),
+		provider: "isolation-fixture",
+		model: "blocking-model",
+		args: [
+			"--no-session",
+			"--no-extensions",
+			"--extension",
+			join(moduleDir(import.meta.url), "fixtures", "blocking-tool-extension.ts"),
+			"--no-skills",
+			"--no-prompt-templates",
+			"--no-themes",
+			"--offline",
+			"--approve",
+		],
+		interactiveEngine: { onDiagnostic: () => {} },
+	});
+}
+
+function createIsolatedRuntime(harness: Harness, client: RpcClient): IsolatedInteractiveRuntime {
+	const localRuntime = new AgentSessionRuntime(
+		harness.session,
+		{
+			cwd: harness.tempDir,
+			agentDir: harness.tempDir,
+			settingsManager: harness.settingsManager,
+		} as never,
+		async () => {
+			throw new Error("unused runtime factory");
+		},
+	);
+	return new IsolatedInteractiveRuntime(
+		localRuntime,
+		async () => {
+			throw new Error("unused runtime factory");
+		},
+		client,
+	);
 }
 
 test("shutdown stops the child, joins the in-flight attempt, and reports no failure", async () => {
@@ -145,6 +191,81 @@ serialTest(
 			assert.equal(isAlive(firstPid), false, "the original child outlived the stop");
 		} finally {
 			await client.stop();
+		}
+	},
+	60_000,
+);
+
+serialTest(
+	"a second stop after restart begins still cancels the replacement",
+	async () => {
+		const client = createBlockingClient();
+		try {
+			await client.start();
+			const firstPid = client.getEnginePid();
+			assert.ok(firstPid, "engine child never reported its pid");
+
+			const firstStop = client.stop();
+			const restart = client.restart(undefined).then(
+				() => undefined,
+				(error: unknown) => error,
+			);
+			const secondStop = client.stop();
+			assert.strictEqual(secondStop, firstStop, "concurrent stops must share the teardown");
+
+			await firstStop;
+			const outcome = await restart;
+			await sleep(250);
+			const observedPid = client.getEnginePid();
+			assert.equal(
+				observedPid,
+				firstPid,
+				`a replacement child was spawned after the second stop (firstPid=${firstPid}, observedPid=${observedPid})`,
+			);
+			assert.ok(outcome instanceof Error, "a superseded restart must not report success");
+			assert.match((outcome as Error).message, /restart cancelled/i);
+			assert.equal(isAlive(firstPid), false, "the original child outlived the stop");
+		} finally {
+			await client.stop();
+		}
+	},
+	60_000,
+);
+
+serialTest(
+	"isolated runtime disposal leaves no child after an overlapping replacement",
+	async () => {
+		const harness = await createHarness();
+		const client = createBlockingClient();
+		const runtime = createIsolatedRuntime(harness, client);
+		try {
+			await client.start();
+			const firstPid = client.getEnginePid();
+			assert.ok(firstPid, "engine child never reported its pid");
+
+			const firstStop = client.stop();
+			const restart = client.restart(undefined).then(
+				() => undefined,
+				(error: unknown) => error,
+			);
+			const disposal = runtime.dispose();
+
+			await firstStop;
+			await disposal;
+			const outcome = await restart;
+			await sleep(250);
+			const observedPid = runtime.getEnginePid();
+			assert.equal(
+				observedPid,
+				firstPid,
+				`a replacement child survived disposal (firstPid=${firstPid}, observedPid=${observedPid})`,
+			);
+			assert.ok(outcome instanceof Error, "disposal must cancel an overlapping restart");
+			assert.match((outcome as Error).message, /restart cancelled/i);
+			assert.equal(isAlive(firstPid), false, "the original child outlived disposal");
+		} finally {
+			await runtime.dispose();
+			harness.cleanup();
 		}
 	},
 	60_000,


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789708989&installation_model_id=10562&pr_number=2526&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2526&signature=9ba7d22cc868d8d91fd2864e34bb16c33992e9c94619ffeaaf8414c72a70c79e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change prevents isolated interactive-runtime shutdown from allowing post-disposal startup work or replacement child processes to continue, and adds regression coverage for overlapping stop, restart, and disposal behavior. The focused lifecycle coverage passed. One style requirement remains: the expanded timeout used by the real-child-process tests should be expressed as a named constant so its purpose and shared policy are clear.

<h3>Confidence Score: 4/5</h3>

The runtime shutdown behavior is covered by focused tests, with no functional defect found in the reviewed change.

The only final finding is a non-security P2 style issue; under the scoring rules, P2-only findings result in a score of 4.

**Files Needing Attention:** test/unit/interactive-engine-shutdown-fence.test.ts should replace both bare 60-second test timeouts with a descriptive shared constant.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
test/unit/interactive-engine-shutdown-fence.test.ts:237
**Bare structural test timeout**

The two new real-child-process tests use a bare `60_000` timeout, which does not communicate why they require an expanded execution budget and makes timeout-policy changes harder to apply consistently. Use a descriptive named constant at this call site, including for the matching timeout near line 278.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/bastani-inc/atomic/commit/d494303bb108a8baf0ef9e9e158f336f6df0974b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54692686)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->