### PR TITLE
fix(workflows): remove merge conflict markers from adversarial runner

### DIFF
--- a/packages/workflows/builtin/adversarial-verification-runner.ts
+++ b/packages/workflows/builtin/adversarial-verification-runner.ts
@@ -1,20 +1,12 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { Type } from "typebox";
-<<<<<<< HEAD
 import type { WorkflowRunContext, WorkflowSerializableValue, WorkflowTaskResult } from "../src/shared/types.js";
-=======
-import type { WorkflowRunContext, WorkflowSerializableValue } from "../src/shared/types.js";
->>>>>>> origin/main
 import {
 	renderConsolidatorPrompt,
 	renderRepairPrompt,
 	renderWorkerPrompt,
 } from "./adversarial-verification-prompts.js";
-<<<<<<< HEAD
-=======
-import { stableArtifactRoot } from "./pattern-artifact-root.js";
->>>>>>> origin/main
 import {
 	build_scoring_prompt,
 	scoring_prompt_reads,
@@ -241,7 +233,6 @@ export async function runAdversarialVerification(ctx: WorkflowRunContext<Inputs>
 	await writeFile(criteriaPath, renderCriteriaMarkdown(resolvedCriteria));
 	await ctx.task("worker", { prompt: renderWorkerPrompt(ctx.inputs.task), context: "fresh", output: candidatePath, outputMode: "file-only" });
 
-<<<<<<< HEAD
 	const verifierCount = ctx.inputs.verifier_count ?? 3;
 	const maxRepairs = ctx.inputs.max_repairs ?? 2;
 	const acceptMean = ctx.inputs.accept_mean ?? 14;
@@ -249,25 +240,11 @@ export async function runAdversarialVerification(ctx: WorkflowRunContext<Inputs>
 	const expectedCount = resolvedCriteria.criteria.length * verifierCount;
 	let repairsCompleted = 0;
 	let consecutiveIndeterminate = 0;
-	let finalDecision: VerificationDecision = { kind: "indeterminate", missing: expectedCount };
+	let finalDecision: VerificationDecision;
 	let finalMean = 0;
-	let scoreTablePath = join(root, "verification-summary-0.json");
-	let reviewReportPath = join(root, "review-0.json");
+	let scoreTablePath: string;
+	let reviewReportPath: string;
 	let remainingWork: string[] = [];
-=======
-  const verifierCount = ctx.inputs.verifier_count ?? 3;
-  const maxRepairs = ctx.inputs.max_repairs ?? 2;
-  const acceptMean = ctx.inputs.accept_mean ?? 14;
-  const reaskLimit = Math.max(0, Math.floor(ctx.inputs.reask_limit ?? 1));
-  const expectedCount = resolvedCriteria.criteria.length * verifierCount;
-  let repairsCompleted = 0;
-  let consecutiveIndeterminate = 0;
-  let finalDecision: VerificationDecision;
-  let finalMean = 0;
-  let scoreTablePath: string;
-  let reviewReportPath: string;
-  let remainingWork: string[] = [];
->>>>>>> origin/main
 
 	for (let round = 0; ; round += 1) {
 		const candidateBody = await readFile(candidatePath, "utf8");
@@ -337,7 +314,6 @@ export async function runAdversarialVerification(ctx: WorkflowRunContext<Inputs>
 			if (pending.length === 0) break;
 		}
 
-<<<<<<< HEAD
 		const validReportsByCell = new Map(validResults.map((item) => [item.cell.name, item.report]));
 		const scoreReports = cells.flatMap((cell) => {
 			const report = validReportsByCell.get(cell.name);
@@ -357,20 +333,6 @@ export async function runAdversarialVerification(ctx: WorkflowRunContext<Inputs>
 			decision,
 			usage: fold_usage(roundResults),
 		};
-=======
-    const validReportsByCell = new Map(validResults.map((item) => [item.cell.name, item.report]));
-    const scoreReports = cells.flatMap((cell) => {
-      const report = validReportsByCell.get(cell.name);
-      return report === undefined ? [] : [report];
-    });
-    const scores = scoreReports.map(toCriterionScore);
-    const roundResult = { scores, invalidCount, expectedCount };
-    const decision = decide_verification(roundResult, { acceptMean, quorumFraction: QUORUM_FRACTION });
-    finalDecision = decision;
-    finalMean = meanScore(scoreReports);
-    scoreTablePath = join(root, `verification-summary-${round}.json`);
-    reviewReportPath = join(root, `review-${round}.json`);
->>>>>>> origin/main
 
 		if (decision.kind === "accept") {
 			remainingWork = [];


### PR DESCRIPTION
Hotfix: #2521 admin-merge left conflict markers in `packages/workflows/builtin/adversarial-verification-runner.ts`. Restores the complete V6 file.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789750850&installation_model_id=10562&pr_number=2537&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2537&signature=f7a73a993bf1a2f31e035382f7eb31c88fd81948f3de396e155b107d6f5d7bc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This hotfix removes unresolved merge-conflict text from `packages/workflows/builtin/adversarial-verification-runner.ts` and retains the verification runner’s scoring, repair, re-ask, and artifact-reporting behavior.

The preceding revision failed to parse at a merge-conflict marker. The updated file parsed successfully, the focused adversarial workflow suite passed all 11 tests across acceptance, repair/re-ask, veto, and indeterminate outcomes, and repository type validation completed successfully.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on successful parsing, focused workflow coverage, and repository type validation.

No remaining defects were found. The repaired runner was exercised through its key acceptance, repair, re-ask, veto, and indeterminate behaviors.

**Files Needing Attention:** No files need further attention; validation covered `packages/workflows/builtin/adversarial-verification-runner.ts` directly.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The preceding and updated versions of packages/workflows/builtin/adversarial-verification-runner.ts were parsed, showing the pre-hotfix parse failed at a merge-conflict marker while the hotfix version parsed successfully with 39 top-level statements.
- I ran the adversarial generate unit tests with Vitest; all 11 focused workflow tests passed, covering acceptance, repair/re-ask, veto, and indeterminate outcomes.
- I ran npm run typecheck; the root TypeScript project and Atomic workspace completed successfully.
- Before/after parser captures demonstrate the hotfix outcome: the pre-fix parse failed and the current runner parses.
- Focused workflow execution passed 1 test file out of 11 tests with no source changes.

<a href="https://app.greptile.com/trex/runs/19641524/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(workflows): remove merge conflict ma..."](https://github.com/bastani-inc/atomic/commit/fdb80bf90e4b7c4fe3b23bd55076c1c3c325554d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54839346)</sub>

<!-- /greptile_comment -->