### PR TITLE
docs(changelog): 0.9.14-alpha.5 release notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.14-alpha.5] - 2026-08-19
+
 ### Added
 
 - Added HumanLayer's bundled `show-me` skill for visual explanations, diagrams, code-shape sketches, and focused HTML artifacts. Sourced from https://github.com/humanlayer/skills and distributed under the MIT License.

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.14-alpha.5] - 2026-08-19
+
 ### Added
 
 - Added pure progress-trend evidence and injected control score-series support that can raise wall-clock attention priority without creating failure states, suppressing signals, or scheduling model calls ([#2489](https://github.com/bastani-inc/atomic/issues/2489)).

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.14-alpha.5] - 2026-08-19
+
 ### Added
 
 - Added optional run-budget declarations on workflow config, authored definitions, and `workflow` tool runs or resumes. `maxDurationMs`, `maxTokens`, `maxCost`, and `warnAtPercent` resolve per field with run overrides taking precedence over definition and config values; `0` disables a dimension. Invalid declarations now fail validation, and `budget_exceeded` is reserved as a resumable returned blocked status; these declarations provide the resolution core for the duration enforcement below ([#2212](https://github.com/bastani-inc/atomic/issues/2212)).


### PR DESCRIPTION
## Summary

Release notes for the `0.9.14-alpha.5` prerelease. The accumulated `[Unreleased]` entries in `packages/coding-agent`, `packages/subagents`, and `packages/workflows` move under a `## [0.9.14-alpha.5] - 2026-08-19` heading.

## Changes

- `packages/coding-agent/CHANGELOG.md` — bundled `show-me` skill, quiet Ctrl+C during first-paint binding, slash drafts that stay in the editor while packages load, queue-control RPC reachability, and the `ask_user_question` preview-row offset fix.
- `packages/subagents/CHANGELOG.md` — pure progress-trend evidence and injected control score-series that can raise wall-clock attention priority without creating failure states.
- `packages/workflows/CHANGELOG.md` — run-budget declarations and duration/token/cost enforcement, `show-me` plus shape-first `create-spec`, adversarial-verification mean/veto and tournament soft-selection, Goal/Ralph re-verification and convergence evidence, and `ctx.tool` detail parity.

## Versionless base

No version stamping here. Every `packages/*/package.json`, the `@bastani/atomic-natives` pin, `packages/natives/native/index.js`, `Cargo.toml`, and `Cargo.lock` stay at the `0.0.0` placeholder. `scripts/cut-release.ts` materializes `0.9.14-alpha.5` on the detached `Release 0.9.14-alpha.5` commit after this merges.

## Notes

- Local validation: `bunx vitest --run --project unit test/unit/changelog.test.ts test/unit/package-metadata.test.ts test/unit/pi-0.84.2-docs-contract.test.ts` (43 passed). Pre-commit `npm run check` and `npm run test:unit` passed. Pre-push `npm run test:integration` and `npm run test:ci-contracts` passed.
- Diff is changelog-only. Intercom, MCP, natives, and web-access had empty `[Unreleased]` sections and were left unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789767269&installation_model_id=10562&pr_number=2542&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2542&signature=197f7ec3964ad1495b07921dad8b7d141f727722eab65084e916e58c4d1a3e7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change cuts the accumulated release notes for the coding-agent, subagents, and workflows packages into `0.9.14-alpha.5`, dated 2026-08-19, while leaving each `Unreleased` section empty for future work.

The release headings were checked against the production changelog parser and package metadata expectations. All three headings parse as the intended prerelease version and date, retain the required separation from `Unreleased`, and preserve the versionless package-manifest contract. The repository changelog tests also passed.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the release-note structure is accepted by the production parser and repository changelog tests.

The changed documents were exercised before and after the release cut with an authored contract check, then validated with the repository changelog parser test suite. No defects remain.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The release-contract validator was run against HEAD^ and HEAD for the three changed changelogs, confirming the parent revision lacked the target sections and that the release-cut revision parsed all three 0.9.14-alpha.5 headings and passed the Unreleased, date, changed-file, and versionless-manifest checks.
- A bun vitest run on test/unit/changelog.test.ts completed, and all 11 changelog parser and released-section tests passed.
- Before capture the target release sections were absent and the contract validation failed; after capture all three new sections were parsed as 0.9.14-alpha.5 and the contract validation passed with exit code 0, with no security impact and no confirmed defect or file/line finding.

<a href="https://app.greptile.com/trex/runs/19697380/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): add 0.9.14-alpha.5 rele..."](https://github.com/bastani-inc/atomic/commit/f960a6297e2cf23b1c5d4b8136839a6a24672162) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54942596)</sub>

<!-- /greptile_comment -->