### PR TITLE
fix(workflows): satisfy noUncheckedIndexedAccess in selection math

### DIFF
--- a/packages/coding-agent/scripts/verify-workflow-sdk-types.ts
+++ b/packages/coding-agent/scripts/verify-workflow-sdk-types.ts
@@ -133,6 +133,17 @@ const VARIANTS: readonly Variant[] = [
 		},
 	},
 	{
+		name: "auto-include-no-unchecked-indexed-access",
+		description: "Regression lock for issue #2543: auto-included workflow types remain type-safe with noUncheckedIndexedAccess.",
+		expect: "pass",
+		files: {
+			"package.json": consumerPackageJson("ext-and-workflow-no-unchecked-indexed-access", { extensions: ["./src/index.ts"], workflows: ["./workflows"] }),
+			"tsconfig.json": tsconfig({ noUncheckedIndexedAccess: true, allowImportingTsExtensions: true }),
+			"src/index.ts": `import { VERSION } from "@bastani/atomic";\nexport const myExtensionVersion: string = VERSION;\n`,
+			"workflows/hello.ts": WORKFLOW_FILE,
+		},
+	},
+	{
 		name: "negative-no-optin",
 		description: "Negative control: pure workflow-only package with NO opt-in must fail with TS2307 (the bug this fix closes).",
 		expect: "fail",

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed consumer TypeScript errors in `selection-math` when `noUncheckedIndexedAccess` is enabled ([#2543](https://github.com/bastani-inc/atomic/issues/2543)).
+
 ## [0.9.14-alpha.5] - 2026-08-19
 
 ### Added

--- a/packages/workflows/builtin/selection-math.ts
+++ b/packages/workflows/builtin/selection-math.ts
@@ -127,10 +127,10 @@ export function soft_win(scoreA: number, scoreB: number): number {
 /** Add each preference to both candidates' win mass and comparison count. */
 export function accumulate(prefs: readonly Preference[], w: number[], c: number[]): void {
 	for (const { a, b, p } of prefs) {
-		w[a] += p;
-		c[a] += 1;
-		w[b] += 1 - p;
-		c[b] += 1;
+		w[a]! += p;
+		c[a]! += 1;
+		w[b]! += 1 - p;
+		c[b]! += 1;
 	}
 }
 


### PR DESCRIPTION
## Summary

`packages/workflows/builtin/selection-math.ts` ships as raw TypeScript inside `@bastani/atomic`, so consumers typecheck it directly. Under `noUncheckedIndexedAccess`, the four indexed compound assignments in `accumulate` are `number | undefined`, and a consumer `tsc --noEmit` fails with four `TS2532` errors at lines 130–133.

This adds the non-null assertions the rest of the file already uses, and locks the regression in the SDK type verifier.

Fixes #2543.

## Changes

- **`packages/workflows/builtin/selection-math.ts`** — `w[a]! += p; c[a]! += 1; w[b]! += 1 - p; c[b]! += 1;`. No behavior change: `a` and `b` are candidate indices the caller sized `w`/`c` for, which `test/unit/selection-math.test.ts` asserts. The style matches `mean_preference` in the same file, which already used `!`.
- **`packages/coding-agent/scripts/verify-workflow-sdk-types.ts`** — new `expect: "pass"` variant `auto-include-no-unchecked-indexed-access`, with tsconfig extras `{ noUncheckedIndexedAccess: true, allowImportingTsExtensions: true }`, reusing the existing `auto-include-via-atomic-import` consumer files. Importing `@bastani/atomic` pulls ambient → every builtin → tournament → selection-math, so the variant exercises the real consumer path.
- **`packages/workflows/CHANGELOG.md`** — one `### Fixed` entry under `## [Unreleased]`. No released section touched.

Diff is 3 files, +19 −4.

## Verification

| Check | Result |
| --- | --- |
| Smoke `tsc` on `selection-math.ts` (`--strict --noUncheckedIndexedAccess --allowImportingTsExtensions --module NodeNext --moduleResolution NodeNext --skipLibCheck --ignoreConfig`) | Before: `(130,3) (131,3) (132,3) (133,3) error TS2532`, exit 1. After: no output, exit 0 |
| New verifier variant | Fails before the fix — and it is the *only* variant that fails, with the four `TS2532` resolving inside `node_modules/@bastani/atomic/dist/.../selection-math.ts(130–133)`, i.e. the consumer bug end-to-end. Passes after |
| `bun run verify:workflow-types` (from `packages/coding-agent`) | All 5 variants pass, exit 0 |
| `npm run test:unit -- test/unit/selection-math.test.ts` | 1 file, 9 tests passed |
| `npm run check` | biome + both typecheck passes + shrinkwrap check, exit 0 |

### Two notes on how those commands had to be run

Both are properties of this checkout, not of the fix.

1. **The smoke command needs `--ignoreConfig`.** The repo pins `typescript@7.0.2`, which raises `TS5112: tsconfig.json is present but will not be loaded if files are specified on commandline` before any type checking. That error fires identically with and without the fix, so it cannot distinguish the two states. `--ignoreConfig` is TypeScript's own suggested remedy and leaves every other flag intact.
2. **`verify:workflow-types` cannot run on a versionless base unaided.** On a clean tree it fails at the *first* variant with `No version matching "0.0.0" found for specifier "@bastani/atomic-natives"` — the versionless-release-base design in `AGENTS.md`, pre-existing and unrelated to this issue. It was made runnable by temporarily stamping the published `0.9.14-alpha.5` with `scripts/bump-version.ts`, running the verifier, then restoring the `0.0.0` placeholder (confirmed: `"version": "0.0.0"`, natives pin `0.0.0`, empty `git status`).

## Known limitation (not addressed here)

All three reviewers independently raised the same non-blocking point, classified beyond this issue's scope: the new variant is the only guard against this class of consumer-facing type break, but nothing runs it automatically. `verify:workflow-types` is referenced only by its own definition in `packages/coding-agent/package.json` — no CI job and no prek hook invokes it. Wiring it up (and giving it an escape hatch for versionless bases) is worth a follow-up issue.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789774779&installation_model_id=10562&pr_number=2545&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2545&signature=f945ca4fe6d0275e4bf6ac39dc35bf3213b11ce912f321c80ed652b1442b4262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes the raw workflow selection helper compatible with consumer projects that enable `noUncheckedIndexedAccess`, adds a matching SDK type-check fixture, and documents the fix. The potential consumer type-check failure was disproved by comparing the preceding revision and this revision under identical strict compiler settings: the earlier code produced four TS2532 indexed-accumulator errors, while the updated code completed successfully. The focused selection-math test suite also passed all 9 tests.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the strict consumer compilation path now succeeds and focused selection-math behavior remains passing.

No remaining defects were evidenced. The affected type-checking path was exercised before and after the fix, reproducing the prior compiler failure and confirming that the updated implementation resolves it.

**Files Needing Attention:** No files need further attention; `packages/workflows/builtin/selection-math.ts` received direct strict-compilation and focused test coverage.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran an authored regression script that type-checked HEAD^ and the current packages/workflows/builtin/selection-math.ts with strict TypeScript and noUncheckedIndexedAccess; the predecessor exited with four TS2532 errors at the w and c indexed accumulator updates, while the updated source exited successfully, and then I ran the focused selection-math unit tests which all passed.
- I re-validated the type-path stability by comparing before and after results: the predecessor produced TS2532 errors, while the current selection-math.ts exits 0 under the same strict options, and the focused behavior coverage remained green.
- I prepared and attached artifacts documenting the regression script, TypeScript outcomes, and unit test results to support review.

<a href="https://app.greptile.com/trex/runs/19717594/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(workflows): satisfy noUncheckedIndex..."](https://github.com/bastani-inc/atomic/commit/4291eff53e7cb5c964e86610df918f7eb7a3aeb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54981416)</sub>

<!-- /greptile_comment -->