### PR TITLE
docs(changelog): 0.9.14-alpha.6 release notes

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.14-alpha.6] - 2026-08-19
+
 ### Fixed
 
 - Fixed consumer TypeScript errors in `selection-math` when `noUncheckedIndexedAccess` is enabled ([#2543](https://github.com/bastani-inc/atomic/issues/2543)).


### PR DESCRIPTION
## Summary

Release notes for the `0.9.14-alpha.6` prerelease. The pending `[Unreleased]` entry in `packages/workflows` moves under a `## [0.9.14-alpha.6] - 2026-08-19` heading.

## Changes

- `packages/workflows/CHANGELOG.md` — records the `selection-math` fix that clears consumer TypeScript errors when `noUncheckedIndexedAccess` is enabled ([#2543](https://github.com/bastani-inc/atomic/issues/2543)).

No other package changed: `coding-agent`, `intercom`, `mcp`, `natives`, `subagents`, and `web-access` all had empty `[Unreleased]` sections and were left alone.

## Versionless base

No version stamping here. Every `packages/*/package.json`, the `@bastani/atomic-natives` pin, `packages/natives/native/index.js`, `Cargo.toml`, and `Cargo.lock` stay at the `0.0.0` placeholder. `scripts/cut-release.ts` materializes `0.9.14-alpha.6` on the detached `Release 0.9.14-alpha.6` commit after this merges.

## Notes

- Diff is changelog-only: one file, two added lines.
- Local validation: `bun run check` (biome, `tsc --noEmit`, coding-agent `tsgo` build typecheck, shrinkwrap check) and `bun run test:ci-contracts` (8 files, 46 tests) passed.
- Pre-commit hooks ran `npm run check` and `npm run test:unit`; pre-push hooks ran `npm run test:integration` and `npm run test:ci-contracts`. All passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789777580&installation_model_id=10562&pr_number=2546&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2546&signature=549a2b95b74ee04ef6c37b91bc9d0108b35fb018271f5d86c0a8ffed4323094d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds the `0.9.14-alpha.6` workflows release section dated 2026-08-19 and places the existing selection-math TypeScript compatibility note within it. The release-note placement was checked before and after the change: headings and dates remain in descending release order, the note appears once in the new release’s Fixed section, and it matches the immediately preceding workflows compatibility fix. No defects were found.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the documentation change correctly records the intended workflows fix in the new prerelease section.

The executed release-note check verified the exact before-and-after placement, Markdown release ordering, date, and association with the preceding selection-math compatibility commit. No actionable findings remain.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The executable changelog release validation script was run to compare the pre-release state (HEAD^) and post-release state (HEAD) and locate the Unreleased and 0.9.14-alpha.6 entries.
- The before-state result showed the compatibility note under Unreleased, and the after-state result moved it to 0.9.14-alpha.6 with the expected heading order, date, and Fixed subsection.
- The base-to-HEAD diff was whitespace-clean and contained no unrelated changelog changes.

<a href="https://app.greptile.com/trex/runs/19723925/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): add 0.9.14-alpha.6 rele..."](https://github.com/bastani-inc/atomic/commit/73463354b801cd575c0916c5701a1e646558cfab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54992622)</sub>

<!-- /greptile_comment -->