### PR TITLE
fix(ci): drop natives globalSetup from vitest ci project

### DIFF
--- a/test/ci/ci-workflow-contracts.test.ts
+++ b/test/ci/ci-workflow-contracts.test.ts
@@ -67,6 +67,27 @@ test("every test suite entry point resolves to one shared per-test timeout", asy
 	assert.match(await readText(join(root, ".github/workflows/test.yml")), /run-flaky-test-suite\.ts/u);
 });
 
+test("native global setup stays on unit and integration projects only", async () => {
+	const config = (await import("../../vitest.config.js")) as {
+		default: {
+			test?: {
+				projects?: { test?: { name?: string; globalSetup?: string[] } }[];
+			};
+		};
+	};
+	const projects = config.default.test?.projects ?? [];
+	const nativeSetup = ["./test/global-setup-natives.ts"];
+	for (const name of ["unit", "integration"]) {
+		const project = projects.find((entry) => entry.test?.name === name);
+		assert.ok(project, `missing vitest project: ${name}`);
+		assert.deepEqual(project.test?.globalSetup, nativeSetup, `${name} must keep native global setup`);
+	}
+
+	const ci = projects.find((entry) => entry.test?.name === "ci");
+	assert.ok(ci, "missing vitest project: ci");
+	assert.equal(ci.test?.globalSetup, undefined, "ci must not run the native global setup");
+});
+
 /**
  * No package script may write a workspace selector after `npm run <script>`.
  *

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,7 +12,7 @@ export { TEST_TIMEOUT_MS };
 const setupFiles = ["./test/setup-workflow-durability.ts"];
 
 /**
- * Runs once per project, before any file is collected. It builds
+ * Runs once for the unit and integration projects, before any file is collected. It builds
  * `@bastani/atomic-natives` only when no compiled binding exists, because a
  * missing binding no longer degrades gracefully: `packages/subagents` imports
  * the Rust control plane statically, so the bundled extension throws during
@@ -24,7 +24,7 @@ const setupFiles = ["./test/setup-workflow-durability.ts"];
  */
 const globalSetup = ["./test/global-setup-natives.ts"];
 
-const project = (name: string, directory: string) => ({
+const project = (name: string, directory: string, usesNativeSetup = true) => ({
 	resolve: { alias: sharedAliases },
 	test: {
 		name,
@@ -34,7 +34,7 @@ const project = (name: string, directory: string) => ({
 		include: [`${directory}/**/*.test.ts`],
 		exclude: ["**/node_modules/**"],
 		setupFiles,
-		globalSetup,
+		...(usesNativeSetup ? { globalSetup } : {}),
 		testTimeout: TEST_TIMEOUT_MS,
 		hookTimeout: TEST_TIMEOUT_MS,
 	},
@@ -45,12 +45,15 @@ const project = (name: string, directory: string) => ({
  * flake retry and the diagnostics artifact names all survive the move off
  * `bun test <dir>` unchanged.
  *
+ * The CI contract suite only inspects workflow and source state, so it omits
+ * the native setup; unit and integration keep it above.
+ *
  * No `pool`, `maxWorkers`, `poolOptions` or `fileParallelism`: pi sets none, and
  * a suite that only passes serialized is concealing a test that assumes an idle
  * machine rather than fixing it.
  */
 export default defineConfig({
 	test: {
-		projects: [project("unit", "test/unit"), project("integration", "test/integration"), project("ci", "test/ci")],
+		projects: [project("unit", "test/unit"), project("integration", "test/integration"), project("ci", "test/ci", false)],
 	},
 });


### PR DESCRIPTION
## Summary

`npm run test:ci-contracts` is the only test command on the Linux `static-checks` job, and that job deliberately carries no Rust toolchain. It was nonetheless compiling `@bastani/atomic-natives` on every run.

The cause was in `vitest.config.ts`: the shared `project()` helper applied `globalSetup: ["./test/global-setup-natives.ts"]` to all three projects, so the `ci` project inherited a native build it never uses. The `test/ci` suites only inspect workflow and source state; none of them load the native binding.

`project()` now takes a `usesNativeSetup` parameter. The `ci` project passes `false`, so the `globalSetup` key is absent from its resolved config entirely — a spread, not an empty array, and no env-var opt-out inside the setup file. `unit` and `integration` are unchanged.

## Changes

- **`vitest.config.ts`** (+7 −4) — `usesNativeSetup` parameter on the `project()` helper; `ci` opts out. Two comment blocks corrected so they no longer claim the setup runs for every project.
- **`test/ci/ci-workflow-contracts.test.ts`** (+21) — new contract `native global setup stays on unit and integration projects only`. It imports the config and asserts the resolved `ci` project has no `globalSetup`, while `unit` and `integration` each still carry exactly `["./test/global-setup-natives.ts"]`. Deleting the setup for everyone fails the contract too, not just re-wiring `ci`.

No other file is touched. No changelog entry: per `AGENTS.md`, CI configuration is infrastructure-level and does not change shipped package behavior. No version bump, no release tags, no Rust added to `static-checks`.

## Acceptance criteria and evidence

| # | Criterion | Evidence |
| --- | --- | --- |
| 1 | `ci` does not run `test/global-setup-natives.ts` | Behavioural, not config inspection alone: `crates/atomic-natives/build.rs` was touched so the on-disk `.node` became older than the Rust sources, which makes the setup print a staleness warning. A `ci` test file then ran clean with **zero** occurrences of that line. |
| 2 | `unit` and `integration` still run it | The same probe produced the warning in both projects. |
| 3 | `static-checks` still has no rust-toolchain; topology test still forbids it | `test-workflow-topology.test.ts` passes 9/9 including `assert.doesNotMatch(staticChecks, /rust-toolchain/u)`; the job block contains 0 `rust-toolchain` occurrences and its only test step is `npm run test:ci-contracts`. |
| 4 | A contract fails if `ci` is wired back | Reverting the `false` argument fails the new test with `AssertionError: ci must not run the native global setup` (1 failed / 24 passed). |
| 5 | `test:ci-contracts` passes without compiling natives | The compiled `.node` was moved aside, leaving the tracked `index.js`/`index.d.ts` in place — exactly the state CI has after `npm ci --ignore-scripts`. The suite ran 8 files / 47 tests green in 105 s and the directory still contained no `.node`. Binding restored and checksum-verified. |
| 6 | No changelog, version bump, or Rust added | The commit touches only the two files above. |

## Validation

- `npm run test:ci-contracts` with the compiled binding removed — 47 passed, no `.node` produced
- `npm run check` — biome (2558 files) clean, `tsc --noEmit` clean, `tsgo` clean, shrinkwrap up to date
- Pre-push hooks on this branch ran `npm run check`, `test:unit`, `test:integration` and `test:ci-contracts` — all passed

## Review notes

Three independent reviewers signed off with no blocking findings. Two related P3 observations, both classified `beyond_objective` and recorded for future maintainers rather than as defects in this change:

- The new contract guards the per-project key. A root-level `test.globalSetup` in the same `defineConfig` call would still reach the `ci` project and would not be seen by this assertion. That path is outside the stated criterion, which speaks about the `ci` project being wired back.
- Dropping the `ci` project's `globalSetup` also drops its incidental guard against a future `test/ci` file importing `packages/subagents`, which imports the binding statically. A static closure probe over the current `test/ci` suites and their setup files (674 files visited) found zero such imports, so this is forward-looking only.

One cosmetic note: `usesNativeSetup` is a positional boolean at the call site (`project("ci", "test/ci", false)`). Legible in a 60-line config with three call sites; switching to an options object was judged out of contract.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789794902&installation_model_id=10562&pr_number=2549&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2549&signature=0440b41d19d4374480d86d219cb0fe707e0b46c90728fe682922b9c17b0711e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change prevents the CI workflow contract tests from invoking the native Rust binding setup, while preserving that setup for unit and integration tests.

The behavior was exercised with no compiled native binding and an intercepted native build command. A configuration equivalent to the previous CI setup attempted the native build, whereas the updated CI project completed its targeted contract test with zero native-build invocations. The resolved configuration also verifies that unit and integration retain the native setup and CI does not.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the CI-only configuration now avoids the native build dependency without changing setup for native-dependent test projects.

The relevant behavior was directly exercised under the intended failure condition: without a compiled binding and with native build commands intercepted. The CI contract completed without a build invocation, and the resolved configuration assertion confirmed the required setup assignments for all three projects.

**Files Needing Attention:** No files need follow-up. The exercised behavior is contained in vitest.config.ts and test/ci/ci-workflow-contracts.test.ts.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a parent-equivalent CI project with a blocked native build to exercise the native-setup bypass.
- One targeted test passed and recorded NATIVE\_BUILD\_INVOCATIONS=0, showing no native build was invoked.
- Unit and integration projects retain exactly ./test/global-setup-natives.ts while CI has no globalSetup, demonstrating the CI project skips native setup without removing it from native-dependent projects.
- Reviewed vitest.config.ts and contract sources, confirming the native setup is defined and disabled for CI by the ci flag.
- The executable contract test test/ci/ci-workflow-contracts.test.ts:70-89 verifies all three resolved projects.

<a href="https://app.greptile.com/trex/runs/19752673/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): drop natives globalSetup from v..."](https://github.com/bastani-inc/atomic/commit/3c26eb71baf410f65e558a46607e0d88646c8d21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55046390)</sub>

<!-- /greptile_comment -->