### PR TITLE
fix(test): stop leaking workflow-artifact temp dirs from vitest workers

### DIFF
--- a/test/ci/ci-workflow-contracts.test.ts
+++ b/test/ci/ci-workflow-contracts.test.ts
@@ -67,7 +67,7 @@ test("every test suite entry point resolves to one shared per-test timeout", asy
 	assert.match(await readText(join(root, ".github/workflows/test.yml")), /run-flaky-test-suite\.ts/u);
 });
 
-test("native global setup stays on unit and integration projects only", async () => {
+test("global setups: artifacts everywhere, natives on unit and integration only", async () => {
 	const config = (await import("../../vitest.config.js")) as {
 		default: {
 			test?: {
@@ -76,16 +76,25 @@ test("native global setup stays on unit and integration projects only", async ()
 		};
 	};
 	const projects = config.default.test?.projects ?? [];
-	const nativeSetup = ["./test/global-setup-natives.ts"];
+	const artifactSetup = "./test/global-setup-workflow-artifacts.ts";
+	const nativeSetup = "./test/global-setup-natives.ts";
 	for (const name of ["unit", "integration"]) {
 		const project = projects.find((entry) => entry.test?.name === name);
 		assert.ok(project, `missing vitest project: ${name}`);
-		assert.deepEqual(project.test?.globalSetup, nativeSetup, `${name} must keep native global setup`);
+		assert.deepEqual(
+			project.test?.globalSetup,
+			[artifactSetup, nativeSetup],
+			`${name} must keep the artifact and native global setups`,
+		);
 	}
 
+	// The artifact setup must cover every project: workers inherit the env var
+	// from the orchestrator, which is what keeps per-worker temp dirs from
+	// leaking. The native build stays off the ci project, which only inspects
+	// workflow and source state.
 	const ci = projects.find((entry) => entry.test?.name === "ci");
 	assert.ok(ci, "missing vitest project: ci");
-	assert.equal(ci.test?.globalSetup, undefined, "ci must not run the native global setup");
+	assert.deepEqual(ci.test?.globalSetup, [artifactSetup], "ci runs the artifact setup but not the native build");
 });
 
 /**

--- a/test/global-setup-workflow-artifacts.ts
+++ b/test/global-setup-workflow-artifacts.ts
@@ -1,0 +1,37 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ENV_WORKFLOW_ARTIFACT_DIR } from "../packages/workflows/src/shared/workflow-artifact-env.js";
+
+/**
+ * One workflow-artifact directory per vitest run, owned by the orchestrator.
+ *
+ * `test/setup-workflow-durability.ts` needs `ENV_WORKFLOW_ARTIFACT_DIR` set in
+ * every worker so real builtin workflows cannot write run directories into the
+ * developer's home. Creating the directory in the workers themselves cannot be
+ * leak-free: under the default isolated forks pool each test file gets a fresh
+ * process, and tinypool tears workers down with SIGTERM followed by SIGKILL
+ * after 500 ms, so any worker that loses that race leaks its directory. That
+ * is how 330k `atomic-test-workflow-artifacts-*` directories accumulated in
+ * the OS temp dir, which made every `mkdtemp` under `tmpdir()` machine-wide
+ * take seconds.
+ *
+ * This global setup runs once in the orchestrator, which forks every worker,
+ * so workers inherit the variable and create nothing. The teardown runs after
+ * the pool is gone. An inherited value is respected: the parent owns it, and
+ * with several projects in one invocation only the first project's setup
+ * creates the directory while the rest see it already present.
+ */
+export default function setup(): (() => void) | undefined {
+	if (process.env[ENV_WORKFLOW_ARTIFACT_DIR] !== undefined) return undefined;
+	const artifactDir = mkdtempSync(join(tmpdir(), "atomic-test-workflow-artifacts-"));
+	process.env[ENV_WORKFLOW_ARTIFACT_DIR] = artifactDir;
+	return () => {
+		delete process.env[ENV_WORKFLOW_ARTIFACT_DIR];
+		try {
+			rmSync(artifactDir, { recursive: true, force: true });
+		} catch {
+			// A failed removal is only a leaked temp dir; never fail the run for it.
+		}
+	};
+}

--- a/test/setup-workflow-durability.ts
+++ b/test/setup-workflow-durability.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeEach } from "vitest";
@@ -10,8 +10,35 @@ import { ENV_WORKFLOW_ARTIFACT_DIR } from "../packages/workflows/src/shared/work
  * the user's Atomic config root. Redirect them per test process so suites that
  * execute real builtin workflows cannot accumulate run directories in a
  * developer's home directory.
+ *
+ * The normal path sets nothing here: `test/global-setup-workflow-artifacts.ts`
+ * creates one directory per run in the orchestrator, every worker inherits the
+ * variable, and the orchestrator's teardown removes it. This block is the
+ * fallback for invocations that bypass the repo config's globalSetup.
+ *
+ * When the fallback does create a directory, it removes it on process exit —
+ * under the isolated forks pool that is one directory per test file, and
+ * leaking them is how 330k accumulated in the OS temp dir. The SIGTERM
+ * handler is load-bearing: tinypool ends pool forks with SIGTERM, whose
+ * default disposition skips `exit` listeners, so it is converted to a normal
+ * exit first. Workers that lose tinypool's 500 ms SIGTERM-to-SIGKILL race
+ * still leak, which is why the orchestrator-owned path above is the primary.
  */
-process.env[ENV_WORKFLOW_ARTIFACT_DIR] ??= mkdtempSync(join(tmpdir(), "atomic-test-workflow-artifacts-"));
+if (process.env[ENV_WORKFLOW_ARTIFACT_DIR] === undefined) {
+	const artifactDir = mkdtempSync(join(tmpdir(), "atomic-test-workflow-artifacts-"));
+	process.env[ENV_WORKFLOW_ARTIFACT_DIR] = artifactDir;
+	process.on("exit", () => {
+		try {
+			rmSync(artifactDir, { recursive: true, force: true });
+		} catch {
+			// Never let cleanup turn a green exit into a crash; a survivor is
+			// only a leaked temp dir.
+		}
+	});
+	process.once("SIGTERM", () => {
+		process.exit();
+	});
+}
 
 /**
  * Product runtime always uses DBOS. Unit and integration tests explicitly run

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,17 +12,24 @@ export { TEST_TIMEOUT_MS };
 const setupFiles = ["./test/setup-workflow-durability.ts"];
 
 /**
- * Runs once for the unit and integration projects, before any file is collected. It builds
- * `@bastani/atomic-natives` only when no compiled binding exists, because a
- * missing binding no longer degrades gracefully: `packages/subagents` imports
- * the Rust control plane statically, so the bundled extension throws during
- * module loading and takes roughly twenty unrelated files down with it under
- * errors that name the importer rather than the binding.
+ * Global setups run once per project in the orchestrator process, before any
+ * file is collected.
  *
- * On the happy path this is a single `existsSync`, so CI — which builds the
- * binding in an explicit step first — and any warm worktree pay nothing.
+ * `global-setup-workflow-artifacts` creates the per-run workflow-artifact
+ * directory that `setup-workflow-durability` points workers at, and removes it
+ * in teardown. It runs for all three projects.
+ *
+ * `global-setup-natives` builds `@bastani/atomic-natives` only when no
+ * compiled binding exists, because a missing binding no longer degrades
+ * gracefully: `packages/subagents` imports the Rust control plane statically,
+ * so the bundled extension throws during module loading and takes roughly
+ * twenty unrelated files down with it under errors that name the importer
+ * rather than the binding. On the happy path this is a single `existsSync`, so
+ * CI — which builds the binding in an explicit step first — and any warm
+ * worktree pay nothing. The CI contract project omits it.
  */
-const globalSetup = ["./test/global-setup-natives.ts"];
+const artifactSetup = "./test/global-setup-workflow-artifacts.ts";
+const nativeSetup = "./test/global-setup-natives.ts";
 
 const project = (name: string, directory: string, usesNativeSetup = true) => ({
 	resolve: { alias: sharedAliases },
@@ -34,7 +41,7 @@ const project = (name: string, directory: string, usesNativeSetup = true) => ({
 		include: [`${directory}/**/*.test.ts`],
 		exclude: ["**/node_modules/**"],
 		setupFiles,
-		...(usesNativeSetup ? { globalSetup } : {}),
+		globalSetup: usesNativeSetup ? [artifactSetup, nativeSetup] : [artifactSetup],
 		testTimeout: TEST_TIMEOUT_MS,
 		hookTimeout: TEST_TIMEOUT_MS,
 	},


### PR DESCRIPTION
## Summary

`test/setup-workflow-durability.ts` created one `mkdtemp` per vitest worker process and never removed it. Under the default isolated forks pool that is one directory per test file per run. Measured damage on a dev machine: **330k leaked `atomic-test-workflow-artifacts-*` entries** (of 1.3M total temp-dir entries), which made every `mkdtemp` under `tmpdir()` machine-wide take seconds and pushed real-CLI tests (e.g. `release-publisher-contracts`) past their structural budgets — 145 s for a sequence that takes 5 s in a clean temp dir.

## Changes

- **`test/global-setup-workflow-artifacts.ts` (new):** creates one directory per run in the orchestrator process; every worker inherits `ENV_WORKFLOW_ARTIFACT_DIR` and creates nothing; the globalSetup teardown removes it after the pool is gone. Wired into all three projects.
- **`test/setup-workflow-durability.ts`:** keeps a fallback for invocations that bypass the repo config, now with exit-time cleanup plus a SIGTERM→exit conversion — tinypool ends forks with SIGTERM (then SIGKILL after 500 ms), and Node's default SIGTERM disposition skips `exit` listeners entirely.
- **`test/ci/ci-workflow-contracts.test.ts`:** the globalSetup contract now asserts the artifact setup on all three projects and the native build on unit/integration only.

## Notes

- Why not worker-side cleanup alone: tinypool's 500 ms SIGTERM→SIGKILL teardown race means a loaded worker still leaks; the orchestrator teardown has no such race. The worker fallback exists only for non-repo-config invocations.
- Verified: three repeated multi-file suite runs leak **zero** directories (previously one per test file); `npm run check` and all 47 ci-contract tests green.
- Unrelated to but discovered via #2559, where the pre-push hook timed out on the polluted temp dir.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789877740&installation_model_id=10562&pr_number=2560&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2560&signature=56772127ac2221c5ce27b59c88bd1b7db8bd620fd331facdf55befc7fe933be6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change centralizes workflow-artifact temporary-directory ownership in Vitest’s orchestrator and retains worker-side cleanup for configuration-bypassing test runs. The artifact lifecycle was exercised twice through the root Vitest configuration with concurrent workers: each run used one shared directory while tests were active, and that directory no longer existed after Vitest exited. The temporary-directory leak concern was disproved by these executions. No defects were found.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised root-config test lifecycle.

Two independent concurrent-worker executions confirmed that workers inherit one orchestrator-owned artifact directory, can use it during the run, and that it is removed after the run exits. No publishable defects remain.

**Files Needing Attention:** No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the root-config workflow-artifact end-to-end harness twice with two Vitest workers to validate that a shared orchestrator-owned directory is inherited by workers and cleaned up when tests finish.
- In run 1, workers 3342 and 3343 observed /tmp/greptile-run-run-3/opencode-tmp/atomic-test-workflow-artifacts-NgzoEF, and the directory existed during the run with files from both workers and was removed after exit.
- In run 2, workers 3410 and 3411 observed /tmp/greptile-run-run-3/opencode-tmp/atomic-test-workflow-artifacts-WxzT0o, and the directory was likewise removed after exit.
- The two runs were compared and shown a consistent cleanup pattern across runs.
- Security status was checked and no security issues were identified.

<a href="https://app.greptile.com/trex/runs/19954373/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(test): stop leaking workflow-artifac..."](https://github.com/bastani-inc/atomic/commit/c3245cb48bff102aa061974d27fa88dc3cf3e538) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55438026)</sub>

<!-- /greptile_comment -->