### PR TITLE
chore: onboard repo with crabbox on the exe-dev provider

### DIFF
--- a/.agents/skills/crabbox/SKILL.md
+++ b/.agents/skills/crabbox/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: crabbox
+description: "Detect and use Crabbox for repository tests and validation on remote runners. Use when crabbox.yaml or .crabbox.yaml exists, the crabbox CLI is available, or work needs remote compute, a clean or reusable environment, target-platform coverage, or auditable execution evidence."
+license: MIT
+---
+
+# Crabbox
+
+Use Crabbox for remote project verification. Treat repo-root crabbox.yaml or
+.crabbox.yaml, or an available crabbox CLI, as a signal to use this skill for
+validation work. Inspect repository config before executing it; detection does
+not grant permission to expose secrets or start paid infrastructure.
+
+Workflow:
+- Warm early: crabbox warmup
+- Reuse the returned slug for interactive checks and keep the cbx_ id in scripts/logs.
+- Run checks with crabbox run --id <slug> -- <command>.
+- Use --cache-volume [name=]key:path only when the selected provider supports provider-backed cache volumes.
+- Use crabbox status --id <slug> --wait before broad gates if needed.
+- Use crabbox ssh --id <slug> to inspect the runner when a failure needs live context.
+- Stop with crabbox stop <slug> when finished.
+
+Do not debug product failures on a reused box that fails sync sanity. Stop it, warm a fresh box, and rerun.
+
+Detected workflow:
+- Prefer crabbox job run detected for the broad remote check.
+
+```sh
+crabbox job run detected
+```

--- a/.crabbox.yaml
+++ b/.crabbox.yaml
@@ -1,0 +1,53 @@
+profile: atomic-check
+provider: exe-dev
+exeDev:
+  image: ""
+  cpus: 4
+  memory: 8GB
+  disk: 40GB
+  workRoot: /tmp/crabbox
+  noEmail: true
+sync:
+  delete: true
+  checksum: false
+  gitSeed: true
+  fingerprint: true
+  timeout: 15m
+  warnFiles: 50000
+  warnBytes: 5368709120
+  failFiles: 150000
+  failBytes: 21474836480
+  exclude:
+    - .cache
+    - .turbo
+    - dist
+    - node_modules
+    - .npm
+    - .yarn/cache
+    - target
+run:
+  preflightTools:
+    - node
+    - bun
+    - npm
+    - cargo
+env:
+  allow:
+    - CI
+    - NODE_OPTIONS
+cache:
+  # Optional provider-backed cache volumes. Keep paths outside the synced source tree.
+  volumes: []
+jobs:
+  detected:
+    shell: true
+    command: >
+      (cd 'evals/vendor/pier/apps/viewer' && bun install --frozen-lockfile && bun run 'build') &&
+      npm ci && npm test &&
+      (cd 'packages/coding-agent/examples/extensions/custom-provider-anthropic' && npm ci && npm run 'check') &&
+      (cd 'packages/coding-agent/examples/extensions/gondolin' && npm ci && npm run 'check') &&
+      (cd 'packages/coding-agent/examples/extensions/sandbox' && npm ci && npm run 'check') &&
+      (cd 'packages/coding-agent/examples/extensions/with-deps' && npm ci && npm run 'check') &&
+      cargo test &&
+      (cd 'crates/atomic-natives' && cargo test)
+    stop: auto


### PR DESCRIPTION
## Summary

Onboards the repository with [Crabbox](https://crabbox.sh) so tests and validation lanes can run on remote Linux VMs provisioned through the user's exe.dev SSH account, instead of only on local machines.

## Changes

- `.crabbox.yaml` — repo-local Crabbox config:
  - `provider: exe-dev` with VM sizing of 4 CPU / 8GB / 40GB and work root `/tmp/crabbox`
  - sync excludes for `node_modules`, `dist`, and package-manager caches
  - a `jobs.detected` lane covering `npm ci && npm test`, the vendored evals viewer build, and both `cargo test` lanes (root + `crates/atomic-natives`)
- `.agents/skills/crabbox/SKILL.md` — agent-facing instructions for the warmup/run/stop workflow, alongside the existing `.agents/skills/` entries

## Breaking Changes

None.

## Notes

- **No Actions hydration workflow.** `crabbox init` normally writes `.github/workflows/crabbox.yml`, but `test/ci/ci-workflow-contracts.test.ts` pins GitHub-hosted runners across all workflow files to exactly `macos-26-intel` and `ubuntu-latest`, so the stub's `ubuntu-latest` hydrate job would break `npm run test:ci-contracts`. Actions hydration is optional and defaults to local setup steps.
- **`exeDev.controlHost` is deliberately omitted.** It defaults to `exe.dev`; a repository-defined control host is refused when credentials are inherited from ambient SSH unless explicitly approved via `CRABBOX_EXE_DEV_CONTROL_HOST` or `--exe-dev-control-host`.
- Repo config overrides the user-level provider selection (precedence: repo-local > user config), so other repos keep their own defaults.

**Usage:**

```sh
crabbox run -- npm run test:unit   # one-shot: lease → sync → run → release
crabbox warmup                      # keep a box warm, reuse via --id <slug>
crabbox job run detected            # full detected check lane
```

Verified end to end: `crabbox doctor` reports `provider=exe-dev` ready, and a live smoke test provisioned a VM, ran `uname -a` over SSH, and released it cleanly with no leftover inventory.

Assistant-model: Ox Alpha (Stealth)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789887897&installation_model_id=10562&pr_number=2562&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2562&signature=97fddf45e05963916ffb22a6de26187cad65c61ebdb14c156b9ee436ece2bf67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds an exe.dev Crabbox profile and a detected remote validation command for the vendored viewer, npm suites, extension checks, and Rust tests. The command cannot reach the main npm and Cargo checks when the Pier submodule is absent because its first directory change fails. Its dependency setup also conflicts with the repository’s required npm/package-lock installation path by invoking Bun and allowing npm lifecycle scripts.

<h3>Confidence Score: 3/5</h3>

Not safe to merge until the detected job can run the intended repository checks without requiring a pre-initialized viewer submodule and uses the approved installation commands.

Two independent non-security failures were reproduced directly from the checked-in configuration: the missing Pier directory terminates the shell chain, and the configured install commands conflict with the documented installation policy.

**Files Needing Attention:** `.crabbox.yaml` lines 45–50 need attention; `AGENTS.md` provides the applicable installation requirements.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced proof for a posted P1 finding and attached artifacts showing the focused config execution script, the uninitialized Pier submodule baseline, and a detected job execution with uninitialized Pier.
- T-Rex added additional supporting artifacts for the P1 finding, including a Python script and a focused Crabbox install-policy check output.
- T-Rex performed a general-contract-validation-proof review, noting that the Crabbox YAML references and the extracted command fail due to a missing viewer directory, with no npm or Cargo output.

<a href="https://app.greptile.com/trex/runs/19972237/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Detected job cannot validate npm or Cargo when Pier submodule is uninitialized**

   - **Bug**
     - The first grouped command in `jobs.detected.command` requires `evals/vendor/pier/apps/viewer`. In the observed uninitialized-submodule state this directory does not exist, and the failed `cd` prevents every subsequent `&&` validation command from executing.
   - **Cause**
     - `.crabbox.yaml:45` begins the chained command with `cd 'evals/vendor/pier/apps/viewer'` without ensuring the required git submodule has been initialized.
   - **Fix**
     - Initialize the Pier submodule before this job runs, or make the job explicitly initialize/check the submodule and handle its absence before entering the validation chain.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.crabbox.yaml:45
**Uninitialized submodule aborts validation**

`jobs.detected` starts by entering `evals/vendor/pier/apps/viewer`, but that directory does not exist when the Pier submodule has not been initialized. The failed `cd` terminates the `&&` chain, so the root npm suite and both Cargo test commands never run. Initialize or explicitly check the required submodule before this chain, or make the viewer validation independent of the remaining repository checks.

### Issue 2
.crabbox.yaml:45-50
**Detected job bypasses the required install path**

The job invokes `bun install --frozen-lockfile` at line 45 and invokes `npm ci` without `--ignore-scripts` at lines 46–50. This conflicts with the repository rule requiring `npm ci --ignore-scripts`, using `package-lock.json` as the single verified lockfile, and prohibiting reintroduction of `bun install`. Replace the Bun install path with the approved npm/package-lock path where applicable and add `--ignore-scripts` to every npm clean install.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: onboard repo with crabbox on the ..."](https://github.com/bastani-inc/atomic/commit/d29244825da33c89c047e5bf0681db947ab1f55f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55469203)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->