### PR TITLE
chore: size crabbox exe-dev lanes at 2 cpu / 8gb

### DIFF
--- a/.crabbox.yaml
+++ b/.crabbox.yaml
@@ -2,7 +2,7 @@ profile: atomic-check
 provider: exe-dev
 exeDev:
   image: ""
-  cpus: 4
+  cpus: 2
   memory: 8GB
   disk: 40GB
   workRoot: /tmp/crabbox


### PR DESCRIPTION
## Summary

Follow-up to #2562: right-size the Crabbox exe-dev VM shape for the team plan's shared resource pool.

## Changes

- `exeDev.cpus`: 4 → **2** (memory stays 8GB, disk stays 40GB)

## Rationale

The Team (Medium) plan pools **4 vCPUs · 16 GB across all VMs** — per-VM flags shape a lease, but the pool caps the total:

| Concurrency | Outcome at 2 CPU / 8 GB |
|---|---|
| 1 lane (typical) | half the pool — comfortable |
| 2 lanes (occasional) | exact fit: 4 vCPU + 16 GB |
| 4 lanes (rare) | 2× oversubscribed → slower via exe.dev's soft CPU scheduling / memory reclaim, not failures |

Four-way overlap of heavy test phases is uncommon, so insuring every lane down to 1 vCPU traded everyday speed for protection against a rare case. Disk allocation stays at 40 GB since billing keys off actual ext4 usage against the 200 GB pool, not allocation.

Assistant-model: Ox Alpha (Stealth)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789889097&installation_model_id=10562&pr_number=2563&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2563&signature=db7278c257ac0646fe1ee15635602381fb842dad0a8e15d873e3124fb111055f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change reduces each exe.dev Crabbox lane from 4 CPUs to 2 CPUs while preserving the 8 GB memory allocation, 40 GB disk allocation, and detected validation workload.

The configuration comparison and YAML validation confirmed that the CPU value is the only changed resource setting. A possible timeout regression was disproved: `sync.timeout: 15m` remains unchanged and applies to source synchronization, while neither revision defines a timeout for the detected job.

### T-Rex validation blocked
Provider-side job execution could not be run because the `crabbox` CLI tool is not installed in the environment. This does not affect the completed configuration comparison and timeout-placement check.

<h3>Confidence Score: 5/5</h3>

The configuration change is safe to merge: it only reduces the per-lane CPU allocation and preserves the workload and all other declared resources.

No actionable defects remain. The executed before-and-after YAML check confirmed the sole CPU change and disproved the tested timeout concern by showing that the 15-minute setting is synchronization-only in both revisions.

**Files Needing Attention:** No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused Crabbox CPU and timeout validation to compare base and head YAML configurations.
- Observed that both base and head configs have sync.timeout: 15m and neither defines jobs.detected.timeout, and that the head YAML passes validation with exeDev.cpus changing from 4 to 2.
- Tried to run the Crabbox provider CLI locally, but crabbox was unavailable, so provider-side lease execution could not be performed.
- Re-ran the validation steps and reaffirmed the earlier observations; there is no proven finding (no security issue) according to the second proof.

<a href="https://app.greptile.com/trex/runs/19974231/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: size crabbox exe-dev lanes at 2 c..."](https://github.com/bastani-inc/atomic/commit/65d29bfd7553ad0752f51b50c057eb822c2fd7a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55473708)</sub>

<!-- /greptile_comment -->