### PR TITLE
chore: gate the unit suite on push instead of every commit

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -24,7 +24,11 @@ hooks = [
   { id = "format", name = "biome check --write", entry = "npx --no-install biome check --write --no-errors-on-unmatched", language = "system", files = "\\.(ts|mjs)$" },
   # Renamed off the `bun-` prefix with the toolchain: these run under npm now.
   { id = "check", name = "npm run check", entry = "npm run check", language = "system", pass_filenames = false },
-  { id = "test-unit", name = "npm run test:unit", entry = "npm run test:unit", language = "system", pass_filenames = false },
+  # Push-only. At ~85 s this is the most expensive hook in the file, and with no
+  # stage filter it used to run on every commit and then again on the next push.
+  # `npm run check` (~4 s) stays on pre-commit for fast type feedback; CI runs
+  # the suite regardless, and the contract test only requires that it gate a push.
+  { id = "test-unit", name = "npm run test:unit", entry = "npm run test:unit", language = "system", pass_filenames = false, stages = ["pre-push"] },
   # Push-only. CI runs all three suites, so a hook that stops at test:unit lets an
   # integration or contract failure reach CI by default — which is exactly how a
   # Windows-only line-ending bug and a broken integration fixture both got pushed.


### PR DESCRIPTION
## Summary

Stops paying for the ~85 s unit suite on every commit. `test:unit` had no `stages` filter, so it ran at **pre-commit and again at pre-push** — N commits plus one push executed the suite N+1 times. It now gets the same `pre-push`-only staging `test:integration` and `test:ci-contracts` already have.

## Changes

- `prek.toml`: `test-unit` hook gains `stages = ["pre-push"]` plus a comment explaining why

## Why this is safe

- `test/ci/ci-workflow-contracts.test.ts` ("every CI test suite also gates a push") only requires each CI suite's hook to include `pre-push` in its stages — satisfied. `npm run test:unit`, `test:integration`, and `test:ci-contracts` all still gate the push.
- CI runs all three suites unchanged; nothing loses coverage.
- `npm run check` (~4 s measured) **stays on pre-commit** — cheap, and fast type feedback per commit is worth keeping.
- prek resolves `prek.toml` at runtime, so no hook reinstall is needed.

## Effect

| | before | after |
|---|---|---|
| commit (hooks) | ~90 s+ | **~4.4 s** (measured on this branch's own commit) |
| push (hooks) | full gate, duplicated unit run | full gate, once |
| CI | unchanged | unchanged |

Assistant-model: Ox Alpha (Stealth)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789889301&installation_model_id=10562&pr_number=2564&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2564&signature=fac583cedec7b4440f8028c38cdda0ee5ccc85bf05572480466cd3027208ef3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change defers the unit-test hook until a push while keeping the faster commit-time check in place. The possible failure that the unit suite would either remain attached to commits or no longer run before pushes was disproved: paired dry runs showed no unit-test selection for pre-commit and selection of `npm run test:unit` for pre-push.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the hook configuration behaves as intended for both commit and push workflows.

The changed behavior was directly exercised with matching dry runs under each hook invocation, and the configuration was parsed successfully.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran paired dry-run validations using prek 0.4.11 for the test-unit hook with prek.toml, testing both pre-commit and pre-push stages.
- The pre-commit dry run produced no selected hooks, while the pre-push dry run listed test-unit as a dry-run step, indicating push gating.
- I parsed prek.toml and confirmed test-unit is declared with stages = \["pre-push"\] and appears in the parsed hook list.
- No source files were modified during the validations.
- Artifacts documenting the pre-commit exclusion, pre-push inclusion, and the configured hook list were captured.

<a href="https://app.greptile.com/trex/runs/19974549/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: gate the unit suite on push inste..."](https://github.com/bastani-inc/atomic/commit/91320f636e14e5fd93907ca50f162456a4797e99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55474357)</sub>

<!-- /greptile_comment -->