### PR TITLE
docs(models): refresh DeepSWE and Artificial Analysis benchmark snapshots

### DIFF
--- a/packages/coding-agent/docs/models/artificial-analysis-index.md
+++ b/packages/coding-agent/docs/models/artificial-analysis-index.md
@@ -8,7 +8,7 @@ description: "The external benchmarks that inform Atomic model selection — Art
 Atomic's model-selection docs are keyed to two live external benchmark sources rather than a hand-maintained table of scores. This page lists each benchmark, what it measures, and **when to reference it** for a given workflow role — so the docs stay useful as new models ship without a manual rewrite every time.
 
 <Warning>
-No single benchmark is the source of truth. Use these as inputs and validate against Atomic's own workflow evals — public suites test different task distributions than real engineering loops. When Atomic's numbers disagree with a public index, Atomic's evals win. **Last reviewed: 2026-08-16.**
+No single benchmark is the source of truth. Use these as inputs and validate against Atomic's own workflow evals — public suites test different task distributions than real engineering loops. When Atomic's numbers disagree with a public index, Atomic's evals win. **Last reviewed: 2026-08-21.**
 </Warning>
 
 ## The two sources at a glance
@@ -32,7 +32,7 @@ Artificial Analysis separates performance by benchmark, which lets a workflow pi
 
 ### Composite indices
 
-- **Intelligence Index (v4.1.1)** — composite of the nine evaluations below. Use as a first-pass filter when a new model appears.
+- **Intelligence Index (v4.1.1)** — composite of the nine evaluations below, weighted across four categories: Agents 34%, Coding 24%, Scientific Reasoning 24%, General 18%. Use as a first-pass filter when a new model appears.
 - **Coding Index** — coding-weighted sub-index. Cross-check against DeepSWE.
 - **Agentic Index** — tool use, planning, autonomy, complex problem solving. The best AA signal for orchestrator and reviewer roles.
 

--- a/packages/coding-agent/docs/models/model-selection.md
+++ b/packages/coding-agent/docs/models/model-selection.md
@@ -14,7 +14,7 @@ This page gives workflow authors and runtime policy code a practical way to answ
 It is a **static reference**. It does not change runtime model routing — routing is configured elsewhere. Treat these recommendations as a starting point and validate against your own workflow evals.
 
 <Note>
-The table below is a snapshot of the [DeepSWE](https://deepswe.datacurve.ai/) leaderboard (v1.1, highest published thinking level per model), a long-horizon coding-agent benchmark reporting `pass@1` and average dollars per task. Benchmarks and pricing drift and new models ship constantly, so **treat the live leaderboards as authoritative** and refresh this page from them rather than hand-maintaining scores. See [Benchmark sources & when to reference each](/models/artificial-analysis-index). **Last compiled: 2026-08-16.**
+The table below is a snapshot of the [DeepSWE](https://deepswe.datacurve.ai/) leaderboard (v1.1, highest published thinking level per model), a long-horizon coding-agent benchmark reporting `pass@1` and average dollars per task. Benchmarks and pricing drift and new models ship constantly, so **treat the live leaderboards as authoritative** and refresh this page from them rather than hand-maintaining scores. See [Benchmark sources & when to reference each](/models/artificial-analysis-index). **Last compiled: 2026-08-21.**
 </Note>
 
 ## Benchmark levels are measurement settings
@@ -30,15 +30,16 @@ reports the ambiguity. Use `--provider <provider> --model <id>` or `--model <pro
 
 ## Recommendation chart
 
-The current highest-effort-config Pareto frontier is **claude-opus-5** (accuracy ceiling), **gpt-5.6-sol**, **gpt-5.6-terra**, **gpt-5.6-luna**, **deepseek-v4-pro**, and **deepseek-v4-flash**. Everything else is dominated on DeepSWE cost and accuracy and earns a place only through role fit or provider diversity. For the frontier reasoning, see [Pareto Efficiency](/models/pareto-efficiency).
+The current highest-effort-config Pareto frontier is **claude-opus-5** (accuracy ceiling), **gpt-5.6-sol**, **glm-5.3**, **gpt-5.6-luna**, **deepseek-v4-pro**, and **deepseek-v4-flash**. Everything else is dominated on DeepSWE cost and accuracy and earns a place only through role fit or provider diversity. For the frontier reasoning, see [Pareto Efficiency](/models/pareto-efficiency).
 
 | Model [benchmark measurement level] | pass@1 | $/task | Verdict | Use it for |
 | --- | --- | --- | --- | --- |
 | claude-opus-5 [max] | 74% | $11.84 | Accuracy ceiling / frontier | Final approval and the hardest debugging when one more point can justify the cost |
 | gpt-5.6-sol [max] | 73% | $8.39 | Frontier | High-cost judgment gates; nearly the top score at lower cost than Opus 5 |
-| gpt-5.6-terra [max] | 70% | $3.96 | Frontier — best top-tier value | High-accuracy reviewers and planners |
-| claude-fable-5 [max] | 70% | $21.63 | Drop | Sol and Terra match or beat its score for much less |
-| kimi-k3 [max] | 69% | $4.65 | Diversity fallback | Open-weights diversity, though Terra is cheaper and more accurate on DeepSWE |
+| gpt-5.6-terra [max] | 70% | $3.96 | Off the live board | Last published measurement (July pricing); no longer displayed on the live leaderboard as of the August 20 refresh — re-verify against the source before relying on it |
+| claude-fable-5 [max] | 70% | $21.63 | Drop | Sol matches or beats its score for much less |
+| glm-5.3 [max] | 69% | $3.99 | Frontier — open-weights value | Best open-weights cost/accuracy point; matches Kimi K3's rounded score for less |
+| kimi-k3 [max] | 69% | $4.65 | Dominated | GLM-5.3 matches its rounded score for $0.66 less; Moonshot-family diversity only |
 | gpt-5.6-luna [max] | 67% | $0.61 | Frontier — best general value | Research, orchestration, workers, and code simplification |
 | gpt-5.5 [xhigh] | 67% | $7.23 | Superseded | Luna matches its score for less than one tenth of the task cost |
 | grok-4.6 [xhigh] | 67% | $5.50 | Provider fallback | xAI diversity; Luna has the same rounded score at lower DeepSWE task cost |
@@ -58,10 +59,9 @@ The current highest-effort-config Pareto frontier is **claude-opus-5** (accuracy
 | kimi-k2.7-code [low] | 31% | $2.19 | Superseded | Kimi K3 is the current family fallback |
 | claude-sonnet-4.6 [high] | 30% | $5.52 | Drop everywhere | Removed from all chains |
 | gemini-3.1-pro [high] | 12% | $2.14 | Drop everywhere | Removed from all chains |
-| glm-5.3 [high] | unmeasured | unmeasured | Diversity fallback | Current direct Z.AI fallback; GLM-5.2 measurements are not relabeled |
 
 <Note>
-DeepSWE values above use the v1.1 results and reporting corrections published through August 14, 2026; `pass@1` is rounded as on the live leaderboard and confidence intervals are omitted here. The highest published thinking level is a measurement choice, not a production default. See the live page for intervals, output tokens, steps, lower-effort configurations, and later corrections.
+DeepSWE values above use the v1.1 results and reporting corrections published through August 20, 2026; `pass@1` is rounded as on the live leaderboard and confidence intervals are omitted here. The highest published thinking level is a measurement choice, not a production default. GPT-5.6 Terra's July measurement no longer appears on the live board, so its row keeps the last published values. See the live page for intervals, output tokens, steps, lower-effort configurations, and later corrections.
 </Note>
 
 ## Role-based thinking effort
@@ -82,7 +82,7 @@ Reserve `max` for a high-cost-of-error role or an explicit user request. An expl
 Pick by the cost of being wrong in each role, not by raw accuracy. Match the role to the benchmark that best measures it (see [Benchmark sources](/models/artificial-analysis-index)).
 
 - **Reviewer / judgment gates** — use `max` when the reviewer makes a security, identity, adversarial, or final-approval decision whose wrong verdict discards an entire loop. `claude-opus-5` is the DeepSWE accuracy ceiling; `gpt-5.6-sol` is the lower-cost near-peer. Use another family when decorrelated errors matter.
-- **Codebase mapping / planner** — start at `high` for repository mapping, lifecycle analysis, compatibility, and plans. `gpt-5.6-terra` is the strongest top-tier value at its measured `max` configuration; raise production effort to `max` only when the plan gates a high-cost loop or the user asks for it.
+- **Codebase mapping / planner** — start at `high` for repository mapping, lifecycle analysis, compatibility, and plans. `gpt-5.6-sol` is the strongest top-tier value at its measured `max` configuration, and `glm-5.3` carries the open-weights mid tier; raise production effort to `max` only when the plan gates a high-cost loop or the user asks for it.
 - **Debugger / triage / repair** — start at `high`; deep reasoning pays off when root-causing or repairing is costly. Weight DeepSWE and Terminal-Bench together rather than treating either as a complete measure.
 - **Research / synthesis** — use `high` for demanding research and evidence reconciliation; use `medium` for routine synthesis when the evidence is already strong. `gpt-5.6-luna` remains the workhorse. Benchmark to weight: AA-LCR and AA-Omniscience.
 - **Orchestrator / worker / cheap loops** — Luna offers the best broad cost/accuracy balance. DeepSeek V4 Pro and Flash occupy the budget frontier but take 155 and 153 steps on average; use them only when that longer path fits. Use another family when provider diversity matters.

--- a/packages/coding-agent/docs/models/pareto-efficiency.md
+++ b/packages/coding-agent/docs/models/pareto-efficiency.md
@@ -10,7 +10,7 @@ A model is **Pareto-efficient** (on the frontier) if no other model is both chea
 The axes here are `pass@1` (accuracy) and `average dollars per task` (cost), taken from the [DeepSWE](https://deepswe.datacurve.ai/) coding-agent leaderboard. For the full table and role guidance, see [Model Selection](/models/model-selection).
 
 <Note>
-Figures are a snapshot of DeepSWE v1.1 using the highest published thinking level per model and reporting corrections through August 14, 2026. The frontier moves whenever a model, run, or price changes — DeepSWE publishes a live cost-vs-score scatter, so **read the frontier off the live chart** rather than trusting a static list. **Last compiled: 2026-08-16.**
+Figures are a snapshot of DeepSWE v1.1 using the highest published thinking level per model and reporting corrections through August 20, 2026. The frontier moves whenever a model, run, or price changes — DeepSWE publishes a live cost-vs-score scatter, so **read the frontier off the live chart** rather than trusting a static list. **Last compiled: 2026-08-21.**
 </Note>
 
 ## The frontier
@@ -20,22 +20,22 @@ Six highest-effort model configurations currently sit on the frontier, from the 
 - **deepseek-v4-flash [max]** — 53% for $0.10. The cheapest point, with lower accuracy and 153 average steps.
 - **deepseek-v4-pro [max]** — 63% for $0.24. A large accuracy gain for another $0.14 per task, with 155 average steps.
 - **gpt-5.6-luna [max]** — 67% for $0.61. The best broad value on the board.
-- **gpt-5.6-terra [max]** — 70% for $3.96. The best top-tier value after the July price correction.
+- **glm-5.3 [max]** — 69% for $3.99. The open-weights mid-tier point; matches Kimi K3's rounded score for less.
 - **gpt-5.6-sol [max]** — 73% for $8.39. The lower-cost near-peer to the accuracy leader.
 - **claude-opus-5 [max]** — 74% for $11.84. The current accuracy ceiling.
 
 ## What changed — the frontier moved
 
-The August results and reporting fixes changed both ends of the frontier:
+The August 20 refresh reshuffled the middle of the frontier:
 
-- **Claude Opus 5 [max]** set a new 74% ceiling, one point above Sol, at $11.84 per task.
-- **DeepSeek V4 Flash and Pro [max]** added $0.10 and $0.24 budget-frontier points. Their 153–155 average steps remain a separate latency and loop-length cost.
-- **GPT-5.6 Luna and Terra [max]** now cost $0.61 and $3.96 per task after corrected pricing, strengthening both positions.
+- **GLM-5.3 [max]** is now measured — 69% for $3.99 with 124 average steps — and takes the mid-tier frontier slot.
+- **GPT-5.6 Terra [max]** no longer appears on the live board; its July measurement (70% for $3.96) is retained in [Model Selection](/models/model-selection) as history, not a current frontier point.
+- **Kimi K3 [max]** is now strictly dominated: GLM-5.3 matches its rounded score for $0.66 less per task.
 
 ## Dominated models — and why
 
-- **claude-fable-5 [max]** — Sol is more accurate and much cheaper; Terra matches its rounded score for less than one fifth of the task cost.
-- **kimi-k3 [max]** — Terra is one point more accurate and $0.69 cheaper; Kimi remains useful for open-weights diversity.
+- **claude-fable-5 [max]** — Sol is more accurate and much cheaper; GLM-5.3 comes within a point for less than one fifth of the task cost.
+- **kimi-k3 [max]** — GLM-5.3 matches its rounded score and is $0.66 cheaper; Kimi remains useful for Moonshot-family diversity.
 - **gpt-5.5 [xhigh]** and **grok-4.6 [xhigh]** — Luna matches their rounded 67% for $0.61.
 - **gemini-3.7-flash [high]** — Luna is two points more accurate and less than one third of its task cost.
 - **grok-4.5 [high]**, **muse-spark-1.1 [xhigh]**, **muse-spark-1.2 [xhigh]**, and **gpt-5.4 [xhigh]** — the new DeepSeek and GPT-5.6 points dominate these former budget choices.
@@ -47,8 +47,8 @@ The August results and reporting fixes changed both ends of the frontier:
 Efficiency is not the only axis. A dominated model can still earn a slot when it decorrelates errors or fills a niche:
 
 - **grok-4.6** — retained as the operational xAI and OpenRouter provider-diversity fallback.
-- **glm-5.3 [high]** — unmeasured in the current DeepSWE snapshot; retained as a direct Z.AI provider-diversity fallback. GLM-5.2 results are not relabeled as GLM-5.3.
-- **kimi-k3** — retained as a strong open-weights provider-diversity option despite Terra's strict DeepSWE dominance.
+- **glm-5.2 [max]** — kept only as a measured predecessor; its results are never relabeled as GLM-5.3, which is now measured directly on the frontier.
+- **kimi-k3** — retained as a Moonshot-family provider-diversity option despite GLM-5.3's strict DeepSWE dominance.
 - **claude-opus-4.8 [max]** — retained where Anthropic diversity or its long-context behavior has separate value.
 - **claude-fable-5** — kept where Anthropic-family behavior is specifically wanted, such as the quality-first, unbenchmarked design chain.
 - **Unmeasured models** — a family without current DeepSWE or Artificial Analysis coverage may remain an operational default, but should not inherit a predecessor's score.


### PR DESCRIPTION
## Summary

Refreshes the model docs from the live sources: the DeepSWE leaderboard refresh of **August 20, 2026** and a re-check of the Artificial Analysis Intelligence Index (still **v4.1.1**, launched Aug 6 with grader upgrades — nine evaluations unchanged).

## Changes

- **GLM-5.3 [max] is now measured** on DeepSWE: 69% pass@1, $3.99/task, 124 avg steps. Added to the recommendation table and the Pareto frontier; the old "unmeasured" placeholder row is removed.
- **GPT-5.6 Terra [max] no longer appears on the live board** (absent from both the table and the scatter as of Aug 20). Its July measurement (70%, $3.96) is retained but flagged as off-board history with a re-verify note.
- **Kimi K3 [max] is now strictly dominated** by GLM-5.3 (same rounded score for $0.66 less); verdicts, the dominated/exceptions lists, and the planner scenario guidance are updated to match the new frontier (opus-5 / sol / glm-5.3 / luna / deepseek-pro / deepseek-flash).
- `artificial-analysis-index.md`: recorded the AAII v4.1.1 category weights (Agents 34%, Coding 24%, Scientific Reasoning 24%, General 18%).
- Timestamps bumped to 2026-08-21 ("Last reviewed" / "Last compiled"; DeepSWE results through August 20, 2026).

## Notes

- The DeepSWE changelog page still ends at Aug 14; the Aug 20 changes (GLM-5.3 addition, board pruning) are visible on the leaderboard itself.
- Verified remotely on an exe-dev crabbox runner: `npm ci` + `npm run build` + `vitest --run test/unit/execution-routing-guidance.test.ts` — **35/35 passing**, including the contract assertions over `model-selection.md` phrasing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789898025&installation_model_id=10562&pr_number=2574&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2574&signature=0befb4ea9891ce91e6c790cf7ab22ca4cf04a4e4958413a301c4ef0bfc99e43b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the model-selection reference with the August 20 DeepSWE snapshot and Artificial Analysis v4.1.1 category weights. The model frontier, historical GPT-5.6 Terra treatment, routing guidance contract, and documentation links are consistent and valid.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains; the documentation update is safe to merge.

No accepted blocking findings remain after the model-reference consistency, guidance-contract, and documentation-link checks passed.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The cross-page model snapshot validator was run against the parent and updated revisions and reported six matching frontier rows, unified snapshot dates, and consistent GPT-5.6 Terra treatment.
- The execution-routing-guidance unit test was executed, and all 35 model-selection guidance assertions passed.
- The documentation link checks were run and all 38 Markdown/MDX files and 38 documentation pages passed link validation.
- A log captured the before/after cross-page contract, showing comparable results across runs.
- The exact authored validator source file was uploaded as requested.

<a href="https://app.greptile.com/trex/runs/20041323/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into docs/benchmark-..."](https://github.com/bastani-inc/atomic/commit/7b7c75ffff9c3941aeb9fc29216459759a0f67c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55505424)</sub>

<!-- /greptile_comment -->