### PR TITLE
feat(evals): accept max thinking level in Pier and Harbor adapters

### DIFF
--- a/evals/atomic_harbor.py
+++ b/evals/atomic_harbor.py
@@ -57,7 +57,7 @@ class Atomic(BaseInstalledAgent):
             "thinking",
             cli="--thinking",
             type="enum",
-            choices=["off", "minimal", "low", "medium", "high", "xhigh"],
+            choices=["off", "minimal", "low", "medium", "high", "xhigh", "max"],
         ),
     ]
 

--- a/evals/atomic_pier.py
+++ b/evals/atomic_pier.py
@@ -164,7 +164,7 @@ class Atomic(BaseInstalledAgent):
             "thinking",
             cli="--thinking",
             type="enum",
-            choices=["off", "minimal", "low", "medium", "high", "xhigh"],
+            choices=["off", "minimal", "low", "medium", "high", "xhigh", "max"],
         ),
     ]
 


### PR DESCRIPTION
## Summary

Adds `max` to the `--thinking` enum choices in both eval adapters so benchmark runs can select Atomic's highest reasoning level.

## Changes

- `evals/atomic_pier.py` and `evals/atomic_harbor.py`: thinking choices are now `["off", "minimal", "low", "medium", "high", "xhigh", "max"]`, matching `THINKING_LEVELS` in `packages/coding-agent/src/core/agent-session-types.ts`.

## Notes

- Validated remotely on an exe-dev crabbox runner: `py_compile` on both files plus an AST assertion that each `choices` list equals `THINKING_LEVELS` (with `max`) exactly.
- Local pre-commit `npm run check` and the pre-push unit/integration/ci-contract suites pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789898026&installation_model_id=10562&pr_number=2575&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2575&signature=b314815f23b58ded7b0b77aca12698d29002f7cd5c22beb1ba62170328b4c8f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `max` as an accepted thinking level in the Harbor and Pier Atomic evaluation adapters, matching Atomic’s canonical thinking-level list. Executable validation confirmed both adapters now forward `--thinking max`, preserve the existing levels’ CLI output, and continue rejecting invalid values. No defects were found.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge: both adapters match the canonical thinking-level contract and preserve existing validation behavior.

The exact before-and-after adapter behavior was exercised for every pre-existing thinking level, the new `max` level, and an invalid value in both Harbor and Pier.

**Files Needing Attention:** No further files need attention; the changed Harbor and Pier adapter enum definitions were covered directly.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused Python harness against the parent revision and the updated revision, loading both exact adapter sources, and verified that before the change Harbor and Pier rejected max while preserving CLI output; after the change, both adapters expose the canonical seven choices, build \['--thinking', 'max'\], preserve outputs for existing levels, and reject 'invalid'.
- Compared the harness’ before and after behavior using the harness source and captured command outputs, and attached artifacts showing the pre-change and post-change results.

<a href="https://app.greptile.com/trex/runs/19990641/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(evals): accept max thinking level i..."](https://github.com/bastani-inc/atomic/commit/eb291fc3bfb7ec51dfe5fd3f3050aa1205f1f2a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55505425)</sub>

<!-- /greptile_comment -->