### PR TITLE
fix(widgets): add release signal and mount-failure reporting to reactive widgets

### DIFF
--- a/packages/coding-agent/src/core/extensions/reactive-widget.ts
+++ b/packages/coding-agent/src/core/extensions/reactive-widget.ts
@@ -134,6 +134,7 @@ export function installReactiveWidget<TSnapshot, TTheme = object>(
 	let currentSnap = options.getSnapshot();
 	let currentNow = now();
 	let lastLines: readonly string[] = [];
+	let unsubscribe: (() => void) | undefined;
 	let unsubscribeWidgetRelease: (() => void) | undefined;
 	let mountFailureReported = false;
 
@@ -297,9 +298,18 @@ export function installReactiveWidget<TSnapshot, TTheme = object>(
 		},
 	};
 
-	const unsubscribe = options.subscribe?.(() => controller.refresh("state"));
-	unsubscribeWidgetRelease = options.ui.onWidgetRelease?.(options.key, handleWidgetRelease);
-	controller.refresh("initial");
+	try {
+		unsubscribe = options.subscribe?.(() => controller.refresh("state"));
+		unsubscribeWidgetRelease = options.ui.onWidgetRelease?.(options.key, handleWidgetRelease);
+		controller.refresh("initial");
+	} catch (error) {
+		try {
+			controller.dispose();
+		} catch {
+			// Preserve the original installation failure after rolling back subscriptions.
+		}
+		throw error;
+	}
 
 	return controller;
 }

--- a/packages/coding-agent/src/core/extensions/reactive-widget.ts
+++ b/packages/coding-agent/src/core/extensions/reactive-widget.ts
@@ -11,6 +11,7 @@ export type ReactiveWidgetFactory<TTheme> = (tui: unknown, theme: TTheme) => Rea
 export interface ReactiveWidgetUi<TTheme> {
 	setWidget(key: string, factory: ReactiveWidgetFactory<TTheme> | undefined, options?: ExtensionWidgetOptions): void;
 	requestRender?: () => void;
+	onWidgetRelease?: (key: string, listener: () => void) => () => void;
 }
 
 export interface ReactiveWidgetTimerHandle {
@@ -46,6 +47,11 @@ export interface ReactiveWidgetController {
 	isMounted(): boolean;
 }
 
+export interface ReactiveWidgetMountError {
+	readonly cause: Error;
+	readonly message: string;
+}
+
 export interface InstallReactiveWidgetOptions<TSnapshot, TTheme> {
 	ui: ReactiveWidgetUi<TTheme>;
 	key: string;
@@ -63,6 +69,7 @@ export interface InstallReactiveWidgetOptions<TSnapshot, TTheme> {
 	requestRenderOnUnmount?: boolean;
 	requestRenderOnStateNoop?: boolean;
 	isStaleError?: (error: unknown) => boolean;
+	onMountError?: (error: ReactiveWidgetMountError) => void;
 }
 
 const defaultTimerApi: ReactiveWidgetTimerApi = {
@@ -73,6 +80,15 @@ const defaultTimerApi: ReactiveWidgetTimerApi = {
 const defaultScheduler: ReactiveWidgetScheduler = {
 	queueMicrotask: (handler) => queueMicrotask(handler),
 };
+
+class ReactiveWidgetMountReporterError extends Error {
+	readonly reporterError: Error;
+
+	constructor(reporterError: Error) {
+		super(reporterError.message);
+		this.reporterError = reporterError;
+	}
+}
 
 function getRequestRenderFromHost(host: unknown): (() => void) | undefined {
 	if (typeof host !== "object" || host === null) return undefined;
@@ -118,6 +134,8 @@ export function installReactiveWidget<TSnapshot, TTheme = object>(
 	let currentSnap = options.getSnapshot();
 	let currentNow = now();
 	let lastLines: readonly string[] = [];
+	let unsubscribeWidgetRelease: (() => void) | undefined;
+	let mountFailureReported = false;
 
 	const clearRefreshTimer = (): void => {
 		if (refreshTimer === undefined) return;
@@ -126,6 +144,7 @@ export function installReactiveWidget<TSnapshot, TTheme = object>(
 	};
 
 	const handleError = (error: unknown): void => {
+		if (error instanceof ReactiveWidgetMountReporterError) throw error.reporterError;
 		if (options.isStaleError?.(error)) return;
 		throw error;
 	};
@@ -175,6 +194,17 @@ export function installReactiveWidget<TSnapshot, TTheme = object>(
 		refreshTimer.unref?.();
 	};
 
+	const handleWidgetRelease = (): void => {
+		if (disposed || !mounted) return;
+		mounted = false;
+		lastLines = [];
+		mountedRequestRender = undefined;
+		clearRefreshTimer();
+		scheduler.queueMicrotask(() => {
+			if (!disposed) controller.refresh("manual");
+		});
+	};
+
 	const widgetFactory: ReactiveWidgetFactory<TTheme> = (tui, theme) => {
 		const fallbackRequestRender = getRequestRenderFromHost(tui);
 		if (fallbackRequestRender) mountedRequestRender = fallbackRequestRender;
@@ -202,13 +232,31 @@ export function installReactiveWidget<TSnapshot, TTheme = object>(
 
 				switch (action) {
 					case "mount":
-						options.ui.setWidget(
-							options.key,
-							widgetFactory,
-							options.placement ? { placement: options.placement } : undefined,
-						);
-						mounted = true;
-						if (requestRenderOnMount) requestRender();
+						try {
+							options.ui.setWidget(
+								options.key,
+								widgetFactory,
+								options.placement ? { placement: options.placement } : undefined,
+							);
+							mounted = true;
+							mountFailureReported = false;
+							if (requestRenderOnMount) requestRender();
+						} catch (error) {
+							const cause = error instanceof Error ? error : new Error(String(error));
+							if (!mountFailureReported) {
+								mountFailureReported = true;
+								try {
+									options.onMountError?.({ cause, message: cause.message });
+								} catch (reporterError) {
+									throw new ReactiveWidgetMountReporterError(
+										reporterError instanceof Error ? reporterError : new Error(String(reporterError)),
+									);
+								}
+							}
+							if (options.isStaleError?.(error)) return;
+							handleError(error);
+							return;
+						}
 						break;
 					case "unmount":
 						options.ui.setWidget(options.key, undefined);
@@ -233,6 +281,8 @@ export function installReactiveWidget<TSnapshot, TTheme = object>(
 			if (disposed) return;
 			disposed = true;
 			clearRefreshTimer();
+			unsubscribeWidgetRelease?.();
+			unsubscribeWidgetRelease = undefined;
 			unsubscribe?.();
 			try {
 				options.ui.setWidget(options.key, undefined);
@@ -248,6 +298,7 @@ export function installReactiveWidget<TSnapshot, TTheme = object>(
 	};
 
 	const unsubscribe = options.subscribe?.(() => controller.refresh("state"));
+	unsubscribeWidgetRelease = options.ui.onWidgetRelease?.(options.key, handleWidgetRelease);
 	controller.refresh("initial");
 
 	return controller;

--- a/packages/coding-agent/src/core/extensions/ui-types.ts
+++ b/packages/coding-agent/src/core/extensions/ui-types.ts
@@ -252,6 +252,9 @@ export interface ExtensionUIContext {
 		options?: ExtensionWidgetOptions,
 	): void;
 
+	/** Observe host-driven widget release events for a key. Returns an unsubscribe function. */
+	onWidgetRelease?(key: string, listener: () => void): () => void;
+
 	/** Set a custom footer component, or undefined to restore the built-in footer.
 	 *
 	 * The factory receives a FooterDataProvider for data not otherwise accessible:

--- a/test/unit/reactive-widget.test.ts
+++ b/test/unit/reactive-widget.test.ts
@@ -287,6 +287,50 @@ describe("installReactiveWidget", () => {
 		controller.dispose();
 	});
 
+	test("rolls back subscriptions when the initial mount fails", () => {
+		const originalError = new Error("renderer init failed during installation");
+		const releaseListeners = new Set<() => void>();
+		const subscriptions = new Set<() => void>();
+		let mountAttempts = 0;
+		const ui: ReactiveWidgetUi<object> = {
+			setWidget(_key, factory): void {
+				if (factory === undefined) return;
+				mountAttempts++;
+				throw originalError;
+			},
+			onWidgetRelease(_key, listener): () => void {
+				releaseListeners.add(listener);
+				return () => releaseListeners.delete(listener);
+			},
+		};
+
+		const install = (): void => {
+			assert.throws(
+				() =>
+					installReactiveWidget({
+						ui,
+						key: "test.widget",
+						subscribe: () => {
+							const subscription = (): void => {};
+							subscriptions.add(subscription);
+							return () => subscriptions.delete(subscription);
+						},
+						getSnapshot: () => ({ visible: true }),
+						getPreviewLines: () => ["run"],
+						render: () => ["run"],
+					}),
+				(error) => error === originalError,
+			);
+			assert.equal(releaseListeners.size, 0, "failed installation must remove the host release listener");
+			assert.equal(subscriptions.size, 0, "failed installation must remove the store subscription");
+		};
+
+		install();
+		install();
+		assert.equal(mountAttempts, 2);
+		assert.equal(releaseListeners.size, 0, "repeated failed installations must not accumulate listeners");
+	});
+
 	test("propagates stale-looking mount reporter failures", () => {
 		const reporterError = new Error("Reporting failed because extension ctx is stale");
 		const ui = {

--- a/test/unit/reactive-widget.test.ts
+++ b/test/unit/reactive-widget.test.ts
@@ -3,8 +3,12 @@ import { describe, test } from "vitest";
 import {
 	decideReactiveWidgetAction,
 	installReactiveWidget,
+	type ReactiveWidgetFactory,
+	type ReactiveWidgetMountError,
 	type ReactiveWidgetTimerHandle,
+	type ReactiveWidgetUi,
 } from "../../packages/coding-agent/src/core/extensions/reactive-widget.js";
+import type { ExtensionWidgetOptions } from "../../packages/coding-agent/src/core/extensions/ui-types.js";
 
 interface FakeTimerHandle extends ReactiveWidgetTimerHandle {
 	id: number;
@@ -126,6 +130,186 @@ describe("installReactiveWidget", () => {
 		assert.equal(widgetCalls[1]?.factory, undefined);
 		scheduler.flush();
 		assert.equal(renderRequests(), 3);
+	});
+
+	test("remounts once after the host releases a live widget", () => {
+		const scheduler = makeScheduler();
+		const widgetCalls: Array<{
+			key: string;
+			factory: ReactiveWidgetFactory<object> | undefined;
+			options: ExtensionWidgetOptions | undefined;
+		}> = [];
+		const releaseListeners = new Map<string, Set<() => void>>();
+		const ui: ReactiveWidgetUi<object> = {
+			setWidget(
+				key: string,
+				factory: ReactiveWidgetFactory<object> | undefined,
+				options?: ExtensionWidgetOptions,
+			): void {
+				widgetCalls.push({ key, factory, options });
+			},
+			requestRender(): void {},
+			onWidgetRelease(key: string, listener: () => void): () => void {
+				const listeners = releaseListeners.get(key) ?? new Set<() => void>();
+				listeners.add(listener);
+				releaseListeners.set(key, listeners);
+				return () => listeners.delete(listener);
+			},
+		};
+		const snapshot = { visible: true, label: "run" };
+		const controller = installReactiveWidget({
+			ui,
+			key: "test.widget",
+			scheduler,
+			getSnapshot: () => snapshot,
+			getPreviewLines: (snap) => (snap.visible ? [snap.label] : []),
+			render: (snap) => [snap.label],
+		});
+
+		assert.equal(widgetCalls.length, 1);
+		for (const listener of releaseListeners.get("test.widget") ?? []) listener();
+		assert.equal(controller.isMounted(), false);
+		scheduler.flush();
+		assert.equal(widgetCalls.length, 2, "release should schedule exactly one fresh mount");
+
+		controller.refresh("state");
+		assert.equal(widgetCalls.length, 2, "ordinary updates after remount must stay in place");
+	});
+
+	test("reports a stale mount failure once without rearming clock refresh", () => {
+		const scheduler = makeScheduler();
+		const timers = makeTimers();
+		let snapshot = { visible: true };
+		let shouldThrow = true;
+		let mountAttempts = 0;
+		let mountErrors = 0;
+		const ui = {
+			setWidget(_key: string, factory: ReactiveWidgetFactory<object> | undefined): void {
+				if (factory === undefined) return;
+				mountAttempts++;
+				if (shouldThrow) throw new Error("This extension ctx is stale after session replacement");
+			},
+			requestRender(): void {},
+		};
+		let mountError: ReactiveWidgetMountError | undefined;
+		const controller = installReactiveWidget({
+			ui,
+			key: "test.widget",
+			scheduler,
+			timers,
+			getSnapshot: () => snapshot,
+			getPreviewLines: (current) => (current.visible ? ["run"] : []),
+			render: () => ["run"],
+			getNextRefreshDelayMs: (current) => (current.visible ? 100 : undefined),
+			isStaleError: (error) => error instanceof Error && error.message.includes("ctx is stale"),
+			onMountError: (error) => {
+				mountError = error;
+				mountErrors++;
+			},
+		});
+
+		assert.equal(mountAttempts, 1, "initial visible state should attempt one mount");
+		assert.equal(mountErrors, 1, "initial stale mount failure should be observable once");
+		assert.ok(mountError);
+		assert.equal(mountError.message, "This extension ctx is stale after session replacement");
+		assert.ok(mountError.cause instanceof Error);
+		assert.equal(mountError.cause.message, mountError.message);
+		const pendingTimers = timers.scheduled.filter((timer) => !timer.cleared);
+		assert.equal(pendingTimers.length, 0, "a failed mount must not arm a clock refresh");
+		for (const timer of pendingTimers) timer.handler();
+		assert.equal(mountAttempts, 1, "without a timer, clock refresh must not retry the mount");
+		assert.equal(mountErrors, 1, "without a timer, clock refresh must not repeat the warning");
+
+		controller.refresh("state");
+		assert.equal(mountAttempts, 2, "a later state refresh may retry the failed mount");
+		assert.equal(mountErrors, 1, "repeated stale failures must not repeat the warning");
+		assert.equal(timers.scheduled.filter((timer) => !timer.cleared).length, 0);
+
+		shouldThrow = false;
+		controller.refresh("state");
+		assert.equal(mountAttempts, 3, "a later successful state refresh should mount");
+		snapshot = { visible: false };
+		controller.refresh("state");
+		shouldThrow = true;
+		snapshot = { visible: true };
+		controller.refresh("state");
+		assert.equal(mountErrors, 2, "a successful mount should reset stale-failure reporting");
+		assert.equal(timers.scheduled.filter((timer) => !timer.cleared).length, 0);
+		controller.dispose();
+	});
+
+	test("reports and rethrows generic mount failures once before retry", () => {
+		const timers = makeTimers();
+		let snapshot = { visible: false };
+		let mountAttempts = 0;
+		let mountError: ReactiveWidgetMountError | undefined;
+		const originalError = new Error("renderer init failed");
+		const ui: ReactiveWidgetUi<object> = {
+			setWidget(_key, factory): void {
+				if (factory === undefined) return;
+				mountAttempts++;
+				throw originalError;
+			},
+			requestRender(): void {},
+		};
+		const controller = installReactiveWidget({
+			ui,
+			key: "test.widget",
+			timers,
+			getSnapshot: () => snapshot,
+			getPreviewLines: (current) => (current.visible ? ["run"] : []),
+			render: () => ["run"],
+			getNextRefreshDelayMs: () => 100,
+			isStaleError: () => false,
+			onMountError: (error) => {
+				mountError = error;
+			},
+		});
+
+		snapshot = { visible: true };
+		assert.throws(
+			() => controller.refresh("state"),
+			(error) => error === originalError,
+		);
+		assert.equal(mountAttempts, 1);
+		assert.ok(mountError);
+		assert.equal(mountError.message, "renderer init failed");
+		assert.equal(mountError.cause, originalError);
+		assert.equal(timers.scheduled.filter((timer) => !timer.cleared).length, 0);
+
+		assert.throws(
+			() => controller.refresh("state"),
+			(error) => error === originalError,
+		);
+		assert.equal(mountAttempts, 2);
+		assert.equal(mountError.message, "renderer init failed");
+		assert.equal(timers.scheduled.filter((timer) => !timer.cleared).length, 0);
+		controller.dispose();
+	});
+
+	test("propagates stale-looking mount reporter failures", () => {
+		const reporterError = new Error("Reporting failed because extension ctx is stale");
+		const ui = {
+			setWidget(): void {
+				throw new Error("This extension ctx is stale after session replacement");
+			},
+		};
+
+		assert.throws(
+			() =>
+				installReactiveWidget({
+					ui,
+					key: "test.widget",
+					getSnapshot: () => ({ visible: true }),
+					getPreviewLines: () => ["run"],
+					render: () => ["run"],
+					isStaleError: (error) => error instanceof Error && error.message.includes("ctx is stale"),
+					onMountError: () => {
+						throw reporterError;
+					},
+				}),
+			(error) => error === reporterError,
+		);
 	});
 
 	test("state no-op refresh still requests paint, clock no-op does not", () => {


### PR DESCRIPTION
Part **1 of 3** of a stacked series fixing extension widget remounting after host release (#2556). Each slice builds and tests on its own and stays under the 500-line review limit.

## Stack order

1. **#2584 — this PR**: core reactive-widget lifecycle primitives (base: `main`)
2. #2585 — host-side release signaling in interactive hosts (base: `issue-2556-widget-core`)
3. #2586 — RPC hardening, workflow widget reattach, docs (base: `issue-2556-widget-host-release`)

## What this slice does

When an interactive host clears or disposes a live extension widget (UI reset, engine teardown), reactive controllers previously kept believing they were mounted: `setWidget` state and internal mount flags drifted from the host, and later updates silently no-op'd or threw.

This slice adds the primitives every later slice consumes:

- `ReactiveWidgetUi.onWidgetRelease?` — an optional per-key subscription. A host release unmounts the controller (`isMounted() === false`), clears cached lines, stops the refresh timer, and schedules exactly one fresh mount on the next refresh. Ordinary state updates after remount keep updating in place instead of re-registering the widget.
- `onMountError` option plus `ReactiveWidgetMountError` — a failed `setWidget` mount is reported exactly once (repeated stale failures stay silent) without rearming clock-based refresh; a later successful state refresh may retry the mount.
- Errors thrown by the mount-error reporter are rethrown through the refresh path via an erasable-syntax wrapper class so reporter bugs surface instead of being swallowed.
- `ExtensionUIContext.onWidgetRelease?` is declared so hosts can opt in to emitting releases.

## Validation

- Targeted vitest on a Crabbox runner: `test/unit/reactive-widget.test.ts` 12/12 passed.
- `npm run check` (biome, root tsc, coding-agent tsgo, shrinkwrap) green on the stack tip.

Refs #2556





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update adds host-release-aware remounting and mount-failure cleanup for reactive widgets. The earlier report that ordinary failed installs retain release listeners is resolved: a repeated-failure runtime check showed both non-throwing subscriptions are removed each time. A cleanup failure remains: when the release listener's unsubscriber throws during rollback of an initial mount failure, the store subscription is left registered.

<h3>Confidence Score: 4/5</h3>

Not ready to merge until failed widget installation attempts clean up the store subscription even when release-listener cleanup throws.

The reproduced cleanup path leaves an inactive store listener behind after a failed mount. The prior ordinary rollback concern was exercised twice and both non-throwing subscriptions were removed on each attempt.

**Files Needing Attention:** packages/coding-agent/src/core/extensions/reactive-widget.ts:285-287

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a P1 finding proof and attached a focused TypeScript regression script for the throwing release-unsubscriber rollback path and a runtime output showing a leaked store subscription after a failed widget installation.
- A focused Bun harness performed two initial mount failures with non-throwing release and store unsubscribers, rethrowing the original mount error, and the focused reactive-widget Vitest suite completed with 13 passing tests.
- A focused lifecycle harness mounted a visible widget, invoked its registered host-release listener, and ran the queued remount, observed two mounts with one render per host, a cleared retired timer and an active replacement timer, while the parent implementation failed to reset mount state, and the reactive-widget unit suite again passed 13 tests.
- A focused code-level validation walked through the reactive widget cleanup path and confirmed the exact sequence: subscriptions are registered, initial refresh runs, and failures dispose before rethrowing the error; after two failures, mount=2, clear=2, storeSubscribe=2, storeUnsubscribe=2, releaseSubscribe=2, and releaseUnsubscribe=2, with no accumulated release listeners.
- Baseline shows the parent commit failing the harness because the release callback does not reset isMounted; the current PR passes with setWidgetCalls: 2, hostRenderCalls: \[1,1\], and timer states: \["cleared","active"\].

<a href="https://app.greptile.com/trex/runs/20100718/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Failed initial reactive-widget installation leaks release listeners**

   - **Bug**
     - `onWidgetRelease` registers successfully, then `controller.refresh("initial")` throws during mounting. Installation exits via the throw without calling the registered unsubscribe callback. Repeating the failed installation retains another listener each time.
   - **Cause**
     - At `packages/coding-agent/src/core/extensions/reactive-widget.ts:300-302`, setup occurs sequentially without a cleanup/rollback path around `controller.refresh("initial")`; only the returned controller's `dispose()` invokes `unsubscribeWidgetRelease`, but no controller is returned when initial refresh throws.
   - **Fix**
     - Guard the initial refresh with `try/catch`; on failure invoke and clear `unsubscribeWidgetRelease`, invoke `unsubscribe` if applicable, clear any timer/state as needed, then rethrow the original error. Add a regression test asserting no release listeners remain after a failed initial mount and retries do not accumulate them.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Failed-install rollback leaks the store subscription if widget-release cleanup throws**

   - **Bug**
     - When initial mounting fails, the outer rollback calls `controller.dispose()`. Its release unsubscriber at line 285 throws before execution reaches the store unsubscriber at line 287. The outer catch suppresses that cleanup error and rethrows the original mount failure, so the failure is not masked but the subscribed store listener remains active.
   - **Cause**
     - `dispose()` performs cleanup as a sequential series of calls without isolating the widget-release cleanup error. A throw from `unsubscribeWidgetRelease?.()` aborts the rest of disposal.
   - **Fix**
     - Make failed-install cleanup attempt both unsubscribers even when either throws (for example, capture cleanup errors around each cleanup action, always invoke the store unsubscriber, then preserve/rethrow the original installation error from the outer rollback).

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

3. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Failed reactive-widget installation can leak a store subscription**

   - **Bug**
     - During installation, the store subscription is created first, then the widget-release subscription, and initial refresh fails. Rollback calls `dispose()`. If `unsubscribeWidgetRelease()` throws, execution exits `dispose()` before `unsubscribe?.()` is reached. The runtime repro observed one store subscription and zero store unsubscriptions while the initial refresh error was rethrown.
   - **Cause**
     - `dispose()` invokes `unsubscribeWidgetRelease?.()` without isolated error handling before reaching `unsubscribe?.()` (packages/coding-agent/src/core/extensions/reactive-widget.ts:285-287). The install rollback catches the resulting disposal error only outside `dispose()` (lines 305-311), preserving the original mount error but not continuing cleanup.
   - **Fix**
     - Make disposal attempt every independent cleanup operation even if one fails, e.g. wrap each unsubscriber in its own try/finally or collect cleanup errors, ensuring `unsubscribe?.()` always executes; preserve the existing original installation error in the outer rollback path.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/src/core/extensions/reactive-widget.ts:285-287
**Cleanup aborts after a throwing release unsubscriber**

A failed initial mount calls `dispose()` to roll back both subscriptions. If `unsubscribeWidgetRelease()` throws here, execution never reaches `unsubscribe?.()` on the following line. The rollback then suppresses the cleanup error and rethrows the original mount error, leaving the store listener registered with no controller returned to dispose it. Repeated failed installs can therefore retain inactive store subscriptions.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(coding-agent): roll back failed widg..."](https://github.com/bastani-inc/atomic/commit/d92ad77fe917a313860c08f2ff6f5ba14e5eb3c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55664458)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->