### PR TITLE
fix(widgets): emit widget release events from interactive hosts

### DIFF
--- a/packages/coding-agent/src/modes/interactive-engine/engine-custom-ui.ts
+++ b/packages/coding-agent/src/modes/interactive-engine/engine-custom-ui.ts
@@ -109,6 +109,7 @@ export class EngineCustomUiService {
 	private readonly stateListeners = new Set<
 		(state: { blockingInlineCustomUiDepth: number; blockingInlineCustomUiActive: boolean }) => void
 	>();
+	private readonly widgetReleaseListeners = new Map<string, Set<() => void>>();
 
 	setWidget(
 		key: string,
@@ -116,7 +117,7 @@ export class EngineCustomUiService {
 		placement?: "aboveEditor" | "belowEditor",
 	): void {
 		const previous = this.widgetIds.get(key);
-		if (previous) this.disposeComponent(previous, false);
+		if (previous) this.disposeComponent(previous, false, false);
 		if (!factory) return;
 		const componentId = `remote_widget_${++this.nextId}`;
 		this.widgetIds.set(key, componentId);
@@ -234,6 +235,15 @@ export class EngineCustomUiService {
 		this.stateListeners.add(listener);
 		return () => this.stateListeners.delete(listener);
 	}
+	onWidgetRelease(key: string, listener: () => void): () => void {
+		const listeners = this.widgetReleaseListeners.get(key) ?? new Set<() => void>();
+		listeners.add(listener);
+		this.widgetReleaseListeners.set(key, listeners);
+		return () => {
+			listeners.delete(listener);
+			if (listeners.size === 0) this.widgetReleaseListeners.delete(key);
+		};
+	}
 
 	focusHostInlineCustomUi(): boolean {
 		return this.getHostCustomUiState().blockingInlineCustomUiActive;
@@ -316,9 +326,9 @@ export class EngineCustomUiService {
 	}
 
 	dispose(): void {
-		for (const componentId of [...this.active.keys()]) this.disposeComponent(componentId, true);
+		for (const componentId of [...this.active.keys()]) this.disposeComponent(componentId, true, false);
 	}
-	private disposeComponent(componentId: string, resolve: boolean): void {
+	private disposeComponent(componentId: string, resolve: boolean, notifyWidgetRelease = true): void {
 		const record = this.active.get(componentId);
 		if (!record) return;
 		this.active.delete(componentId);
@@ -327,9 +337,19 @@ export class EngineCustomUiService {
 		if (record.widgetKey) {
 			if (this.widgetIds.get(record.widgetKey) === componentId) this.widgetIds.delete(record.widgetKey);
 			this.send({ type: "engine_custom_close", componentId });
+			if (notifyWidgetRelease) this.notifyWidgetRelease(record.widgetKey);
 		}
 		this.notifyState();
 		if (resolve) record.resolve(undefined);
+	}
+	private notifyWidgetRelease(key: string): void {
+		for (const listener of this.widgetReleaseListeners.get(key) ?? []) {
+			try {
+				listener();
+			} catch {
+				// A release observer must not break engine UI teardown.
+			}
+		}
 	}
 	private notifyState(): void {
 		const state = this.getHostCustomUiState();

--- a/packages/coding-agent/src/modes/interactive-engine/remote-component.ts
+++ b/packages/coding-agent/src/modes/interactive-engine/remote-component.ts
@@ -10,7 +10,7 @@ export type RemoteComponentRuntime = Pick<
 	"onEngineMessage" | "onGenerationEnded" | "sendEngineCommand"
 >;
 
-export type RemoteComponentUI = Pick<ExtensionUIContext, "custom" | "requestRender" | "setWidget">;
+export type RemoteComponentUI = Pick<ExtensionUIContext, "custom" | "requestRender" | "setWidget" | "onWidgetRelease">;
 
 interface MountedRemoteComponent {
 	component: RemoteComponent;
@@ -22,6 +22,7 @@ interface MountedRemoteComponent {
 	handlesInternalUiAction: boolean;
 	handle?: OverlayHandle;
 	widgetKey?: string;
+	unsubscribeWidgetRelease?: () => void;
 }
 
 /**
@@ -253,6 +254,15 @@ export class RemoteComponentController {
 		return false;
 	}
 
+	private releaseWidget(widgetKey: string): void {
+		for (const [componentId, record] of this.mounted) {
+			if (record.widgetKey !== widgetKey) continue;
+			this.mounted.delete(componentId);
+			record.unsubscribeWidgetRelease?.();
+			record.unsubscribeWidgetRelease = undefined;
+			this.terminalModes.onUnmount(componentId);
+		}
+	}
 	/**
 	 * Close every mounted component.
 	 *
@@ -276,6 +286,7 @@ export class RemoteComponentController {
 		this.mounted.clear();
 		for (const [componentId, record] of records) {
 			this.terminalModes.onUnmount(componentId);
+			record.unsubscribeWidgetRelease?.();
 			record.component.dispose(reason === "host-shutdown" && !record.engineDone);
 			if (record.widgetKey) this.ui.setWidget(record.widgetKey, undefined);
 			else if (reason === "generation-lost") record.done(undefined);
@@ -356,6 +367,7 @@ export class RemoteComponentController {
 				() => rows,
 				handlesInternalUiAction,
 			);
+			const unsubscribeWidgetRelease = this.ui.onWidgetRelease?.(widgetKey, () => this.releaseWidget(widgetKey));
 			this.mounted.set(componentId, {
 				component,
 				done: () => {},
@@ -363,6 +375,7 @@ export class RemoteComponentController {
 				handlesCtrlC,
 				handlesInternalUiAction,
 				widgetKey,
+				unsubscribeWidgetRelease,
 			});
 			this.ui.setWidget(
 				widgetKey,
@@ -419,6 +432,7 @@ export class RemoteComponentController {
 		if (!record) return;
 		this.terminalModes.onUnmount(componentId);
 		this.mounted.delete(componentId);
+		record.unsubscribeWidgetRelease?.();
 		if (record.widgetKey) this.ui.setWidget(record.widgetKey, undefined);
 		record.component.dispose();
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-extension-context.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-extension-context.ts
@@ -103,6 +103,35 @@ InteractiveModeBase.prototype.onHostCustomUiStateChange = function (
 	};
 };
 
+InteractiveModeBase.prototype.onExtensionWidgetRelease = function (
+	this: InteractiveModeBase,
+	key: string,
+	listener: () => void,
+): () => void {
+	let widgetReleaseListeners = this.widgetReleaseListeners;
+	if (!widgetReleaseListeners) {
+		widgetReleaseListeners = new Map();
+		this.widgetReleaseListeners = widgetReleaseListeners;
+	}
+	const listeners = widgetReleaseListeners.get(key) ?? new Set<() => void>();
+	listeners.add(listener);
+	widgetReleaseListeners.set(key, listeners);
+	return () => {
+		listeners.delete(listener);
+		if (listeners.size === 0) widgetReleaseListeners.delete(key);
+	};
+};
+
+InteractiveModeBase.prototype.notifyExtensionWidgetRelease = function (this: InteractiveModeBase, key: string): void {
+	for (const listener of this.widgetReleaseListeners?.get(key) ?? []) {
+		try {
+			listener();
+		} catch {
+			/* ignore observer errors */
+		}
+	}
+};
+
 InteractiveModeBase.prototype.createProjectTrustContext = function (
 	this: InteractiveModeBase,
 	cwd: string,
@@ -144,6 +173,7 @@ InteractiveModeBase.prototype.createExtensionUIContext = function (this: Interac
 		setHiddenThinkingLabel: (label) => this.setHiddenThinkingLabel(label),
 		setWidget: (key, content, options) => this.setExtensionWidget(key, content, options),
 		setFooter: (factory) => this.setExtensionFooter(factory),
+		onWidgetRelease: (key, listener) => this.onExtensionWidgetRelease(key, listener),
 		setHeader: (factory) => this.setExtensionHeader(factory),
 		setTitle: (title) => this.ui.terminal.setTitle(title),
 		custom: (factory, options) => this.showExtensionCustom(factory, options),

--- a/packages/coding-agent/src/modes/interactive/interactive-extension-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-extension-runtime.ts
@@ -210,15 +210,19 @@ InteractiveModeBase.prototype.setExtensionWidget = function (
 };
 
 InteractiveModeBase.prototype.clearExtensionWidgets = function (this: InteractiveModeBase): void {
-	for (const widget of this.extensionWidgetsAbove.values()) {
+	const releasedKeys = new Set<string>();
+	for (const [key, widget] of this.extensionWidgetsAbove) {
 		widget.dispose?.();
+		releasedKeys.add(key);
 	}
-	for (const widget of this.extensionWidgetsBelow.values()) {
+	for (const [key, widget] of this.extensionWidgetsBelow) {
 		widget.dispose?.();
+		releasedKeys.add(key);
 	}
 	this.extensionWidgetsAbove.clear();
 	this.extensionWidgetsBelow.clear();
 	this.renderWidgets();
+	for (const key of releasedKeys) this.notifyExtensionWidgetRelease(key);
 };
 
 InteractiveModeBase.prototype.resetExtensionUI = function (this: InteractiveModeBase): void {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-base.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-base.ts
@@ -425,6 +425,8 @@ export class InteractiveModeBase {
 
 	hostCustomUiStateListeners = new Set<HostCustomUiStateListener>();
 
+	widgetReleaseListeners = new Map<string, Set<() => void>>();
+
 	transcriptOverlayReserve: TranscriptOverlayReserve | undefined = undefined;
 
 	themeController: InteractiveThemeController;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-surface.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-surface.ts
@@ -190,6 +190,8 @@ declare module "./interactive-mode-base.ts" {
 		shouldDeferInlineCustomUiFocus(): boolean;
 		focusHostInlineCustomUi(): boolean;
 		onHostCustomUiStateChange(listener: HostCustomUiStateListener): () => void;
+		onExtensionWidgetRelease(key: string, listener: () => void): () => void;
+		notifyExtensionWidgetRelease(key: string): void;
 		createProjectTrustContext(cwd: string): ProjectTrustContext;
 		createExtensionUIContext(): ExtensionUIContext;
 		showExtensionSelector(

--- a/test/unit/engine-custom-ui-hidden-invalidate.test.ts
+++ b/test/unit/engine-custom-ui-hidden-invalidate.test.ts
@@ -10,11 +10,29 @@
  */
 
 import assert from "node:assert/strict";
-import type { OverlayHandle } from "@earendil-works/pi-tui";
+import type { Component, OverlayHandle, TUI } from "@earendil-works/pi-tui";
 import { describe, test } from "vitest";
+import {
+	installReactiveWidget,
+	type ReactiveWidgetFactory,
+	type ReactiveWidgetUi,
+} from "../../packages/coding-agent/src/core/extensions/reactive-widget.ts";
 import { KeybindingsManager } from "../../packages/coding-agent/src/core/keybindings.ts";
+import type { Theme } from "../../packages/coding-agent/src/modes/interactive/theme/theme.ts";
 import { EngineCustomUiService } from "../../packages/coding-agent/src/modes/interactive-engine/engine-custom-ui.ts";
-import { parseInteractiveEngineMessage } from "../../packages/coding-agent/src/modes/interactive-engine/protocol.ts";
+import {
+	type InteractiveEngineCommand,
+	type InteractiveEngineMessage,
+	parseInteractiveEngineMessage,
+	serializeInteractiveEngineFrame,
+} from "../../packages/coding-agent/src/modes/interactive-engine/protocol.ts";
+import {
+	RemoteComponentController,
+	type RemoteComponentRuntime,
+	type RemoteComponentUI,
+	type TuiRendererLifecycle,
+} from "../../packages/coding-agent/src/modes/interactive-engine/remote-component.ts";
+import { sleep } from "../helpers/runtime.js";
 
 interface Harness {
 	service: EngineCustomUiService;
@@ -110,4 +128,196 @@ describe("EngineCustomUiService targeted invalidation (#1856)", () => {
 
 		service.dispose();
 	});
+});
+
+test("widget release listeners distinguish replacement from host disposal", async () => {
+	const lines: string[] = [];
+	const service = new EngineCustomUiService((line) => lines.push(line), new KeybindingsManager());
+	let releases = 0;
+	service.onWidgetRelease("test.widget", () => {
+		releases++;
+	});
+	const factory = () => stubComponent();
+	service.setWidget("test.widget", factory, "belowEditor");
+	await sleep(0);
+	const firstOpen = lines
+		.map((line) => parseInteractiveEngineMessage(line))
+		.find((message) => message?.type === "engine_custom_open");
+	if (firstOpen?.type !== "engine_custom_open") throw new Error("expected first widget open");
+
+	lines.length = 0;
+	service.setWidget("test.widget", factory, "belowEditor");
+	await sleep(0);
+	assert.equal(releases, 0, "replacing a widget must not look like a host release");
+	const secondOpen = lines
+		.map((line) => parseInteractiveEngineMessage(line))
+		.find((message) => message?.type === "engine_custom_open");
+	if (secondOpen?.type !== "engine_custom_open") throw new Error("expected second widget open");
+
+	assert.equal(
+		service.handleLine(
+			serializeInteractiveEngineFrame({ type: "engine_custom_dispose", componentId: secondOpen.componentId }),
+		),
+		true,
+	);
+	assert.equal(releases, 1, "host disposal must notify the widget controller");
+	service.dispose();
+});
+
+test("full teardown does not release or resurrect widget mounts", async () => {
+	const lines: string[] = [];
+	const service = new EngineCustomUiService((line) => lines.push(line), new KeybindingsManager());
+	let releases = 0;
+	const factory = () => stubComponent();
+	service.onWidgetRelease("test.widget", () => {
+		// Simulate a live reactive controller reacting to a host-release signal.
+		releases++;
+		service.setWidget("test.widget", factory, "belowEditor");
+	});
+	service.setWidget("test.widget", factory, "belowEditor");
+	await sleep(0);
+	const firstOpen = lines
+		.map((line) => parseInteractiveEngineMessage(line))
+		.find((message) => message?.type === "engine_custom_open");
+	if (firstOpen?.type !== "engine_custom_open") throw new Error("expected first widget open");
+
+	lines.length = 0;
+	service.dispose();
+	await sleep(0);
+	const afterDispose = lines.map((line) => parseInteractiveEngineMessage(line));
+	assert.equal(releases, 0, "full engine teardown must not publish a widget release");
+	assert.equal(
+		afterDispose.some((message) => message?.type === "engine_custom_open"),
+		false,
+		"full engine teardown must not reopen a widget on the disposed service",
+	);
+});
+
+test("a host release remounts through the engine transport with a fresh open", async () => {
+	const runtimeListeners: Array<(message: InteractiveEngineMessage) => void> = [];
+	const output: InteractiveEngineMessage[] = [];
+	const commands: InteractiveEngineCommand[] = [];
+	const hostWidgets = new Map<string, Component & { dispose?(): void }>();
+	const hostMounts: string[] = [];
+	const hostReleaseListeners = new Map<string, Set<() => void>>();
+	const service = new EngineCustomUiService((line) => {
+		const message = parseInteractiveEngineMessage(line);
+		if (!message) throw new Error("expected a valid engine message");
+		output.push(message);
+		for (const listener of [...runtimeListeners]) listener(message);
+	}, new KeybindingsManager());
+	const runtime: RemoteComponentRuntime = {
+		onGenerationEnded: (_listener) => () => {},
+		onEngineMessage: (listener) => {
+			runtimeListeners.push(listener);
+			return () => {
+				const index = runtimeListeners.indexOf(listener);
+				if (index >= 0) runtimeListeners.splice(index, 1);
+			};
+		},
+		sendEngineCommand: (command) => {
+			commands.push(command);
+			service.handleLine(serializeInteractiveEngineFrame(command));
+		},
+	};
+	let hostReleaseEvents = 0;
+
+	const ui: RemoteComponentUI = {
+		custom: <T>() => new Promise<T>(() => {}),
+		requestRender: () => {},
+		setWidget: (
+			key: string,
+			content: string[] | undefined | ((tui: TUI, theme: Theme) => Component & { dispose?(): void }),
+		): void => {
+			if (content === undefined) {
+				const previous = hostWidgets.get(key);
+				previous?.dispose?.();
+				hostWidgets.delete(key);
+				return;
+			}
+			if (Array.isArray(content)) throw new Error("unexpected string widget");
+			const component = content({ terminal: { rows: 24 } } as TUI, {} as Theme);
+			hostWidgets.set(key, component);
+			hostMounts.push(key);
+		},
+		onWidgetRelease: (key, listener) => {
+			const listeners = hostReleaseListeners.get(key) ?? new Set<() => void>();
+			const wrapped = (): void => {
+				hostReleaseEvents++;
+				listener();
+			};
+			listeners.add(wrapped);
+			hostReleaseListeners.set(key, listeners);
+			return () => listeners.delete(wrapped);
+		},
+	};
+	const lifecycle: TuiRendererLifecycle = {
+		isFullscreen: () => false,
+		onRendererReplaced: () => () => {},
+	};
+	const remoteController = new RemoteComponentController(runtime, ui, lifecycle);
+	let snapshot = { visible: true, label: "one" };
+	const reactiveUi: ReactiveWidgetUi<Theme> = {
+		setWidget: (key, factory: ReactiveWidgetFactory<Theme> | undefined, options) =>
+			service.setWidget(
+				key,
+				factory as ((tui: TUI, theme: Theme) => Component & { dispose?(): void }) | undefined,
+				options?.placement,
+			),
+		requestRender: () => service.requestRender(),
+		onWidgetRelease: (key, listener) => service.onWidgetRelease(key, listener),
+	};
+	const reactiveController = installReactiveWidget({
+		ui: reactiveUi,
+		key: "test.widget",
+		getSnapshot: () => snapshot,
+		getPreviewLines: (current) => (current.visible ? [current.label] : []),
+		render: (current) => [current.label],
+	});
+	const flushTransport = async (): Promise<void> => {
+		for (let i = 0; i < 5; i++) await sleep(0);
+	};
+	await flushTransport();
+	const openIds = (): string[] =>
+		output
+			.filter(
+				(message): message is Extract<InteractiveEngineMessage, { type: "engine_custom_open" }> =>
+					message.type === "engine_custom_open",
+			)
+			.map((message) => message.componentId);
+	assert.deepEqual(openIds(), ["remote_widget_1"]);
+	assert.equal(hostWidgets.size, 1);
+	assert.deepEqual(hostMounts, ["test.widget"]);
+
+	const hostEntries = [...hostWidgets.entries()];
+	const releasedHostListeners = [...hostReleaseListeners.entries()].map(
+		([key, listeners]) => [key, [...listeners]] as const,
+	);
+	for (const [, component] of hostEntries) component.dispose?.();
+	hostWidgets.clear();
+	for (const [key, listeners] of releasedHostListeners) {
+		for (const listener of listeners) listener();
+		assert.equal(key, "test.widget");
+	}
+	assert.equal(hostReleaseEvents, 1, "host clear must publish the released widget key");
+	await flushTransport();
+	assert.equal(
+		commands.some((command) => command.type === "engine_custom_dispose" && command.componentId === "remote_widget_1"),
+		true,
+		"host disposal must send engine_custom_dispose through the protocol",
+	);
+	assert.deepEqual(openIds(), ["remote_widget_1", "remote_widget_2"]);
+	assert.equal(hostWidgets.size, 1);
+	assert.deepEqual(hostMounts, ["test.widget", "test.widget"]);
+
+	snapshot = { visible: true, label: "two" };
+	reactiveController.refresh("state");
+	await flushTransport();
+	assert.deepEqual(openIds(), ["remote_widget_1", "remote_widget_2"], "ordinary updates must not reopen the widget");
+
+	reactiveController.dispose();
+	service.dispose();
+	await flushTransport();
+	assert.deepEqual(openIds(), ["remote_widget_1", "remote_widget_2"], "teardown must not resurrect the widget");
+	remoteController.dispose();
 });

--- a/test/unit/interactive-extension-custom-ui-overlay.test.ts
+++ b/test/unit/interactive-extension-custom-ui-overlay.test.ts
@@ -1,8 +1,12 @@
 import assert from "node:assert/strict";
+import type { Component, TUI } from "@earendil-works/pi-tui";
 import { test } from "vitest";
 import { InteractiveModeBase } from "../../packages/coding-agent/src/modes/interactive/interactive-mode-base.ts";
 import "../../packages/coding-agent/src/modes/interactive/interactive-extension-custom-ui.ts";
 import { initTheme } from "../../packages/coding-agent/src/modes/interactive/theme/theme.ts";
+import "../../packages/coding-agent/src/modes/interactive/interactive-extension-context.ts";
+import "../../packages/coding-agent/src/modes/interactive/interactive-extension-runtime.ts";
+import { installReactiveWidget } from "../../packages/coding-agent/src/core/extensions/reactive-widget.ts";
 import { sleep } from "../helpers/runtime.js";
 
 initTheme("dark");
@@ -202,4 +206,73 @@ test("an in-process overlay that omits the opt-in leaves its component unmarked"
 	);
 	done(undefined);
 	await settled;
+});
+
+test("clearExtensionWidgets and resetExtensionUI reattach a live below-editor widget", () => {
+	const scheduled: Array<() => void> = [];
+	const mode = Object.assign(Object.create(InteractiveModeBase.prototype), {
+		extensionWidgetsAbove: new Map(),
+		extensionWidgetsBelow: new Map(),
+		widgetReleaseListeners: new Map(),
+		renderWidgets: () => {},
+		ui: { hideOverlay: () => {}, requestRender: () => {} },
+		clearExtensionTerminalInputListeners: () => {},
+		setExtensionFooter: () => {},
+		setExtensionHeader: () => {},
+		footerDataProvider: { clearExtensionStatuses: () => {} },
+		footer: { invalidate: () => {} },
+		autocompleteProviderWrappers: [],
+		setCustomEditorComponent: () => {},
+		setupAutocompleteProvider: () => {},
+		defaultEditor: { onExtensionShortcut: undefined },
+		interactiveEngineShortcutHandler: () => false,
+		updateTerminalTitle: () => {},
+		workingMessage: undefined,
+		workingVisible: true,
+		setWorkingIndicator: () => {},
+		loadingAnimation: undefined,
+		chatContainer: { children: [] },
+		streamingComponent: undefined,
+		setHiddenThinkingLabel: () => {},
+	});
+	const snapshot = { visible: true };
+	const controller = installReactiveWidget({
+		ui: {
+			setWidget: (key, factory, options) => {
+				const hostFactory =
+					factory === undefined
+						? undefined
+						: (tui: TUI, theme: Parameters<NonNullable<typeof factory>>[1]): Component & { dispose?(): void } => {
+								const component = factory(tui, theme);
+								return {
+									render: (width) => component.render(width),
+									invalidate: component.invalidate ?? (() => {}),
+									...(component.dispose ? { dispose: () => component.dispose?.() } : {}),
+								};
+							};
+				InteractiveModeBase.prototype.setExtensionWidget.call(mode, key, hostFactory, options);
+			},
+			onWidgetRelease: (key, listener) =>
+				InteractiveModeBase.prototype.onExtensionWidgetRelease.call(mode, key, listener),
+		},
+		key: "test.widget",
+		placement: "belowEditor",
+		scheduler: { queueMicrotask: (handler: () => void) => scheduled.push(handler) },
+		getSnapshot: () => snapshot,
+		getPreviewLines: (current) => (current.visible ? ["running"] : []),
+		render: () => ["running"],
+	});
+	while (scheduled.length > 0) scheduled.shift()!();
+	assert.equal(mode.extensionWidgetsBelow.has("test.widget"), true);
+
+	InteractiveModeBase.prototype.clearExtensionWidgets.call(mode);
+	assert.equal(mode.extensionWidgetsBelow.has("test.widget"), false);
+	while (scheduled.length > 0) scheduled.shift()!();
+	assert.equal(mode.extensionWidgetsBelow.has("test.widget"), true);
+
+	InteractiveModeBase.prototype.resetExtensionUI.call(mode);
+	assert.equal(mode.extensionWidgetsBelow.has("test.widget"), false);
+	while (scheduled.length > 0) scheduled.shift()!();
+	assert.equal(mode.extensionWidgetsBelow.has("test.widget"), true);
+	controller.dispose();
 });


### PR DESCRIPTION
Part **2 of 3** of a stacked series fixing extension widget remounting after host release (#2556). Each slice builds and tests on its own and stays under the 500-line review limit.

## Stack order

1. #2584 — core reactive-widget lifecycle primitives (base: `main`)
2. **#2585 — this PR**: host-side release signaling in interactive hosts (base: `issue-2556-widget-core`)
3. #2586 — RPC hardening, workflow widget reattach, docs (base: `issue-2556-widget-host-release`)

## What this slice does

The primitives from #2584 need hosts that actually announce releases. This slice wires both interactive hosts:

- `EngineCustomUiService` (isolated engine) tracks per-key release listeners, notifies them whenever a widget component is disposed outside an explicit re-register, and swallows observer errors so teardown can never break.
- `RemoteComponentController` subscribes on mount and unmounts the remote component as soon as its widget key is released, so stale remote mounts are discarded before the extension remounts; full teardown paths unsubscribe cleanly.
- The interactive mode's extension UI context exposes `onWidgetRelease` through prototype helpers backed by a listener map on `InteractiveModeBase`, and `clearExtensionWidgets` notifies each cleared key after disposal — this is what fires during a host UI reset.

## Validation

- Targeted vitest on a Crabbox runner: `test/unit/engine-custom-ui-hidden-invalidate.test.ts` + `test/unit/interactive-extension-custom-ui-overlay.test.ts` 12/12 passed.
- `npm run check` (biome, root tsc, coding-agent tsgo, shrinkwrap) green on the stack tip.

Refs #2556





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds release notifications so interactive widget controllers can discard mounts that their host has removed. During `/reload`, however, clearing widgets publishes a release event that queues a reactive remount before the reload operation begins, allowing outgoing widget UI to reappear briefly.

<h3>Confidence Score: 4/5</h3>

Not ready to merge until reload teardown prevents outgoing widgets from remounting.

The executed reload flow shows that a widget removed during reset is mounted again before the session reload starts.

**Files Needing Attention:** packages/coding-agent/src/modes/interactive/interactive-extension-runtime.ts; packages/coding-agent/src/core/extensions/reactive-widget.ts; packages/coding-agent/src/modes/interactive/interactive-slash-commands.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof validating a posted P1 finding.
- The focused interactive widget reload-gap harness source and its targeted unit tests (JS imports and TS imports) were inspected to verify the reload flow.
- Remounting key source locations and inspecting harness assertions confirmed the after state reload-start: mounted=true.
- Uploaded contract-validation artifacts include direct command captures and the authored harness from trex-artifacts, used to validate the remount and after-state behavior.

<a href="https://app.greptile.com/trex/runs/20100722/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Released reactive widget remounts during reload's next-tick gap**

   - **Bug**
     - A live reactive widget cleared by reset transiently mounts again before `session.reload()` starts. The executed current-PR trace records `host.release`, then `widget.mount`, then `session.reload:start` with `at-reload-mounted:true`.
   - **Cause**
     - `clearExtensionWidgets` notifies widget-release listeners after clearing at `packages/coding-agent/src/modes/interactive/interactive-extension-runtime.ts:225`. The reactive controller's release handler at `packages/coding-agent/src/core/extensions/reactive-widget.ts:197-205` schedules a microtask refresh. `/reload` yields with `process.nextTick` at `packages/coding-agent/src/modes/interactive/interactive-slash-commands.ts:58`, allowing the queued refresh to remount before the subsequent reload call.
   - **Fix**
     - Prevent release callbacks from scheduling a refresh during reset/reload, for example by disposing/suspending workflow reactive-widget controllers before release notification, or by passing a reset/reload reason that makes the reactive controller release permanently rather than refresh. Add a regression test asserting no `setWidget(factory)` occurs between reset and `session.reload()`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Release-driven reactive widget can remount before /reload starts the session reload**

   - **Bug**
     - `clearExtensionWidgets()` notifies the live widget controller synchronously. Its release callback queues a microtask that remounts the still-visible widget while `/reload` is paused at `await process.nextTick(...)`; the observed current trace has the second `widget:mount` at index 8 before `session.reload:begin` at index 12.
   - **Cause**
     - The release notification at `interactive-extension-runtime.ts:225` occurs before the reload command's `process.nextTick` await at `interactive-slash-commands.ts:58`; the reactive controller schedules its remount using `queueMicrotask` in `reactive-widget.ts:204-206`.
   - **Fix**
     - Ensure reload teardown prevents release listeners from scheduling a remount during reload, or begin/invalidate the session reload lifecycle before releasing widgets so a queued controller refresh cannot mount into the outgoing UI.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

3. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Released reactive widgets remount before /reload enters session reload**

   - **Bug**
     - `resetExtensionUI()` clears live extension widgets, which synchronously notifies release listeners. The reactive widget release listener queues a manual refresh; `/reload` then awaits a next-tick yield before invoking the coordinator/session reload. The focused executed harness observed the second mount before reload entry and asserted `reload-start:mounted=true`.
   - **Cause**
     - `clearExtensionWidgets()` calls `notifyExtensionWidgetRelease()` after clearing maps (`interactive-extension-runtime.ts:212-226`); `installReactiveWidget()` queues `controller.refresh("manual")` in its release handler (`reactive-widget.ts:198-207`); `handleReloadCommand()` yields at `interactive-slash-commands.ts:58` before calling reload at `:68-69`.
   - **Fix**
     - Prevent reactive release refreshes during reload teardown (for example, dispose/revoke the relevant controllers before clearing widgets, or add a reload-generation/teardown guard that makes queued release refreshes no-ops until the new session UI is installed).

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/src/modes/interactive/interactive-extension-runtime.ts:225
**Released reactive widgets remount during reload**

`clearExtensionWidgets()` publishes release notifications after it removes the live widget. A reactive widget listener turns that notification into a queued refresh, and `/reload` yields before starting the session reload. The released outgoing widget can therefore mount again during that gap. Suppress release-driven refreshes during reload teardown, or dispose the relevant controller before notifying release listeners.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(widgets): emit widget release events..."](https://github.com/bastani-inc/atomic/commit/26fe3123808122b015fc87556e7713c8e379ce84) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55664467)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->