### PR TITLE
fix(workflows): stay silent when no host UI exists during extension load

### DIFF
--- a/packages/workflows/src/tui/store-widget-installer.ts
+++ b/packages/workflows/src/tui/store-widget-installer.ts
@@ -112,7 +112,10 @@ export function installStoreWidget(
 ): () => void {
 	const ui = pi.ui;
 	if (!ui?.setWidget) {
-		reportWidgetFailure(ui, "Workflow progress widget is unavailable in this host.");
+		// An absent ui slice is normal during extension load: factories run
+		// before the host binds ctx.ui, and session_start re-installs against
+		// the real UI. Only a present-but-widget-less ui names a degraded host.
+		if (ui) reportWidgetFailure(ui, "Workflow progress widget is unavailable in this host.");
 		return () => {};
 	}
 	const setWidget = ui.setWidget;

--- a/test/unit/store-widget-installer-02.test.ts
+++ b/test/unit/store-widget-installer-02.test.ts
@@ -428,7 +428,7 @@ describe("installStoreWidget", () => {
 		assert.equal(last.factory, undefined);
 	});
 
-	test("logs an unavailable host without throwing when pi.ui is absent", () => {
+	test("stays silent when pi.ui is absent (pre-session factory install)", () => {
 		const piNoUI: { ui?: undefined; events?: undefined } = {};
 		const storeNoUI = createStore();
 		let dispose: (() => void) | undefined;
@@ -438,7 +438,7 @@ describe("installStoreWidget", () => {
 			});
 		});
 		assert.equal(typeof dispose, "function");
-		assert.deepEqual(messages, ["Workflow progress widget is unavailable in this host."]);
+		assert.deepEqual(messages, []);
 	});
 
 	test("logs an unavailable host without throwing when notify is absent", () => {


### PR DESCRIPTION
## Summary

The workflow progress widget installer warned "Workflow progress widget is unavailable in this host." once per interactive startup, flashing for a single frame in the chat surface. Extension factories load before the host binds `ctx.ui`, so the eager factory-time install always found `pi.ui` undefined — and #2591-era change `210383cc` turned that previously silent path into a visible warning.

## Changes

- `installStoreWidget` now reports an unavailable widget host only when a UI slice exists but lacks `setWidget` (a genuinely degraded host). An entirely absent `ui` slice — the guaranteed pre-`session_start` state — stays silent, because `session_start` re-installs against the real UI moments later.
- Updated the unit test that codified the noisy expectation to assert silence when `pi.ui` is absent; degraded-host (`ui` without `setWidget`) and mount-failure warnings are unchanged and still covered.

## Notes

- Degraded-host reporting via `ui.notify` and mount-failure reporting are preserved; only the guaranteed-at-load-time false positive is gone.
- Full installer suites pass (46 tests) and `npm run typecheck` is clean.

Assistant-model: Ox Alpha (Stealth)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789945541&installation_model_id=10562&pr_number=2591&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2591&signature=a3dbc89ff89f98c5ec9a844e22af39e88d4d895dfda8e8db837374e2c0e5460b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change removes the transient unavailable-widget warning that occurred before the host UI was bound, while retaining the warning for a host that exposes a UI slice without widget support. A before-and-after lifecycle check confirmed that the early installation now stays silent, returns a safe disposer, and does not prevent a later UI-bound installation from mounting the workflow widget. The focused widget-installer test suite passed all 24 tests.

<h3>Confidence Score: 5/5</h3>

The update is safe to merge: it suppresses only the expected startup diagnostic and preserves degraded-host reporting and later widget mounting.

No defects were found. The changed path was exercised before and after the update, including absent UI, a UI host without widget support, and a subsequent UI-bound widget installation; the focused test suite also passed.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reran a narrow Vitest unit harness on the PR changes and confirmed the focused unit suite passed all 24 tests, validating startup behavior and degraded-host diagnostics.
- Compared pre-PR and post-PR UI behavior and confirmed the early missing-UI console error was removed; after UI binding, a run mounted workflow.run under belowEditor with a present UI.
- Validated post-execution behavior showing a callable no-op disposer for absent UI and a single mount after UI binding.
- Uploaded temporary test harness sources and Vitest configuration used for lifecycle verification, and confirmed no source changes were tracked in the PR.

<a href="https://app.greptile.com/trex/runs/20117909/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(workflows): stay silent when no host..."](https://github.com/bastani-inc/atomic/commit/d0ce197e6ef01777c25451cd1bb66ef839dc7aa2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55752493)</sub>

<!-- /greptile_comment -->