### PR TITLE
docs: prepare 0.9.15-alpha.1 release notes

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,8 @@ This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history live
 
 ## [Unreleased]
 
+## [0.9.15-alpha.1] - 2026-08-21
+
 ### Breaking Changes
 
 - Built-in xAI models now use the OpenAI Responses API only. Completions is no longer registered on the xAI provider.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.15-alpha.1] - 2026-08-21
+
 ### Breaking Changes
 
 - Two exported SDK types each lose a field, because subagent delegation is now a fixed one-level rule rather than a configurable depth. `WorkflowStageOrchestrationContext.constraints` no longer has the required nesting-depth number and is now `{ disableWorkflowTool: true }`; `SubagentChildPolicy` no longer has the optional inherited delegation limit and keeps `depth` alone. Code that constructs a stage orchestration context must drop the removed required field.

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.15-alpha.1] - 2026-08-21
+
 ### Changed
 
 - Switched the optional peer from `@earendil-works/pi-ai` to `@bastani/pi-ai`.

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.15-alpha.1] - 2026-08-21
+
 ### Breaking Changes
 
 - Subagent delegation is now exactly one level deep and is no longer configurable. A top-level session — main chat or a workflow stage — may call the `subagent` tool; a session that was itself admitted as a subagent child may not. Every launch, `resume`, and `interrupt` attempted from inside a child is refused with a single fixed message; the observing actions `list`, `get`, `status`, and `doctor` remain available to a child. Workflow stages are unchanged and still delegate once. The Rust `SubagentControl` admission door now refuses any child deeper than the single permitted level, and the executor refuses a child before any run starts, so the rule holds at both doors.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.15-alpha.1] - 2026-08-21
+
 ### Changed
 
 - Workflow-stage orchestration context no longer carries a subagent delegation-depth constraint. Stage delegation itself is unchanged: a stage is a top-level session and still launches subagents once. What changed is that the children it launches can no longer delegate further, and nothing configures that.


### PR DESCRIPTION
## Summary

Prepare the package changelogs for prerelease `0.9.15-alpha.1` while keeping the release base versionless.

## Changes

- Cut the current Unreleased notes under `0.9.15-alpha.1` in the AI, coding-agent, MCP, subagents, and workflows changelogs.
- Keep all package manifests, lockfiles, Cargo files, and generated version checks at `0.0.0`.
- Limit the branch diff to the five intended changelog files.

## Validation

- `bun run test:ci-contracts` — 47 tests passed.
- Bun release-invariant check — changelog-only diff, expected release headings, and all versionless files confirmed.
- Commit and push hooks — check, unit, integration, and CI-contract suites passed.

## Notes

This PR only prepares release notes. It does not merge, stamp versions, tag, or publish. After merge, `scripts/cut-release.ts` may stamp the detached `Release 0.9.15-alpha.1` commit and push the version tag once.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789946413&installation_model_id=10562&pr_number=2593&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2593&signature=a693a41724a81b82d23db41b4dcc38ecdc42872ce4370502f8495a7d76a14d59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds dated `0.9.15-alpha.1` release notes for the AI, coding-agent, MCP, subagents, and workflows packages. The documented package changes correspond to implementation work that preceded these notes, and release publishing supplies and validates the release version independently of template package metadata.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the change is limited to release documentation and the documented release sections match the associated package work.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the release notes contract check script against base 0.9.14 and the current release-notes commit; it exited with code 0 and showed all five 0.9.15-alpha.1 headings are newly present, with each package having preceding implementation commits: workflows 13, subagents 6, MCP 2, coding-agent 22, and AI 14.
- Verified via the second contract validation that execution finished with exit code 0, with the base lacking the headings and HEAD now containing them, and noted the publish workflow lines that supply and validate the release VERSION against package metadata, including @bastani/pi-ai.

<a href="https://app.greptile.com/trex/runs/20124267/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["docs: prepare 0.9.15-alpha.1 release not..."](https://github.com/bastani-inc/atomic/commit/4b8cdedc8b25a98520f395d94912e1a85977a4d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55755449)</sub>

<!-- /greptile_comment -->