### PR TITLE
fix(release): stamp @bastani/pi-ai with first-party versions

### DIFF
--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -222,7 +222,9 @@ function shieldBadgeVersion(version: string): string {
 }
 
 function shouldBumpFirstPartyDependency(name: string): boolean {
-	return name === "@bastani/atomic-natives" || name.startsWith("@bastani/atomic-natives-");
+	return (
+		name === "@bastani/pi-ai" || name === "@bastani/atomic-natives" || name.startsWith("@bastani/atomic-natives-")
+	);
 }
 
 function bumpFirstPartyDependencyRanges(content: PackageJson, version: string): number {

--- a/test/unit/bump-version-script.test.ts
+++ b/test/unit/bump-version-script.test.ts
@@ -74,6 +74,7 @@ function createFixtureRoot(): string {
 		name: "@fixture/alpha",
 		version: "0.1.0",
 		private: true,
+		dependencies: { "@bastani/pi-ai": "0.1.0" },
 		optionalDependencies: { "@bastani/atomic-natives-linux-x64-musl": "0.1.0" },
 	});
 	writeJson(join(root, "packages", "beta", "package.json"), {
@@ -127,7 +128,7 @@ if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHE
 			"packages/alpha": {
 				name: "@fixture/alpha",
 				version: "0.1.0",
-				dependencies: { "@bastani/atomic-natives": "0.1.0", "third-party": "9.9.9" },
+				dependencies: { "@bastani/atomic-natives": "0.1.0", "@bastani/pi-ai": "0.1.0", "third-party": "9.9.9" },
 				optionalDependencies: {
 					"@bastani/atomic-natives-linux-x64-gnu": "0.1.0",
 					"@bastani/atomic-natives-linux-x64-musl": "0.1.0",
@@ -175,6 +176,7 @@ describe("scripts/bump-version.ts", () => {
 			assert.equal(rootPackageJson.dependencies?.["@bastani/atomic-natives"], "1.2.3-alpha.1");
 			const alphaPackageJson = readJson(join(root, "packages", "alpha", "package.json"));
 			assert.equal(alphaPackageJson.version, "1.2.3-alpha.1");
+			assert.equal(alphaPackageJson.dependencies?.["@bastani/pi-ai"], "1.2.3-alpha.1");
 			assert.equal(
 				alphaPackageJson.optionalDependencies?.["@bastani/atomic-natives-linux-x64-musl"],
 				"1.2.3-alpha.1",
@@ -211,6 +213,7 @@ describe("scripts/bump-version.ts", () => {
 				"1.2.3-alpha.1",
 			);
 			assert.equal(lock.packages["packages/alpha"]?.dependencies?.["@bastani/atomic-natives"], "1.2.3-alpha.1");
+			assert.equal(lock.packages["packages/alpha"]?.dependencies?.["@bastani/pi-ai"], "1.2.3-alpha.1");
 			assert.equal(
 				lock.packages["packages/alpha"]?.optionalDependencies?.["@bastani/atomic-natives-linux-x64-gnu"],
 				"1.2.3-alpha.1",


### PR DESCRIPTION
## Summary

`cut-release` for `0.9.15-alpha.1` failed after the changelog PR merged: `bump-version.ts` stamped `packages/ai` to the release version but left `@bastani/atomic` requesting `@bastani/pi-ai@0.0.0`, so `generate-coding-agent-shrinkwrap.mjs` rejected the tree.

Stamp `@bastani/pi-ai` the same way as `@bastani/atomic-natives`.

## Test plan

- [x] `npm run test:unit -- test/unit/bump-version-script.test.ts`
- [ ] After merge: `bun run scripts/cut-release.ts 0.9.15-alpha.1 --base main --push --yes`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789949852&installation_model_id=10562&pr_number=2595&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2595&signature=dbbb413e715082e3139a23ddc0203f995ebbae62a2fc1b7cd2da96b0e9528854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes release stamping treat `@bastani/pi-ai` as a first-party dependency, so workspace manifests and direct workspace entries in `package-lock.json` receive the release version together. A representative workspace run confirmed that pi-ai consumer ranges now update in both locations while unrelated and nested third-party dependency versions remain unchanged. The focused release-stamping test file passed all three tests.

<h3>Confidence Score: 5/5</h3>

The release-stamping behavior is safe to merge based on the exercised manifest and lockfile update flow.

The release script was run against the same representative workspace before and after the change, confirming that stale pi-ai ranges are updated by the new implementation without rewriting unrelated dependencies. The focused repository test suite also completed successfully.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the release stamping validation script before the PR and then after, and both runs exited with code 0.
- Observed that before the change the pi-ai workspace version changed while its consumer manifest and direct lockfile remained at 0.1.0; after the change, all pi-ai versions moved to 1.2.3-alpha.1, while unrelated and nested dependencies stayed unchanged.
- Ran the unit tests for the bump-version-script and confirmed all tests passed (3/3) with exit code 0.

<a href="https://app.greptile.com/trex/runs/20125930/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(release): stamp @bastani/pi-ai with ..."](https://github.com/bastani-inc/atomic/commit/4d50dff792a152d7e9f7c005653a05c9c6b252e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55767048)</sub>

<!-- /greptile_comment -->