### PR TITLE
fix(release): skip unpublished natives fetch and restore pi-ai alias

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -409,7 +409,7 @@ After native and smoke jobs pass, `build`:
 
 1. Installs with `npm ci --ignore-scripts` and runs `npm run check:shrinkwrap`.
 2. Generates native platform package directories and the native root manifest.
-3. Hydrates `@bastani/pi-ai` model data from models.dev, then runs `scripts/build-binaries.sh --skip-install --offline-model-data` for all eight archives.
+3. Hydrates `@bastani/pi-ai` model data from models.dev, then runs `scripts/build-binaries.sh --skip-install --offline-model-data` for all eight archives. The script uses the just-staged `packages/natives/native/*.node` artifacts and does not `npm install` `@bastani/atomic-natives-*@$VERSION` from the registry (those packages are what this release publishes). If a registry install is attempted and fails, restore is `npm ci --ignore-scripts` followed by re-aliasing `@earendil-works/pi-ai` onto `packages/ai` and rebuilding `@bastani/pi-ai`.
 4. Validates package identity, versions, public/private metadata, binary entrypoint, workspace dependency ranges, build outputs, eight native modules, and eight exact-version native optional dependencies.
 5. Packs exactly ten npm tarballs.
 6. Extracts release notes from `packages/coding-agent/CHANGELOG.md`.

--- a/scripts/build-binaries.sh
+++ b/scripts/build-binaries.sh
@@ -90,6 +90,21 @@ if [[ -n "$PLATFORM" ]]; then
     esac
 fi
 
+alias_pi_ai() {
+    echo "==> Aliasing @earendil-works/pi-ai onto packages/ai..."
+    node scripts/alias-pi-ai.mjs
+}
+
+build_pi_ai() {
+    if [[ "$OFFLINE_MODEL_DATA" == "true" ]]; then
+        echo "==> Building @bastani/pi-ai with bundled model data..."
+        npm run build:offline --workspace=@bastani/pi-ai
+    else
+        echo "==> Building @bastani/pi-ai..."
+        npm run build --workspace=@bastani/pi-ai
+    fi
+}
+
 if [[ "$SKIP_INSTALL" == "false" ]]; then
     echo "==> Installing dependencies..."
     npm ci --ignore-scripts
@@ -97,15 +112,8 @@ else
     echo "==> Reusing caller-installed dependencies (--skip-install)"
 fi
 
-echo "==> Aliasing @earendil-works/pi-ai onto packages/ai..."
-node scripts/alias-pi-ai.mjs
-if [[ "$OFFLINE_MODEL_DATA" == "true" ]]; then
-    echo "==> Building @bastani/pi-ai with bundled model data..."
-    npm run build:offline --workspace=@bastani/pi-ai
-else
-    echo "==> Building @bastani/pi-ai..."
-    npm run build --workspace=@bastani/pi-ai
-fi
+alias_pi_ai
+build_pi_ai
 
 if [[ "$SKIP_DEPS" == "false" ]]; then
     echo "==> Installing cross-platform Atomic native bindings..."
@@ -124,6 +132,12 @@ if [[ "$SKIP_DEPS" == "false" ]]; then
     # than let npm prune the installed tree on its way to ETARGET.
     if [[ "$natives_version" == "0.0.0" ]]; then
         echo "==> Skipping cross-platform bindings: packages/natives is at the 0.0.0 placeholder"
+    elif compgen -G "packages/natives/native/*.node" >/dev/null; then
+        # publish.yml stages the just-built bindings before this script. Fetching
+        # @bastani/atomic-natives-*@$VERSION from npm can only fail: this release
+        # is what would publish them. The failed --force install then requires
+        # npm ci, which drops the pi-ai alias and breaks the coding-agent build.
+        echo "==> Skipping registry install of @bastani/atomic-natives-*: local native artifacts are already staged"
     elif ! npm install --include=optional --no-save --package-lock=false --force --ignore-scripts \
         "${natives_targets[@]}"; then
         # `--no-save --force` mutates node_modules before it fails, and it prunes
@@ -131,6 +145,8 @@ if [[ "$SKIP_DEPS" == "false" ]]; then
         # broke the release binary). Put the tree back before continuing.
         echo "==> Cross-platform bindings unavailable; restoring the dependency tree"
         npm ci --ignore-scripts
+        alias_pi_ai
+        build_pi_ai
     fi
 
     echo "==> Staging cross-platform native bindings for clipboard..."

--- a/test/unit/build-binaries-platform-packaging.test.ts
+++ b/test/unit/build-binaries-platform-packaging.test.ts
@@ -84,3 +84,26 @@ test("x64 release binaries target Bun's baseline CPU runtime", () => {
 
 	assertBuildScriptSyntax();
 });
+
+test("tagged payload builds do not fetch unpublished natives and re-alias pi-ai after restore", () => {
+	const buildScript = readFileSync(buildScriptPath, "utf8");
+
+	assert.match(
+		buildScript,
+		/Skipping registry install of @bastani\/atomic-natives-\*: local native artifacts are already staged/u,
+	);
+	assert.match(buildScript, /packages\/natives\/native\/\*\.node/u);
+	assert.match(
+		buildScript,
+		/^alias_pi_ai\(\) \{\n\s+echo "==> Aliasing @earendil-works\/pi-ai onto packages\/ai\.\.\."\n\s+node scripts\/alias-pi-ai\.mjs\n\}$/mu,
+	);
+
+	const restoreStart = buildScript.indexOf("Cross-platform bindings unavailable; restoring the dependency tree");
+	assert.notEqual(restoreStart, -1, "failed registry install must restore node_modules");
+	const restoreBlock = buildScript.slice(restoreStart, restoreStart + 400);
+	assert.match(restoreBlock, /npm ci --ignore-scripts/u);
+	assert.match(restoreBlock, /alias_pi_ai/u);
+	assert.match(restoreBlock, /build_pi_ai/u);
+
+	assertBuildScriptSyntax();
+});


### PR DESCRIPTION
## Summary

`Publish 0.9.15-alpha.1` failed in **Build release payload** after `npm install @bastani/atomic-natives-*@0.9.15-alpha.1` crashed (`edgesOut`), `npm ci` restored `node_modules`, and `@bastani/atomic` typechecked against two different `pi-ai` copies.

- Skip the registry fetch when `packages/natives/native/*.node` are already staged (the publish.yml path).
- If a registry fetch is attempted and fails, restore with `npm ci` then re-alias and rebuild `@bastani/pi-ai`.

## Test plan

- [x] `npm run test:unit -- test/unit/build-binaries-platform-packaging.test.ts`
- [ ] Recut `0.9.15-alpha.1` after merge and confirm payload builds

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789950931&installation_model_id=10562&pr_number=2596&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2596&signature=fd89d0e14548c1f1f758e7dd3e98f287a9deb6e884dd99fbe3f91e72a8762e59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change updates release archive construction to reuse native artifacts already built for the release rather than attempting to download packages that are not yet published. If a native-package download does fail, it restores dependencies, recreates the pi-ai workspace alias, and rebuilds pi-ai before continuing.

An isolated release-build check exercised both paths. With staged native artifacts, no registry install was attempted. With a simulated unavailable native package, dependency restoration recreated the alias and completed the offline pi-ai build. No defects were found.

<h3>Confidence Score: 5/5</h3>

The tested release artifact and dependency-recovery paths behave as intended and are safe to merge.

The relevant shell branches were exercised with real Bash, Node, and the repository alias script. The check confirmed that staged artifacts bypass the unavailable registry path and that recovery restores the pi-ai alias and build.

**Files Needing Attention:** No files need additional attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran an isolated release-build harness against the parent implementation and the updated scripts/build-binaries.sh using real Bash, Node, and scripts/alias-pi-ai.mjs.
- Observed that the parent build script attempted a mocked native registry install and did not rebuild pi-ai after dependency restoration.
- Validated that the updated build path skipped registry-install calls when a staged .node existed, and under a simulated registry failure, it performed dependency restoration, recreated the pi-ai alias, and rebuilt it.
- Compared the before and after run logs showing the transition from registry install to staged native skip and restored pi-ai alias rebuild.
- Documented that the testing harness uses real Bash, Node, and alias-pi-ai.mjs and that npm/bun are scoped fakes to keep scenarios deterministic.

<a href="https://app.greptile.com/trex/runs/20127739/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(release): skip unpublished natives f..."](https://github.com/bastani-inc/atomic/commit/238a26b226fa589a5b6022fab4361d36a3e5a1b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55770365)</sub>

<!-- /greptile_comment -->