### PR TITLE
docs: prepare 0.9.15 release notes

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,34 @@ This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history live
 
 ## [Unreleased]
 
+## [0.9.15] - 2026-08-21
+
+Cumulative release of the `0.9.15-alpha.1` prerelease. The summary below covers the user-visible outcome of that work; the per-change detail remains in the prerelease section below.
+
+### Breaking Changes
+
+- Built-in xAI models now use the OpenAI Responses API only; Completions is no longer registered on the xAI provider.
+- Renamed the exported `GoogleThinkingLevel` type to `GoogleApiThinkingLevel` and added `ResolvedGoogleThinkingLevel` for normalized adapter levels.
+
+### Added
+
+- Added provider-neutral `toolChoice` on simple stream requests.
+- Generalized OpenAI Completions thinking-token budget fields through `thinkingTokenBudgetField`, with `supportsThinkingTokenBudget` retained as the vLLM alias.
+- Added pi's runtime `User-Agent` to Anthropic, Azure Responses, Google, Vertex, Mistral, OpenAI Completions, and OpenAI Responses requests.
+
+### Changed
+
+- `@bastani/pi-ai` now generates its models.dev catalog during package builds and uses the generated catalog for offline compilation.
+- Vendored and rebranded the package as `@bastani/pi-ai` in the Atomic monorepo, with later tagged Atomic releases publishing it through trusted publishing.
+- Moved `COPILOT_GITHUB_TOKEN` env-token host routing into the exported `@bastani/pi-ai/providers/github-copilot-env` module ([#2522](https://github.com/bastani-inc/atomic/issues/2522)).
+
+### Fixed
+
+- Fixed raw `COPILOT_GITHUB_TOKEN` chat authentication by sending `Copilot-Integration-Id: copilot-developer-cli`, while preserving exchanged OAuth-token behavior ([#2522](https://github.com/bastani-inc/atomic/issues/2522)).
+- Fixed Amazon Bedrock Converse Stream and `pi-messages` dropping static custom-model headers; caller headers still override model headers and `null` still suppresses a static header.
+- Fixed stalled OpenAI Completions, OpenAI Responses, Anthropic Messages, `pi-messages`, Mistral, and Codex provider streams by applying idle deadlines that abort the request and surface retryable transport errors. Native Codex WebSocket streams now use `streamDeadlineMs` rather than the HTTP timeout ([#2553](https://github.com/bastani-inc/atomic/issues/2553)).
+- Ported upstream fixes for Copilot throttling, Kimi cache reads, DeepSeek thinking levels, Google thinking maps, Bedrock headers and reasoning, model catalogs, Anthropic fallback pricing, Azure tool choice, Z.AI effort metadata, and OpenAI reasoning replay. Cerebras now defaults to `gpt-oss-120b`, and the unused OpenTelemetry dependency was removed.
+
 ## [0.9.15-alpha.1] - 2026-08-21
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [Unreleased]
 
+## [0.9.15] - 2026-08-21
+
+Cumulative release of the `0.9.15-alpha.1` prerelease. The summary below covers the user-visible outcome of that work; the per-change detail remains in the prerelease section below.
+
+### Breaking Changes
+
+- Subagent delegation is now fixed at one level. `WorkflowStageOrchestrationContext.constraints` no longer has the required nesting-depth field and is now `{ disableWorkflowTool: true }`; `SubagentChildPolicy` no longer has the optional inherited delegation limit and keeps `depth` alone. SDK callers that construct stage orchestration contexts must drop the removed field.
+
+### Changed
+
+- Vendored `@earendil-works/pi-ai` into the Atomic monorepo as `@bastani/pi-ai` and switched first-party imports, loader aliases, shrinkwrap, and tagged release publishing to the workspace package. Legacy extensions that import `@earendil-works/pi-ai` still resolve through the loader.
+- `@bastani/pi-ai` now refreshes its models.dev catalog at package build instead of shipping the frozen v0.84.2 snapshot.
+- Moved `COPILOT_GITHUB_TOKEN` env-token host routing into `@bastani/pi-ai/providers/github-copilot-env`, preserving `models.json` endpoint overrides ([#2522](https://github.com/bastani-inc/atomic/issues/2522)).
+- SQLite resource selectors now use `node:sqlite` only. The `bun:sqlite` fallback was removed as Atomic's Bun floor moved to 1.4.0; Node ≥ 22.13 and Bun ≥ 1.4.0 provide `node:sqlite` without a flag.
+
+### Fixed
+
+- Fixed fine-grained PATs supplied through `COPILOT_GITHUB_TOKEN` failing with `Personal Access Tokens are not supported for this endpoint`. Raw tokens now send `Copilot-Integration-Id: copilot-developer-cli`, exchanged OAuth tokens retain their behavior, and explicit provider/model header overrides keep precedence ([#2522](https://github.com/bastani-inc/atomic/issues/2522)).
+- Fixed workflow stages hanging after GitHub Copilot stream decompression failures. Provider stream stalls now settle as transient transport errors and can retry or fail over; the new `streamDeadlineMs` setting bounds idle gaps and supports duration strings or disabling the deadline ([#2553](https://github.com/bastani-inc/atomic/issues/2553)).
+- Extension widgets now remount once after the interactive host clears or disposes them, preserve in-place updates, and discard stale isolated-engine mounts before reopening ([#2556](https://github.com/bastani-inc/atomic/issues/2556)).
+- Ported unreleased upstream pi-ai fixes for Copilot throttling, provider usage and reasoning metadata, Bedrock headers and reasoning, Anthropic fallback pricing, Azure tool choice, model catalogs, xAI Responses routing, stream request options, User-Agent headers, and OpenAI reasoning replay. Cerebras now defaults to `gpt-oss-120b`, and the unused OpenTelemetry dependency was removed.
+
 ## [0.9.15-alpha.1] - 2026-08-21
 
 ### Breaking Changes

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.15] - 2026-08-21
+
+Cumulative release of the `0.9.15-alpha.1` prerelease. The summary below covers the user-visible outcome of that work; the per-change detail remains in the prerelease section below.
+
+### Changed
+
+- Switched the optional peer from `@earendil-works/pi-ai` to `@bastani/pi-ai`.
+
 ## [0.9.15-alpha.1] - 2026-08-21
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+## [0.9.15] - 2026-08-21
+
+Cumulative release of the `0.9.15-alpha.1` prerelease. The summary below covers the user-visible outcome of that work; the per-change detail remains in the prerelease section below.
+
+### Breaking Changes
+
+- Subagent delegation is now fixed at one level. A top-level chat or workflow stage may launch subagents, but a subagent child may not launch, resume, or interrupt another child. Read-only management actions remain available, and the executor plus Rust admission boundary both enforce the rule.
+
+### Removed
+
+- Removed the extension config and agent frontmatter options for delegation depth. Stale keys remain parseable and are ignored; agent-management rewrites strip the old frontmatter field.
+- Removed inherited per-child delegation limits and the unreachable multi-level nested-run transport, registry, recursive status, and result payload fields. Direct-child status and results remain unchanged, and startup still cleans route directories left by older versions.
+
+### Changed
+
+- Switched the optional peer from `@earendil-works/pi-ai` to `@bastani/pi-ai`.
+- Updated the fanout-child boundary prompt to reflect that child delegation is unavailable.
+- Replaced built-in `gpt-5.6-luna:max` primary and fallback pins with `gpt-5.6-sol`, using `:medium` for worker and analysis agents and `:low` for locator and pattern agents.
+
 ## [0.9.15-alpha.1] - 2026-08-21
 
 ### Breaking Changes

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.15] - 2026-08-21
+
+Cumulative release of the `0.9.15-alpha.1` prerelease. The summary below covers the user-visible outcome of that work; the per-change detail remains in the prerelease section below.
+
+### Changed
+
+- Workflow-stage orchestration context no longer carries a subagent delegation-depth constraint. A stage remains a top-level session and may still delegate once, while its subagent children cannot delegate further.
+
+### Fixed
+
+- Fixed `/workflow` dispatch, list, and status cards being held as steering messages while an agent streamed. Rendered cards now enter the transcript at once without starting a turn; lifecycle notices still nudge the model.
+- Persistent workflow progress widgets now reattach after host UI resets or remote-engine release while keeping mount-once, in-place updates ([#2556](https://github.com/bastani-inc/atomic/issues/2556)).
+- Fixed one stalled heartbeat send blocking all later workflow heartbeats in the session. In-flight sends now have a two-minute watchdog, release the run's pending slot on expiry, advance the shared FIFO queue, and guard against late double settlement while preserving retry behavior ([#2557](https://github.com/bastani-inc/atomic/issues/2557)).
+- Fixed disposal of a confirmed-paused stage turning an acknowledged pause into a terminal failure. Disposal now waits while the run remains paused and resumable; abort and kill still fail visibly ([#2558](https://github.com/bastani-inc/atomic/issues/2558)).
+- Fixed a workflow stage session leak when a confirmed-paused stage was cleared from the live registry, resumed through its stale handle, and completed. Deferred cleanup now drains once on terminal completion.
+
 ## [0.9.15-alpha.1] - 2026-08-21
 
 ### Changed


### PR DESCRIPTION
## Summary

Prepare the cumulative release notes for Atomic 0.9.15 while keeping the release base versionless.

## Changes

- Add 0.9.15 release sections for `@bastani/pi-ai`, `@bastani/atomic`, MCP, subagents, and workflows.
- Preserve the detailed 0.9.15-alpha.1 notes below each cumulative release summary.
- Keep package manifests, lockfiles, Cargo metadata, and generated native version checks at `0.0.0`.

## Validation

- Bun release-section validation passed for all five changelogs.
- `git diff --check origin/main` passed.
- Commit and push hooks passed repository checks, unit tests, integration tests, and CI contract tests.

## Notes

This PR changes changelogs only. It does not merge, tag, stamp versions, or publish packages.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789954640&installation_model_id=10562&pr_number=2598&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2598&signature=d6c21e919d95f21a595ca8a19de2a35e0c81c95b1f74dd76583e826af1931a4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds cumulative 0.9.15 release summaries to the AI, coding-agent, MCP, subagents, and workflows changelogs. The release notes are currently placed in manually created `0.9.15` sections while `Unreleased` remains empty. Move the new entries under `Unreleased` so the release process can promote them consistently.

<h3>Confidence Score: 4/5</h3>

Not merge-safe until the changelog entries follow the repository’s required unreleased-entry workflow.

The final finding is one non-security P2 repository-rule violation, which maps to a score of 4.

**Files Needing Attention:** packages/ai/CHANGELOG.md and the matching changelogs in packages/coding-agent, packages/mcp, packages/subagents, and packages/workflows need their new 0.9.15 content moved under `Unreleased`.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/ai/CHANGELOG.md:7
**Premature versioned changelog sections**

The new entries leave `Unreleased` empty and manually create a `0.9.15` section, bypassing the repository requirement that new changelog entries remain under `Unreleased` until the release process promotes them. The same pattern occurs in the coding-agent, MCP, subagents, and workflows changelogs.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: prepare 0.9.15 release notes"](https://github.com/bastani-inc/atomic/commit/3181997b6e0362749fb3b029136daa28bcbd4a62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55779410)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->