### PR TITLE
fix(workflows): handle missing release branch refs

### DIFF
--- a/.atomic/workflows/lib/publish-release.ts
+++ b/.atomic/workflows/lib/publish-release.ts
@@ -559,13 +559,11 @@ async function inspectPreparation(input: {
 	if (remoteSha !== undefined && !/^[0-9a-f]{40}$/u.test(remoteSha))
 		throw new Error(`${input.release.branch} remote identity is malformed`);
 
-	const localBranch = await input.transport.run(
-		["git", "show-ref", "--verify", `refs/heads/${input.release.branch}`],
-		input.cwd,
-		input.signal,
-	);
+	const localRef = `refs/heads/${input.release.branch}`;
+	const localRefCommand = ["git", "rev-parse", "--verify", "--quiet", "--end-of-options", localRef] as const;
+	const localBranch = await input.transport.run(localRefCommand, input.cwd, input.signal);
 	if (localBranch.exitCode !== 0 && localBranch.exitCode !== 1) {
-		throw new ReleaseCommandError(["git", "show-ref", "--verify", `refs/heads/${input.release.branch}`], localBranch);
+		throw new ReleaseCommandError(localRefCommand, localBranch);
 	}
 	const localSha = localBranch.exitCode === 0 ? localBranch.stdout.split(/\s+/u)[0] : undefined;
 

--- a/test/unit/publish-release-workflow.test.ts
+++ b/test/unit/publish-release-workflow.test.ts
@@ -139,8 +139,8 @@ function exactPreparationResponse(argv: readonly string[], worktreeStatus = ""):
 	if (command.includes("git ls-remote --heads origin refs/heads/main")) {
 		return commandResult(`${baseSha}\trefs/heads/main`);
 	}
-	if (command.includes(`git show-ref --verify refs/heads/${release.branch}`)) {
-		return commandResult(`${headSha} refs/heads/${release.branch}`);
+	if (command.includes(`git rev-parse --verify --quiet --end-of-options refs/heads/${release.branch}`)) {
+		return commandResult(headSha);
 	}
 	if (command.includes("/pulls?state=open")) return commandResult(JSON.stringify([apiPull()]));
 	return undefined;
@@ -219,6 +219,42 @@ test("configured checks preserve branch-protection and ruleset order, app identi
 			{ context: "legacy", appId: null },
 		],
 	);
+});
+
+test("preparation adapter treats an absent local prerelease branch as preparation state", async () => {
+	const prerelease = {
+		kind: "prerelease" as const,
+		version: "0.9.16-alpha.1",
+		branch: "prerelease/0.9.16-alpha.1",
+	};
+	const transport = fakeTransport((argv) => {
+		const command = argv.join(" ");
+		if (command === "git status --porcelain=v1 --untracked-files=all") return commandResult();
+		if (command === `git ls-remote --heads origin refs/heads/${prerelease.branch}`) return commandResult();
+		if (command === "git ls-remote --heads origin refs/heads/main") {
+			return commandResult(`${baseSha}\trefs/heads/main`);
+		}
+		if (command === `git show-ref --verify refs/heads/${prerelease.branch}`) {
+			return commandResult("", 128, `fatal: 'refs/heads/${prerelease.branch}' - not a valid ref`);
+		}
+		if (command === `git rev-parse --verify --quiet --end-of-options refs/heads/${prerelease.branch}`) {
+			return commandResult("", 1);
+		}
+		if (command.includes("/pulls?state=open")) return commandResult("[]");
+		throw new Error(`unexpected fake command: ${command}`);
+	});
+
+	const result = await createReleaseBoundary("/safe/fake/repository", { transport }).inspectPreparation({
+		cwd: "/safe/fake/repository",
+		release: prerelease,
+		baseRef: "main",
+		signal: new AbortController().signal,
+	});
+
+	assert.deepEqual(result, {
+		mode: "prepare",
+		summary: `No existing ${prerelease.branch} branch or open PR; prepare from ${baseSha}.`,
+	});
 });
 
 test("release-0.9.15 retry regression reuses the exact changelog-only branch, commit, and PR", () => {


### PR DESCRIPTION
## Summary

Fix the release preflight on Git versions that report an absent local branch as exit 128 for `git show-ref --verify`.

## Changes

- Probe local release refs with `git rev-parse --verify --quiet --end-of-options`.
- Preserve exact SHA output for existing refs.
- Add regression coverage for an absent prerelease branch.

## Validation

- `npx vitest --run --project unit test/unit/publish-release-workflow.test.ts` (28 passed)
- `npm run check`
- `npm run test:unit` (691 files, 6925 passed, 2 skipped)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790059878&installation_model_id=10562&pr_number=2608&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2608&signature=bd1f853322236be19a0a4f1f1aa21a25e565586f34c7b3455e28820d418989ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change allows release preparation to continue when the local release branch has not yet been created, while preserving reuse of an existing branch and rejection of unexpected Git failures. An isolated Git repository exercise confirmed that an existing branch resolves to its exact SHA and is reused, a missing branch enters preparation, and an unexpected exit code remains rejected.

### T-Rex validation blocked

The repository's focused Vitest suite could not collect because the required `@bastani/pi-ai/compat` package artifact is unavailable. The affected release-preflight behavior was nevertheless exercised directly against isolated real Git repositories.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the release-preflight path handles absent branches as intended without weakening handling of unexpected Git failures.

No defects were found. Direct execution against isolated Git repositories covered local-branch reuse, absent-branch preparation, and rejection of an unexpected failure.

**Files Needing Attention:** No files need further changes. The focused Vitest suite remains unavailable until `@bastani/pi-ai/compat` is restored.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran an executable Bun fixture that created isolated bare-origin and cloned Git repositories, then invoked the release workflow library against the parent and changed revisions.
- In the original parent revision, a missing local release ref was rejected by git show-ref exit 128.
- In the changed revision, the release flow reached prepare, an existing ref reused its exact SHA, and the absent-ref rejection persisted.
- A baseline log shows the absent branch is rejected, while a changed log shows the probe reaches prepare and reuses the SHA, with the absent branch still rejected.
- The uploaded executable fixture source release-preflight-local-ref-probe-e2e-script.ts demonstrates the test wiring used to generate temporary repos and drive the workflow library.

<a href="https://app.greptile.com/trex/runs/20227223/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(workflows): handle missing release b..."](https://github.com/bastani-inc/atomic/commit/4fcc8e465e93d57ba5c4abec4b9f52c784279539) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55968819)</sub>

<!-- /greptile_comment -->