### PR TITLE
test(workflows): isolate stage subagent intercom

### DIFF
--- a/test/unit/workflow-stage-bundled-resources.test.ts
+++ b/test/unit/workflow-stage-bundled-resources.test.ts
@@ -1,6 +1,7 @@
 /// <reference path="../../packages/coding-agent/src/utils/highlight-js-lib-index.d.ts" />
 
 import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -111,6 +112,7 @@ async function createWorkflowStageSession(options: {
 		workflowRunId: "run-test",
 		workflowStageId: "stage-test",
 		workflowStageName: "Stage Test",
+		intercomGroup: `workflow-test:${randomUUID()}`,
 		constraints: {
 			disableWorkflowTool: true,
 		},


### PR DESCRIPTION
## Summary

Prevent the workflow-stage bundled-resource fixture from inheriting a live Atomic session's ambient Intercom group and leaking fixture subagent completion notices into the user chat.

## Changes

- Assign each synthetic workflow-stage session a unique explicit Intercom group.
- Match production workflow invocation isolation instead of falling back to ambient environment state.

## Validation

- `npx vitest --run --project unit test/unit/workflow-stage-bundled-resources.test.ts` (9 passed)
- `npm run check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790060145&installation_model_id=10562&pr_number=2609&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2609&signature=2581a61b3b9d867b168b175f969b085651725ab446ac57f60f1f68e23d6bcc9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change assigns each synthetic workflow-session fixture a unique Intercom group, so its subagents do not use an ambient user-chat group. Focused runtime checks verified that the generated group is used for the session, inherited by child work, and preserves subagent delegation behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised Intercom-group propagation and workflow subagent delegation behavior.

No actionable defects were found. The focused checks compared ambient-group behavior with the explicit UUID group and confirmed the expected isolated routing behavior.

**Files Needing Attention:** No files need follow-up.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused Intercom contract test and observed ambient group resolution when no explicit Intercom group was provided, then confirmed that the UUID-scoped group yields the same value across home, inherited, and child contexts.
- Ran the focused workflow-stage subagent delegation test and observed that the selected test passed, confirming fixture-created subagents can run under the isolated group.
- Reviewed the before-context Intercom log to verify ambient group resolution when the stage context lacks intercomGroup.
- Reviewed the after-context Intercom log to verify that the generated UUID group is the home, inherited, and child group.

<a href="https://app.greptile.com/trex/runs/20227405/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["test(workflows): isolate stage subagent ..."](https://github.com/bastani-inc/atomic/commit/a80eb5088ed77381c503f44af5323f02aecf5946) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55969159)</sub>

<!-- /greptile_comment -->