### PR TITLE
fix(release): accept current unprotected branch response

### DIFF
--- a/.atomic/workflows/lib/publish-release.ts
+++ b/.atomic/workflows/lib/publish-release.ts
@@ -514,6 +514,10 @@ async function ghJson<T>(
 	return parseJson<T>(await checkedCommand(transport, ["gh", "api", endpoint], cwd, signal));
 }
 
+const UNPROTECTED_BRANCH_STDOUT =
+	'{"message":"Branch not protected","documentation_url":"https://docs.github.com/rest/branches/branch-protection#get-status-checks-protection","status":"404"}';
+const UNPROTECTED_BRANCH_STDERR = "gh: Branch not protected (HTTP 404)";
+
 async function optionalClassicProtection<T>(
 	transport: ReleaseCommandTransport,
 	endpoint: string,
@@ -523,7 +527,12 @@ async function optionalClassicProtection<T>(
 	const command = ["gh", "api", endpoint] as const;
 	const result = await transport.run(command, cwd, signal);
 	if (result.exitCode === 0) return parseJson<T>(result.stdout);
-	if (result.stdout.trim() === "" && result.stderr.trim() === "gh: Branch not protected (HTTP 404)") return undefined;
+	if (
+		result.exitCode === 1 &&
+		result.stdout === UNPROTECTED_BRANCH_STDOUT &&
+		result.stderr === UNPROTECTED_BRANCH_STDERR
+	)
+		return undefined;
 	throw new ReleaseCommandError(command, result);
 }
 

--- a/test/unit/publish-release-workflow.test.ts
+++ b/test/unit/publish-release-workflow.test.ts
@@ -26,6 +26,8 @@ const releaseSha = "3".repeat(40);
 const release = { kind: "release" as const, version: "1.2.3", branch: "release/1.2.3" };
 const pullRequest = { url: "https://github.com/bastani-inc/atomic/pull/42", number: 42, headSha };
 const expectedCi = { release, baseRef: "main", pullRequest };
+const unprotectedBranchResponse =
+	'{"message":"Branch not protected","documentation_url":"https://docs.github.com/rest/branches/branch-protection#get-status-checks-protection","status":"404"}';
 
 function ciSnapshot(overrides: Partial<RequiredChecksSnapshot> = {}): RequiredChecksSnapshot {
 	return {
@@ -538,7 +540,7 @@ test("the exact classic unprotected-branch response is the only allowed absent s
 		const command = argv.join(" ");
 		if (command.endsWith(`/pulls/${pullRequest.number}`)) return commandResult(JSON.stringify(apiPull()));
 		if (command.includes("/protection/required_status_checks")) {
-			return commandResult("", 1, "gh: Branch not protected (HTTP 404)");
+			return commandResult(unprotectedBranchResponse, 1, "gh: Branch not protected (HTTP 404)");
 		}
 		if (command.includes("/rules/branches/main")) {
 			return commandResult(
@@ -601,6 +603,51 @@ test("a generic classic protection 404 cannot hide a partial required-check set"
 		}).waitForRequiredChecks({ release, baseRef: "main", pullRequest, signal: new AbortController().signal }),
 		/protection\/required_status_checks failed.*HTTP 404: Not Found/u,
 	);
+});
+
+test("malformed or mismatched classic protection stdout fails closed", async () => {
+	const cases = [
+		{ name: "empty legacy body", stdout: "", exitCode: 1 },
+		{ name: "malformed JSON", stdout: "{", exitCode: 1 },
+		{
+			name: "mismatched JSON",
+			stdout: JSON.stringify({
+				message: "Not Found",
+				documentation_url: "https://docs.github.com/rest/branches/branch-protection#get-status-checks-protection",
+				status: "404",
+			}),
+			exitCode: 1,
+		},
+		{ name: "mismatched exit code", stdout: unprotectedBranchResponse, exitCode: 2 },
+	] as const;
+	for (const candidate of cases) {
+		const transport = fakeTransport((argv) => {
+			const command = argv.join(" ");
+			if (command.endsWith(`/pulls/${pullRequest.number}`)) return commandResult(JSON.stringify(apiPull()));
+			if (command.includes("/protection/required_status_checks")) {
+				return commandResult(candidate.stdout, candidate.exitCode, "gh: Branch not protected (HTTP 404)");
+			}
+			if (command.includes("/rules/branches/main")) return commandResult(JSON.stringify([]));
+			if (command.includes("/check-runs")) return commandResult(JSON.stringify({ check_runs: [] }));
+			if (command.includes("/status?")) return commandResult(JSON.stringify({ statuses: [] }));
+			throw new Error(`unexpected fake command: ${command}`);
+		});
+		await assert.rejects(
+			createReleaseBoundary("/safe/fake/repository", { transport }).waitForRequiredChecks({
+				release,
+				baseRef: "main",
+				pullRequest,
+				signal: new AbortController().signal,
+			}),
+			/protection\/required_status_checks failed.*Branch not protected/u,
+			candidate.name,
+		);
+		assert.equal(
+			transport.calls.some((argv) => argv.join(" ").includes("/rules/branches/main")),
+			false,
+			candidate.name,
+		);
+	}
 });
 test("release-0.9.15 CI regression keeps configured checks pending until they materialize", () => {
 	const result = evaluateRequiredChecks(ciSnapshot(), expectedCi);


### PR DESCRIPTION
## Summary

Fix the repository-local publish workflow so GitHub CLI's current unprotected-branch response is treated as absent classic protection rather than a fatal lookup error. Ruleset discovery still runs, and all other classic or ruleset failures remain fail-closed.

## Changes

- Match only the exact exit code, JSON stdout, and stderr emitted by `gh api` for an unprotected branch.
- Continue to paginated branch-ruleset discovery after that exact response.
- Add public release-boundary regression coverage for the real response shape.
- Preserve negative coverage for generic 404s, empty or malformed bodies, mismatched JSON, wrong exit codes, and ruleset lookup or parse failures.

## Validation

- `npm run test:unit -- test/unit/publish-release-workflow.test.ts` — 29 passed
- `npm run test:ci-contracts` — 48 passed
- `npm run check` — passed

## Scope

This PR changes only the publish-release helper and its unit tests. It does not change release notes, versions, release branches, tags, or publish state.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790062335&installation_model_id=10562&pr_number=2612&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2612&signature=2d1f8c79db90a30df9819ef46a023128c8fa5e1f540fb48e4af1531d9e23af21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The release workflow now recognizes GitHub CLI’s current unprotected-branch response and continues to evaluate ruleset-required checks. A production-boundary harness exercised newline-terminated GitHub CLI-style error streams through the real child-process transport: the updated code trims both streams, accepts the expected response, and completes the ruleset-only required-check path.

The concern that trailing newlines in GitHub CLI output would prevent the strict response match was disproved by this execution. The parent implementation rejected the same response before ruleset inspection, while this change accepted it and evaluated the required ruleset check.

## T-Rex validation blocked

The repository’s focused Vitest command could not load because the workspace package `@bastani/pi-ai/compat` is missing. The production-boundary harness completed independently of that package.

<h3>Confidence Score: 5/5</h3>

The changed release-gating behavior completed successfully with the expected GitHub CLI error response and a ruleset-only required check.

No publishable defects remain. The changed behavior was exercised through the production child-process transport with realistic newline-terminated command output, confirming that stream normalization occurs before the exact response comparison.

**Files Needing Attention:** No files require author changes. The focused Vitest suite remains unavailable until the workspace export `@bastani/pi-ai/compat` is restored.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the trex-artifacts/github-cli-unprotected-branch-harness.sh to exercise the release boundary through a real child-process transport while substituting gh on PATH, and observed that the parent rejected the unprotected-branch response while the updated implementation accepted the normalized response and completed the rules-only check path.
- Validated gh CLI behavior showing exit code 1 with stdout JSON ending in a newline and stderr ending in a newline, and confirmed that the PR flow now runs the rules-only check after production transport trimming, contradicting the hypothesis that trailing-newline semantics block strict recognition.

<a href="https://app.greptile.com/trex/runs/20229278/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(release): accept current unprotected..."](https://github.com/bastani-inc/atomic/commit/507a45837beb0d96a7abe11522fe876b97fd90d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55972469)</sub>

<!-- /greptile_comment -->