### PR TITLE
fix(ci): honor sequential test timeouts

### DIFF
--- a/scripts/test-duration-guard.ts
+++ b/scripts/test-duration-guard.ts
@@ -115,7 +115,7 @@ export function reportedTestCount(json: string): number {
 	return (report.testResults ?? []).reduce((total, result) => total + (result.assertionResults?.length ?? 0), 0);
 }
 
-const DECLARATION_HEAD = "(?:\\.(?:only|skip|todo|failing|serial|concurrent))*\\s*\\(";
+const DECLARATION_HEAD = "(?:\\.(?:only|skip|todo|failing|serial|concurrent|sequential))*\\s*\\(";
 const DESCRIBE = /^(\s*)describe(?:\.(?:only|skip|todo|each|if))*\s*\(/u;
 const CLOSER = /^(\s*)\},\s*([0-9][0-9_]*|[A-Za-z_$][A-Za-z0-9_$]*)\s*\)\s*;?\s*$/u;
 const TRAILING_VALUE = /^\s*([0-9][0-9_]*|[A-Za-z_$][A-Za-z0-9_$]*)\s*,?\s*$/u;

--- a/test/unit/test-duration-guard.test.ts
+++ b/test/unit/test-duration-guard.test.ts
@@ -274,6 +274,46 @@ test("repository declarations resolve to their real budgets", async () => {
 	assert.equal(notification.size, 0, "no test may restate the suite default as an explicit lower budget");
 });
 
+test("the real sequential workflow reload declaration keeps its explicit timeout budget", () => {
+	const file = "test/unit/workflow-run-state-real-reload.test.ts";
+	const name = "user-global agent launch keeps its real publish watcher through resource and installed full reload";
+	const scored = evaluateDurations(
+		report([{ file, tests: [{ title: name, status: "passed", duration: 21_611 }] }]),
+		30_000,
+		root,
+	);
+	const sample = scored.samples[0];
+	assert.equal(sample?.timeoutMs, 120_000);
+	assert.equal(sample?.explicit, true);
+	assert.equal(sample?.ratio, 21_611 / 120_000);
+	assert.deepEqual(scored.warnings, []);
+	assert.deepEqual(scored.failures, []);
+});
+
+test("unsupported wrappers and lookalike members do not donate timeout budgets", () => {
+	const source = [
+		"test.each([1])(",
+		'  "table wrapper",',
+		"  async () => {",
+		"  },",
+		"  90_000,",
+		");",
+		"",
+		"test.runIf(true)(",
+		'  "conditional wrapper",',
+		"  async () => {",
+		"  },",
+		"  120_000,",
+		");",
+		"",
+		'helper.test.sequential("foreign member", async () => {',
+		"}, 180_000);",
+		'test.sequentially("lookalike member", async () => {',
+		"}, 240_000);",
+	].join("\n");
+	assert.deepEqual([...declaredTimeouts(source)], []);
+});
+
 /**
  * The budget now lives in the resolved vitest config rather than a `--timeout`
  * flag, so resolution follows the same one indirection CI uses: `npm run


### PR DESCRIPTION
## Summary

Fix the flaky-test duration gate so explicit timeouts on supported Vitest member-form calls such as `test.sequential(name, fn, timeout)` are honored. The real workflow reload test now scores its 21,611ms duration against its declared 120,000ms budget instead of the 30,000ms suite default.

## Changes

- Add `sequential` to the duration parser's supported direct Vitest modifier whitelist.
- Add a regression that evaluates the real workflow reload declaration through the public duration-guard interface.
- Add negative coverage for unsupported wrappers, foreign members, and lookalike member names.

## Validation

- `npm run test:unit -- test/unit/test-duration-guard.test.ts` — 14 passed
- `npm run test:scripts` — 4 passed
- Relevant duration-guard, flaky-runner, and real-reload unit tests passed
- Relevant CI-contract tests passed
- `npm run check` passed
- `git diff --check main...HEAD` passed

## Notes

This is a CI infrastructure fix, so no package changelog is needed. Existing plain `test(...)` timeout handling, scoped-name matching, default budgets, warn/fail ratios, retries, and blind-report handling remain unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790067608&installation_model_id=10562&pr_number=2614&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2614&signature=ed827d1ffa0bd9d2e683cab98d3d367619c060075dcaba9960fa68a2939fec7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes the CI duration guard recognize explicit timeouts on direct `test.sequential(...)` declarations. The real workflow reload test now resolves to its intended 120-second timeout rather than the 30-second project default, while unsupported wrappers and lookalike member expressions remain excluded.

No actionable defects were found. The change is safe to merge.

<h3>Confidence Score: 5/5</h3>

The updated parser correctly applies the explicit timeout for direct sequential tests without accepting unsupported declaration forms.

A focused before-and-after reproduction exercised the real workflow reload declaration, and the focused unit suite passed all 14 tests.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran a focused TypeScript reproduction against the pre-change-equivalent parser and the updated parser to validate the real workflow reload declaration.
- I observed that the pre-change parser used timeoutMs of 30000 with explicit false, while the updated parser used timeoutMs of 120000 with explicit true, and that unsupported test forms returned no timeout budgets.
- I ran the duration-guard unit tests with Vitest and all 14 tests passed, confirming the duration guard honors the intended sequential timeout and exclusions.
- I compared pre- and post-patch results for the real workflow reload, noting the pre-patch ratio around 0.72 with roughly 21611 ms impact, and the post-patch ratio around 0.18 with a 120000 ms timeout and that rejected forms produced empty results.

<a href="https://app.greptile.com/trex/runs/20234413/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): honor sequential test timeouts"](https://github.com/bastani-inc/atomic/commit/68433d2e9d10a5b6b6d29242c1b267610b5ae9f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55980793)</sub>

<!-- /greptile_comment -->