### PR TITLE
docs: prepare 0.9.16-alpha.1 prerelease notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.16-alpha.1] - 2026-08-23
+
 ### Fixed
 
 - Foreground child decisions, structured interviews, and `intercom.ask` calls resolved to their launching parent now pause the retained child and return the question plus ordered attachments through the parent `subagent` call instead of deadlocking behind Intercom reply delivery. Real typed foreground children receive exact broker authorization for `contact_supervisor`, including successful non-blocking progress delivery. Bare run-ID resume preserves each paused child's session, cwd, Intercom group, execution settings, canonical index, worktree, and dirty changes while rebuilding control and detach callbacks; a sibling completed at the ask boundary stays terminal without blocking paused siblings. Queued work remains unlaunched and unauthorized, worktree diff capture and cleanup wait for terminal resume, and completed children remain non-resumable ([#2589](https://github.com/bastani-inc/atomic/issues/2589)).

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.16-alpha.1] - 2026-08-23
+
 ### Breaking Changes
 
 - Parent-targeted blocking asks no longer pause a child for `subagent` resume. They end the child and return a fresh-subagent `[TASK_CONTEXT]` handoff; migrate supervisors to launch a new child with the answer ([#2604](https://github.com/bastani-inc/atomic/issues/2604)).

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.16-alpha.1] - 2026-08-23
+
 ### Added
 
 - Added the opaque retained-Postgres lease used by workflow durability: direct log-redirected spawn, Unix uid/gid ownership with inherited supplementary groups cleared before a root privilege drop, process-instance-safe PostgreSQL fast shutdown on Unix and Windows, bounded wait/reap, retry retention after timeout, and explicit release without termination ([#2544](https://github.com/bastani-inc/atomic/pull/2544) by [@darionco](https://github.com/darionco)).

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.16-alpha.1] - 2026-08-23
+
 ### Breaking Changes
 
 - Removed the public `subagent({ action: "resume" })` action and its `index`/`message` inputs. Completed, interrupted, and parent-question children are terminal; migrate follow-ups to a fresh `subagent({ agent, task })` launch with explicit `[TASK_CONTEXT]` and expect a new run identity ([#2604](https://github.com/bastani-inc/atomic/issues/2604)).

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.16-alpha.1] - 2026-08-23
+
 ### Fixed
 
 - Fixed Windows embedded Postgres startup waiting forever when the daemon inherited `pg_ctl` pipes by directly spawning Postgres behind an opaque native process lease. Orderly shutdown now sends fast shutdown and bounded-waits on that exact retained child/HANDLE, preventing mutable-pidfile and PID-reuse races while leaving attached clusters untouched; failed or timed-out shutdown retains the lease for retry. Linux root runtime copies are now exact, root-owned, read/execute-only generations for the dropped Postgres account, with source and post-rename validation, atomically replaced monotonic setup heartbeats, final publication-lease checks, and bounded fail-closed corruption handling ([#2547](https://github.com/bastani-inc/atomic/issues/2547), [#2544](https://github.com/bastani-inc/atomic/pull/2544) by [@darionco](https://github.com/darionco)).


### PR DESCRIPTION
## Summary

Prepare the package release notes for the `0.9.16-alpha.1` prerelease.

## Changes

- Add the `0.9.16-alpha.1` release heading to the coding-agent, intercom, natives, subagents, and workflows changelogs.
- Keep the diff changelog-only.
- Keep package manifests, `package-lock.json`, Cargo files, generated native version checks, and version badges at the versionless `0.0.0` placeholder.

## Validation

- `bun run test:unit test/unit/changelog.test.ts`
- `git diff --check`
- Verified the five prepared changelogs are the only paths changed from `main`.
- Verified all release-base version targets remain at `0.0.0`.
- Commit and push hooks passed the repository checks and test suites.

## Notes

This PR does not merge, tag, stamp package versions, or start publication. After merge, the release flow may use `scripts/cut-release.ts` to create the detached release commit and push the version tag once.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790070837&installation_model_id=10562&pr_number=2615&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2615&signature=93f3022d70fe66bf4948bc9f8c1e4cd31dbd6c41d62d2fcd86c495b5e432ecc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change prepares the 0.9.16-alpha.1 release notes for coding-agent, intercom, natives, subagents, and workflows. The new sections were checked with the repository’s changelog parser: each prerelease heading parses correctly, is ordered directly after Unreleased, and contains the relevant release notes. The possible issue of entries remaining assigned to Unreleased was disproved by this executed check.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the release-note structure is accepted by the repository’s parser for all five modified package changelogs.

The executed before-and-after parser validation confirmed that every new 0.9.16-alpha.1 section is recognized as alpha revision 1, correctly ordered, and leaves Unreleased empty.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the prerelease changelog validation script against HEAD^ baseline and HEAD candidate to verify 0.9.16-alpha.1 handling across the five affected changelogs; the baseline showed 0.9.16-alpha.1 was absent before the change, and the candidate headings parsed 0.9.16-alpha.1 as alpha revision 1 after Unreleased with no release-note content in Unreleased.
- Captured and reviewed the validation results, confirming that before capture 0.9.16-alpha.1 was absent and after capture the candidate headings are parsed and correctly associated, with no notes remaining in Unreleased.
- Created and archived validation artifacts, including the reproducible prerelease changelog validation script and the baseline/candidate validation logs, for reviewer access.

<a href="https://app.greptile.com/trex/runs/20237319/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: prepare 0.9.16-alpha.1 prerelease ..."](https://github.com/bastani-inc/atomic/commit/94137c2cd48dbe8c749479d842cbcf181f7f9f12) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55986390)</sub>

<!-- /greptile_comment -->