### PR TITLE
fix(release): verify exact publish run identity

### DIFF
--- a/.atomic/workflows/lib/publish-release.ts
+++ b/.atomic/workflows/lib/publish-release.ts
@@ -330,7 +330,8 @@ export function evaluatePublishRuns(
 		if (run.workflowPath !== ".github/workflows/publish.yml") {
 			return { status: "failed", summary: `Publish workflow path drifted to ${run.workflowPath}.` };
 		}
-		if (run.workflowName !== "Publish" || run.displayTitle !== `Publish ${expected.release.version}`) {
+		const workflowIdentity = `Publish ${expected.release.version}`;
+		if (run.workflowName !== workflowIdentity || run.displayTitle !== workflowIdentity) {
 			return { status: "failed", summary: `Publish workflow identity drifted for run ${run.id}.` };
 		}
 		if (run.event !== "push")
@@ -338,7 +339,13 @@ export function evaluatePublishRuns(
 		if (run.headSha !== expected.releaseSha)
 			return { status: "failed", summary: `Publish run ${run.id} SHA drifted to ${run.headSha}.` };
 	}
-	const exact = [...taggedRuns].sort((left, right) => right.id - left.id)[0];
+	if (taggedRuns.length > 1) {
+		return {
+			status: "failed",
+			summary: `Multiple publish runs materialized for ${expected.release.version}: ${taggedRuns.map((run) => run.id).join(", ")}.`,
+		};
+	}
+	const exact = taggedRuns[0];
 	if (exact === undefined)
 		return { status: "pending", summary: `Publish ${expected.release.version} has not materialized.` };
 	if (exact.status !== "completed")

--- a/test/unit/publish-release-workflow.test.ts
+++ b/test/unit/publish-release-workflow.test.ts
@@ -24,6 +24,13 @@ const headSha = "1".repeat(40);
 const baseSha = "2".repeat(40);
 const releaseSha = "3".repeat(40);
 const release = { kind: "release" as const, version: "1.2.3", branch: "release/1.2.3" };
+const publishedReleaseSha = "5d0bed847a646e3ad6bcf63346e5523679b5615e";
+const publishedRelease = {
+	kind: "prerelease" as const,
+	version: "0.9.16-alpha.1",
+	branch: "prerelease/0.9.16-alpha.1",
+};
+const expectedPublish = { release: publishedRelease, releaseSha: publishedReleaseSha };
 const pullRequest = { url: "https://github.com/bastani-inc/atomic/pull/42", number: 42, headSha };
 const expectedCi = { release, baseRef: "main", pullRequest };
 const unprotectedBranchResponse =
@@ -52,11 +59,11 @@ function publishRun(overrides: Partial<PublishRun> = {}): PublishRun {
 		id: 100,
 		repository: "bastani-inc/atomic",
 		workflowPath: ".github/workflows/publish.yml",
-		workflowName: "Publish",
-		displayTitle: "Publish 1.2.3",
+		workflowName: "Publish 0.9.16-alpha.1",
+		displayTitle: "Publish 0.9.16-alpha.1",
 		event: "push",
-		headBranch: "1.2.3",
-		headSha: releaseSha,
+		headBranch: "0.9.16-alpha.1",
+		headSha: publishedReleaseSha,
 		status: "completed",
 		conclusion: "success",
 		url: "https://github.com/bastani-inc/atomic/actions/runs/100",
@@ -746,14 +753,175 @@ test("polling propagates aborts and inspection errors", async () => {
 	);
 });
 
-test("publish evaluation fails on identity drift and terminal failure", () => {
-	assert.match(
-		evaluatePublishRuns([publishRun({ headSha: "8".repeat(40) })], { release, releaseSha }).summary,
-		/SHA drifted/u,
+test("real GitHub REST publish payload accepts the custom run name as the exact workflow identity", () => {
+	const result = evaluatePublishRuns(
+		[
+			{
+				id: 32633038643,
+				repository: "bastani-inc/atomic",
+				workflowPath: ".github/workflows/publish.yml",
+				workflowName: "Publish 0.9.16-alpha.1",
+				displayTitle: "Publish 0.9.16-alpha.1",
+				event: "push",
+				headBranch: "0.9.16-alpha.1",
+				headSha: "5d0bed847a646e3ad6bcf63346e5523679b5615e",
+				status: "completed",
+				conclusion: "success",
+				url: "https://github.com/bastani-inc/atomic/actions/runs/32633038643",
+			},
+		],
+		{
+			release: {
+				kind: "prerelease",
+				version: "0.9.16-alpha.1",
+				branch: "prerelease/0.9.16-alpha.1",
+			},
+			releaseSha: "5d0bed847a646e3ad6bcf63346e5523679b5615e",
+		},
 	);
-	const failed = evaluatePublishRuns([publishRun({ conclusion: "failure" })], { release, releaseSha });
-	assert.equal(failed.status, "failed");
-	assert.match(failed.summary, /completed with failure/u);
+
+	assert.deepEqual(result, {
+		status: "passed",
+		summary: "Publish run 32633038643 completed successfully.",
+		evidenceUrl: "https://github.com/bastani-inc/atomic/actions/runs/32633038643",
+	});
+});
+
+test("createReleaseBoundary maps the real REST payload and accepts the exact custom run identity", async () => {
+	const payload = {
+		workflow_runs: [
+			{
+				id: 32633038643,
+				name: "Publish 0.9.16-alpha.1",
+				display_title: "Publish 0.9.16-alpha.1",
+				path: ".github/workflows/publish.yml",
+				event: "push",
+				head_branch: "0.9.16-alpha.1",
+				head_sha: "5d0bed847a646e3ad6bcf63346e5523679b5615e",
+				status: "completed",
+				conclusion: "success",
+				html_url: "https://github.com/bastani-inc/atomic/actions/runs/32633038643",
+				repository: { full_name: "bastani-inc/atomic" },
+			},
+		],
+	};
+	const transport = fakeTransport((argv) => {
+		assert.deepEqual(argv, [
+			"gh",
+			"api",
+			"repos/bastani-inc/atomic/actions/workflows/publish.yml/runs?event=push&per_page=100",
+		]);
+		return commandResult(JSON.stringify(payload));
+	});
+	const signal = new AbortController().signal;
+
+	const result = await createReleaseBoundary("/safe/fake/repository", { transport }).waitForPublish({
+		release: publishedRelease,
+		releaseSha: "5d0bed847a646e3ad6bcf63346e5523679b5615e",
+		signal,
+	});
+
+	assert.deepEqual(result, {
+		status: "passed",
+		summary: "Publish run 32633038643 completed successfully.",
+		evidenceUrl: "https://github.com/bastani-inc/atomic/actions/runs/32633038643",
+	});
+	assert.deepEqual(transport.signals, [signal]);
+});
+
+test("exact queued and in-progress publish runs retain the pending result shape", () => {
+	for (const status of ["queued", "in_progress"] as const) {
+		assert.deepEqual(evaluatePublishRuns([publishRun({ status, conclusion: null })], expectedPublish), {
+			status: "pending",
+			summary: `Publish run 100 is ${status}.`,
+			evidenceUrl: "https://github.com/bastani-inc/atomic/actions/runs/100",
+		});
+	}
+});
+
+test("publish verification fails closed on every exact identity mismatch without prefix or normalization", () => {
+	const cases: readonly {
+		readonly label: string;
+		readonly overrides: Partial<PublishRun>;
+		readonly summary: RegExp;
+	}[] = [
+		{ label: "unversioned API name", overrides: { workflowName: "Publish" }, summary: /workflow identity drifted/u },
+		{
+			label: "prefixed API name",
+			overrides: { workflowName: "Publish 0.9.16-alpha.1 retry" },
+			summary: /workflow identity drifted/u,
+		},
+		{
+			label: "normalized API name",
+			overrides: { workflowName: "publish 0.9.16-alpha.1" },
+			summary: /workflow identity drifted/u,
+		},
+		{
+			label: "mismatched display title",
+			overrides: { displayTitle: "Publish 0.9.16-alpha.1 retry" },
+			summary: /workflow identity drifted/u,
+		},
+		{
+			label: "normalized display title",
+			overrides: { displayTitle: "publish 0.9.16-alpha.1" },
+			summary: /workflow identity drifted/u,
+		},
+		{
+			label: "mismatched workflow path",
+			overrides: { workflowPath: ".github/workflows/Publish.yml" },
+			summary: /workflow path drifted/u,
+		},
+		{
+			label: "mismatched repository",
+			overrides: { repository: "bastani-inc/atomic-fork" },
+			summary: /repository drifted/u,
+		},
+		{
+			label: "mismatched event",
+			overrides: { event: "workflow_dispatch" },
+			summary: /event drifted/u,
+		},
+		{
+			label: "mismatched release SHA",
+			overrides: { headSha: "5d0bed847a646e3ad6bcf63346e5523679b5615f" },
+			summary: /SHA drifted/u,
+		},
+	];
+
+	for (const candidate of cases) {
+		const result = evaluatePublishRuns([publishRun(candidate.overrides)], expectedPublish);
+		assert.equal(result.status, "failed", candidate.label);
+		assert.match(result.summary, candidate.summary, candidate.label);
+	}
+});
+
+test("a mismatched tag branch is treated as missing and retains the missing-run pending shape", () => {
+	const missing = {
+		status: "pending" as const,
+		summary: "Publish 0.9.16-alpha.1 has not materialized.",
+	};
+	assert.deepEqual(evaluatePublishRuns([], expectedPublish), missing);
+	assert.deepEqual(evaluatePublishRuns([publishRun({ headBranch: "0.9.16-alpha.2" })], expectedPublish), missing);
+});
+
+test("duplicate exact-tag publish runs fail closed without mutating raw input order", () => {
+	const runs = [publishRun({ id: 99 }), publishRun({ id: 100 })];
+	const result = evaluatePublishRuns(runs, expectedPublish);
+
+	assert.equal(result.status, "failed");
+	assert.match(result.summary, /multiple publish runs.*0\.9\.16-alpha\.1/iu);
+	assert.deepEqual(
+		runs.map((run) => run.id),
+		[99, 100],
+	);
+});
+
+test("a completed publish run with a failure conclusion retains the failed result shape", () => {
+	assert.deepEqual(evaluatePublishRuns([publishRun({ conclusion: "failure" })], expectedPublish), {
+		status: "failed",
+		summary: "Publish run 100 completed with failure.",
+		evidenceUrl: "https://github.com/bastani-inc/atomic/actions/runs/100",
+	});
 });
 
 test("safe fake-boundary E2E executes production Git/GitHub adapters through delayed CI and publish", async () => {
@@ -812,7 +980,7 @@ test("safe fake-boundary E2E executes production Git/GitHub adapters through del
 							: [
 									{
 										id: 100,
-										name: "Publish",
+										name: "Publish 1.2.3",
 										display_title: "Publish 1.2.3",
 										path: ".github/workflows/publish.yml",
 										event: "push",


### PR DESCRIPTION
## Summary

Fix the repository-local `publish-release` verifier to accept GitHub Actions' real REST identity for the version-bound custom `publish.yml` run name. The gate still checks every publish run field and terminal state strictly.

## Changes

- Require REST `name` and `display_title` to equal the exact `Publish ${target_version}` identity produced by the workflow's custom run name.
- Reject duplicate runs for the exact release tag instead of selecting one.
- Add regression coverage through exported `evaluatePublishRuns` and REST-backed `createReleaseBoundary` behavior using run `32633038643`, tag `0.9.16-alpha.1`, and release SHA `5d0bed847a646e3ad6bcf63346e5523679b5615e`.
- Keep mismatched names, titles, paths, repositories, events, tag branches, SHAs, failure conclusions, duplicates, and missing runs fail-closed.

## Validation

- `npx --no-install vitest --run --project unit test/unit/publish-release-workflow.test.ts` — 35/35 passed
- `npm run check` — passed
- Pre-push hooks, including unit, integration, and CI-contract suites — passed

## Notes

This changes only verifier code and focused tests. It does not change workflow YAML or package behavior, so no package changelog entry is included. No existing publish run, tag, release, npm publication, or PR was mutated while preparing this fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790073327&installation_model_id=10562&pr_number=2616&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2616&signature=3f7e52445c75931618a440cb387490933dacbede6aa34e82418758cf74bdfb38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change tightens publish-release verification around the exact version-bound GitHub Actions run identity and rejects duplicate tag-push runs. A successful release can still be incorrectly reported as missing when its publish run is older than the newest 100 push runs: the verifier repeatedly fetches only the first results page and eventually times out instead of finding the completed matching run on a later page.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until workflow-run pagination is added, because valid completed publishes can be missed under normal repository activity.

A focused executable harness exercised the production release boundary with 100 unrelated first-page workflow runs and a matching successful run on page two. It observed repeated first-page requests, no page-two request, and a resulting timeout.

**Files Needing Attention:** .atomic/workflows/lib/publish-release.ts needs paginated retrieval of GitHub workflow runs; test/unit/publish-release-workflow.test.ts should cover a matching run on a later page.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused executable pagination validation harness to exercise the pagination flow.
- Observed a publish waiter timeout and that page two was not requested during the run.
- Validated the TypeScript validation output accompanying the pagination tests.
- Reviewed the general contract validation output, noting a runtime timeout and duplicate fetch pattern, and documented a proposed fix to paginate across pages.
- Posted a second finding-comment-proof for P1.

<a href="https://app.greptile.com/trex/runs/20239199/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `.atomic/workflows/lib/publish-release.ts`, line 750-755 ([link](https://github.com/bastani-inc/atomic/blob/484eb7ed7dd40435998a7e19084ad7e6f7549064/.atomic/workflows/lib/publish-release.ts#L750-L755)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Publish waiter ignores later workflow-run pages**

   The workflow-runs request fetches only the first 100 push runs. If 100 newer unrelated runs fill that page while the exact successful run for this release is on page 2, `evaluatePublishRuns` receives no matching run, remains pending, and `waitForPublish` eventually fails the release with a timeout. Paginate and aggregate the workflow-run response before evaluating the exact run identity and duplicate-run condition.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Focused executable pagination validation harness](https://app.greptile.com/trex/artifacts/cd98fb6e-fc25-4e69-b3fa-06352470077f)**

   - Authored Bun harness injects fake REST responses containing 100 unrelated page-1 runs and an exact successful page-2 run, then exercises the production release boundary; it establishes the missed pagination condition.

   **[Observed publish waiter timeout with page two not requested](https://app.greptile.com/trex/artifacts/c6f520e6-9a38-4b9b-8c84-dbcb9ebb0861)**

   - Captured Bun execution shows exit code 0 for the asserted repro, the timeout failure, two page-1 requests, and \`page2Requested: false\`; the waiter cannot discover the successful page-2 run.

   **[TypeScript validation output](https://app.greptile.com/trex/artifacts/4fec8805-5a7c-43d2-a162-e776da562394)**

   - Captured \`npx tsc --noEmit --pretty false\` output exits successfully after the authored harness was added; the validation harness type-checks with the repository.

   <a href="https://app.greptile.com/trex/runs/20239199/artifacts?artifact=cd98fb6e-fc25-4e69-b3fa-06352470077f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .atomic/workflows/lib/publish-release.ts
   Line: 750-755

   Comment:
   **Publish waiter ignores later workflow-run pages**

   The workflow-runs request fetches only the first 100 push runs. If 100 newer unrelated runs fill that page while the exact successful run for this release is on page 2, `evaluatePublishRuns` receives no matching run, remains pending, and `waitForPublish` eventually fails the release with a timeout. Paginate and aggregate the workflow-run response before evaluating the exact run identity and duplicate-run condition.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Publish waiter ignores successful runs after the first workflow-runs page**

   - **Bug**
     - When 100 newer unrelated push runs fill page 1 and the exact completed successful release run is on page 2, `waitForPublish` requests page 1 repeatedly, reports that the publish has not materialized, and eventually returns a timeout failure.
   - **Cause**
     - `publishRuns` makes exactly one request to `repos/bastani-inc/atomic/actions/workflows/publish.yml/runs?event=push&per_page=100` without a pagination loop. `evaluatePublishRuns` correctly treats an absent run as pending, but receives only page 1.
   - **Fix**
     - Paginate the workflow-runs endpoint, aggregating pages until a response contains fewer than 100 runs (or otherwise exhausts the result set), before calling `evaluatePublishRuns`. Add a boundary test with 100 unrelated page-1 runs and an exact successful page-2 run.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.atomic/workflows/lib/publish-release.ts:750-755
**Publish waiter ignores later workflow-run pages**

The workflow-runs request fetches only the first 100 push runs. If 100 newer unrelated runs fill that page while the exact successful run for this release is on page 2, `evaluatePublishRuns` receives no matching run, remains pending, and `waitForPublish` eventually fails the release with a timeout. Paginate and aggregate the workflow-run response before evaluating the exact run identity and duplicate-run condition.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(release): verify exact publish run i..."](https://github.com/bastani-inc/atomic/commit/484eb7ed7dd40435998a7e19084ad7e6f7549064) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55990001)</sub>

<!-- /greptile_comment -->