### PR TITLE
fix(prompts): remove bundled writing rules from the default system prompt

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Removed
+
+- Removed the bundled writing-rule set from the default system prompt's `Guidelines` section. The unrelated "Be concise in your responses" and "Show file paths clearly when working with files" guidelines remain.
+
 ## [0.9.16-alpha.1] - 2026-08-23
 
 ### Fixed

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -122,14 +122,6 @@ Use context files for project conventions, commands, safety rules, and preferenc
 
 ### System Prompt Files
 
-Atomic's default `Guidelines` section applies Orwell's six writing rules to every standard session:
-
-1. Never use a familiar printed metaphor, simile, or figure of speech.
-2. Never use a long word where a short one will do.
-3. Cut every word that can be cut.
-4. Use active rather than passive voice where possible.
-5. Prefer everyday English to foreign phrases, scientific terms, and jargon.
-6. Break any rule rather than say anything outright barbarous.
 
 Replace the default system prompt with:
 

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -122,7 +122,6 @@ Use context files for project conventions, commands, safety rules, and preferenc
 
 ### System Prompt Files
 
-
 Replace the default system prompt with:
 
 - `.atomic/SYSTEM.md` for a project

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -7,15 +7,6 @@ import { formatSkillsForPrompt, type Skill } from "./skills.ts";
 
 const DEFAULT_PROMPT_TOOLS = ["read", "bash", "edit", "write", "find", "search", "ask_user_question", "todo"] as const;
 
-const DEFAULT_COMMUNICATION_GUIDELINES = [
-	"Never use a familiar printed metaphor, simile, or figure of speech.",
-	"Never use a long word where a short one will do.",
-	"Cut every word that can be cut.",
-	"Use active rather than passive voice where possible.",
-	"Prefer everyday English to foreign phrases, scientific terms, and jargon.",
-	"Break any rule rather than say anything outright barbarous.",
-] as const;
-
 export interface SystemPromptModel {
 	/** Provider identifier for the selected model. */
 	provider: string;
@@ -160,11 +151,6 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
 		if (normalized.length > 0) {
 			addGuideline(normalized);
 		}
-	}
-
-	// Always include these
-	for (const guideline of DEFAULT_COMMUNICATION_GUIDELINES) {
-		addGuideline(guideline);
 	}
 
 	addGuideline("Be concise in your responses");

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -149,29 +149,21 @@ describe("buildSystemPrompt", () => {
 		});
 	});
 
-	test("omits the removed writing guidance while keeping other default guidelines", () => {
+	test("renders exactly the default guidelines and nothing else", () => {
 		const prompt = buildSystemPrompt({
 			selectedTools: [],
 			contextFiles: [],
 			skills: [],
 			cwd: process.cwd(),
 		});
+		const guidelines = prompt.slice(prompt.indexOf("Guidelines:\n"), prompt.indexOf("\n\nAtomic documentation"));
 
-		for (const rule of [
-			"Never use a familiar printed metaphor, simile, or figure of speech.",
-			"Never use a long word where a short one will do.",
-			"Cut every word that can be cut.",
-			"Use active rather than passive voice where possible.",
-			"Prefer everyday English to foreign phrases, scientific terms, and jargon.",
-			"Break any rule rather than say anything outright barbarous.",
-		]) {
-			expect(prompt).not.toContain(rule);
-		}
-		expect(prompt).toContain("- Be concise in your responses");
-		expect(prompt).toContain("- Show file paths clearly when working with files");
+		expect(guidelines).toBe(`Guidelines:
+- Be concise in your responses
+- Show file paths clearly when working with files`);
 	});
 
-	test("keeps custom and unrelated default guidelines when promptGuidelines are present", () => {
+	test("renders custom guidelines before the exact default guidelines", () => {
 		const prompt = buildSystemPrompt({
 			selectedTools: [],
 			promptGuidelines: ["**Workflows**: Workflow-specific sentinel."],
@@ -181,9 +173,10 @@ describe("buildSystemPrompt", () => {
 		});
 		const guidelines = prompt.slice(prompt.indexOf("Guidelines:\n"), prompt.indexOf("\n\nAtomic documentation"));
 
-		expect(guidelines).toContain("- **Workflows**: Workflow-specific sentinel.");
-		expect(guidelines).toContain("- Be concise in your responses");
-		expect(guidelines).toContain("- Show file paths clearly when working with files");
+		expect(guidelines).toBe(`Guidelines:
+- **Workflows**: Workflow-specific sentinel.
+- Be concise in your responses
+- Show file paths clearly when working with files`);
 	});
 
 	describe("workflow guidance", () => {

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -1,13 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { buildSystemPrompt } from "../src/core/system-prompt.ts";
 
-const DEFAULT_COMMUNICATION_GUIDELINES = `- Never use a familiar printed metaphor, simile, or figure of speech.
-- Never use a long word where a short one will do.
-- Cut every word that can be cut.
-- Use active rather than passive voice where possible.
-- Prefer everyday English to foreign phrases, scientific terms, and jargon.
-- Break any rule rather than say anything outright barbarous.`;
-
 describe("buildSystemPrompt", () => {
 	describe("empty tools", () => {
 		test("shows (none) for empty tools list", () => {
@@ -156,7 +149,7 @@ describe("buildSystemPrompt", () => {
 		});
 	});
 
-	test("includes all six core communication rules without promptGuidelines", () => {
+	test("omits the removed writing guidance while keeping other default guidelines", () => {
 		const prompt = buildSystemPrompt({
 			selectedTools: [],
 			contextFiles: [],
@@ -164,10 +157,21 @@ describe("buildSystemPrompt", () => {
 			cwd: process.cwd(),
 		});
 
-		expect(prompt).toContain(`Guidelines:\n${DEFAULT_COMMUNICATION_GUIDELINES}`);
+		for (const rule of [
+			"Never use a familiar printed metaphor, simile, or figure of speech.",
+			"Never use a long word where a short one will do.",
+			"Cut every word that can be cut.",
+			"Use active rather than passive voice where possible.",
+			"Prefer everyday English to foreign phrases, scientific terms, and jargon.",
+			"Break any rule rather than say anything outright barbarous.",
+		]) {
+			expect(prompt).not.toContain(rule);
+		}
+		expect(prompt).toContain("- Be concise in your responses");
+		expect(prompt).toContain("- Show file paths clearly when working with files");
 	});
 
-	test("keeps core communication rules when tool promptGuidelines are present", () => {
+	test("keeps custom and unrelated default guidelines when promptGuidelines are present", () => {
 		const prompt = buildSystemPrompt({
 			selectedTools: [],
 			promptGuidelines: ["**Workflows**: Workflow-specific sentinel."],
@@ -178,7 +182,8 @@ describe("buildSystemPrompt", () => {
 		const guidelines = prompt.slice(prompt.indexOf("Guidelines:\n"), prompt.indexOf("\n\nAtomic documentation"));
 
 		expect(guidelines).toContain("- **Workflows**: Workflow-specific sentinel.");
-		expect(guidelines).toContain(DEFAULT_COMMUNICATION_GUIDELINES);
+		expect(guidelines).toContain("- Be concise in your responses");
+		expect(guidelines).toContain("- Show file paths clearly when working with files");
 	});
 
 	describe("workflow guidance", () => {

--- a/test/unit/execution-routing-guidance.test.ts
+++ b/test/unit/execution-routing-guidance.test.ts
@@ -59,23 +59,6 @@ describe("workflow-first execution routing", () => {
 		}
 	});
 
-	test("keeps all six core communication rules out of workflow promptGuidelines", () => {
-		const modelVisibleWorkflowGuidance = workflowGuidance.join("\n");
-		const coreCommunicationRules = [
-			"Never use a familiar printed metaphor, simile, or figure of speech.",
-			"Never use a long word where a short one will do.",
-			"Cut every word that can be cut.",
-			"Use active rather than passive voice where possible.",
-			"Prefer everyday English to foreign phrases, scientific terms, and jargon.",
-			"Break any rule rather than say anything outright barbarous.",
-		];
-
-		expect(modelVisibleWorkflowGuidance).not.toContain("**Communication**:");
-		for (const rule of coreCommunicationRules) {
-			expect(modelVisibleWorkflowGuidance).not.toContain(rule);
-		}
-	});
-
 	test("treats loop and stop-condition phrasing as a strong workflow signal", () => {
 		for (const phrase of [
 			"loop or stop-condition wording as a strong workflow signal",


### PR DESCRIPTION
## Summary

Removes the bundled six-rule writing guidance (Orwell's rules) from Atomic's default system prompt, along with the user-facing docs, tests, and assertions that carried or enforced it. The unrelated concise-communication guidance stays exactly as it was.

Every standard session previously received these six bullets in the prompt's `Guidelines:` block. They are now gone from the shipped prompt. The block ends with the two preserved bullets:

```
Guidelines:
- Be concise in your responses
- Show file paths clearly when working with files
```

## Changes

| File | Change |
| --- | --- |
| `packages/coding-agent/src/core/system-prompt.ts` | Deletes the `DEFAULT_COMMUNICATION_GUIDELINES` constant and the loop that appended it. The two `addGuideline` calls that follow are untouched. |
| `packages/coding-agent/docs/usage.md` | Drops the numbered rule list from `### System Prompt Files`, plus the blank line it left behind. |
| `packages/coding-agent/test/system-prompt.test.ts` | Two tests rewritten from `toContain` against a six-sentence constant to exact equality (`toBe`) on the sliced `Guidelines:` block. The constant is gone. |
| `test/unit/execution-routing-guidance.test.ts` | Removes the test that stored all six sentences as constants. |
| `packages/coding-agent/CHANGELOG.md` | One `### Removed` entry under `## [Unreleased]`. Released sections are byte-identical. |

Net: 5 files, 14 insertions, 52 deletions.

## Why the routing test was deleted rather than trimmed

`test/unit/execution-routing-guidance.test.ts` held the six sentences as literal constants, which is exactly the kind of retained copy this change removes. Its companion `not.toContain("**Communication**:")` assertion went with it. `git log -S '**Communication**:'` shows that assertion was born in `b399492895` — the same commit that moved the rules into core guidance — so its only referent was the block now being removed. No independent `**Communication**:` block exists before or after. Reviewers recorded the loss of that marker assertion as a non-blocking P3: nothing now asserts over `packages/workflows` guidance content, which is a pre-existing gap this change does not worsen.

## Negative coverage is stronger, not weaker

The replacement assertions use exact equality on the rendered `Guidelines:` block. That rejects *any* unexpected bullet without naming one, so the tests store none of the removed text while catching more than the per-string `not.toContain` loop they replace.

Regression sensitivity was proven by mutation rather than asserted: restoring the constant and its injection loop yields 2 failed / 34 passed at the new assertions; reverting yields 36/36.

## Verification

Run first-hand across the orchestrator and three independent reviewers:

- `npm run test --workspace=@bastani/atomic -- system-prompt` — 36/36 passed
- `npm run test --workspace=@bastani/atomic` — 475 files, 3906 passed, 39 skipped
- `npm run test:unit` — 691 files, 6933 passed, 2 skipped
- `npx vitest --run --project unit test/unit/execution-routing-guidance.test.ts` — 34/34 passed
- `npm run check` / `npm run typecheck` — exit 0 (biome, `tsc --noEmit`, `tsgo -p tsconfig.build.json --noEmit`, shrinkwrap)
- `biome check --error-on-warnings .` — exit 0 over 2566 files
- `bun run docs:check` — passed, 38 pages
- Pre-push hooks on this branch — `test:unit`, `test:integration`, `test:ci-contracts` all passed

Completeness sweeps: `git grep -F` for each of the six sentences returns zero tracked files; a repo-wide `grep -rl --binary-files=text` including ignored and untracked files also returns zero; `grep -a -c` on `packages/coding-agent/test/fixtures/*.jsonl` returns 0. The only surviving mentions are two historical lines inside released `CHANGELOG.md` sections (562, 809), which name the rules without quoting them and must stay under the changelog-immutability rule.

**End-to-end, not just unit tests.** Two reviewers independently captured the prompt the real CLI sends, through different harnesses — one via a registered local OpenAI-compatible provider, one via a `session_start` hook writing `ctx.getSystemPrompt()` to disk. Both captures show all six sentences absent from the entire payload and both preserved bullets present. `buildSystemPrompt` has only two non-test call sites (`agent-session-state.ts:127`, `server/create-harness.ts:311`), so there is no second assembly path.

Changelog immutability was proven by hash: the range from `## [0.9.16-alpha.1]` to EOF hashes identically on `origin/main` and on this branch.

## Review status

Approved by three independent reviewers (completion, evidence, risk) with no blocking findings and one non-blocking P3, described above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790099633&installation_model_id=10562&pr_number=2618&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2618&signature=f0b915e9671501024d228b83d248cc8ed8fe7babed670903f710f1a4d231b2c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the six bundled Orwell writing rules from Atomic’s default system prompt while retaining the concise-response and clear-file-path guidance. Documentation, changelog text, and prompt assertions were updated to match the shipped prompt. A focused behavior check disproved the suspected regression: the updated prompt omits all six removed rules while preserving ordered, deduplicated custom guidance and applicable bash file-operation guidance.

<h3>Confidence Score: 5/5</h3>

The prompt behavior is safe to merge: intended rules are removed and unrelated default, custom, and tool-dependent guidance remains intact.

A focused executable comparison exercised the relevant prompt-construction paths before and after the change, and the targeted system-prompt suite passed with all 12 tests successful. No defects remain in the final review.

**Files Needing Attention:** No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the parent prompt behavior with the updated implementation using a focused Bun assertion script.
- Verified that the updated prompt removes all six former writing rules while preserving the two default guidelines, ordered deduplicated custom guidance, and bash-derived file-operation guidance.
- Ran the system prompt test suite with Bun (vitest) and all 12 tests passed.
- Before capture shows the parent prompt contained all six Orwell rules while preserving custom ordering and bash guidance.
- After capture shows six Orwell rules removed and all requested retained/custom/tool-dependent behavior passing.

<a href="https://app.greptile.com/trex/runs/20263982/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["test(prompts): assert exact default guid..."](https://github.com/bastani-inc/atomic/commit/acea278379aba44a4768412c7c578f327908f79b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56039484)</sub>

<!-- /greptile_comment -->