### PR TITLE
docs: prepare 0.9.16-alpha.2 prerelease notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.16-alpha.2] - 2026-08-23
+
 ### Changed
 
 - Main-chat model fallback is now session-sticky: after failover, later turns keep using the selected fallback model and thinking level until an explicit `/model` selection or model cycle changes it.

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.16-alpha.2] - 2026-08-23
+
 ### Breaking Changes
 
 - Removed the `subagent({ action: "doctor" })` management action and the `/subagents-doctor` slash command. `doctor` is no longer a valid `action` value, and the observing management actions available to a child are now `list`, `get`, and `status`. Agent discovery still reports invalid-frontmatter files through its load diagnostics; use `intercom({ action: "status" })` to inspect intercom bridge state.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.16-alpha.2] - 2026-08-23
+
 ### Added
 
 - Added Lauren Tan's bundled `bro`, `how`, `teach`, `unslop`, and `why` pstack skills for plain-language restatement, codebase explanation, teaching, writing cleanup, and evidence-backed design rationale. Sourced from https://github.com/cursor/plugins and distributed under the MIT License.


### PR DESCRIPTION
## Summary

Prepare the package release notes for the `0.9.16-alpha.2` prerelease.

## Changes

- Add the `0.9.16-alpha.2` release heading to the coding-agent, subagents, and workflows changelogs.
- Keep the diff changelog-only.
- Keep package manifests, `package-lock.json`, Cargo files, generated native version checks, and version badges at the versionless `0.0.0` placeholder.

## Validation

- `bun run test:unit test/unit/changelog.test.ts`
- Parsed the three prepared changelogs: `0.9.16-alpha.2` is alpha revision 2, ordered directly after Unreleased, and sits above `0.9.16-alpha.1`.
- `git diff --check`
- Verified the three prepared changelogs are the only paths changed from `main`.
- Verified all release-base version targets remain at `0.0.0`.
- Commit and push hooks passed the repository checks and test suites.

## Notes

This PR does not merge, tag, stamp package versions, or start publication. After merge, the release flow may use `scripts/cut-release.ts` to create the detached release commit and push the version tag once.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790114779&installation_model_id=10562&pr_number=2621&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2621&signature=c1512fc5fc209f1bf56ead1e28be5cdcbdda9690f4eabe1ce90d2250b96edd2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change creates the `0.9.16-alpha.2` release boundary in the coding-agent, subagents, and workflows changelogs. The release-note placement check confirmed that all pending notes moved intact into one correctly dated alpha.2 section, each `Unreleased` section is empty, and all alpha.1-and-older content is unchanged. No issues were found.

## T-Rex validation blocked

The supplemental changelog unit test could not load because the local `@bastani/pi-ai/compat` package is missing from this checkout. The focused Markdown comparison completed successfully and covered the changed release-note boundaries.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the change is limited to release-note boundaries and the affected content was verified intact.

The executed parent-to-HEAD comparison verified section ordering, unique alpha.2 headings, release dates, complete note preservation, empty Unreleased sections, and unchanged historical release content. No defects remain.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the authored prerelease-boundary validation script to verify the prerelease boundary across revisions.
- Validated that pending notes under Unreleased were moved into the 0.9.16-alpha.2 section and that Unreleased is now empty.
- Verified the focused validation exited with status code 0 for both revisions, and noted that the repository unit validation is captured separately as blocked due to a missing workspace package.
- Reviewed the boundary-related logs to corroborate the boundary state changes for parent and HEAD revisions and to understand the blocked unit validation cause.

<a href="https://app.greptile.com/trex/runs/20282144/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: prepare 0.9.16-alpha.2 prerelease ..."](https://github.com/bastani-inc/atomic/commit/a1d154eb70eafb6a38407f3f0fabddbc64b98374) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56079032)</sub>

<!-- /greptile_comment -->