### PR TITLE
docs: prepare 0.9.16-alpha.3 prerelease notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.16-alpha.3] - 2026-08-23
+
 ### Changed
 
 - Installed builtin extensions (`workflows`, `subagents`, `mcp`, `web-access`, `intercom`) now ship as prebundled ESM entry files. Resource trees (`skills/`, `agents/`, workflow builtins) stay on disk; leftover extension TypeScript is pruned from the npm/binary payload. Source maps stay in the published `dist/`, matching upstream pi.


### PR DESCRIPTION
## Summary

Prepare the package release notes for the `0.9.16-alpha.3` prerelease.

## Changes

- Add the `0.9.16-alpha.3` release heading to the coding-agent changelog.
- Keep the diff changelog-only.
- Keep package manifests, `package-lock.json`, Cargo files, generated native version checks, and version badges at the versionless `0.0.0` placeholder.

## Validation

- `bun run test:unit test/unit/changelog.test.ts`
- Parsed the prepared changelog: `0.9.16-alpha.3` is alpha revision 3, ordered directly after Unreleased, and sits above `0.9.16-alpha.2`.
- `git diff --check`
- Verified `packages/coding-agent/CHANGELOG.md` is the only path changed from `main`.
- Verified all release-base version targets remain at `0.0.0`.
- Commit and push hooks passed the repository checks and test suites.

## Notes

This PR does not merge, tag, stamp package versions, or start publication. After merge, the release flow may use `scripts/cut-release.ts` to create the detached release commit and push the version tag once.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790127800&installation_model_id=10562&pr_number=2623&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2623&signature=335f85fdf463acc71630c2859999cfa014ac1da525d93162a4aba316eed478c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the `0.9.16-alpha.3` prerelease section to `packages/coding-agent/CHANGELOG.md` and places the existing Changed note under that release.

The release-note placement concern was disproved: a targeted check confirmed that Unreleased is empty and that the changelog sequence is `Unreleased → 0.9.16-alpha.3 → 0.9.16-alpha.2 → 0.9.16-alpha.1`. The repository changelog test suite also passed all 12 tests.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the changelog entry is correctly ordered, owns its release note, and passes the repository's changelog checks.

The only changed file received a targeted structural validation plus the repository changelog test suite, with no defects found.

**Files Needing Attention:** None. `packages/coding-agent/CHANGELOG.md` was validated.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex compared the current CHANGELOG.md against the alpha.3 baseline and found a missing 0.9.16-alpha.3 heading.
- T-Rex re-ran the changelog validation to confirm the baseline failure and then validated the updated changelog, which showed the new heading and an empty Unreleased section with ownership of the Changed entry.
- T-Rex built the required workspace and ran the repository unit tests for the changelog validation; all 12 tests passed.
- T-Rex produced artifacts to verify the alpha.3 changelog update, including the targeted changelog validation script and the repository changelog unit test output.

<a href="https://app.greptile.com/trex/runs/20297718/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: prepare 0.9.16-alpha.3 prerelease ..."](https://github.com/bastani-inc/atomic/commit/ef6552aa6afed8b0be57971ad190278900c51154) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56109555)</sub>

<!-- /greptile_comment -->