### PR TITLE
fix(coding-agent): keep prebundled extensions on Atomic credentials

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Workflow stages on installed/prebundled builds now resolve credentials from `~/.atomic/agent` again. The companion extension bundle was treating `@bastani/workflows` as the app package, so stages created an empty `~/.workflows/agent` and reported `No API key found` for every provider.
+
 ## [0.9.16-alpha.3] - 2026-08-23
 
 ### Changed

--- a/packages/coding-agent/src/config-package-identity.ts
+++ b/packages/coding-agent/src/config-package-identity.ts
@@ -1,0 +1,66 @@
+import { existsSync, readFileSync } from "fs";
+import { dirname, join } from "path";
+import { BUILTIN_PACKAGE_DIR_NAMES } from "./core/builtin-install-layout.ts";
+
+export const COMPANION_BUILTIN_PACKAGE_NAMES: readonly string[] = BUILTIN_PACKAGE_DIR_NAMES.map(
+	(dirName) => `@bastani/${dirName}`,
+);
+
+type PackageIdentityJson = {
+	readonly name?: string;
+	readonly atomicConfig?: unknown;
+	readonly piConfig?: unknown;
+};
+
+export function isCompanionBuiltinPackageName(name: string | undefined): boolean {
+	return name !== undefined && COMPANION_BUILTIN_PACKAGE_NAMES.includes(name);
+}
+
+export function packageJsonDefinesAppIdentity(pkg: PackageIdentityJson): boolean {
+	if (pkg.name === "@bastani/atomic" || pkg.name === "@mariozechner/pi") return true;
+	return hasObjectField(pkg.atomicConfig) || hasObjectField(pkg.piConfig);
+}
+
+/**
+ * Walk from a bundled or compiled module directory to the Atomic app package.
+ *
+ * Prebundled companion extensions live under `dist/builtin/<name>/` with their
+ * own `package.json`. The first package.json from those bundles is
+ * `@bastani/workflows` (or another companion), which must not become APP_NAME.
+ */
+export function resolvePackageDirFrom(startDir: string): string {
+	let dir = startDir;
+	let firstPackageDir: string | undefined;
+	while (dir !== dirname(dir)) {
+		const packageJsonPath = join(dir, "package.json");
+		if (existsSync(packageJsonPath)) {
+			firstPackageDir ??= dir;
+			if (shouldUsePackageDir(readPackageIdentity(packageJsonPath))) {
+				return dir;
+			}
+		}
+		dir = dirname(dir);
+	}
+	return firstPackageDir ?? startDir;
+}
+
+function shouldUsePackageDir(pkg: PackageIdentityJson): boolean {
+	if (packageJsonDefinesAppIdentity(pkg)) return true;
+	return !isCompanionBuiltinPackageName(pkg.name);
+}
+
+function hasObjectField(value: unknown): boolean {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readPackageIdentity(packageJsonPath: string): PackageIdentityJson {
+	try {
+		const parsed: unknown = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+		if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+			return parsed as PackageIdentityJson;
+		}
+	} catch {
+		// Unreadable or invalid JSON is not an app identity package.
+	}
+	return {};
+}

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "fs";
 import { dirname, join, resolve } from "path";
+import { resolvePackageDirFrom } from "./config-package-identity.ts";
 import { getHomeDir, normalizePath } from "./utils/paths.ts";
 import { isSplitLauncherRuntime, moduleFileFromMetaUrl } from "./utils/split-launcher.ts";
 
@@ -104,16 +105,10 @@ export function getPackageDir(): string {
 		// Bun binary: process.execPath points to the compiled executable
 		return dirname(process.execPath);
 	}
-	// Node.js: walk up from __dirname until we find package.json
-	let dir = __dirname;
-	while (dir !== dirname(dir)) {
-		if (existsSync(join(dir, "package.json"))) {
-			return dir;
-		}
-		dir = dirname(dir);
-	}
-	// Fallback (shouldn't happen)
-	return __dirname;
+	// Node.js: walk up from __dirname to the Atomic app package. Prebundled
+	// companion extensions ship under dist/builtin/<name>/ with their own
+	// package.json; stopping at the first one made APP_NAME "workflows".
+	return resolvePackageDirFrom(__dirname);
 }
 
 /**

--- a/test/unit/config-package-identity.test.ts
+++ b/test/unit/config-package-identity.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "vitest";
+import {
+	COMPANION_BUILTIN_PACKAGE_NAMES,
+	isCompanionBuiltinPackageName,
+	packageJsonDefinesAppIdentity,
+	resolvePackageDirFrom,
+} from "../../packages/coding-agent/src/config-package-identity.ts";
+import { BUILTIN_PACKAGE_DIR_NAMES } from "../../packages/coding-agent/src/core/builtin-install-layout.ts";
+
+test("companion package names stay aligned with shipped builtin directories", () => {
+	assert.deepEqual(
+		COMPANION_BUILTIN_PACKAGE_NAMES,
+		BUILTIN_PACKAGE_DIR_NAMES.map((dirName) => `@bastani/${dirName}`),
+	);
+	assert.equal(isCompanionBuiltinPackageName("@bastani/workflows"), true);
+	assert.equal(isCompanionBuiltinPackageName("@bastani/atomic"), false);
+});
+
+test("atomicConfig or the Atomic package name marks app identity", () => {
+	assert.equal(packageJsonDefinesAppIdentity({ name: "@bastani/atomic" }), true);
+	assert.equal(packageJsonDefinesAppIdentity({ name: "@mariozechner/pi" }), true);
+	assert.equal(
+		packageJsonDefinesAppIdentity({
+			name: "@bastani/workflows",
+			atomicConfig: { name: "atomic", configDir: ".atomic" },
+		}),
+		true,
+	);
+	assert.equal(packageJsonDefinesAppIdentity({ name: "@bastani/workflows" }), false);
+});
+
+test("prebundled workflows package.json does not become the Atomic app root", () => {
+	const root = mkdtempSync(join(tmpdir(), "atomic-package-identity-"));
+	const atomicRoot = join(root, "node_modules", "@bastani", "atomic");
+	const bundleDir = join(atomicRoot, "dist", "builtin", "workflows", "src", "extension");
+	mkdirSync(bundleDir, { recursive: true });
+	writeFileSync(
+		join(atomicRoot, "package.json"),
+		JSON.stringify({
+			name: "@bastani/atomic",
+			atomicConfig: { name: "atomic", configDir: ".atomic" },
+		}),
+		"utf-8",
+	);
+	writeFileSync(
+		join(atomicRoot, "dist", "builtin", "workflows", "package.json"),
+		JSON.stringify({ name: "@bastani/workflows" }),
+		"utf-8",
+	);
+
+	assert.equal(resolvePackageDirFrom(bundleDir), atomicRoot);
+});


### PR DESCRIPTION
## Summary

Prebundled companion extensions were resolving app identity from `@bastani/workflows`, so workflow stages opened an empty `~/.workflows/agent` and reported `No API key found` for every provider. Walk past those package.json files to `@bastani/atomic` so stages use `~/.atomic/agent` again.

## Changes

- add `resolvePackageDirFrom()` that skips companion builtin package names unless they declare `atomicConfig` / `piConfig`
- use it from `getPackageDir()` instead of stopping at the first package.json
- cover the installed `dist/builtin/workflows/...` layout with a unit test

## Notes

Regression from the 0.9.16-alpha.3 prebundle layout (`7bf0d2c662`). Source checkouts were unaffected because they load raw TypeScript from `packages/workflows`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790132631&installation_model_id=10562&pr_number=2624&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2624&signature=7add358c8d5e3c257c59c54c8cae13769c4173d962ed2f592e392f292839c2e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change updates package-root discovery so bundled companion extensions locate the enclosing Atomic application package, preserving the application identity and credential-directory behavior for installed builtin layouts.

One P2 repository-convention issue remains in the new package-identity parsing path: its fields are typed ambiguously and its associated test bypasses the project’s cross-runtime filesystem helper convention.

<h3>Confidence Score: 4/5</h3>

The functional package-resolution change is safe to merge once the repository-convention concern is addressed.

There is one independent non-security P2 finding, which yields a score of 4 under the scoring policy.

**Files Needing Attention:** packages/coding-agent/src/config-package-identity.ts needs its package-identity field typing brought in line with the repository’s type-precision convention; the associated identity-resolution test should use the project’s cross-runtime filesystem helper.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/src/config-package-identity.ts:11-12
**Avoid ambiguous identity field types**

The new parser represents package identity fields and parsed JSON as `unknown`, while the accompanying test directly uses `node:fs`; this bypasses the repository’s type-precision and cross-runtime test-helper conventions, increasing maintenance cost for this identity-resolution path.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(coding-agent): keep prebundled exten..."](https://github.com/bastani-inc/atomic/commit/17439cee654939962ceda85f3bce299f0555c262) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56120916)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->