### PR TITLE
docs: prepare 0.9.16-alpha.4 prerelease notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.16-alpha.4] - 2026-08-23
+
 ### Fixed
 
 - Workflow stages on installed/prebundled builds now resolve credentials from `~/.atomic/agent` again. The companion extension bundle was treating `@bastani/workflows` as the app package, so stages created an empty `~/.workflows/agent` and reported `No API key found` for every provider.
+
 
 ## [0.9.16-alpha.3] - 2026-08-23
 


### PR DESCRIPTION
## Summary

Prepare the package release notes for the `0.9.16-alpha.4` prerelease.

## Changes

- Add the `0.9.16-alpha.4` release heading to the coding-agent changelog.
- Keep the diff changelog-only.
- Keep package manifests, `package-lock.json`, Cargo files, generated native version checks, and version badges at the versionless `0.0.0` placeholder.

## Validation

- `bun run test:unit test/unit/changelog.test.ts`
- Parsed the prepared changelog: `0.9.16-alpha.4` is alpha revision 4, ordered directly after Unreleased, and sits above `0.9.16-alpha.3`.
- `git diff --check`
- Verified `packages/coding-agent/CHANGELOG.md` is the only path changed from `main`.
- Verified all release-base version targets remain at `0.0.0`.
- Commit and push hooks passed the repository checks and test suites.

## Notes

This PR does not merge, tag, stamp package versions, or start publication. After merge, the release flow may use `scripts/cut-release.ts` to create the detached release commit and push the version tag once.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790133922&installation_model_id=10562&pr_number=2625&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2625&signature=ab8b44f791f635016b2e1f9449ec3dcba4fcd15988ae320127abf22674cc3ae2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds the `0.9.16-alpha.4` release heading and assigns the credential-resolution fix to that release. The entry has been moved out of `Unreleased`, which conflicts with the required changelog staging workflow.

<h3>Confidence Score: 4/5</h3>

The release-note content is clear, but the changelog placement should be corrected before merge to preserve the required release workflow.

There is one non-security P2 finding. Under the scoring policy, a review containing only P2 findings receives a score of 4.

**Files Needing Attention:** packages/coding-agent/CHANGELOG.md

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/CHANGELOG.md:5
**Release heading bypasses Unreleased**

Adding the alpha.4 heading above `### Fixed` moves the credential-resolution entry out of `## [Unreleased]`, bypassing the repository's required staging workflow for new changelog entries.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: prepare 0.9.16-alpha.4 prerelease ..."](https://github.com/bastani-inc/atomic/commit/0f0d6fedb8606675051d4bb2391c12869de24b06) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56123895)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->