### PR TITLE
fix(coding-agent): type package identity fields

### DIFF
--- a/packages/coding-agent/src/config-package-identity.ts
+++ b/packages/coding-agent/src/config-package-identity.ts
@@ -6,10 +6,13 @@ export const COMPANION_BUILTIN_PACKAGE_NAMES: readonly string[] = BUILTIN_PACKAG
 	(dirName) => `@bastani/${dirName}`,
 );
 
-type PackageIdentityJson = {
+type JsonObject = { readonly [key: string]: JsonValue };
+type JsonValue = boolean | JsonObject | JsonValue[] | null | number | string;
+
+export type PackageIdentityJson = {
 	readonly name?: string;
-	readonly atomicConfig?: unknown;
-	readonly piConfig?: unknown;
+	readonly atomicConfig?: JsonObject;
+	readonly piConfig?: JsonObject;
 };
 
 export function isCompanionBuiltinPackageName(name: string | undefined): boolean {
@@ -18,7 +21,7 @@ export function isCompanionBuiltinPackageName(name: string | undefined): boolean
 
 export function packageJsonDefinesAppIdentity(pkg: PackageIdentityJson): boolean {
 	if (pkg.name === "@bastani/atomic" || pkg.name === "@mariozechner/pi") return true;
-	return hasObjectField(pkg.atomicConfig) || hasObjectField(pkg.piConfig);
+	return pkg.atomicConfig !== undefined || pkg.piConfig !== undefined;
 }
 
 /**
@@ -49,16 +52,30 @@ function shouldUsePackageDir(pkg: PackageIdentityJson): boolean {
 	return !isCompanionBuiltinPackageName(pkg.name);
 }
 
-function hasObjectField(value: unknown): boolean {
+function isJsonValue(value: unknown): value is JsonValue {
+	if (value === null || typeof value === "boolean" || typeof value === "string") return true;
+	if (typeof value === "number") return Number.isFinite(value);
+	if (Array.isArray(value)) return value.every(isJsonValue);
+	if (typeof value !== "object" || Object.getPrototypeOf(value) !== Object.prototype) return false;
+	return Object.values(value).every(isJsonValue);
+}
+
+function isJsonObject(value: JsonValue): value is JsonObject {
 	return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function readPackageIdentity(packageJsonPath: string): PackageIdentityJson {
 	try {
 		const parsed: unknown = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
-		if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
-			return parsed as PackageIdentityJson;
-		}
+		if (!isJsonValue(parsed) || !isJsonObject(parsed)) return {};
+		const name = parsed.name;
+		const atomicConfig = parsed.atomicConfig;
+		const piConfig = parsed.piConfig;
+		return {
+			...(typeof name === "string" ? { name } : {}),
+			...(atomicConfig !== undefined && isJsonObject(atomicConfig) ? { atomicConfig } : {}),
+			...(piConfig !== undefined && isJsonObject(piConfig) ? { piConfig } : {}),
+		};
 	} catch {
 		// Unreadable or invalid JSON is not an app identity package.
 	}

--- a/test/unit/config-package-identity.test.ts
+++ b/test/unit/config-package-identity.test.ts
@@ -1,6 +1,4 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "vitest";
 import {
@@ -10,6 +8,7 @@ import {
 	resolvePackageDirFrom,
 } from "../../packages/coding-agent/src/config-package-identity.ts";
 import { BUILTIN_PACKAGE_DIR_NAMES } from "../../packages/coding-agent/src/core/builtin-install-layout.ts";
+import { makeTempDirectory, removeTempDirectory, writeFileEnsuringDir } from "../helpers/runtime.js";
 
 test("companion package names stay aligned with shipped builtin directories", () => {
 	assert.deepEqual(
@@ -30,27 +29,58 @@ test("atomicConfig or the Atomic package name marks app identity", () => {
 		}),
 		true,
 	);
+	assert.equal(
+		packageJsonDefinesAppIdentity({
+			name: "@bastani/workflows",
+			piConfig: { name: "pi", configDir: ".pi" },
+		}),
+		true,
+	);
 	assert.equal(packageJsonDefinesAppIdentity({ name: "@bastani/workflows" }), false);
 });
 
-test("prebundled workflows package.json does not become the Atomic app root", () => {
-	const root = mkdtempSync(join(tmpdir(), "atomic-package-identity-"));
-	const atomicRoot = join(root, "node_modules", "@bastani", "atomic");
-	const bundleDir = join(atomicRoot, "dist", "builtin", "workflows", "src", "extension");
-	mkdirSync(bundleDir, { recursive: true });
-	writeFileSync(
-		join(atomicRoot, "package.json"),
-		JSON.stringify({
-			name: "@bastani/atomic",
-			atomicConfig: { name: "atomic", configDir: ".atomic" },
-		}),
-		"utf-8",
-	);
-	writeFileSync(
-		join(atomicRoot, "dist", "builtin", "workflows", "package.json"),
-		JSON.stringify({ name: "@bastani/workflows" }),
-		"utf-8",
-	);
+test("prebundled workflows package.json does not become the Atomic app root", async () => {
+	const root = makeTempDirectory("atomic-package-identity-");
+	try {
+		const atomicRoot = join(root, "node_modules", "@bastani", "atomic");
+		const bundleDir = join(atomicRoot, "dist", "builtin", "workflows", "src", "extension");
+		await writeFileEnsuringDir(
+			join(atomicRoot, "package.json"),
+			JSON.stringify({
+				name: "@bastani/atomic",
+				atomicConfig: { name: "atomic", configDir: ".atomic" },
+			}),
+		);
+		await writeFileEnsuringDir(
+			join(atomicRoot, "dist", "builtin", "workflows", "package.json"),
+			JSON.stringify({ name: "@bastani/workflows" }),
+		);
 
-	assert.equal(resolvePackageDirFrom(bundleDir), atomicRoot);
+		assert.equal(resolvePackageDirFrom(bundleDir), atomicRoot);
+	} finally {
+		removeTempDirectory(root);
+	}
+});
+
+test("prebundled companion with a non-object atomicConfig still walks to Atomic", async () => {
+	const root = makeTempDirectory("atomic-package-identity-primitive-");
+	try {
+		const atomicRoot = join(root, "node_modules", "@bastani", "atomic");
+		const bundleDir = join(atomicRoot, "dist", "builtin", "workflows", "src", "extension");
+		await writeFileEnsuringDir(
+			join(atomicRoot, "package.json"),
+			JSON.stringify({
+				name: "@bastani/atomic",
+				atomicConfig: { name: "atomic", configDir: ".atomic" },
+			}),
+		);
+		await writeFileEnsuringDir(
+			join(atomicRoot, "dist", "builtin", "workflows", "package.json"),
+			JSON.stringify({ name: "@bastani/workflows", atomicConfig: true }),
+		);
+
+		assert.equal(resolvePackageDirFrom(bundleDir), atomicRoot);
+	} finally {
+		removeTempDirectory(root);
+	}
 });


### PR DESCRIPTION
## Summary

Address the Greptile review on #2624 so package-identity parsing no longer keeps `atomicConfig` / `piConfig` as `unknown` or casts the whole `package.json` blob.

## Changes

- Parse identity JSON into typed `name` and object config fields only
- Switch the unit fixtures to `test/helpers/runtime.ts` instead of `node:fs`
- Cover `piConfig` identity and a non-object `atomicConfig` companion package

## Notes

Intended to land on `main` before the paused `0.9.16-alpha.4` tag cut. No user-facing behavior change, so no changelog entry.

Related: https://github.com/bastani-inc/atomic/pull/2624#discussion_r3840505272

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790135541&installation_model_id=10562&pr_number=2626&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2626&signature=50e7c2a4d4a1d791900174858c598f4dcf4bf90f0d9f9fa2d3980e60800cd94a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change narrows package-manifest handling to application identity fields and adds `piConfig` identity support. Package-root resolution was exercised with real temporary manifests: a normal companion package resolves to the Atomic root, but an otherwise equivalent manifest containing an unrelated `1e400` value resolves to the companion package instead. The identity extraction needs to retain valid identity fields when unrelated parsed manifest values are non-finite.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until companion package identity remains available when unrelated manifest metadata parses to a non-finite number.

The failing resolution path was reproduced with the exported resolver, a real nested package layout, and baseline and overflow-number manifest inputs.

**Files Needing Attention:** packages/coding-agent/src/config-package-identity.ts needs its manifest identity extraction adjusted so unrelated values do not invalidate a valid companion name.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a reproducible overflow resolution script to accompany the posted P1 finding.
- The run showed the baseline companion manifest resolves to the Atomic root while the overflow companion manifest resolves to the companion root.
- Contract validation confirmed that overflow values in a companion manifest can shift identity resolution to the companion root, explaining why the system starts from the Atomic root when overflow is present.
- Execution of the overflow-resolution command across inputs demonstrated consistent root selection outcomes and provided artifact evidence for review.

<a href="https://app.greptile.com/trex/runs/20307159/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Overflow numeric values in companion manifests make app-root resolution stop at the companion**

   - **Bug**
     - `JSON.parse` accepts the syntactically valid JSON number `1e400` and produces `Infinity`. The full-document JSON-value validation rejects that non-finite number, discarding even the valid `name: "@bastani/workflows"`. With no name available, the resolver regards the first companion `package.json` as a non-companion package and returns its directory rather than the ancestor Atomic root.
   - **Cause**
     - `readPackageIdentity` requires every value in the parsed manifest to pass `isJsonValue`; `isJsonValue` rejects non-finite numbers before extracting the identity fields needed by resolution.
   - **Fix**
     - Extract and validate `name`, `atomicConfig`, and `piConfig` from a parsed plain object without requiring unrelated manifest fields to be JSON-safe, or otherwise preserve the valid string `name` when unrelated values are non-finite.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/src/config-package-identity.ts:70
**Whole-document validation erases identity**

A companion manifest can validly contain an overflowing JSON number such as `1e400`: `JSON.parse` produces `Infinity`, which makes `isJsonValue(parsed)` reject the entire document before `name` is extracted. The resolver then loses the valid `@bastani/workflows` name and treats the companion directory as an application package, returning it instead of the enclosing Atomic root. Extract the identity fields from the parsed object independently of unrelated manifest values.

### Issue 2
packages/coding-agent/src/config-package-identity.ts:55
**Ambiguous parser input type**

The new `isJsonValue` guard accepts `unknown`, contrary to the repository requirement to use specific types; this leaves the parser boundary weakly specified and moves the accepted input contract into recursive runtime checks.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(coding-agent): type package identity..."](https://github.com/bastani-inc/atomic/commit/9fc0d869962c3a899d9096839f1a3ddfc0846cf9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56127926)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->