### PR TITLE
docs: align quickstart with README install order and formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,9 @@ bun add -g @bastani/atomic
 
 Atomic does not require package install scripts. Add `--ignore-scripts` to a package install command if you want to disable dependency lifecycle scripts.
 
-Alternatively, install the self-contained release archive, which needs no Node.js or package manager. On macOS or Linux:
+Alternatively, install the self-contained release archive, which needs no Node.js or package manager.
+
+On macOS or Linux:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/bastani-inc/atomic/main/install.sh | sh

--- a/README.md
+++ b/README.md
@@ -289,7 +289,13 @@ On Windows, run this in PowerShell:
 irm https://raw.githubusercontent.com/bastani-inc/atomic/main/install.ps1 | iex
 ```
 
-The archive installer verifies `SHA256SUMS`, keeps versioned payloads, and links its launcher from `~/.local/bin/atomic` on macOS/Linux or `%LOCALAPPDATA%\atomic\bin\atomic.cmd` on Windows, printing PATH guidance when needed. Set `ATOMIC_VERSION` to pin an exact release tag, `ATOMIC_INSTALL_DIR` or `ATOMIC_BIN_DIR` to change locations, and `GITHUB_TOKEN` or `GH_TOKEN` if shared GitHub API limits are a concern. On macOS/Linux, relative install and bin directories resolve against the physical directory where the installer starts. The Linux musl archives bundle their C++ runtime libraries and run on stock Alpine without an `apk add` step; Android and Termux remain unsupported. See the [Quickstart](https://docs.bastani.ai/quickstart) for path-resolution and Windows `PATHEXT` details.
+The archive installer verifies `SHA256SUMS`, keeps versioned payloads, and links its launcher from `~/.local/bin/atomic` on macOS/Linux or `%LOCALAPPDATA%\atomic\bin\atomic.cmd` on Windows, printing PATH guidance when needed. It accepts a few environment variables:
+
+- `ATOMIC_VERSION` — pin an exact release tag.
+- `ATOMIC_INSTALL_DIR` / `ATOMIC_BIN_DIR` — change the install and launcher locations. On macOS/Linux, relative directories resolve against the physical directory where the installer starts.
+- `GITHUB_TOKEN` / `GH_TOKEN` — optional; raises GitHub API limits on shared networks.
+
+The Linux musl archives bundle their C++ runtime libraries and run on stock Alpine without an `apk add` step; Android and Termux remain unsupported. See the [Quickstart](https://docs.bastani.ai/quickstart) for path-resolution and Windows `PATHEXT` details.
 
 ### Authenticate and run
 

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -12,11 +12,21 @@ This page gets you from install to a useful first Atomic session. Atomic is the 
 
 ### Package managers
 
-Install the published package globally with npm, pnpm, or Bun:
+Install with npm:
 
 ```bash
 npm install -g @bastani/atomic
+```
+
+With pnpm:
+
+```bash
 pnpm add -g @bastani/atomic
+```
+
+With Bun:
+
+```bash
 bun add -g @bastani/atomic
 ```
 
@@ -38,18 +48,16 @@ irm https://raw.githubusercontent.com/bastani-inc/atomic/main/install.ps1 | iex
 
 The installer downloads only the matching GitHub Release archive and `SHA256SUMS`, verifies the checksum, and keeps the complete payload in a versioned directory.
 
-**Default paths:**
+Default paths:
 
 - macOS/Linux: `~/.local/share/atomic` for versioned payloads and `~/.local/bin/atomic` for the launcher. The installer prints a paste-safe `export PATH=...` command if needed.
 - Windows: `%LOCALAPPDATA%\atomic` for payloads and `%LOCALAPPDATA%\atomic\bin\atomic.cmd` for the launcher. The installer updates the User PATH and current process, then asks you to restart the terminal.
 
-**Custom locations.** Use `ATOMIC_INSTALL_DIR` and `ATOMIC_BIN_DIR` to change those paths:
+The installer accepts these environment variables:
 
-- On macOS/Linux, relative values resolve against the physical directory where the installer starts, and both are used exactly as given, including any trailing whitespace or newline.
-- The install root cannot equal or sit inside the launcher path (`ATOMIC_BIN_DIR/atomic`), and `ATOMIC_BIN_DIR` cannot sit inside the install root's `current` or `versions` directories, which the installer replaces on every install. Impossible layouts fail before any download or filesystem change.
-- A custom Unix `ATOMIC_BIN_DIR` containing `:` cannot be one PATH entry, so the installer prints direct-run guidance instead.
+#### ATOMIC_VERSION
 
-**Exact versions.** Set `ATOMIC_VERSION` to an exact release tag, or pass a flag that overrides it:
+Pin an exact release tag instead of the latest release, or pass a flag that overrides it:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/bastani-inc/atomic/main/install.sh | sh -s -- --ref 0.9.11
@@ -61,7 +69,17 @@ curl -fsSL https://raw.githubusercontent.com/bastani-inc/atomic/main/install.sh 
 
 Pins use Atomic's `MAJOR.MINOR.PATCH` or `MAJOR.MINOR.PATCH-alpha.REVISION` release tag form and are honored literally: if GitHub answers with a different release tag, the installer stops before downloading anything rather than installing a version you did not ask for.
 
-**GitHub API limits.** `GITHUB_TOKEN` or `GH_TOKEN` is optional and raises GitHub API limits on shared networks. Curl and GNU Wget keep the token in a protected temporary file instead of process arguments. BusyBox Wget remains supported without a token, and with a token when the latest-release redirect avoids the API; if an authenticated API fallback is needed, install curl or GNU Wget rather than exposing the token.
+#### ATOMIC_INSTALL_DIR
+
+Override the install root that holds the versioned payloads (default `~/.local/share/atomic` on macOS/Linux, `%LOCALAPPDATA%\atomic` on Windows). On macOS/Linux, a relative value resolves against the physical directory where the installer starts and is used exactly as given, including any trailing whitespace or newline. The install root cannot equal or sit inside the launcher path (`ATOMIC_BIN_DIR/atomic`); impossible layouts fail before any download or filesystem change.
+
+#### ATOMIC_BIN_DIR
+
+Override the launcher directory (default `~/.local/bin` on macOS/Linux, `%LOCALAPPDATA%\atomic\bin` on Windows). Relative values resolve the same way as `ATOMIC_INSTALL_DIR`. It cannot sit inside the install root's `current` or `versions` directories, which the installer replaces on every install. A Unix value containing `:` cannot be one PATH entry, so the installer prints direct-run guidance instead of editing PATH.
+
+#### GITHUB_TOKEN / GH_TOKEN
+
+Optional; raises GitHub API limits on shared networks. Curl and GNU Wget keep the token in a protected temporary file instead of process arguments. BusyBox Wget remains supported without a token, and with a token when the latest-release redirect avoids the API; if an authenticated API fallback is needed, install curl or GNU Wget rather than exposing the token.
 
 ### Which runtime runs your workflows
 
@@ -82,11 +100,21 @@ atomic
 
 For a default archive install on macOS or Linux, remove `~/.local/share/atomic` and the `~/.local/bin/atomic` link. On Windows, remove `%LOCALAPPDATA%\atomic`; if you set `ATOMIC_BIN_DIR`, also remove `atomic.cmd` and the `atomic-current` junction from that directory, then remove the directory from your User PATH.
 
-For a package install, remove the global package with the same package manager:
+For a package install, remove the global package with the same package manager. With npm:
 
 ```bash
 npm uninstall -g @bastani/atomic
+```
+
+With pnpm:
+
+```bash
 pnpm remove -g @bastani/atomic
+```
+
+With Bun:
+
+```bash
 bun remove -g @bastani/atomic
 ```
 

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -48,20 +48,21 @@ irm https://raw.githubusercontent.com/bastani-inc/atomic/main/install.ps1 | iex
 
 The installer downloads only the matching GitHub Release archive and `SHA256SUMS`, verifies the checksum, and keeps the complete payload in a versioned directory.
 
-Default paths:
+On macOS or Linux, the default paths are `~/.local/share/atomic` for versioned payloads and `~/.local/bin/atomic` for the launcher. The installer prints a paste-safe `export PATH=...` command if needed.
 
-- macOS/Linux: `~/.local/share/atomic` for versioned payloads and `~/.local/bin/atomic` for the launcher. The installer prints a paste-safe `export PATH=...` command if needed.
-- Windows: `%LOCALAPPDATA%\atomic` for payloads and `%LOCALAPPDATA%\atomic\bin\atomic.cmd` for the launcher. The installer updates the User PATH and current process, then asks you to restart the terminal.
+On Windows, the defaults are `%LOCALAPPDATA%\atomic` for payloads and `%LOCALAPPDATA%\atomic\bin\atomic.cmd` for the launcher. The installer updates the User PATH and current process, then asks you to restart the terminal.
 
 The installer accepts these environment variables:
 
 #### ATOMIC_VERSION
 
-Pin an exact release tag instead of the latest release, or pass a flag that overrides it:
+Pin an exact release tag instead of the latest release, or pass a flag that overrides it. On macOS or Linux:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/bastani-inc/atomic/main/install.sh | sh -s -- --ref 0.9.11
 ```
+
+On Windows PowerShell:
 
 ```powershell
 & ([scriptblock]::Create((irm https://raw.githubusercontent.com/bastani-inc/atomic/main/install.ps1))) -Ref 0.9.11
@@ -98,7 +99,9 @@ atomic
 
 ## Uninstall
 
-For a default archive install on macOS or Linux, remove `~/.local/share/atomic` and the `~/.local/bin/atomic` link. On Windows, remove `%LOCALAPPDATA%\atomic`; if you set `ATOMIC_BIN_DIR`, also remove `atomic.cmd` and the `atomic-current` junction from that directory, then remove the directory from your User PATH.
+On macOS or Linux, for a default archive install, remove `~/.local/share/atomic` and the `~/.local/bin/atomic` link.
+
+On Windows, remove `%LOCALAPPDATA%\atomic`. If you set `ATOMIC_BIN_DIR`, also remove `atomic.cmd` and the `atomic-current` junction from that directory, then remove the directory from your User PATH.
 
 For a package install, remove the global package with the same package manager. With npm:
 

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -34,7 +34,9 @@ Atomic does not require package install scripts. Add `--ignore-scripts` if you w
 
 ### Release archive
 
-Alternatively, install the self-contained release archive, which needs no Node.js or package manager. On macOS or Linux:
+Alternatively, install the self-contained release archive, which needs no Node.js or package manager.
+
+On macOS or Linux:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/bastani-inc/atomic/main/install.sh | sh

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -4,15 +4,27 @@ This page gets you from install to a useful first Atomic session. Atomic is the 
 
 ## Prerequisites
 
-- **Release archive install:** macOS and Linux need `tar` and either `curl` or `wget`; Windows uses built-in PowerShell commands. Node.js and a package manager are not required.
-- **Package install:** Node.js 24 LTS or newer plus npm, pnpm, Yarn, or Bun. Use Bun 1.4.0+ for Bun installs or workflow-authoring examples.
-- **Model-provider access** — Use `/login` after startup. Supports provider subscriptions and APIs.
+- **Package install:** Node.js 22.19 or newer plus npm, pnpm, Yarn, or Bun. Use Bun 1.4.0+ for Bun installs or workflow-authoring examples.
+- **Release archive install:** macOS and Linux need `tar` and either `curl` or `wget`; Windows uses built-in PowerShell commands. This path does not need Node.js or a package manager.
+- **Model-provider access** — use a supported subscription login or API key. Run `/login` after startup.
 
 ## Install
 
+### Package managers
+
+Install the published package globally with npm, pnpm, or Bun:
+
+```bash
+npm install -g @bastani/atomic
+pnpm add -g @bastani/atomic
+bun add -g @bastani/atomic
+```
+
+Atomic does not require package install scripts. Add `--ignore-scripts` if you want to disable dependency lifecycle scripts during a package install.
+
 ### Release archive
 
-On macOS or Linux:
+Alternatively, install the self-contained release archive, which needs no Node.js or package manager. On macOS or Linux:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/bastani-inc/atomic/main/install.sh | sh
@@ -24,11 +36,20 @@ On Windows PowerShell:
 irm https://raw.githubusercontent.com/bastani-inc/atomic/main/install.ps1 | iex
 ```
 
-The default macOS/Linux paths are `~/.local/share/atomic` for versioned payloads and `~/.local/bin/atomic` for the launcher. The Windows defaults are `%LOCALAPPDATA%\atomic` and `%LOCALAPPDATA%\atomic\bin\atomic.cmd`. The Unix installer prints a paste-safe `export PATH=...` command if needed. A custom Unix `ATOMIC_BIN_DIR` containing `:` cannot be one PATH entry, so the installer prints direct-run guidance instead. The Windows installer updates the User PATH and current process, then asks you to restart the terminal.
+The installer downloads only the matching GitHub Release archive and `SHA256SUMS`, verifies the checksum, and keeps the complete payload in a versioned directory.
 
-Use `ATOMIC_INSTALL_DIR` and `ATOMIC_BIN_DIR` to change those paths. Set `ATOMIC_VERSION` to an exact release tag, or pass a flag that overrides it:
+**Default paths:**
 
-Relative `ATOMIC_INSTALL_DIR` and `ATOMIC_BIN_DIR` values on macOS/Linux resolve against the physical directory where the installer starts, and both are used exactly as given, including any trailing whitespace or newline. The install root cannot equal or sit inside the launcher path (`ATOMIC_BIN_DIR/atomic`), and `ATOMIC_BIN_DIR` cannot sit inside the install root's `current` or `versions` directories, which the installer replaces on every install; impossible layouts fail before any download or filesystem change. Exact pins use Atomic's `MAJOR.MINOR.PATCH` or `MAJOR.MINOR.PATCH-alpha.REVISION` release tag form, and a pin is honored literally: if GitHub answers with a different release tag, the installer stops before downloading anything rather than installing a version you did not ask for.
+- macOS/Linux: `~/.local/share/atomic` for versioned payloads and `~/.local/bin/atomic` for the launcher. The installer prints a paste-safe `export PATH=...` command if needed.
+- Windows: `%LOCALAPPDATA%\atomic` for payloads and `%LOCALAPPDATA%\atomic\bin\atomic.cmd` for the launcher. The installer updates the User PATH and current process, then asks you to restart the terminal.
+
+**Custom locations.** Use `ATOMIC_INSTALL_DIR` and `ATOMIC_BIN_DIR` to change those paths:
+
+- On macOS/Linux, relative values resolve against the physical directory where the installer starts, and both are used exactly as given, including any trailing whitespace or newline.
+- The install root cannot equal or sit inside the launcher path (`ATOMIC_BIN_DIR/atomic`), and `ATOMIC_BIN_DIR` cannot sit inside the install root's `current` or `versions` directories, which the installer replaces on every install. Impossible layouts fail before any download or filesystem change.
+- A custom Unix `ATOMIC_BIN_DIR` containing `:` cannot be one PATH entry, so the installer prints direct-run guidance instead.
+
+**Exact versions.** Set `ATOMIC_VERSION` to an exact release tag, or pass a flag that overrides it:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/bastani-inc/atomic/main/install.sh | sh -s -- --ref 0.9.11
@@ -38,19 +59,9 @@ curl -fsSL https://raw.githubusercontent.com/bastani-inc/atomic/main/install.sh 
 & ([scriptblock]::Create((irm https://raw.githubusercontent.com/bastani-inc/atomic/main/install.ps1))) -Ref 0.9.11
 ```
 
-`GITHUB_TOKEN` or `GH_TOKEN` is optional and raises GitHub API limits on shared networks. Curl and GNU Wget keep the token in a protected temporary file instead of process arguments. BusyBox Wget remains supported without a token, and with a token when the latest-release redirect avoids the API; if an authenticated API fallback is needed, install curl or GNU Wget rather than exposing the token. The installer downloads only the matching GitHub Release archive and `SHA256SUMS`, verifies the checksum, and keeps the complete payload in a versioned directory.
+Pins use Atomic's `MAJOR.MINOR.PATCH` or `MAJOR.MINOR.PATCH-alpha.REVISION` release tag form and are honored literally: if GitHub answers with a different release tag, the installer stops before downloading anything rather than installing a version you did not ask for.
 
-### Package managers
-
-Package installs still require Node.js. Install the published package globally with npm, pnpm, or Bun:
-
-```bash
-npm install -g @bastani/atomic
-pnpm add -g @bastani/atomic
-bun add -g @bastani/atomic
-```
-
-Atomic does not require package install scripts. Add `--ignore-scripts` if you want to disable dependency lifecycle scripts during a package install.
+**GitHub API limits.** `GITHUB_TOKEN` or `GH_TOKEN` is optional and raises GitHub API limits on shared networks. Curl and GNU Wget keep the token in a protected temporary file instead of process arguments. BusyBox Wget remains supported without a token, and with a token when the latest-release redirect avoids the API; if an authenticated API fallback is needed, install curl or GNU Wget rather than exposing the token.
 
 ### Which runtime runs your workflows
 


### PR DESCRIPTION
## Summary
- Reorder the coding-agent quickstart install docs to match the README: package managers first, release archive second
- Break the dense release-archive installer paragraphs (in both the README and quickstart) into labeled, scannable sections: default paths, custom locations, exact version pins, and GitHub API limits
- Fix the quickstart Node prerequisite from "24 LTS" to 22.19, matching the README and `engines.node >=22.19.0`

## Notes
- Existing anchors (`/quickstart#release-archive`, `/quickstart#uninstall`) are unchanged, so links from `index.md`, `usage.md`, and `packages.md` still resolve.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790176232&installation_model_id=10562&pr_number=2633&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2633&signature=778ea49b5ee53ea991059aabfb4c6435864681ebd1a1456703038f3dbbc02b83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This documentation update presents package-manager and release-archive installation paths with platform-specific prerequisites, configuration options, and uninstall guidance. The documented macOS/Linux archive installation flow, including relative custom paths, checksum verification, PATH guidance, version pins, downloader fallback, and token precedence, was exercised successfully; documentation link validation also passed.

A Windows-specific path-resolution error remains in the Quickstart: it describes relative custom bin paths using the macOS/Linux behavior even though PowerShell resolves the bin and install directories independently. This can cause users to install or clean up the launcher from an unexpected location. The change is not ready to merge until that guidance is corrected.

<h3>Confidence Score: 4/5</h3>

Not ready to merge because the Quickstart can direct Windows users to incorrect custom launcher locations.

The documentation mismatch is directly supported by the PowerShell installer’s independent path resolution, the contrasting POSIX implementation and runtime result, and the focused installer documentation contract failure.

**Files Needing Attention:** packages/coding-agent/docs/quickstart.md needs platform-specific relative-path guidance for ATOMIC_INSTALL_DIR and ATOMIC_BIN_DIR.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding and attached installation-related artifacts that document base guidance and path handling.
- T-Rex produced a second P1 finding-proof for another item, but did not attach artifacts to it.
- The general-contract-validation-proof clarified a cross-platform discrepancy: Windows resolves relative install paths to the PowerShell process current directory, whereas POSIX anchors to the install root.
- The contract validation points to the specific files involved (Quickstart, install.ps1, install.sh) and notes the lack of an explicit cross-platform relative-path contract in the Quickstart.

<a href="https://app.greptile.com/trex/runs/20386788/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/coding-agent/docs/quickstart.md`, line 92 ([link](https://github.com/bastani-inc/atomic/blob/26100590a60822c255de8de8abc9dd7fd88f7386/packages/coding-agent/docs/quickstart.md#L92)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Windows custom bin paths resolve independently**

   The statement that relative `ATOMIC_BIN_DIR` values resolve the same way as `ATOMIC_INSTALL_DIR` is only correct on macOS/Linux. `install.ps1` resolves each relative path independently from the PowerShell working directory, so Windows users can create the launcher somewhere other than this guidance implies and later follow incomplete cleanup instructions. Scope this sentence to macOS/Linux and document the Windows behavior, or recommend absolute custom paths on Windows.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Base installation guidance](https://app.greptile.com/trex/artifacts/c2a64015-83fe-423b-9425-60e9793e951c)**

   - The captured base-documentation search shows package-manager commands but no release-archive or installer-environment-variable guidance, confirming the new archive contract is introduced by this change—the takeaway is that the reviewed guidance is new.

   **[Installer docs contract failure](https://app.greptile.com/trex/artifacts/7d01b1fe-e8aa-4103-bd10-a8ab73ce06bf)**

   - The executed focused CI contract test fails because Quickstart does not contain the expected explicit relative \`ATOMIC\_INSTALL\_DIR\` and \`ATOMIC\_BIN\_DIR\` contract—the takeaway is that the changed documentation violates its repository contract test.

   **[POSIX archive installer flow](https://app.greptile.com/trex/artifacts/697aaeb4-e1f7-42f0-8bad-86a675c2926a)**

   - The executed fixture tests pass for redirect resolution, archive installation, checksum validation, PATH guidance, pin forms, downloader fallback, and token precedence—the takeaway is that these documented POSIX archive paths work.

   **[POSIX relative custom paths](https://app.greptile.com/trex/artifacts/1572de38-2822-4fc0-a8b7-40a764cdc4fd)**

   - The executed POSIX installer fixture passes with relative install and bin roots anchored to one physical working directory—the takeaway is that the documented macOS/Linux relative-path behavior is correct.

   **[Windows and POSIX path comparison](https://app.greptile.com/trex/artifacts/f9710552-f48f-42aa-815e-426b572d9fe0)**

   - The numbered documentation and installer excerpts show Quickstart’s unqualified wording beside Windows independent \`GetFullPath\` handling and POSIX shared-start-directory handling—the takeaway is that the wording is incorrect for Windows.

   **[Documentation link validation](https://app.greptile.com/trex/artifacts/59f2db17-7f65-495b-b775-7e02fe090b88)**

   - The executed documentation link checker passes for all 38 Markdown and MDX pages—the takeaway is that link integrity is not affected.

   <a href="https://app.greptile.com/trex/runs/20386788/artifacts?artifact=c2a64015-83fe-423b-9425-60e9793e951c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/coding-agent/docs/quickstart.md
   Line: 92

   Comment:
   **Windows custom bin paths resolve independently**

   The statement that relative `ATOMIC_BIN_DIR` values resolve the same way as `ATOMIC_INSTALL_DIR` is only correct on macOS/Linux. `install.ps1` resolves each relative path independently from the PowerShell working directory, so Windows users can create the launcher somewhere other than this guidance implies and later follow incomplete cleanup instructions. Scope this sentence to macOS/Linux and document the Windows behavior, or recommend absolute custom paths on Windows.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Quickstart incorrectly generalizes relative ATOMIC_BIN_DIR resolution to Windows**

   - **Bug**
     - `packages/coding-agent/docs/quickstart.md:92` unqualifiedly says relative `ATOMIC_BIN_DIR` values resolve like `ATOMIC_INSTALL_DIR`. On Windows, `install.ps1:709-713` resolves the bin directory independently from PowerShell’s current directory, so users can install and later uninstall from a location different from the one the documentation implies.
   - **Cause**
     - The documentation summarizes POSIX’s shared physical-starting-directory behavior without documenting the Windows installer’s separate current-working-directory resolution.
   - **Fix**
     - Limit the existing statement to macOS/Linux and document that Windows resolves relative `ATOMIC_INSTALL_DIR` and `ATOMIC_BIN_DIR` independently from the PowerShell current working directory, or recommend absolute paths on Windows.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/docs/quickstart.md:92
**Windows custom bin paths resolve independently**

The statement that relative `ATOMIC_BIN_DIR` values resolve the same way as `ATOMIC_INSTALL_DIR` is only correct on macOS/Linux. `install.ps1` resolves each relative path independently from the PowerShell working directory, so Windows users can create the launcher somewhere other than this guidance implies and later follow incomplete cleanup instructions. Scope this sentence to macOS/Linux and document the Windows behavior, or recommend absolute custom paths on Windows.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(readme): put release-archive platfo..."](https://github.com/bastani-inc/atomic/commit/26100590a60822c255de8de8abc9dd7fd88f7386) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56276756)</sub>

<!-- /greptile_comment -->