### PR TITLE
docs(overview): match quickstart install order and formatting

### DIFF
--- a/packages/coding-agent/docs/index.md
+++ b/packages/coding-agent/docs/index.md
@@ -9,7 +9,29 @@ Atomic is the loop engine for all engineering work: a terminal coding-agent runt
 
 ## Quick start
 
-Install the self-contained release archive on macOS or Linux:
+Install the published package globally with npm:
+
+```bash
+npm install -g @bastani/atomic
+```
+
+With pnpm:
+
+```bash
+pnpm add -g @bastani/atomic
+```
+
+With Bun:
+
+```bash
+bun add -g @bastani/atomic
+```
+
+Package installation requires Node.js. Atomic does not require package install scripts; add `--ignore-scripts` if you want to disable dependency lifecycle scripts during a package install.
+
+Alternatively, install the self-contained release archive, which needs no Node.js or package manager.
+
+On macOS or Linux:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/bastani-inc/atomic/main/install.sh | sh
@@ -21,17 +43,7 @@ On Windows PowerShell:
 irm https://raw.githubusercontent.com/bastani-inc/atomic/main/install.ps1 | iex
 ```
 
-Archive installation does not require Node.js or a package manager. It verifies the GitHub Release checksum and installs the full payload under a versioned root. See the [Quickstart](/quickstart#release-archive) for exact-version flags, default paths, `ATOMIC_INSTALL_DIR`, `ATOMIC_BIN_DIR`, `ATOMIC_VERSION`, optional `GITHUB_TOKEN`/`GH_TOKEN`, and PATH guidance.
-
-Package installation still requires Node.js. With npm, pnpm, or Bun:
-
-```bash
-npm install -g @bastani/atomic
-pnpm add -g @bastani/atomic
-bun add -g @bastani/atomic
-```
-
-Atomic does not require package install scripts. Add `--ignore-scripts` if you want to disable dependency lifecycle scripts during a package install.
+The archive installer verifies the GitHub Release checksum and installs the full payload under a versioned root. See the [Quickstart](/quickstart#release-archive) for its parameters (`ATOMIC_VERSION`, `ATOMIC_INSTALL_DIR`, `ATOMIC_BIN_DIR`, `GITHUB_TOKEN`/`GH_TOKEN`), default paths, and PATH guidance.
 
 ### Alpine and musl Linux archives
 

--- a/packages/coding-agent/docs/index.md
+++ b/packages/coding-agent/docs/index.md
@@ -45,12 +45,6 @@ irm https://raw.githubusercontent.com/bastani-inc/atomic/main/install.ps1 | iex
 
 The archive installer verifies the GitHub Release checksum and installs the full payload under a versioned root. See the [Quickstart](/quickstart#release-archive) for its parameters (`ATOMIC_VERSION`, `ATOMIC_INSTALL_DIR`, `ATOMIC_BIN_DIR`, `GITHUB_TOKEN`/`GH_TOKEN`), default paths, and PATH guidance.
 
-### Alpine and musl Linux archives
-
-The shell installer detects Alpine and selects `atomic-linux-x64-musl.tar.gz` or `atomic-linux-arm64-musl.tar.gz`. Each archive includes its matching native search and PTY bindings plus payload-local `libgcc` and `libstdc++` runtimes. It runs on stock Alpine without installing runtime packages.
-
-The musl archives deliberately omit a clipboard native binding because `@mariozechner/clipboard` 0.3.9 publishes metadata-only musl stubs without a `.node` payload; Atomic uses Linux clipboard commands and OSC52 fallback instead. They also omit `@embedded-postgres/*` binary packages because those packages are glibc-linked. Durable workflows on Alpine therefore require external Postgres via `DBOS_SYSTEM_DATABASE_URL` or Docker; without a durable backend, Atomic uses a loud non-durable in-memory fallback.
-
 Then run it in a project directory:
 
 ```bash

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -90,7 +90,12 @@ How you install Atomic decides which runtime hosts it: a package-manager install
 
 ### Alpine and musl Linux archives
 
-The shell installer detects Alpine and selects `atomic-linux-x64-musl.tar.gz` or `atomic-linux-arm64-musl.tar.gz`. These archives bundle payload-local `libgcc` and `libstdc++`, so stock Alpine needs no runtime package install. See the [Alpine and musl Linux archive notes](/index#alpine-and-musl-linux-archives) for the clipboard fallback and external Postgres or Docker requirement for durable workflows.
+The shell installer detects Alpine and selects `atomic-linux-x64-musl.tar.gz` or `atomic-linux-arm64-musl.tar.gz`. Each archive includes its matching native search and PTY bindings plus payload-local `libgcc` and `libstdc++` runtimes, so stock Alpine needs no runtime package install.
+
+Two features work differently on musl:
+
+- **Clipboard:** the musl archives omit a clipboard native binding because `@mariozechner/clipboard` 0.3.9 publishes metadata-only musl stubs without a `.node` payload; Atomic uses Linux clipboard commands and OSC52 fallback instead.
+- **Durable workflows:** the archives omit the glibc-linked `@embedded-postgres/*` binary packages, so durable workflows on Alpine require external Postgres via `DBOS_SYSTEM_DATABASE_URL` or Docker. Without a durable backend, Atomic uses a loud non-durable in-memory fallback.
 
 Then start Atomic in the project directory you want it to work on:
 


### PR DESCRIPTION
## Summary
- Reorder the Overview (`docs/index.md`) quick start to lead with package-manager installation, matching the README and the quickstart restructure in #2633
- Split npm, pnpm, and Bun into separate code blocks with short lead-ins
- Give the macOS/Linux and Windows archive commands their own labeled lead-ins
- Keep the archive details to one short paragraph that links to the Quickstart's per-parameter installer docs (`ATOMIC_VERSION`, `ATOMIC_INSTALL_DIR`, `ATOMIC_BIN_DIR`, `GITHUB_TOKEN`/`GH_TOKEN`) instead of restating them

## Notes
- The `### Alpine and musl Linux archives` section is unchanged; the quickstart links to its `/index#alpine-and-musl-linux-archives` anchor, so it stays on this page
- Based on `main`, independent of #2633; the `/quickstart#release-archive` anchor it links to exists both before and after that PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790176964&installation_model_id=10562&pr_number=2634&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2634&signature=6e434896b99439734b58340bd2f1d561c634cc6a498af86877ddd9c31dedb3c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The installation documentation moves Alpine/musl archive guidance into Quickstart, but the package README still points readers to the removed Overview anchor. The README link was exercised directly and does not resolve to the promised guidance; the corrected Quickstart destination does resolve.

<h3>Confidence Score: 4/5</h3>

The documentation change should not merge until the package README directs Alpine/musl users to the relocated guidance.

The affected link and its replacement were both resolved with an executed Markdown-anchor check. The current destination has no matching heading, while the proposed Quickstart destination has the intended heading.

**Files Needing Attention:** `packages/coding-agent/README.md` needs its Alpine/musl platform link updated.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified the posted P2 finding by inspecting the Markdown anchor resolver source and related resolution logs, confirming that the current README target lacks the Alpine heading while the Quickstart target includes it.
- Noted a second P2 finding was posted; there are no artifacts attached to this proof.
- Validated the Alpine link contract by comparing before and after resolutions using the anchor-check script; before state had the README target resolve to docs/index.md with zero matching headings, after state showed the Quickstart target resolving to one matching heading.

<a href="https://app.greptile.com/trex/runs/20388037/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/coding-agent/README.md`, line 82 ([link](https://github.com/bastani-inc/atomic/blob/9c5b67e856999034767318cf0c3203af318edac5/packages/coding-agent/README.md#L82)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Alpine/musl README link targets a removed anchor**

   The Alpine/musl platform note still links to `docs/index.md#alpine-and-musl-linux-archives`, but Overview no longer contains that heading. The guidance now lives in `docs/quickstart.md`, so readers land on Overview without being taken to the promised compatibility instructions. Point this link at `docs/quickstart.md#alpine-and-musl-linux-archives`.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Executed Markdown anchor resolver source](https://app.greptile.com/trex/artifacts/b4801d96-f52a-41a4-8931-0ad7824dac22)**

   - The executable source parses the README link, resolves its local target, and matches the requested anchor against Markdown headings, with the takeaway that the check is reproducible.

   **[Current README target resolves without the Alpine heading](https://app.greptile.com/trex/artifacts/7e3dedfc-16a3-4416-90b8-2137a50ffb00)**

   - This capture runs the production docs validator and the anchor resolver against the current README target, showing zero matching headings in index.md while the heading is in Quickstart, with the takeaway that the reported broken navigation is confirmed.

   **[Quickstart candidate target resolves to the Alpine heading](https://app.greptile.com/trex/artifacts/127437d7-88a2-4578-b94e-6865f3f93f86)**

   - This capture runs the same production validator and resolver using the Quickstart candidate target, showing one matching heading at quickstart.md line 91, with the takeaway that the corrected destination is verified.

   <a href="https://app.greptile.com/trex/runs/20388037/artifacts?artifact=b4801d96-f52a-41a4-8931-0ad7824dac22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/coding-agent/README.md
   Line: 82

   Comment:
   **Alpine/musl README link targets a removed anchor**

   The Alpine/musl platform note still links to `docs/index.md#alpine-and-musl-linux-archives`, but Overview no longer contains that heading. The guidance now lives in `docs/quickstart.md`, so readers land on Overview without being taken to the promised compatibility instructions. Point this link at `docs/quickstart.md#alpine-and-musl-linux-archives`.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>


2. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **README Alpine/musl link points at a missing anchor**

   - **Bug**
     - `packages/coding-agent/README.md:82` links Alpine/musl Linux to `docs/index.md#alpine-and-musl-linux-archives`. `packages/coding-agent/docs/index.md:1-104` no longer contains that heading, while `packages/coding-agent/docs/quickstart.md:91` defines `### Alpine and musl Linux archives`; navigation therefore opens the Overview page without reaching the guidance.
   - **Cause**
     - The Alpine/musl section was moved from Overview to Quickstart, but the README reference was not updated. The existing validator (`packages/coding-agent/scripts/validate-docs-links.ts:117-121,243-275`) preserves fragments as suffixes but validates pages/targets rather than target-document heading anchors, so `bun run docs:check` does not report this condition.
   - **Fix**
     - Update the README target at line 82 to `docs/quickstart.md#alpine-and-musl-linux-archives`; additionally consider extending the docs validator to validate local Markdown fragments against generated heading slugs.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/README.md:82
**Alpine/musl README link targets a removed anchor**

The Alpine/musl platform note still links to `docs/index.md#alpine-and-musl-linux-archives`, but Overview no longer contains that heading. The guidance now lives in `docs/quickstart.md`, so readers land on Overview without being taken to the promised compatibility instructions. Point this link at `docs/quickstart.md#alpine-and-musl-linux-archives`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: move Alpine/musl archive notes fro..."](https://github.com/bastani-inc/atomic/commit/9c5b67e856999034767318cf0c3203af318edac5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56281114)</sub>

<!-- /greptile_comment -->