### PR TITLE
feat(intercom): correlation-keyed multi-waiter registry for concurrent asks

### DIFF
--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+### Added
+
+- Concurrent blocking asks now use a correlation-keyed waiter registry, with configurable `maxPendingAsks` capacity and a structured refusal when full.
+
+### Changed
+
+- Session teardown rejects every pending reply waiter while preserving per-waiter reply, timeout, abort, cancel, and peer-disconnect settlement.
+
 ### Fixed
 
 - Blocking `ask` and `contact_supervisor` waits now fail promptly with the departed session's name when their target disconnects after delivery, instead of hanging until the 10-minute timeout ([#2627](https://github.com/bastani-inc/atomic/issues/2627)).

--- a/packages/intercom/closed-workflow-stage-message.ts
+++ b/packages/intercom/closed-workflow-stage-message.ts
@@ -17,7 +17,7 @@ export function routeClosedWorkflowStageMessage(
   entry: InboundMessageEntry,
   admission: InboundMessageAdmission,
   tracker: ReplyTracker,
-  waiter: ReplyWaiterRecord | null,
+  waiter: ReplyWaiterRecord | Iterable<ReplyWaiterRecord> | null,
   deliver: () => Promise<void>,
   currentClient: () => IntercomClient | null,
   isCurrent: () => boolean,

--- a/packages/intercom/config.ts
+++ b/packages/intercom/config.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "fs";
 import { getAgentConfigPaths } from "@bastani/atomic";
+import { DEFAULT_MAX_PENDING_REPLY_WAITS } from "./reply-waiter.ts";
 
 export interface IntercomConfig {
   /** Broker command used to spawn the broker process (e.g. "npx", "bun", or "node") */
@@ -10,6 +11,9 @@ export interface IntercomConfig {
 
   /** Require confirmation before non-reply sends from interactive sessions */
   confirmSend: boolean;
+
+  /** Maximum concurrent blocking asks for this session. */
+  maxPendingAsks: number;
 
   /** Optional custom status suffix shown after automatic lifecycle status */
   status?: string;
@@ -34,6 +38,7 @@ const defaults: IntercomConfig = {
   brokerCommand: DEFAULT_BROKER_COMMAND,
   brokerArgs: [...DEFAULT_BROKER_ARGS],
   confirmSend: false,
+  maxPendingAsks: DEFAULT_MAX_PENDING_REPLY_WAITS,
   enabled: true,
   replyHint: true,
 };
@@ -83,6 +88,13 @@ export function loadConfig(): IntercomConfig {
         throw new Error(`"confirmSend" must be a boolean`);
       }
       config.confirmSend = parsedConfig.confirmSend;
+    }
+
+    if (Object.hasOwn(parsedConfig, "maxPendingAsks")) {
+      if (!Number.isInteger(parsedConfig.maxPendingAsks) || Number(parsedConfig.maxPendingAsks) < 1) {
+        throw new Error(`"maxPendingAsks" must be an integer greater than or equal to 1`);
+      }
+      config.maxPendingAsks = Number(parsedConfig.maxPendingAsks);
     }
 
     if (Object.hasOwn(parsedConfig, "enabled")) {

--- a/packages/intercom/index-heavy.ts
+++ b/packages/intercom/index-heavy.ts
@@ -6,7 +6,7 @@ import { InlineMessageComponent } from "./ui/inline-message.js";
 import { loadConfig, type IntercomConfig } from "./config.ts";
 import type { SessionInfo, Message } from "./types.js";
 import { ReplyTracker } from "./reply-tracker.js";
-import { ReplyWaiterSlot } from "./reply-waiter.ts";
+import { DEFAULT_REPLY_TIMEOUT_MS, ReplyWaiterRegistry } from "./reply-waiter.ts";
 import { registerContactSupervisorTool } from "./contact-supervisor-tool.js";
 import { registerIntercomTool } from "./intercom-tool.js";
 import { registerIntercomOverlay } from "./overlay.js";
@@ -72,13 +72,13 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
   let joinedGroup: string | null = null;
   const activeTools = new Map<string, string>();
   let replyTracker = new ReplyTracker();
-  const replyWaiters = new ReplyWaiterSlot();
+  const replyWaiters = new ReplyWaiterRegistry(DEFAULT_REPLY_TIMEOUT_MS, config.maxPendingAsks);
   const foregroundDetachHandoff = new ForegroundDetachHandoff(pi);
   const pendingIdleMessages = new InboundIdleQueue();
   const inboundDeliveries = new InboundMessageAdmission();
   const supervisorAuthorizations = new SupervisorAuthorizationRegistry();
   let inboundFlushTimer: NodeJS.Timeout | null = null;
-  function rejectReplyWaiter(error: Error): void { replyWaiters.rejectCurrent(error); }
+  function rejectReplyWaiter(error: Error): void { replyWaiters.rejectAll(error); }
   function clearReconnectTimer(): void { if (reconnectTimer) clearTimeout(reconnectTimer); reconnectTimer = null; }
   function clearInboundFlushTimer(): void { if (inboundFlushTimer) clearTimeout(inboundFlushTimer); inboundFlushTimer = null; }
   function getLiveContext(ctx: ExtensionContext | null = runtimeContext, generation = runtimeGeneration): ExtensionContext | null {
@@ -251,7 +251,7 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
       && liveContext.orchestrationContext.messageAdmission?.isOpen() === false;
     if (stageClosed) {
       routeClosedWorkflowStageMessage(
-        entry, inboundDeliveries, replyTracker, replyWaiters.current(),
+        entry, inboundDeliveries, replyTracker, replyWaiters.pending(),
         () => sendIncomingMessage(entry, "trigger", messageGeneration, false),
         () => client,
         () => Boolean(getLiveContext(liveContext, messageGeneration)),
@@ -261,7 +261,7 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
     const admission = inboundDeliveries.admit(from, message);
     if (admission.kind !== "reserved") return;
     const reservation = admission.reservation;
-    if (routeIncomingReply(replyWaiters.current(), from, message)) {
+    if (routeIncomingReply(replyWaiters.pending(), from, message)) {
       inboundDeliveries.commit(reservation);
       return;
     }
@@ -363,7 +363,7 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
       if (client !== nextClient) {
         return;
       }
-      routePeerDisconnect(replyWaiters.current(), notice);
+      routePeerDisconnect(replyWaiters.pending(), notice);
     });
     nextClient.on("disconnected", (error: Error) => {
       if (client !== nextClient) {
@@ -534,7 +534,6 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
     setJoinedGroup,
     clearJoinedGroup,
     replyTracker: () => replyTracker,
-    hasReplyWaiter: () => replyWaiters.has(),
   });
   registerIntercomOverlay(pi, {
     runtimeGeneration: () => runtimeGeneration,

--- a/packages/intercom/intercom-tool.ts
+++ b/packages/intercom/intercom-tool.ts
@@ -27,19 +27,13 @@ interface IntercomToolDeps {
   setJoinedGroup(group: string): void;
   clearJoinedGroup(): void;
   confirmSend: boolean;
-  /**
-   * Atomically reserve the single reply-waiter slot. Returns a structured
-   * refusal when another blocking ask already holds it, so concurrent calls
-   * never observe a rejected promise.
-   */
+  /** Atomically reserves one correlation-keyed reply waiter. */
   beginReplyWait(from: string, replyTo: string, signal?: AbortSignal): ReplyWaitAdmission;
   replyTracker: ReplyTracker | (() => ReplyTracker);
-  /** Advisory fast-path check; beginReplyWait is the authoritative reservation. */
-  hasReplyWaiter(): boolean;
 }
 
 export function registerIntercomTool(pi: ExtensionAPI, deps: IntercomToolDeps): void {
-  const { childOrchestratorMetadata, ensureConnected, syncPresenceIdentity, beginReplyWait, hasReplyWaiter } = deps;
+  const { childOrchestratorMetadata, ensureConnected, syncPresenceIdentity, beginReplyWait } = deps;
   const resolveTarget = deps.resolveSessionTarget ?? resolveSessionTargetId;
   const getMetadata = typeof childOrchestratorMetadata === "function"
     ? childOrchestratorMetadata
@@ -396,18 +390,14 @@ does not grant cross-group access: contact_supervisor is the only cross-group pa
                 details: { error: true },
               };
             }
-            if (hasReplyWaiter()) {
-              return {
-                content: [{ type: "text", text: "Already waiting for a reply" }],
-                isError: true,
-                details: { error: true },
-              };
-            }
             const questionId = randomUUID();
             const admission = beginReplyWait(sendTo, questionId, _signal);
             if (!admission.ok) {
+              const text = admission.reason === "busy"
+                ? `Too many pending asks (${admission.limit}); reply-wait slots are full`
+                : "Cancelled";
               return {
-                content: [{ type: "text", text: admission.reason === "busy" ? "Already waiting for a reply" : "Cancelled" }],
+                content: [{ type: "text", text }],
                 isError: true,
                 details: { error: true },
               };

--- a/packages/intercom/peer-disconnect-routing.ts
+++ b/packages/intercom/peer-disconnect-routing.ts
@@ -10,16 +10,22 @@ export interface PeerDisconnectNotice {
 	peerName?: string;
 }
 
-/** Rejects only the exact departed-peer/thread pair for a blocking tool waiter. */
-export function routePeerDisconnect(
-	waiter: PeerDisconnectWaiter | null | undefined,
-	notice: PeerDisconnectNotice,
-): boolean {
-	if (!waiter) return false;
+type PeerDisconnectWaiters = PeerDisconnectWaiter | Iterable<PeerDisconnectWaiter> | null | undefined;
+
+function matches(waiter: PeerDisconnectWaiter, notice: PeerDisconnectNotice): boolean {
 	const peerTarget = notice.peerName || notice.peerSessionId;
-	const peerMatches =
-		peerTarget.toLowerCase() === waiter.from.toLowerCase() || notice.peerSessionId === waiter.from;
-	if (!peerMatches || notice.replyTo !== waiter.replyTo) return false;
-	waiter.reject(new Error(`Session "${notice.peerName ?? notice.peerSessionId}" disconnected before replying`));
-	return true;
+	const peerMatches = peerTarget.toLowerCase() === waiter.from.toLowerCase() || notice.peerSessionId === waiter.from;
+	return peerMatches && notice.replyTo === waiter.replyTo;
+}
+
+/** Rejects only the first exact departed-peer/thread pair for a blocking tool waiter. */
+export function routePeerDisconnect(waiters: PeerDisconnectWaiters, notice: PeerDisconnectNotice): boolean {
+	if (!waiters) return false;
+	const candidates = Symbol.iterator in Object(waiters) ? waiters : [waiters];
+	for (const waiter of candidates as Iterable<PeerDisconnectWaiter>) {
+		if (!matches(waiter, notice)) continue;
+		waiter.reject(new Error(`Session "${notice.peerName ?? notice.peerSessionId}" disconnected before replying`));
+		return true;
+	}
+	return false;
 }

--- a/packages/intercom/reply-routing.ts
+++ b/packages/intercom/reply-routing.ts
@@ -6,12 +6,22 @@ export interface PendingReplyRoute {
 	resolve(message: Message): void;
 }
 
-/** Routes only the exact sender/thread pair to a blocking tool waiter. */
-export function routeIncomingReply(waiter: PendingReplyRoute | null | undefined, from: SessionInfo, message: Message): boolean {
-	if (!waiter) return false;
+type PendingReplyRoutes = PendingReplyRoute | Iterable<PendingReplyRoute> | null | undefined;
+
+function matches(waiter: PendingReplyRoute, from: SessionInfo, message: Message): boolean {
 	const senderTarget = from.name || from.id;
 	const fromMatches = senderTarget.toLowerCase() === waiter.from.toLowerCase() || from.id === waiter.from;
-	if (!fromMatches || message.replyTo !== waiter.replyTo) return false;
-	waiter.resolve(message);
-	return true;
+	return fromMatches && message.replyTo === waiter.replyTo;
+}
+
+/** Routes only the first exact sender/thread pair to a blocking tool waiter. */
+export function routeIncomingReply(waiters: PendingReplyRoutes, from: SessionInfo, message: Message): boolean {
+	if (!waiters) return false;
+	const candidates = Symbol.iterator in Object(waiters) ? waiters : [waiters];
+	for (const waiter of candidates as Iterable<PendingReplyRoute>) {
+		if (!matches(waiter, from, message)) continue;
+		waiter.resolve(message);
+		return true;
+	}
+	return false;
 }

--- a/packages/intercom/reply-waiter.ts
+++ b/packages/intercom/reply-waiter.ts
@@ -23,49 +23,52 @@ export interface ReplyWait {
 
 export type ReplyWaitAdmission =
   | { ok: true; wait: ReplyWait }
-  | { ok: false; reason: "busy" | "cancelled" };
+  | { ok: false; reason: "busy"; limit: number }
+  | { ok: false; reason: "cancelled" };
 
 export const DEFAULT_REPLY_TIMEOUT_MS = 10 * 60 * 1000;
+export const DEFAULT_MAX_PENDING_REPLY_WAITS = 6;
 
 /**
- * Single-slot reply waiter with atomic admission.
- *
- * Admission is a synchronous check-and-reserve: when two blocking asks race
- * (parallel tool calls, cross-tool intercom/contact_supervisor concurrency),
- * the first reservation wins and every concurrent loser receives a structured
- * `{ ok: false, reason: "busy" }` refusal instead of a rejected promise.
- * Cancellation and failure paths settle only their own waiter, so a losing or
- * failing call can never tear down a reservation owned by another call.
+ * Correlation-keyed reply waiter registry with synchronous per-question
+ * admission, a bounded capacity, scoped per-record cleanup, and reject-all
+ * teardown. Each waiter retains its own timeout, abort signal, and cancellation.
  */
-export class ReplyWaiterSlot {
-  private waiter: ReplyWaiterRecord | null = null;
+export class ReplyWaiterRegistry {
+  private readonly waiters = new Map<string, ReplyWaiterRecord>();
+  private readonly maxPending: number;
 
-  constructor(private readonly timeoutMs: number = DEFAULT_REPLY_TIMEOUT_MS) {}
+  constructor(
+    private readonly timeoutMs: number = DEFAULT_REPLY_TIMEOUT_MS,
+    maxPending: number = DEFAULT_MAX_PENDING_REPLY_WAITS,
+  ) {
+    this.maxPending = Math.max(1, maxPending);
+  }
 
-  /** The currently pending waiter, used for inbound reply correlation. */
-  current(): ReplyWaiterRecord | null {
-    return this.waiter;
+  pending(): ReplyWaiterRecord[] {
+    return [...this.waiters.values()];
   }
 
   has(): boolean {
-    return this.waiter !== null;
+    return this.waiters.size > 0;
   }
 
-  /**
-   * Rejects whichever waiter is currently pending. Reserved for slot-wide
-   * teardown (session shutdown/replacement, broker disconnect); individual
-   * tool calls must use their own `ReplyWait.cancel` instead.
-   */
-  rejectCurrent(error: Error): void {
-    this.waiter?.reject(error);
+  size(): number {
+    return this.waiters.size;
+  }
+
+  get limit(): number {
+    return this.maxPending;
+  }
+
+  rejectAll(error: Error): void {
+    for (const waiter of this.pending()) waiter.reject(error);
   }
 
   begin(from: string, replyTo: string, signal?: AbortSignal): ReplyWaitAdmission {
-    if (this.waiter) {
-      return { ok: false, reason: "busy" };
-    }
-    if (signal?.aborted) {
-      return { ok: false, reason: "cancelled" };
+    if (signal?.aborted) return { ok: false, reason: "cancelled" };
+    if (this.waiters.size >= this.maxPending) {
+      return { ok: false, reason: "busy", limit: this.maxPending };
     }
     let record!: ReplyWaiterRecord;
     const promise = new Promise<Message>((resolve, reject) => {
@@ -73,16 +76,12 @@ export class ReplyWaiterSlot {
       const timeout = setTimeout(() => {
         record.reject(new Error(`No reply from "${from}" within ${Math.round(this.timeoutMs / 60_000)} minutes`));
       }, this.timeoutMs);
-      const onAbort = () => {
-        record.reject(new Error("Cancelled"));
-      };
+      const onAbort = () => record.reject(new Error("Cancelled"));
       const cleanup = () => {
         settled = true;
         clearTimeout(timeout);
         signal?.removeEventListener("abort", onAbort);
-        if (this.waiter === record) {
-          this.waiter = null;
-        }
+        if (this.waiters.get(replyTo) === record) this.waiters.delete(replyTo);
       };
       signal?.addEventListener("abort", onAbort, { once: true });
       record = {
@@ -99,7 +98,7 @@ export class ReplyWaiterSlot {
           reject(error);
         },
       };
-      this.waiter = record;
+      this.waiters.set(replyTo, record);
     });
     // Pre-attach a handler so a rejection that fires while the owner is
     // between awaits can never crash the process as an unhandled rejection.

--- a/test/integration/completed-stage-intercom-ask.test.ts
+++ b/test/integration/completed-stage-intercom-ask.test.ts
@@ -4,7 +4,7 @@ import { Type } from "typebox";
 import { test } from "vitest";
 import { routeIncomingReply } from "../../packages/intercom/reply-routing.js";
 import { ReplyTracker } from "../../packages/intercom/reply-tracker.js";
-import { ReplyWaiterSlot } from "../../packages/intercom/reply-waiter.js";
+import { ReplyWaiterRegistry } from "../../packages/intercom/reply-waiter.js";
 import type { Message, SessionInfo } from "../../packages/intercom/types.js";
 import { workflow } from "../../packages/workflows/src/authoring/workflow.js";
 import { registerCompletedStageIntercomAskRouter } from "../../packages/workflows/src/extension/completed-stage-intercom-ask.js";
@@ -88,7 +88,7 @@ test("parallel workflow revives completed A for B's exact correlated ask and ter
 	const registry = createStageControlRegistry();
 	const events = new EventEmitter();
 	const targetTracker = new ReplyTracker();
-	const callerWaiter = new ReplyWaiterSlot();
+	const callerWaiter = new ReplyWaiterRegistry();
 	const wrongReplyAttempts: boolean[] = [];
 	const postMortemPrompts: string[] = [];
 	const target: SessionInfo = {
@@ -122,7 +122,7 @@ test("parallel workflow revives completed A for B's exact correlated ask and ter
 						postMortemPrompts.push(text);
 						targetTracker.beginTurn();
 						const pending = targetTracker.resolveReplyTarget({});
-						const waiter = callerWaiter.current();
+						const waiter = callerWaiter.pending();
 						assert.ok(waiter);
 						wrongReplyAttempts.push(
 							routeIncomingReply(

--- a/test/unit/intercom-blocking-tools-integration.test.ts
+++ b/test/unit/intercom-blocking-tools-integration.test.ts
@@ -18,7 +18,7 @@ import {
 import { routePeerDisconnect } from "../../packages/intercom/peer-disconnect-routing.js";
 import { routeIncomingReply } from "../../packages/intercom/reply-routing.js";
 import { ReplyTracker } from "../../packages/intercom/reply-tracker.js";
-import { ReplyWaiterSlot } from "../../packages/intercom/reply-waiter.js";
+import { ReplyWaiterRegistry } from "../../packages/intercom/reply-waiter.js";
 import type { Attachment, Message, SessionInfo } from "../../packages/intercom/types.js";
 import type { AgentConfig } from "../../packages/subagents/src/agents/agent-types.js";
 import { runSync } from "../../packages/subagents/src/runs/foreground/execution.js";
@@ -80,7 +80,7 @@ function fixture(kind: "intercom" | "supervisor", options: FixtureOptions = {}) 
 	const emitter = new EventEmitter();
 	let connectCalls = 0;
 	let resolverCalls = 0;
-	const slot = new ReplyWaiterSlot();
+	const slot = new ReplyWaiterRegistry();
 	const client = {
 		sessionId: "child-id",
 		supervisorSessionId: "parent-id",
@@ -192,14 +192,14 @@ function fixture(kind: "intercom" | "supervisor", options: FixtureOptions = {}) 
 		sent,
 		waiterCalls,
 		get waiter() {
-			return slot.current() ?? undefined;
+			return slot.pending()[0];
 		},
 		get tool() {
 			assert.ok(tool);
 			return tool;
 		},
 		reply(text: string, replyError?: string) {
-			const current = slot.current();
+			const current = slot.pending()[0];
 			assert.ok(current);
 			current.resolve({
 				id: "reply",
@@ -210,7 +210,7 @@ function fixture(kind: "intercom" | "supervisor", options: FixtureOptions = {}) 
 			});
 		},
 		disconnect(peerName: string) {
-			const current = slot.current();
+			const current = slot.pending()[0];
 			assert.ok(current);
 			return routePeerDisconnect(current, {
 				replyTo: current.replyTo,
@@ -852,7 +852,7 @@ for (const kind of ["intercom", "supervisor"] as const) {
 			);
 
 			let registered: Tool | undefined;
-			const slot = new ReplyWaiterSlot();
+			const slot = new ReplyWaiterRegistry();
 			const surfaced: Message[] = [];
 			const handoff = new ForegroundDetachHandoff(piForHandoff as never, 1000);
 			const from: SessionInfo = {
@@ -960,10 +960,10 @@ for (const kind of ["intercom", "supervisor"] as const) {
 			assert.equal(detached.detached, true);
 			assert.equal(surfaced.length, 1);
 			assert.deepEqual(order.slice(0, 3), ["probe", "commit", "surface"]);
-			assert.equal(slot.current()?.replyTo, surfaced[0]?.id);
+			assert.equal(slot.pending()[0]?.replyTo, surfaced[0]?.id);
 			order.push("reply");
 			const routed = routeIncomingReply(
-				slot.current(),
+				slot.pending(),
 				{
 					id: "parent-id",
 					name: "parent",

--- a/test/unit/intercom-broker-peer-disconnect.test.ts
+++ b/test/unit/intercom-broker-peer-disconnect.test.ts
@@ -9,7 +9,7 @@ import { createMessageReader, writeMessage } from "../../packages/intercom/broke
 import { getBrokerSocketPath } from "../../packages/intercom/broker/paths.js";
 import { getJitiCliPath } from "../../packages/intercom/broker/spawn.js";
 import { type PeerDisconnectNotice, routePeerDisconnect } from "../../packages/intercom/peer-disconnect-routing.js";
-import { ReplyWaiterSlot } from "../../packages/intercom/reply-waiter.js";
+import { ReplyWaiterRegistry } from "../../packages/intercom/reply-waiter.js";
 import type { BrokerMessage, ClientMessage } from "../../packages/intercom/types.js";
 
 const repoRoot = resolve(import.meta.dirname, "../..");
@@ -260,11 +260,11 @@ test("real client stays connected when a pending peer disconnects", async () => 
 test("real client rejects the exact waiter when its target disconnects", async () => {
 	const asker = new IntercomClient();
 	const target = new WireClient();
-	const slot = new ReplyWaiterSlot();
+	const slot = new ReplyWaiterRegistry();
 	const targetName = "waiter-release-target";
 	const questionId = "waiter-release-question";
 	asker.on("peer_disconnected", (notice: PeerDisconnectNotice) => {
-		routePeerDisconnect(slot.current(), notice);
+		routePeerDisconnect(slot.pending(), notice);
 	});
 	await asker.connect({ ...session, name: "waiter-release-asker" });
 	const targetId = await register(target, targetName);

--- a/test/unit/intercom-closed-workflow-stage-message.test.ts
+++ b/test/unit/intercom-closed-workflow-stage-message.test.ts
@@ -7,7 +7,7 @@ import intercom from "../../packages/intercom/index.js";
 import { registerIntercomTool } from "../../packages/intercom/intercom-tool.js";
 import { routeIncomingReply } from "../../packages/intercom/reply-routing.js";
 import { ReplyTracker } from "../../packages/intercom/reply-tracker.js";
-import { ReplyWaiterSlot } from "../../packages/intercom/reply-waiter.js";
+import { ReplyWaiterRegistry } from "../../packages/intercom/reply-waiter.js";
 import type { Message, SessionInfo } from "../../packages/intercom/types.js";
 import {
 	type CompletedStageHandleResolver,
@@ -349,7 +349,7 @@ test("the ask tool receives the production-composed correlated revival failure w
 	const composition = productionComposition("workflow-first", () => undefined);
 	const targetAdmission = new InboundMessageAdmission();
 	const targetTracker = new ReplyTracker();
-	const callerWaiter = new ReplyWaiterSlot();
+	const callerWaiter = new ReplyWaiterRegistry();
 	const caller: SessionInfo = {
 		id: "stage-b-intercom",
 		name: "B",
@@ -371,7 +371,7 @@ test("the ask tool receives the production-composed correlated revival failure w
 	const targetClient = {
 		isConnected: () => true,
 		async send(_to: string, options: { text: string; replyTo?: string; replyError?: string }) {
-			const routed = routeIncomingReply(callerWaiter.current(), target, {
+			const routed = routeIncomingReply(callerWaiter.pending(), target, {
 				id: "correlated-failure",
 				timestamp: Date.now(),
 				replyTo: options.replyTo,
@@ -451,7 +451,6 @@ test("the ask tool receives the production-composed correlated revival failure w
 			beginReplyWait(from: string, replyTo: string, signal?: AbortSignal) {
 				return callerWaiter.begin(from, replyTo, signal);
 			},
-			hasReplyWaiter: () => callerWaiter.has(),
 			confirmSend: false,
 			replyTracker: new ReplyTracker(),
 		} as never,

--- a/test/unit/intercom-concurrent-ask.test.ts
+++ b/test/unit/intercom-concurrent-ask.test.ts
@@ -4,7 +4,7 @@ import { registerContactSupervisorTool } from "../../packages/intercom/contact-s
 import { registerIntercomTool } from "../../packages/intercom/intercom-tool.js";
 import { routeIncomingReply } from "../../packages/intercom/reply-routing.js";
 import { ReplyTracker } from "../../packages/intercom/reply-tracker.js";
-import { ReplyWaiterSlot } from "../../packages/intercom/reply-waiter.js";
+import { ReplyWaiterRegistry } from "../../packages/intercom/reply-waiter.js";
 import type { SessionInfo } from "../../packages/intercom/types.js";
 import { sleep } from "../helpers/runtime.js";
 
@@ -33,7 +33,7 @@ interface SendBehavior {
  */
 function fixture(options: { send?: SendBehavior; resolveGate?: Promise<void> } = {}) {
 	const tools = new Map<string, Tool>();
-	const slot = new ReplyWaiterSlot();
+	const slot = new ReplyWaiterRegistry();
 	const sent: Array<{ to: string; message: { messageId?: string; text: string } }> = [];
 	const send = async (to: string, message: { messageId?: string; text: string }) => {
 		if (options.send?.delayMs) await sleep(options.send.delayMs);
@@ -102,7 +102,7 @@ function fixture(options: { send?: SendBehavior; resolveGate?: Promise<void> } =
 			return tool.execute("call", { reason: "need_decision", message: "Choose" }, signal, undefined, context);
 		},
 		replyToPending() {
-			const waiter = slot.current();
+			const waiter = slot.pending()[0];
 			assert.ok(waiter, "a pending waiter is required to reply");
 			const routed = routeIncomingReply(waiter, from, {
 				id: "parent-reply",
@@ -134,32 +134,26 @@ afterAll(() => {
 });
 
 describe("concurrent blocking intercom requests", () => {
-	test("two concurrent asks: the loser gets a structured error and the winner still completes", async () => {
+	test("two concurrent asks are both admitted and complete independently", async () => {
 		let release!: () => void;
 		const resolveGate = new Promise<void>((resolve) => {
 			release = resolve;
 		});
 		const current = fixture({ send: { delayMs: 15 }, resolveGate });
 
-		// Start both in the same tick so both pass the advisory pre-check
-		// before either reserves the waiter slot — the exact interleaving that
-		// used to surface a pre-rejected promise.
+		// Start both in the same tick, as parallel sibling tool calls do.
 		const first = current.ask();
 		const second = current.ask();
 		await sleep(0);
 		release();
-		await sleep(5);
-
-		const loser = await second;
-		assert.equal(loser.isError, true);
-		assert.match(loser.content[0]?.text ?? "", /Already waiting for a reply/);
-
-		await sleep(15);
-		assert.equal(current.sent.length, 1, "only the winning ask sends its question");
+		await sleep(20);
+		assert.equal(current.sent.length, 2, "both asks send their questions");
 		current.replyToPending();
-		const winner = await first;
-		assert.equal(winner.isError, false);
-		assert.match(winner.content[0]?.text ?? "", /Approved/);
+		current.replyToPending();
+		for (const result of await Promise.all([first, second])) {
+			assert.equal(result.isError, false);
+			assert.match(result.content[0]?.text ?? "", /Approved/);
+		}
 	});
 
 	test("cross-tool concurrency: ask and contact_supervisor share one reservation without interference", async () => {
@@ -239,7 +233,7 @@ describe("concurrent blocking intercom requests", () => {
 		assert.equal(current.slot.has(), false);
 	});
 
-	test("replies correlate by exact sender and thread id even after a losing concurrent attempt", async () => {
+	test("replies correlate by exact sender and thread id with concurrent asks", async () => {
 		let release!: () => void;
 		const resolveGate = new Promise<void>((resolve) => {
 			release = resolve;
@@ -250,9 +244,8 @@ describe("concurrent blocking intercom requests", () => {
 		await sleep(0);
 		release();
 		await sleep(5);
-		assert.equal((await loser).isError, true);
 
-		const waiter = current.slot.current();
+		const waiter = current.slot.pending();
 		assert.ok(waiter);
 		const from: SessionInfo = {
 			id: "parent-id",
@@ -277,13 +270,15 @@ describe("concurrent blocking intercom requests", () => {
 			{
 				id: "wrong-sender",
 				timestamp: Date.now(),
-				replyTo: waiter.replyTo,
+				replyTo: waiter[0]!.replyTo,
 				content: { text: "Right thread, wrong session" },
 			},
 		);
 		assert.equal(wrongSender, false, "parent or unrelated sessions cannot resolve a child-to-child ask");
 		current.replyToPending();
 		assert.match((await winner).content[0]?.text ?? "", /Approved/);
+		current.replyToPending();
+		assert.match((await loser).content[0]?.text ?? "", /Approved/);
 	});
 
 	test("aborting a blocking ask mid-send frees the slot for a second ask, and the first call's late cleanup never disturbs the new reservation", async () => {

--- a/test/unit/intercom-id-targeting.test.ts
+++ b/test/unit/intercom-id-targeting.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from "vitest";
 import { registerIntercomTool } from "../../packages/intercom/intercom-tool.js";
 import { routeIncomingReply } from "../../packages/intercom/reply-routing.js";
 import { ReplyTracker } from "../../packages/intercom/reply-tracker.js";
-import { ReplyWaiterSlot } from "../../packages/intercom/reply-waiter.js";
+import { ReplyWaiterRegistry } from "../../packages/intercom/reply-waiter.js";
 import type { Message, SessionInfo } from "../../packages/intercom/types.js";
 import { sleep } from "../helpers/runtime.js";
 
@@ -77,7 +77,7 @@ function toolFixture(replyTracker: ReplyTracker, sessions: SessionInfo[] = []) {
 			return { id: message.messageId ?? "reply-message", delivered: true };
 		},
 	};
-	const waiterSlot = new ReplyWaiterSlot();
+	const waiterSlot = new ReplyWaiterRegistry();
 	registerIntercomTool(
 		{
 			registerTool(value: Tool) {
@@ -92,7 +92,6 @@ function toolFixture(replyTracker: ReplyTracker, sessions: SessionInfo[] = []) {
 			beginReplyWait: (from: string, replyTo: string, signal?: AbortSignal) =>
 				waiterSlot.begin(from, replyTo, signal),
 			replyTracker,
-			hasReplyWaiter: () => waiterSlot.has(),
 		} as never,
 	);
 	assert.ok(tool);
@@ -145,9 +144,9 @@ describe("Intercom full session ID targeting", () => {
 			context,
 		);
 		await sleep(0);
-		const waiter = current.waiterSlot.current();
+		const waiter = current.waiterSlot.pending()[0];
 		const routed =
-			waiter === null
+			waiter === undefined
 				? false
 				: routeIncomingReply(waiter, recipient, {
 						id: "threaded-reply",

--- a/test/unit/intercom-peer-disconnect-routing.test.ts
+++ b/test/unit/intercom-peer-disconnect-routing.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { routePeerDisconnect } from "../../packages/intercom/peer-disconnect-routing.js";
 import { routeIncomingReply } from "../../packages/intercom/reply-routing.js";
-import { ReplyWaiterSlot } from "../../packages/intercom/reply-waiter.js";
+import { ReplyWaiterRegistry } from "../../packages/intercom/reply-waiter.js";
 import type { Message, SessionInfo } from "../../packages/intercom/types.js";
 
 const peer: SessionInfo = {
@@ -25,37 +25,37 @@ function notice(replyTo: string) {
 
 describe("peer disconnect reply routing", () => {
 	test("a reply arriving first resolves the waiter and makes a later disconnect notice a no-op", async () => {
-		const slot = new ReplyWaiterSlot();
+		const slot = new ReplyWaiterRegistry();
 		const admission = slot.begin(peer.name!, "question-1");
 		assert.ok(admission.ok);
 
-		assert.equal(routeIncomingReply(slot.current(), peer, reply("question-1")), true);
-		assert.equal(routePeerDisconnect(slot.current(), notice("question-1")), false);
+		assert.equal(routeIncomingReply(slot.pending(), peer, reply("question-1")), true);
+		assert.equal(routePeerDisconnect(slot.pending(), notice("question-1")), false);
 		assert.equal((await admission.wait.promise).content.text, "answer");
 	});
 
 	test("a disconnect arriving first rejects the waiter and makes a later reply a no-op", async () => {
-		const slot = new ReplyWaiterSlot();
+		const slot = new ReplyWaiterRegistry();
 		const admission = slot.begin(peer.name!, "question-1");
 		assert.ok(admission.ok);
 
-		assert.equal(routePeerDisconnect(slot.current(), notice("question-1")), true);
-		assert.equal(routeIncomingReply(slot.current(), peer, reply("question-1")), false);
+		assert.equal(routePeerDisconnect(slot.pending(), notice("question-1")), true);
+		assert.equal(routeIncomingReply(slot.pending(), peer, reply("question-1")), false);
 		await assert.rejects(admission.wait.promise, /Session "Peer Name" disconnected before replying/);
 	});
 
 	test("duplicate disconnect notices are idempotent", async () => {
-		const slot = new ReplyWaiterSlot();
+		const slot = new ReplyWaiterRegistry();
 		const admission = slot.begin(peer.id, "question-1");
 		assert.ok(admission.ok);
 
-		assert.equal(routePeerDisconnect(slot.current(), notice("question-1")), true);
-		assert.equal(routePeerDisconnect(slot.current(), notice("question-1")), false);
+		assert.equal(routePeerDisconnect(slot.pending(), notice("question-1")), true);
+		assert.equal(routePeerDisconnect(slot.pending(), notice("question-1")), false);
 		await assert.rejects(admission.wait.promise, /Session "Peer Name" disconnected before replying/);
 	});
 
 	test("an unknown replyTo leaves the pending waiter unsettled", async () => {
-		const slot = new ReplyWaiterSlot();
+		const slot = new ReplyWaiterRegistry();
 		const admission = slot.begin(peer.id, "question-1");
 		assert.ok(admission.ok);
 		let settled = false;
@@ -63,16 +63,16 @@ describe("peer disconnect reply routing", () => {
 			settled = true;
 		});
 
-		assert.equal(routePeerDisconnect(slot.current(), notice("unknown-question")), false);
+		assert.equal(routePeerDisconnect(slot.pending(), notice("unknown-question")), false);
 		await Promise.resolve();
 		assert.equal(settled, false);
-		assert.equal(slot.current()?.replyTo, "question-1");
-		slot.current()!.resolve(reply("question-1"));
+		assert.equal(slot.pending()[0]?.replyTo, "question-1");
+		slot.pending()[0]!.resolve(reply("question-1"));
 		await admission.wait.promise;
 	});
 
 	test("a non-matching peer leaves the exact pending waiter unsettled", async () => {
-		const slot = new ReplyWaiterSlot();
+		const slot = new ReplyWaiterRegistry();
 		const admission = slot.begin("other-peer", "question-1");
 		assert.ok(admission.ok);
 		let settled = false;
@@ -80,11 +80,11 @@ describe("peer disconnect reply routing", () => {
 			settled = true;
 		});
 
-		assert.equal(routePeerDisconnect(slot.current(), notice("question-1")), false);
+		assert.equal(routePeerDisconnect(slot.pending(), notice("question-1")), false);
 		await Promise.resolve();
 		assert.equal(settled, false);
-		assert.equal(slot.current()?.from, "other-peer");
-		slot.current()!.resolve(reply("question-1"));
+		assert.equal(slot.pending()[0]?.from, "other-peer");
+		slot.pending()[0]!.resolve(reply("question-1"));
 		await admission.wait.promise;
 	});
 

--- a/test/unit/intercom-reply-waiter.test.ts
+++ b/test/unit/intercom-reply-waiter.test.ts
@@ -1,11 +1,17 @@
 import assert from "node:assert/strict";
 import { afterAll, beforeAll, describe, test } from "vitest";
-import { ReplyWaiterSlot } from "../../packages/intercom/reply-waiter.js";
+import { routePeerDisconnect } from "../../packages/intercom/peer-disconnect-routing.js";
+import { routeIncomingReply } from "../../packages/intercom/reply-routing.js";
+import { type ReplyWaitAdmission, ReplyWaiterRegistry } from "../../packages/intercom/reply-waiter.js";
 import type { Message } from "../../packages/intercom/types.js";
 import { sleep } from "../helpers/runtime.js";
 
 function reply(replyTo: string, text = "answer"): Message {
 	return { id: `reply-${replyTo}`, timestamp: Date.now(), replyTo, content: { text } };
+}
+
+function assertNoLeaks(registry: ReplyWaiterRegistry): void {
+	assert.equal(registry.size(), 0, "reply waiter registry must be empty");
 }
 
 const unhandledRejections: unknown[] = [];
@@ -22,53 +28,75 @@ afterAll(() => {
 	assert.deepEqual(unhandledRejections, [], "reply waiter lifecycles must never produce unhandled rejections");
 });
 
-describe("ReplyWaiterSlot admission", () => {
-	test("admits one waiter and refuses concurrent admission with a structured busy result", async () => {
-		const slot = new ReplyWaiterSlot();
-		const winner = slot.begin("peer", "q-1");
-		assert.equal(winner.ok, true);
-		const loser = slot.begin("peer", "q-2");
-		assert.deepEqual(loser, { ok: false, reason: "busy" });
-		assert.equal(slot.current()?.replyTo, "q-1", "a losing admission must not disturb the winner's reservation");
+describe("ReplyWaiterRegistry admission", () => {
+	test("admits through the cap and correlates same-target replies out of order", async () => {
+		const registry = new ReplyWaiterRegistry(1_000, 3);
+		const waits = ["q-1", "q-2", "q-3"].map((id) => registry.begin("peer", id));
+		assert.ok(waits.every((wait) => wait.ok));
+		assert.equal(registry.size(), 3);
+		assert.deepEqual(registry.begin("peer", "q-4"), { ok: false, reason: "busy", limit: 3 });
+		for (const id of ["q-2", "q-3", "q-1"]) {
+			assert.equal(
+				routeIncomingReply(registry.pending(), { id: "peer", name: "peer" } as never, reply(id, id)),
+				true,
+			);
+		}
+		for (let index = 0; index < waits.length; index++) {
+			const admission: ReplyWaitAdmission = waits[index]!;
+			assert.ok(admission.ok);
+			assert.equal((await admission.wait.promise).content.text, `q-${index + 1}`);
+		}
+		assertNoLeaks(registry);
+	});
 
-		slot.current()!.resolve(reply("q-1"));
-		assert.ok(winner.ok);
-		assert.equal((await winner.wait.promise).replyTo, "q-1");
-		assert.equal(slot.has(), false, "the slot frees once the winner settles");
+	test("reopens capacity after one waiter settles", async () => {
+		const registry = new ReplyWaiterRegistry(1_000, 2);
+		const first = registry.begin("peer-a", "q-1");
+		const sibling = registry.begin("peer-b", "q-2");
+		assert.ok(first.ok && sibling.ok);
+		first.wait.cancel(new Error("done"));
+		await assert.rejects(first.wait.promise, /done/);
+		const replacement = registry.begin("peer-c", "q-3");
+		assert.ok(replacement.ok);
+		registry.rejectAll(new Error("teardown"));
+		await Promise.all(
+			[sibling.wait.promise, replacement.wait.promise].map((promise) => assert.rejects(promise, /teardown/)),
+		);
+		assertNoLeaks(registry);
 	});
 
 	test("refuses admission with a structured cancelled result for an already-aborted signal", () => {
-		const slot = new ReplyWaiterSlot();
+		const slot = new ReplyWaiterRegistry();
 		const controller = new AbortController();
 		controller.abort();
 		assert.deepEqual(slot.begin("peer", "q-1", controller.signal), { ok: false, reason: "cancelled" });
-		assert.equal(slot.has(), false);
+		assertNoLeaks(slot);
 	});
 
 	test("frees the slot after resolve, reject, and cancel so later asks can start", async () => {
-		const slot = new ReplyWaiterSlot();
+		const slot = new ReplyWaiterRegistry();
 
 		const first = slot.begin("peer", "q-1");
 		assert.ok(first.ok);
 		first.wait.cancel(new Error("send failed"));
 		await assert.rejects(first.wait.promise, /send failed/);
-		assert.equal(slot.has(), false);
+		assertNoLeaks(slot);
 
 		const second = slot.begin("peer", "q-2");
 		assert.ok(second.ok);
-		slot.rejectCurrent(new Error("disconnected"));
+		slot.rejectAll(new Error("disconnected"));
 		await assert.rejects(second.wait.promise, /disconnected/);
-		assert.equal(slot.has(), false);
+		assertNoLeaks(slot);
 
 		const third = slot.begin("peer", "q-3");
 		assert.ok(third.ok);
-		slot.current()!.resolve(reply("q-3"));
+		slot.pending()[0]!.resolve(reply("q-3"));
 		assert.equal((await third.wait.promise).replyTo, "q-3");
-		assert.equal(slot.has(), false);
+		assertNoLeaks(slot);
 	});
 
 	test("cancel settles only its own waiter and is a no-op afterwards", async () => {
-		const slot = new ReplyWaiterSlot();
+		const slot = new ReplyWaiterRegistry();
 		const first = slot.begin("peer", "q-1");
 		assert.ok(first.ok);
 		first.wait.cancel(new Error("first failed"));
@@ -79,42 +107,83 @@ describe("ReplyWaiterSlot admission", () => {
 		// A stale cancel from the settled first waiter must not tear down the
 		// second reservation.
 		first.wait.cancel(new Error("stale cancel"));
-		assert.equal(slot.current()?.replyTo, "q-2");
-		slot.current()!.resolve(reply("q-2"));
+		assert.equal(slot.pending()[0]?.replyTo, "q-2");
+		slot.pending()[0]!.resolve(reply("q-2"));
 		assert.equal((await second.wait.promise).replyTo, "q-2");
+		assertNoLeaks(slot);
 	});
 
 	test("abort mid-wait rejects with Cancelled and cleans up only its own waiter", async () => {
-		const slot = new ReplyWaiterSlot();
+		const slot = new ReplyWaiterRegistry();
 		const controller = new AbortController();
 		const admission = slot.begin("peer", "q-1", controller.signal);
 		assert.ok(admission.ok);
 		controller.abort();
 		await assert.rejects(admission.wait.promise, /Cancelled/);
-		assert.equal(slot.has(), false);
+		assertNoLeaks(slot);
 
 		const next = slot.begin("peer", "q-2");
 		assert.ok(next.ok);
 		controller.abort();
-		assert.equal(slot.current()?.replyTo, "q-2", "an old abort signal must not affect a newer waiter");
+		assert.equal(slot.pending()[0]?.replyTo, "q-2", "an old abort signal must not affect a newer waiter");
 		next.wait.cancel(new Error("cleanup"));
+		await assert.rejects(next.wait.promise, /cleanup/);
+		assertNoLeaks(slot);
 	});
 
 	test("times out with a descriptive error and frees the slot", async () => {
-		const slot = new ReplyWaiterSlot(10);
+		const slot = new ReplyWaiterRegistry(10);
 		const admission = slot.begin("planner", "q-1");
 		assert.ok(admission.ok);
 		await assert.rejects(admission.wait.promise, /No reply from "planner"/);
-		assert.equal(slot.has(), false);
+		assertNoLeaks(slot);
 	});
 
+	test("reply, disconnect, and cancel races settle only their owners", async () => {
+		const registry = new ReplyWaiterRegistry(15, 6);
+		const replied = registry.begin("peer", "reply-first");
+		const disconnected = registry.begin("peer", "disconnect-first");
+		const cancelled = registry.begin("peer", "cancel-first");
+		const timedOut = registry.begin("peer", "timeout-first");
+		assert.ok(replied.ok && disconnected.ok && cancelled.ok && timedOut.ok);
+		assert.equal(routeIncomingReply(registry.pending(), { id: "peer" } as never, reply("reply-first")), true);
+		assert.equal(routePeerDisconnect(registry.pending(), { peerSessionId: "peer", replyTo: "reply-first" }), false);
+		assert.equal(
+			routePeerDisconnect(registry.pending(), { peerSessionId: "peer", replyTo: "disconnect-first" }),
+			true,
+		);
+		assert.equal(routeIncomingReply(registry.pending(), { id: "peer" } as never, reply("disconnect-first")), false);
+		cancelled.wait.cancel(new Error("cancelled first"));
+		assert.equal(routeIncomingReply(registry.pending(), { id: "peer" } as never, reply("cancel-first")), false);
+		assert.equal(routeIncomingReply(registry.pending(), { id: "other" } as never, reply("timeout-first")), false);
+		assert.equal((await replied.wait.promise).replyTo, "reply-first");
+		await assert.rejects(disconnected.wait.promise, /disconnected/);
+		await assert.rejects(cancelled.wait.promise, /cancelled first/);
+		await assert.rejects(timedOut.wait.promise, /No reply/);
+		assertNoLeaks(registry);
+	});
+
+	test("rejectAll rejects every pending waiter", async () => {
+		const registry = new ReplyWaiterRegistry();
+		const waits = [registry.begin("a", "q-1"), registry.begin("b", "q-2")];
+		assert.ok(waits.every((wait) => wait.ok));
+		registry.rejectAll(new Error("shutdown"));
+		for (const wait of waits) {
+			assert.ok(wait.ok);
+			await assert.rejects(wait.wait.promise, /shutdown/);
+		}
+		assertNoLeaks(registry);
+	});
 	test("a rejected waiter left unawaited across macrotasks never becomes an unhandled rejection", async () => {
-		const slot = new ReplyWaiterSlot();
-		const admission = slot.begin("peer", "q-1");
-		assert.ok(admission.ok);
-		// Reject while the owner is "between awaits" and never awaits afterwards.
-		admission.wait.cancel(new Error("delivery failed"));
+		const slot = new ReplyWaiterRegistry();
+		const admissions = [slot.begin("peer", "q-1"), slot.begin("peer", "q-2")];
+		assert.ok(admissions.every((admission) => admission.ok));
+		for (const admission of admissions) {
+			assert.ok(admission.ok);
+			admission.wait.cancel(new Error("delivery failed"));
+		}
 		await sleep(5);
 		assert.deepEqual(unhandledRejections, []);
+		assertNoLeaks(slot);
 	});
 });

--- a/test/unit/intercom-terminal-ordering-barrier.test.ts
+++ b/test/unit/intercom-terminal-ordering-barrier.test.ts
@@ -4,7 +4,7 @@ import { createEventBus } from "../../packages/coding-agent/src/core/event-bus.j
 import { InboundIdleQueue } from "../../packages/intercom/inbound-idle-queue.js";
 import type { InboundMessageEntry } from "../../packages/intercom/intercom-utils.js";
 import { routeIncomingReply } from "../../packages/intercom/reply-routing.js";
-import { ReplyWaiterSlot } from "../../packages/intercom/reply-waiter.js";
+import { ReplyWaiterRegistry } from "../../packages/intercom/reply-waiter.js";
 import { registerSubagentRelay } from "../../packages/intercom/subagent-relay.js";
 import {
 	emitGlobalTerminalOrderingBarrier,
@@ -626,13 +626,13 @@ describe("per-child terminal ordering barrier", () => {
 	test("a correlated ask reply bypasses unrelated queued ordinary sends", async () => {
 		const queue = new InboundIdleQueue();
 		queue.enqueue(entry(source("other-session", "other-child"), "ordinary", 1));
-		const waiters = new ReplyWaiterSlot(1_000);
+		const waiters = new ReplyWaiterRegistry(1_000);
 		const admission = waiters.begin("asking-child", "ask-id");
 		assert.equal(admission.ok, true);
 		if (!admission.ok) return;
 		const reply: Message = { id: "reply-id", timestamp: 2, replyTo: "ask-id", content: { text: "answer" } };
 
-		assert.equal(routeIncomingReply(waiters.current(), source("asking-session", "asking-child"), reply), true);
+		assert.equal(routeIncomingReply(waiters.pending(), source("asking-session", "asking-child"), reply), true);
 		assert.equal((await admission.wait.promise).id, "reply-id");
 		assert.deepEqual(
 			queue.drain().map((queued) => queued.message.id),

--- a/test/unit/intercom-tool-groups.test.ts
+++ b/test/unit/intercom-tool-groups.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "vitest";
 import { registerIntercomTool } from "../../packages/intercom/intercom-tool.js";
 import { ReplyTracker } from "../../packages/intercom/reply-tracker.js";
-import { ReplyWaiterSlot } from "../../packages/intercom/reply-waiter.js";
+import { ReplyWaiterRegistry } from "../../packages/intercom/reply-waiter.js";
 import type { SessionInfo } from "../../packages/intercom/types.js";
 
 type ToolResult = {
@@ -61,7 +61,7 @@ function fixture(homeGroup = "default") {
 			return { id: "message-id", delivered: true };
 		},
 	};
-	const waiterSlot = new ReplyWaiterSlot();
+	const waiterSlot = new ReplyWaiterRegistry();
 	registerIntercomTool(
 		{
 			registerTool(value: Tool) {
@@ -83,7 +83,6 @@ function fixture(homeGroup = "default") {
 			beginReplyWait: (from: string, replyTo: string, signal?: AbortSignal) =>
 				waiterSlot.begin(from, replyTo, signal),
 			replyTracker: new ReplyTracker(),
-			hasReplyWaiter: () => waiterSlot.has(),
 		} as never,
 	);
 	assert.ok(tool);

--- a/test/unit/intercom-workflow-stage-delivery-failure.test.ts
+++ b/test/unit/intercom-workflow-stage-delivery-failure.test.ts
@@ -3,7 +3,7 @@ import { test } from "vitest";
 import { InboundMessageAdmission } from "../../packages/intercom/inbound-message-admission.js";
 import { routeIncomingReply } from "../../packages/intercom/reply-routing.js";
 import { ReplyTracker } from "../../packages/intercom/reply-tracker.js";
-import { ReplyWaiterSlot } from "../../packages/intercom/reply-waiter.js";
+import { ReplyWaiterRegistry } from "../../packages/intercom/reply-waiter.js";
 import type { Message, SessionInfo } from "../../packages/intercom/types.js";
 import {
 	createWorkflowStageDeliveryFailureHandler,
@@ -33,7 +33,7 @@ const ask: Message = {
 };
 
 test("a destination-side running-stage admission failure rejects the exact ask without its long timeout", async () => {
-	const waiter = new ReplyWaiterSlot();
+	const waiter = new ReplyWaiterRegistry();
 	const admission = waiter.begin(target.id, ask.id);
 	assert.equal(admission.ok, true);
 	if (!admission.ok) throw new Error("reply waiter admission failed");
@@ -50,7 +50,7 @@ test("a destination-side running-stage admission failure rejects the exact ask w
 				isConnected: () => true,
 				async send(to: string, options: { text: string; replyTo?: string; replyError?: string }) {
 					assert.equal(to, asker.id);
-					const routed = routeIncomingReply(waiter.current(), target, {
+					const routed = routeIncomingReply(waiter.pending(), target, {
 						id: "delivery-failure",
 						timestamp: Date.now(),
 						replyTo: options.replyTo,


### PR DESCRIPTION
Part 3/4 of the stacked implementation for #2627 and #2628.

Replaces the single-slot `ReplyWaiterSlot` with a correlation-keyed registry so N concurrent blocking asks run in parallel, with a configurable cap, preserved no-unhandled-rejection and scoped-cleanup guarantees, and reject-all teardown.

Refs #2628.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790177656&installation_model_id=10562&pr_number=2636&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2636&signature=1d2be48d20a477ece11c4b9a267f86a6934326e0f2dbcb5b84a72bff70ca1eaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change enables multiple concurrent blocking Intercom asks with bounded admission, exact reply correlation, and cleanup on disconnect or shutdown. One repository import-convention issue remains in the new Intercom configuration wiring: raw `.ts` source extensions should use the project’s `.js` ESM convention.

<h3>Confidence Score: 4/5</h3>

The concurrency and lifecycle changes are covered by the completed focused Intercom checks; merge after correcting the ESM import extensions.

There is one independent P2, non-security repository-rule finding. Under the scoring policy, P2-only findings result in a score of 4.

**Files Needing Attention:** packages/intercom/config.ts and packages/intercom/index-heavy.ts should replace their new raw `.ts` relative import extensions with `.js`.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/intercom/config.ts:3
**Use the ESM import extension**

This new source import uses a raw `.ts` extension instead of the repository-required `.js` ESM convention; the same pattern occurs in `packages/intercom/index-heavy.ts`, adding inconsistent resolution requirements for the raw-TypeScript package.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(intercom): correlation-keyed multi-..."](https://github.com/bastani-inc/atomic/commit/39803d6c2088e5440a3eaeb25c1c1ee8e0b0c1ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56326152)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->