### PR TITLE
docs(ai): record latest upstream Pi AI sync point

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history lives in [earendil-works/pi](https://github.com/earendil-works/pi/blob/v0.84.2/packages/ai/CHANGELOG.md).
+This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history at the audited Pi `main` sync point (`dcd461925db2edf69a43c8135db1180d418afd54`) lives in [earendil-works/pi](https://github.com/earendil-works/pi/blob/dcd461925db2edf69a43c8135db1180d418afd54/packages/ai/CHANGELOG.md).
 
 ## [Unreleased]
 

--- a/packages/ai/NOTICE.md
+++ b/packages/ai/NOTICE.md
@@ -5,7 +5,8 @@
 monorepo at `packages/ai` and publishes at the same version as `@bastani/atomic`.
 
 - Upstream package: [`@earendil-works/pi-ai`](https://www.npmjs.com/package/@earendil-works/pi-ai)
-- Forked from tag: `v0.84.2` (`914cf1472e715297caa30db4b9535d534a9eb718`)
+- Original fork point: `v0.84.2` (`914cf1472e715297caa30db4b9535d534a9eb718`)
+- Pi AI fixes synced through latest upstream `main`: `earendil-works/pi@dcd461925db2edf69a43c8135db1180d418afd54`
 - Catalog JSON under `src/providers/data/` is generated at build time from models.dev, matching upstream. It is not committed.
 
 Original work is Copyright (c) 2025 Mario Zechner and is licensed under the MIT License.

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -1,6 +1,6 @@
 # @bastani/pi-ai
 
-Bastani-branded fork of [`@earendil-works/pi-ai`](https://www.npmjs.com/package/@earendil-works/pi-ai) from [earendil-works/pi](https://github.com/earendil-works/pi). Forked at **v0.84.2** (`914cf1472e715297caa30db4b9535d534a9eb718`); `@bastani/pi-ai` publishes at the same version as Atomic. `npm run build` refreshes the models.dev catalog, same as upstream.
+Bastani-branded fork of [`@earendil-works/pi-ai`](https://www.npmjs.com/package/@earendil-works/pi-ai) from [earendil-works/pi](https://github.com/earendil-works/pi). Originally forked at **v0.84.2** (`914cf1472e715297caa30db4b9535d534a9eb718`); upstream Pi AI fixes are synced through [`dcd461925db2edf69a43c8135db1180d418afd54`](https://github.com/earendil-works/pi/commit/dcd461925db2edf69a43c8135db1180d418afd54), the latest Pi `main` commit at the sync point. `@bastani/pi-ai` publishes at the same version as Atomic. `npm run build` refreshes the models.dev catalog, same as upstream.
 
 The public API is a drop-in replacement: install `@bastani/pi-ai` and import from `@bastani/pi-ai` instead of `@earendil-works/pi-ai`. See [NOTICE.md](NOTICE.md). This package lives in the Atomic monorepo and publishes from `.github/workflows/publish.yml`. The first npm version must be published by hand so trusted publishing can be attached.
 


### PR DESCRIPTION
## Summary

Audits the vendored `@bastani/pi-ai` fork from its original Pi `v0.84.2` fork point (`914cf1472e715297caa30db4b9535d534a9eb718`) through the exact latest upstream Pi `main` commit (`dcd461925db2edf69a43c8135db1180d418afd54`) and records that sync point.

No additional runtime patch was required: the existing Atomic ports already contain every upstream Pi AI fix in that range. Pi has no later `packages/ai` runtime changes between its final post-`v0.84.3` changelog commit and the requested `main` head.

## Changes

- Record the exact latest Pi `main` sync SHA in the Pi AI README and notice.
- Link the fork changelog to the upstream changelog at that exact commit.
- Preserve Atomic's intentional adaptations for package branding, Copilot token routing, provider-stream deadlines, and static custom headers.

## Notes

The audit found 48 paths changed by upstream under `packages/ai`: 33 are byte-identical in Atomic, while the remaining 15 contain reviewed Atomic-specific adaptations on top of the upstream fixes.

Validation:

- `npm run test --workspace=@bastani/pi-ai` — 116 files passed, 25 skipped; 1,024 tests passed, 831 skipped
- Pre-push hooks — `npm run check`, unit, integration, and CI-contract suites all passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790191702&installation_model_id=10562&pr_number=2652&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2652&signature=f80775c15f6a38ea89c943104f19c97f0bfc7c807322e34611ddb828b2eeaa01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update records the audited Pi AI upstream sync point in the package README, NOTICE, and changelog. The pinned commit was confirmed to exist in `earendil-works/pi`, and the revision-pinned `packages/ai/CHANGELOG.md` link resolves to a file at that commit. No issues were found.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the documentation consistently identifies a valid audited upstream revision and a valid changelog location at that revision.

The review found no publishable defects. Live GitHub responses confirmed the referenced commit, its canonical URL, and the upstream changelog file at the pinned revision.

**Files Needing Attention:** None. `packages/ai/README.md`, `packages/ai/NOTICE.md`, and `packages/ai/CHANGELOG.md` were checked for consistent provenance references.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a network-backed Bash validator to confirm that the local provenance points to a real upstream revision and changelog path.
- Verified the upstream by querying GitHub: the commit API returned the exact SHA and canonical URL, and the contents API showed the changelog file at that revision.
- Validated that the provenance references in packages/ai/README.md:3, packages/ai/NOTICE.md:9, and packages/ai/CHANGELOG.md:3 identify a real upstream revision and changelog path.
- Confirmed via the contents API that the targeted path exists as a file at the correct revision, with path=packages/ai/CHANGELOG.md and a blob SHA, tied to the same revision URL.
- Captured artifacts to support review, including the network validation script and the live validation log.

<a href="https://app.greptile.com/trex/runs/20436188/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(ai): record latest upstream sync po..."](https://github.com/bastani-inc/atomic/commit/74e97d07f8ad5bb0b91b3d10da440d5e1d1d80ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56374461)</sub>

<!-- /greptile_comment -->