### PR TITLE
fix(ai): keep Cloudflare API inference catalog-independent

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -123,6 +123,18 @@ interface ModelsDevProvider {
 
 type ModelsDevCatalog = Record<string, ModelsDevProvider>;
 
+const CLOUDFLARE_DEFAULT_WORKERS_AI_MODEL_ID = "@cf/moonshotai/kimi-k2.6";
+const CLOUDFLARE_DEFAULT_WORKERS_AI_MODEL = {
+	id: CLOUDFLARE_DEFAULT_WORKERS_AI_MODEL_ID,
+	name: "Kimi K2.6",
+	tool_call: true,
+	reasoning: true,
+	reasoning_options: [{ type: "toggle" }, { type: "effort", values: ["low", "medium", "high"] }],
+	modalities: { input: ["text", "image"], output: ["text"] },
+	cost: { input: 0.95, output: 4, cache_read: 0.16 },
+	limit: { context: 262_144, output: 256_000 },
+} satisfies ModelsDevModel;
+
 interface NvidiaNimModelListItem {
 	id: string;
 }
@@ -1637,6 +1649,15 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 			}
 		}
 
+		// This is the built-in default for both Cloudflare providers. Keep its known
+		// Workers AI metadata when models.dev temporarily omits or mis-tags it.
+		const cloudflareWorkersAiProvider = (data["cloudflare-workers-ai"] ??= {});
+		const cloudflareWorkersAiModels = (cloudflareWorkersAiProvider.models ??= {});
+		cloudflareWorkersAiModels[CLOUDFLARE_DEFAULT_WORKERS_AI_MODEL_ID] = {
+			...CLOUDFLARE_DEFAULT_WORKERS_AI_MODEL,
+			...cloudflareWorkersAiModels[CLOUDFLARE_DEFAULT_WORKERS_AI_MODEL_ID],
+			tool_call: true,
+		};
 		// Process Cloudflare Workers AI models
 		if (data["cloudflare-workers-ai"]?.models) {
 			for (const [modelId, model] of Object.entries(data["cloudflare-workers-ai"].models)) {
@@ -1670,9 +1691,9 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 		// Process Cloudflare AI Gateway models
 		if (data["cloudflare-ai-gateway"]?.models) {
 			for (const [prefixedId, model] of Object.entries(data["cloudflare-ai-gateway"].models)) {
-				if (prefixedId.startsWith("workers-ai/")) cloudflareGatewayWorkersAiModelIds.add(prefixedId);
 				const m = model as ModelsDevModel;
 				if (m.tool_call !== true) continue;
+				if (prefixedId.startsWith("workers-ai/")) cloudflareGatewayWorkersAiModelIds.add(prefixedId);
 
 				const slashIdx = prefixedId.indexOf("/");
 				if (slashIdx === -1) continue;

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -1665,9 +1665,12 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 			}
 		}
 
+		const cloudflareGatewayWorkersAiModelIds = new Set<string>();
+
 		// Process Cloudflare AI Gateway models
 		if (data["cloudflare-ai-gateway"]?.models) {
 			for (const [prefixedId, model] of Object.entries(data["cloudflare-ai-gateway"].models)) {
+				if (prefixedId.startsWith("workers-ai/")) cloudflareGatewayWorkersAiModelIds.add(prefixedId);
 				const m = model as ModelsDevModel;
 				if (m.tool_call !== true) continue;
 
@@ -1717,6 +1720,37 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					contextWindow: m.limit?.context || 4096,
 					maxTokens: m.limit?.output || 4096,
 					...(compat ? { compat } : {}),
+				});
+				recordModelsDevReasoningOptions("cloudflare-ai-gateway", id, m);
+			}
+		}
+
+		// Cloudflare's gateway accepts every Workers AI model through its compatibility endpoint even when
+		// models.dev temporarily omits the corresponding workers-ai/* gateway entries.
+		if (data["cloudflare-workers-ai"]?.models) {
+			for (const [modelId, model] of Object.entries(data["cloudflare-workers-ai"].models)) {
+				const id = `workers-ai/${modelId}`;
+				if (cloudflareGatewayWorkersAiModelIds.has(id)) continue;
+				const m = model as ModelsDevModel;
+				if (m.tool_call !== true) continue;
+
+				models.push({
+					id,
+					name: m.name || id,
+					api: "openai-completions",
+					provider: "cloudflare-ai-gateway",
+					baseUrl: CLOUDFLARE_AI_GATEWAY_COMPAT_BASE_URL,
+					reasoning: m.reasoning === true,
+					input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
+					cost: {
+						input: m.cost?.input || 0,
+						output: m.cost?.output || 0,
+						cacheRead: m.cost?.cache_read || 0,
+						cacheWrite: m.cost?.cache_write || 0,
+					},
+					contextWindow: m.limit?.context || 4096,
+					maxTokens: m.limit?.output || 4096,
+					compat: { sendSessionAffinityHeaders: true },
 				});
 				recordModelsDevReasoningOptions("cloudflare-ai-gateway", id, m);
 			}

--- a/packages/ai/src/providers/cloudflare-ai-gateway.ts
+++ b/packages/ai/src/providers/cloudflare-ai-gateway.ts
@@ -9,7 +9,7 @@ import { cloudflareStreams } from "./cloudflare-stream.ts";
 export function cloudflareAIGatewayProvider(): Provider<
 	"anthropic-messages" | "openai-completions" | "openai-responses"
 > {
-	return createProvider({
+	return createProvider<"anthropic-messages" | "openai-completions" | "openai-responses">({
 		id: "cloudflare-ai-gateway",
 		name: "Cloudflare AI Gateway",
 		auth: { apiKey: cloudflareAIGatewayAuth() },

--- a/packages/ai/test/generate-models-cloudflare-gateway.test.ts
+++ b/packages/ai/test/generate-models-cloudflare-gateway.test.ts
@@ -13,97 +13,160 @@ afterEach(() => {
 	for (const root of temporaryRoots.splice(0)) rmSync(root, { force: true, recursive: true });
 });
 
-test("derives missing Cloudflare gateway Workers AI passthroughs from the Workers AI catalog", () => {
-	const fixtureRoot = mkdtempSync(join(tmpdir(), "pi-generate-cloudflare-models-"));
-	temporaryRoots.push(fixtureRoot);
-	const isolatedPackageRoot = join(fixtureRoot, "package");
-	mkdirSync(isolatedPackageRoot);
-	for (const entry of ["package.json", "scripts", "src"]) {
-		cpSync(join(packageRoot, entry), join(isolatedPackageRoot, entry), { recursive: true });
-	}
-
-	const workersModel = {
-		id: "@cf/example/derived",
-		name: "Derived Workers Model",
-		tool_call: true,
-		reasoning: true,
-		reasoning_options: [{ type: "effort", values: ["low", "high"] }],
-		modalities: { input: ["text", "image"] },
-		cost: { input: 1, output: 2, cache_read: 0.25, cache_write: 0.5 },
-		limit: { context: 8192, output: 2048 },
-	};
-	const catalog = {
-		"cloudflare-workers-ai": {
-			models: {
-				[workersModel.id]: workersModel,
-				"@cf/example/native": { id: "@cf/example/native", name: "Workers metadata", tool_call: true },
-				"@cf/example/no-tools": { id: "@cf/example/no-tools", name: "No tools", tool_call: false },
-			},
+test.each([
+	["omitted", undefined, undefined],
+	[
+		"not marked tool-capable by Workers AI",
+		{
+			id: "@cf/moonshotai/kimi-k2.6",
+			name: "Catalog Kimi K2.6",
+			tool_call: false,
+			limit: { context: 131_072, output: 65_536 },
 		},
-		"cloudflare-ai-gateway": {
-			models: {
-				"workers-ai/@cf/example/native": {
-					id: "workers-ai/@cf/example/native",
-					name: "Gateway metadata wins",
-					tool_call: true,
-					cost: { input: 9 },
+		undefined,
+	],
+	[
+		"not marked tool-capable by AI Gateway",
+		undefined,
+		{
+			id: "workers-ai/@cf/moonshotai/kimi-k2.6",
+			name: "Filtered Gateway Kimi K2.6",
+			tool_call: false,
+		},
+	],
+])(
+	"keeps the Cloudflare default catalog-independent when its metadata is %s",
+	(_state, defaultMetadata, gatewayDefaultMetadata) => {
+		const fixtureRoot = mkdtempSync(join(tmpdir(), "pi-generate-cloudflare-models-"));
+		temporaryRoots.push(fixtureRoot);
+		const isolatedPackageRoot = join(fixtureRoot, "package");
+		mkdirSync(isolatedPackageRoot);
+		for (const entry of ["package.json", "scripts", "src"]) {
+			cpSync(join(packageRoot, entry), join(isolatedPackageRoot, entry), { recursive: true });
+		}
+
+		const workersModel = {
+			id: "@cf/example/derived",
+			name: "Derived Workers Model",
+			tool_call: true,
+			reasoning: true,
+			reasoning_options: [{ type: "effort", values: ["low", "high"] }],
+			modalities: { input: ["text", "image"] },
+			cost: { input: 1, output: 2, cache_read: 0.25, cache_write: 0.5 },
+			limit: { context: 8192, output: 2048 },
+		};
+		const catalog = {
+			"cloudflare-workers-ai": {
+				models: {
+					...(defaultMetadata ? { [defaultMetadata.id]: defaultMetadata } : {}),
+					[workersModel.id]: workersModel,
+					"@cf/example/native": { id: "@cf/example/native", name: "Workers metadata", tool_call: true },
+					"@cf/example/no-tools": { id: "@cf/example/no-tools", name: "No tools", tool_call: false },
 				},
 			},
-		},
-	};
-	const preloadPath = join(fixtureRoot, "mock-model-apis.mjs");
-	writeFileSync(
-		preloadPath,
-		`const catalog = ${JSON.stringify(catalog)};\n` +
-			`globalThis.fetch = async (input) => {\n` +
-			`  const url = String(input);\n` +
-			`  if (url === "https://models.dev/api.json") return new Response(JSON.stringify(catalog), { status: 200 });\n` +
-			`  if (url.includes("openrouter.ai")) return new Response(JSON.stringify({ data: [] }), { status: 200 });\n` +
-			`  return new Response(JSON.stringify({ data: [] }), { status: 200 });\n` +
-			`};\n`,
-	);
+			"cloudflare-ai-gateway": {
+				models: {
+					...(gatewayDefaultMetadata ? { [gatewayDefaultMetadata.id]: gatewayDefaultMetadata } : {}),
+					"workers-ai/@cf/example/native": {
+						id: "workers-ai/@cf/example/native",
+						name: "Gateway metadata wins",
+						tool_call: true,
+						cost: { input: 9 },
+					},
+				},
+			},
+		};
+		const preloadPath = join(fixtureRoot, "mock-model-apis.mjs");
+		writeFileSync(
+			preloadPath,
+			`const catalog = ${JSON.stringify(catalog)};\n` +
+				`globalThis.fetch = async (input) => {\n` +
+				`  const url = String(input);\n` +
+				`  if (url === "https://models.dev/api.json") return new Response(JSON.stringify(catalog), { status: 200 });\n` +
+				`  if (url.includes("openrouter.ai")) return new Response(JSON.stringify({ data: [] }), { status: 200 });\n` +
+				`  return new Response(JSON.stringify({ data: [] }), { status: 200 });\n` +
+				`};\n`,
+		);
 
-	const outputPath = join(fixtureRoot, "catalog");
-	const result = spawnSync(
-		process.execPath,
-		[
-			"--import",
-			pathToFileURL(preloadPath).href,
-			"scripts/generate-models.ts",
-			"--json-only",
-			"--json-output",
-			outputPath,
-		],
-		{ cwd: isolatedPackageRoot, encoding: "utf8", timeout: 30_000 },
-	);
-	assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+		const outputPath = join(fixtureRoot, "catalog");
+		const result = spawnSync(
+			process.execPath,
+			[
+				"--import",
+				pathToFileURL(preloadPath).href,
+				"scripts/generate-models.ts",
+				"--json-only",
+				"--json-output",
+				outputPath,
+			],
+			{ cwd: isolatedPackageRoot, encoding: "utf8", timeout: 30_000 },
+		);
+		assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
 
-	const completions = JSON.parse(
-		readFileSync(join(outputPath, "providers/cloudflare-ai-gateway.json"), "utf8"),
-	) as Record<string, { name: string; cost: { input: number } }>;
-	assert.deepEqual(completions["workers-ai/@cf/example/derived"], {
-		id: "workers-ai/@cf/example/derived",
-		name: "Derived Workers Model",
-		api: "openai-completions",
-		provider: "cloudflare-ai-gateway",
-		baseUrl: "https://gateway.ai.cloudflare.com/v1/{CLOUDFLARE_ACCOUNT_ID}/{CLOUDFLARE_GATEWAY_ID}/compat",
-		reasoning: true,
-		input: ["text", "image"],
-		cost: { input: 1, output: 2, cacheRead: 0.25, cacheWrite: 0.5 },
-		contextWindow: 8192,
-		maxTokens: 2048,
-		compat: {
-			sendSessionAffinityHeaders: true,
-			supportsDeveloperRole: false,
-			supportsReasoningEffort: false,
-			supportsLongCacheRetention: false,
-			supportsStrictMode: false,
-			supportsStore: false,
-			maxTokensField: "max_tokens",
-		},
-	});
-	assert.equal(completions["workers-ai/@cf/example/native"].name, "Gateway metadata wins");
-	assert.equal(completions["workers-ai/@cf/example/native"].cost.input, 9);
-	assert.equal(completions["workers-ai/@cf/example/no-tools"], undefined);
-	assert.deepEqual(Object.keys(completions), ["workers-ai/@cf/example/derived", "workers-ai/@cf/example/native"]);
-});
+		const completions = JSON.parse(
+			readFileSync(join(outputPath, "providers/cloudflare-ai-gateway.json"), "utf8"),
+		) as Record<string, { id: string; name: string; cost: { input: number }; provider: string; baseUrl: string }>;
+		const workersCompletions = JSON.parse(
+			readFileSync(join(outputPath, "providers/cloudflare-workers-ai.json"), "utf8"),
+		) as Record<string, { id: string; name: string; provider: string; baseUrl: string }>;
+		assert.deepEqual(completions["workers-ai/@cf/example/derived"], {
+			id: "workers-ai/@cf/example/derived",
+			name: "Derived Workers Model",
+			api: "openai-completions",
+			provider: "cloudflare-ai-gateway",
+			baseUrl: "https://gateway.ai.cloudflare.com/v1/{CLOUDFLARE_ACCOUNT_ID}/{CLOUDFLARE_GATEWAY_ID}/compat",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 1, output: 2, cacheRead: 0.25, cacheWrite: 0.5 },
+			contextWindow: 8192,
+			maxTokens: 2048,
+			compat: {
+				sendSessionAffinityHeaders: true,
+				supportsDeveloperRole: false,
+				supportsReasoningEffort: false,
+				supportsLongCacheRetention: false,
+				supportsStrictMode: false,
+				supportsStore: false,
+				maxTokensField: "max_tokens",
+			},
+		});
+		assert.equal(completions["workers-ai/@cf/example/native"].name, "Gateway metadata wins");
+		assert.equal(completions["workers-ai/@cf/example/native"].cost.input, 9);
+		assert.equal(completions["workers-ai/@cf/example/no-tools"], undefined);
+		const defaultWorkersId = "@cf/moonshotai/kimi-k2.6";
+		const defaultGatewayId = `workers-ai/${defaultWorkersId}`;
+		assert.deepEqual(
+			{
+				id: workersCompletions[defaultWorkersId]?.id,
+				name: workersCompletions[defaultWorkersId]?.name,
+				provider: workersCompletions[defaultWorkersId]?.provider,
+				baseUrl: workersCompletions[defaultWorkersId]?.baseUrl,
+			},
+			{
+				id: defaultWorkersId,
+				name: defaultMetadata?.name ?? "Kimi K2.6",
+				provider: "cloudflare-workers-ai",
+				baseUrl: "https://api.cloudflare.com/client/v4/accounts/{CLOUDFLARE_ACCOUNT_ID}/ai/v1",
+			},
+		);
+		assert.deepEqual(
+			{
+				id: completions[defaultGatewayId]?.id,
+				name: completions[defaultGatewayId]?.name,
+				provider: completions[defaultGatewayId]?.provider,
+				baseUrl: completions[defaultGatewayId]?.baseUrl,
+			},
+			{
+				id: defaultGatewayId,
+				name: defaultMetadata?.name ?? "Kimi K2.6",
+				provider: "cloudflare-ai-gateway",
+				baseUrl: "https://gateway.ai.cloudflare.com/v1/{CLOUDFLARE_ACCOUNT_ID}/{CLOUDFLARE_GATEWAY_ID}/compat",
+			},
+		);
+		assert.deepEqual(Object.keys(completions), [
+			"workers-ai/@cf/example/derived",
+			"workers-ai/@cf/example/native",
+			defaultGatewayId,
+		]);
+	},
+);

--- a/packages/ai/test/generate-models-cloudflare-gateway.test.ts
+++ b/packages/ai/test/generate-models-cloudflare-gateway.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { afterEach, test } from "vitest";
+
+const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+const temporaryRoots: string[] = [];
+
+afterEach(() => {
+	for (const root of temporaryRoots.splice(0)) rmSync(root, { force: true, recursive: true });
+});
+
+test("derives missing Cloudflare gateway Workers AI passthroughs from the Workers AI catalog", () => {
+	const fixtureRoot = mkdtempSync(join(tmpdir(), "pi-generate-cloudflare-models-"));
+	temporaryRoots.push(fixtureRoot);
+	const isolatedPackageRoot = join(fixtureRoot, "package");
+	mkdirSync(isolatedPackageRoot);
+	for (const entry of ["package.json", "scripts", "src"]) {
+		cpSync(join(packageRoot, entry), join(isolatedPackageRoot, entry), { recursive: true });
+	}
+
+	const workersModel = {
+		id: "@cf/example/derived",
+		name: "Derived Workers Model",
+		tool_call: true,
+		reasoning: true,
+		reasoning_options: [{ type: "effort", values: ["low", "high"] }],
+		modalities: { input: ["text", "image"] },
+		cost: { input: 1, output: 2, cache_read: 0.25, cache_write: 0.5 },
+		limit: { context: 8192, output: 2048 },
+	};
+	const catalog = {
+		"cloudflare-workers-ai": {
+			models: {
+				[workersModel.id]: workersModel,
+				"@cf/example/native": { id: "@cf/example/native", name: "Workers metadata", tool_call: true },
+				"@cf/example/no-tools": { id: "@cf/example/no-tools", name: "No tools", tool_call: false },
+			},
+		},
+		"cloudflare-ai-gateway": {
+			models: {
+				"workers-ai/@cf/example/native": {
+					id: "workers-ai/@cf/example/native",
+					name: "Gateway metadata wins",
+					tool_call: true,
+					cost: { input: 9 },
+				},
+			},
+		},
+	};
+	const preloadPath = join(fixtureRoot, "mock-model-apis.mjs");
+	writeFileSync(
+		preloadPath,
+		`const catalog = ${JSON.stringify(catalog)};\n` +
+			`globalThis.fetch = async (input) => {\n` +
+			`  const url = String(input);\n` +
+			`  if (url === "https://models.dev/api.json") return new Response(JSON.stringify(catalog), { status: 200 });\n` +
+			`  if (url.includes("openrouter.ai")) return new Response(JSON.stringify({ data: [] }), { status: 200 });\n` +
+			`  return new Response(JSON.stringify({ data: [] }), { status: 200 });\n` +
+			`};\n`,
+	);
+
+	const outputPath = join(fixtureRoot, "catalog");
+	const result = spawnSync(
+		process.execPath,
+		[
+			"--import",
+			pathToFileURL(preloadPath).href,
+			"scripts/generate-models.ts",
+			"--json-only",
+			"--json-output",
+			outputPath,
+		],
+		{ cwd: isolatedPackageRoot, encoding: "utf8", timeout: 30_000 },
+	);
+	assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+
+	const completions = JSON.parse(
+		readFileSync(join(outputPath, "providers/cloudflare-ai-gateway.json"), "utf8"),
+	) as Record<string, { name: string; cost: { input: number } }>;
+	assert.deepEqual(completions["workers-ai/@cf/example/derived"], {
+		id: "workers-ai/@cf/example/derived",
+		name: "Derived Workers Model",
+		api: "openai-completions",
+		provider: "cloudflare-ai-gateway",
+		baseUrl: "https://gateway.ai.cloudflare.com/v1/{CLOUDFLARE_ACCOUNT_ID}/{CLOUDFLARE_GATEWAY_ID}/compat",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 1, output: 2, cacheRead: 0.25, cacheWrite: 0.5 },
+		contextWindow: 8192,
+		maxTokens: 2048,
+		compat: {
+			sendSessionAffinityHeaders: true,
+			supportsDeveloperRole: false,
+			supportsReasoningEffort: false,
+			supportsLongCacheRetention: false,
+			supportsStrictMode: false,
+			supportsStore: false,
+			maxTokensField: "max_tokens",
+		},
+	});
+	assert.equal(completions["workers-ai/@cf/example/native"].name, "Gateway metadata wins");
+	assert.equal(completions["workers-ai/@cf/example/native"].cost.input, 9);
+	assert.equal(completions["workers-ai/@cf/example/no-tools"], undefined);
+	assert.deepEqual(Object.keys(completions), ["workers-ai/@cf/example/derived", "workers-ai/@cf/example/native"]);
+});

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -2,7 +2,7 @@ import type { AssistantMessage, Usage } from "@bastani/pi-ai/compat";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { readFileSync } from "fs";
 import { join } from "path";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	type CompactionSettings,
 	calculateContextTokens,
@@ -310,15 +310,26 @@ describe("estimateContextTokens", () => {
 	});
 
 	it("preserves the API discriminator for normalized cached usage", () => {
-		const usage = createMockUsage(7_907, 7, 7_936, 0);
-		const message = {
-			...createAssistantMessage("response", usage),
-			api: "openai-codex-responses" as const,
-			provider: "openai-codex",
-		};
-		const result = estimateContextTokens([createUserMessage("hello"), message]);
-		expect(result.tokens).toBe(15_850);
-		expect(shouldCompact(result.tokens, 20_000, { ...DEFAULT_COMPACTION_SETTINGS, reserveTokens: 5_000 })).toBe(true);
+		const now = vi.spyOn(Date, "now");
+		try {
+			now.mockReturnValueOnce(1_000).mockReturnValueOnce(2_000);
+			// Keep construction order aligned with transcript order even when the clock ticks
+			// between messages; a newer prefix intentionally invalidates older usage.
+			const userMessage = createUserMessage("hello");
+			const usage = createMockUsage(7_907, 7, 7_936, 0);
+			const message = {
+				...createAssistantMessage("response", usage),
+				api: "openai-codex-responses" as const,
+				provider: "openai-codex",
+			};
+			const result = estimateContextTokens([userMessage, message]);
+			expect(result.tokens).toBe(15_850);
+			expect(shouldCompact(result.tokens, 20_000, { ...DEFAULT_COMPACTION_SETTINGS, reserveTokens: 5_000 })).toBe(
+				true,
+			);
+		} finally {
+			now.mockRestore();
+		}
 	});
 
 	it("should return zero tokens for empty messages", () => {


### PR DESCRIPTION
## Summary

Keeps Cloudflare AI Gateway's supported API union stable when live model data temporarily omits one API family.

## Validation

- online model-data build
- offline model-data build
- repository typecheck and Biome gates

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790221463&installation_model_id=10562&pr_number=2662&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2662&signature=27f27724a07758652f60bf5722156c21bdc1d644ba5cd2a187db23b18373d84f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Cloudflare model generation now retains Kimi K2.6 when catalog metadata is absent or incorrectly tagged, and adds compatible Workers AI models to the AI Gateway catalog while preserving native Gateway metadata. Focused generator checks passed for the default fallback, derived entries, duplicate prevention, and native-metadata precedence. The AI package typecheck reports the same missing fixture field on both the base branch and this branch, so that failure is not caused by this change.

<h3>Confidence Score: 5/5</h3>

The changed Cloudflare catalog behavior was exercised successfully and is safe to merge.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused Cloudflare generator regression against the prior revision and observed all three Kimi-default scenarios fail when catalog metadata was omitted or marked non-tool-capable.
- Ran the same flow on this revision and observed all Kimi fallback, Workers AI derivation, native Gateway metadata precedence, and duplicate-prevention assertions pass.
- Completed the offline AI package build and generated model-data validation successfully.
- T-Rex produced a proof for a posted P1 finding.
- Reviewed the AI workspace typecheck failure log to confirm compile-state implications of the regression.

<a href="https://app.greptile.com/trex/runs/20527353/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **AI workspace typecheck is blocked by a missing required compat field**

   - **Bug**
     - `npm --workspace=@bastani/pi-ai run typecheck` exits 2 because `test/stream-decompression-e2e.test.ts:47` supplies an `OpenAICompletionsCompat` fixture without required `thinkingTokenBudgetField`. This prevents the requested type/provider contract gate from passing.
   - **Cause**
     - The test fixture was not updated after `thinkingTokenBudgetField` became required in the compat contract.
   - **Fix**
     - Add the appropriate `thinkingTokenBudgetField` value to the compat fixture, then rerun the AI workspace typecheck.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(ai): keep Cloudflare defaults catalo..."](https://github.com/bastani-inc/atomic/commit/d3466ce2e0860689c1cd66377309b699326fbade) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56515697)</sub>

<!-- /greptile_comment -->