### PR TITLE
style(ai): satisfy package checks

### DIFF
--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -21,7 +21,6 @@ import type {
 	Usage,
 } from "../types.ts";
 import { combineAbortSignals } from "../utils/abort-signals.ts";
-import { createStreamDeadline, withStreamDeadline, type StreamDeadlineHandle } from "../utils/stream-deadline.ts";
 import { splitDeferredTools } from "../utils/deferred-tools.ts";
 import {
 	appendAssistantMessageDiagnostic,
@@ -33,6 +32,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { resolveHttpProxyUrlForTarget } from "../utils/node-http-proxy.ts";
 import { getPiUserAgent } from "../utils/pi-user-agent.ts";
+import { createStreamDeadline, type StreamDeadlineHandle, withStreamDeadline } from "../utils/stream-deadline.ts";
 import { uuidv7 } from "../utils/uuid.ts";
 import { createGrammarToolInputProperties } from "./constrained-sampling.ts";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
@@ -254,7 +254,7 @@ export const stream: StreamFunction<"openai-codex-responses", OpenAICodexRespons
 			timestamp: Date.now(),
 		};
 
-		let streamDeadline = createStreamDeadline(options?.streamDeadlineMs, options?.signal);
+		const streamDeadline = createStreamDeadline(options?.streamDeadlineMs, options?.signal);
 
 		try {
 			const apiKey = options?.apiKey;

--- a/packages/ai/src/api/pi-messages.ts
+++ b/packages/ai/src/api/pi-messages.ts
@@ -26,8 +26,8 @@ import { appendAssistantMessageDiagnostic, createAssistantMessageDiagnostic } fr
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord, providerHeadersToRecord } from "../utils/headers.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
-import { createStreamDeadline, withStreamDeadline } from "../utils/stream-deadline.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
+import { createStreamDeadline, withStreamDeadline } from "../utils/stream-deadline.ts";
 
 export interface PiMessagesOptions extends StreamOptions {
 	reasoning?: ThinkingLevel;

--- a/packages/ai/src/utils/stream-deadline.ts
+++ b/packages/ai/src/utils/stream-deadline.ts
@@ -14,7 +14,7 @@
  * that {@link isRetryableAssistantError} classifies as retryable.
  */
 
-import { combineAbortSignals, type CombinedAbortSignal } from "./abort-signals.ts";
+import { type CombinedAbortSignal, combineAbortSignals } from "./abort-signals.ts";
 
 /**
  * Default idle gap allowed between two provider stream events, in milliseconds.

--- a/packages/ai/test/stream-deadline-routes.test.ts
+++ b/packages/ai/test/stream-deadline-routes.test.ts
@@ -17,9 +17,9 @@ const context: Context = {
 const servers: Server[] = [];
 
 function createCodexToken(accountId: string): string {
-	const payload = Buffer.from(JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: accountId } })).toString(
-		"base64",
-	);
+	const payload = Buffer.from(
+		JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: accountId } }),
+	).toString("base64");
 	return `aaa.${payload}.bbb`;
 }
 

--- a/packages/ai/test/stream-deadline.test.ts
+++ b/packages/ai/test/stream-deadline.test.ts
@@ -2,8 +2,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { fauxAssistantMessage } from "../src/providers/faux.ts";
 import { isRetryableAssistantError, type RetryPolicy, retryAssistantCall } from "../src/utils/retry.ts";
 import {
-	DEFAULT_STREAM_DEADLINE_MS,
 	createStreamDeadline,
+	DEFAULT_STREAM_DEADLINE_MS,
 	resolveStreamDeadlineMs,
 	StreamDeadlineError,
 	withStreamDeadline,
@@ -105,10 +105,14 @@ describe("stream deadline (#2553)", () => {
 		async function* providerRead(): AsyncGenerator<string, void, undefined> {
 			try {
 				await new Promise<void>((_resolve, reject) => {
-					deadline.signal?.addEventListener("abort", () => {
-						abortObserved = true;
-						reject(deadline.signal?.reason);
-					}, { once: true });
+					deadline.signal?.addEventListener(
+						"abort",
+						() => {
+							abortObserved = true;
+							reject(deadline.signal?.reason);
+						},
+						{ once: true },
+					);
 				});
 			} finally {
 				cleanupObserved = true;
@@ -153,9 +157,9 @@ describe("stream deadline (#2553)", () => {
 		expect(error).toBeInstanceOf(StreamDeadlineError);
 		const message = (error as StreamDeadlineError).message;
 		expect(message).toContain("stream deadline exceeded");
-		expect(
-			isRetryableAssistantError(fauxAssistantMessage("", { stopReason: "error", errorMessage: message })),
-		).toBe(true);
+		expect(isRetryableAssistantError(fauxAssistantMessage("", { stopReason: "error", errorMessage: message }))).toBe(
+			true,
+		);
 	});
 
 	it("closes the source iterator when the deadline fires so the underlying request is torn down", async () => {

--- a/packages/ai/test/stream-decompression-e2e.test.ts
+++ b/packages/ai/test/stream-decompression-e2e.test.ts
@@ -38,15 +38,20 @@ const compat = {
 	chatTemplateArgs: {},
 	zaiToolStream: false,
 	supportsThinkingTokenBudget: false,
+	thinkingTokenBudgetField: undefined,
 	supportsStrictMode: true,
 	supportsOpenAIGrammarTools: false,
 	cacheControlFormat: undefined,
 	sendSessionAffinityHeaders: false,
 	sessionAffinityFormat: "openai",
 	supportsLongCacheRetention: false,
-} satisfies Omit<Required<OpenAICompletionsCompat>, "cacheControlFormat" | "deferredToolsMode"> & {
+} satisfies Omit<
+	Required<OpenAICompletionsCompat>,
+	"cacheControlFormat" | "deferredToolsMode" | "thinkingTokenBudgetField"
+> & {
 	cacheControlFormat?: OpenAICompletionsCompat["cacheControlFormat"];
 	deferredToolsMode?: OpenAICompletionsCompat["deferredToolsMode"];
+	thinkingTokenBudgetField?: OpenAICompletionsCompat["thinkingTokenBudgetField"];
 };
 
 function buildModel(baseUrl: string): Model<"openai-completions"> {


### PR DESCRIPTION
## Summary
- apply the outstanding Biome import, const, and formatting fixes in `@bastani/pi-ai`
- update the decompression fixture for the required thinking-token budget compatibility field

## Validation
- `npm run check --workspace=@bastani/pi-ai`
- 26 focused stream deadline/decompression tests
- root `npm run check`
- mandatory pre-push unit, integration, and CI-contract suites

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790233560&installation_model_id=10562&pr_number=2664&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2664&signature=6c97175cac3c066a8cbfed7a39e53a7b94d6bec6e33491a58aa35021f1f9754a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update applies import ordering and formatting changes in the AI package, makes the stream-deadline handle immutable, and extends the decompression fixture with optional thinking-token-budget compatibility metadata. Focused decompression and stalled-stream tests passed both before and after the fixture update. A local HTTP streaming check also confirmed that undefined thinking-budget metadata is not emitted in the provider request, disproving the potential request-serialization regression.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge: exercised streaming behavior and outgoing request serialization remain unchanged.

No defects remain in the final findings. The behavior-sensitive fixture change was checked through focused tests before and after the update and through a real local SSE request path.

**Files Needing Attention:** No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused decompression and stalled-stream recovery tests against both the parent commit and the updated commit, and both runs passed 2 of 2 tests.
- Ran a focused local HTTP SSE harness using the updated compatibility fixture; it completed a streamed text response and confirmed that thinkingTokenBudgetField, thinking\_token\_budget, and thinking\_budget were absent from the transmitted JSON.
- The validation harness ran the before-focused and after-focused tests across the parent/current and updated commits, and both runs passed (2/2, exit 0).
- The request-path harness completed a real SSE stream and confirmed that undefined compatibility metadata is absent from the transmitted JSON (1/1, exit 0).

<a href="https://app.greptile.com/trex/runs/20536876/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["style(ai): satisfy package checks"](https://github.com/bastani-inc/atomic/commit/551972d0cf1a62541ed7b4722d6c9c996a705a6c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56555665)</sub>

<!-- /greptile_comment -->