### PR TITLE
feat(workflows): raise public workflow tool request deadline to two minutes

### DIFF
--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -2997,7 +2997,7 @@ The workflow tool action surface is:
 - messaging on nonterminal root runs and run control: `send`, `pause`, `interrupt`, `quit`, `resume`
 - rediscovery: `reload`
 
-Every registered `workflow` tool call has one hard 30-second wall-clock deadline at the shared public tool boundary. The deadline covers request handling through the returned result; for background `run` and `resume`, it therefore covers startup/resume admission and acknowledgement only, not the workflow execution that continues after acknowledgement. A deadline returns one structured result:
+Every registered `workflow` tool call has one hard two-minute wall-clock deadline at the shared public tool boundary. The deadline covers request handling through the returned result; for background `run` and `resume`, it therefore covers startup/resume admission and acknowledgement only, not the workflow execution that continues after acknowledgement. A deadline returns one structured result:
 
 ```json
 {
@@ -3005,8 +3005,8 @@ Every registered `workflow` tool call has one hard 30-second wall-clock deadline
   "runId": "339e05a4-2289-408e-9076-d1a348f582ae",
   "status": "failed",
   "code": "WORKFLOW_TIMEOUT",
-  "timeoutMs": 30000,
-  "error": "Workflow run request timed out after 30000ms. The outcome is unknown. Inspect workflow status before retrying."
+  "timeoutMs": 120000,
+  "error": "Workflow run request timed out after 120000ms. The outcome is unknown. Inspect workflow status before retrying."
 }
 ```
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Raised the public `workflow` tool request deadline from 30 seconds to two minutes. Timed-out requests still return `WORKFLOW_TIMEOUT` with `timeoutMs: 120000`, abort cancellable work, discard late settlement, and never retry. Mutating actions keep the unknown-outcome warning that tells callers to inspect workflow status before retrying ([#2654](https://github.com/bastani-inc/atomic/issues/2654)).
+
 ### Fixed
 
 - Fixed a completed `ctx.task` leaving the root raw `running` with no active stage or tool and no path to the next budget boundary. The durable task-result checkpoint now fails closed, duration is rechecked after that checkpoint, quit/interrupt can abort a never-settling persist, a checkpoint created after its signal is already aborted settles without an unobserved rejection, an active task-checkpoint control — including one owned by an expanded child run — is not diagnosed as a stranded root, bulk interrupt forwards an injected tool-control registry, cancellation settles the DBOS write queue, and a terminal-only stage checkpoint replays the complete `WorkflowTaskResult` — the exact persisted text including schema-backed `maxOutput` truncation, structured output including `null`, generated worktree artifacts, warnings, session, and model metadata — without rerunning the task. A workflow that catches a task-tail quit rejection and returns outputs still stays paused. Exact-id quit or interrupt of a nested task tail now quits the aggregate root so the parent snapshot and durable handle do not stay raw `running`. Exact `/workflow status <id>` uses the live tool-control registry so a task tail is not reported as stranded. Same-process DBOS hydration rejects unknown checkpoint history instead of replaying around it ([#2650](https://github.com/bastani-inc/atomic/issues/2650)).

--- a/packages/workflows/src/extension/workflow-tool-registration.ts
+++ b/packages/workflows/src/extension/workflow-tool-registration.ts
@@ -16,7 +16,7 @@ interface WorkflowToolRegistrationOptions {
 
 export type WorkflowToolRegistrar = Pick<ExtensionAPI, "registerTool">;
 
-export const WORKFLOW_TOOL_REQUEST_TIMEOUT_MS = 30_000;
+export const WORKFLOW_TOOL_REQUEST_TIMEOUT_MS = 120_000;
 
 type WorkflowToolExecutor = (
 	args: WorkflowToolArgs,

--- a/test/unit/workflow-public-tool-timeout.test.ts
+++ b/test/unit/workflow-public-tool-timeout.test.ts
@@ -60,7 +60,8 @@ afterEach(() => {
 });
 
 describe("public workflow tool request deadline", () => {
-	test("times out every public action once at 30 seconds, cancels supported work, and ignores late settlement", async () => {
+	test("times out every public action once at two minutes, cancels supported work, and ignores late settlement", async () => {
+		assert.equal(WORKFLOW_TOOL_REQUEST_TIMEOUT_MS, 120_000);
 		vi.useFakeTimers();
 		let invocationCount = 0;
 		let active:
@@ -93,7 +94,7 @@ describe("public workflow tool request deadline", () => {
 			assert.equal(invocationCount, index + 1);
 
 			await vi.advanceTimersByTimeAsync(WORKFLOW_TOOL_REQUEST_TIMEOUT_MS - 1);
-			assert.equal(settled, false, `${action} must remain pending at 29,999ms`);
+			assert.equal(settled, false, `${action} must remain pending at ${WORKFLOW_TOOL_REQUEST_TIMEOUT_MS - 1}ms`);
 			await vi.advanceTimersByTimeAsync(1);
 			const result = await pending;
 			assert.equal(settled, true);


### PR DESCRIPTION
## Summary

Raise the production `workflow` tool request deadline from 30 seconds to two minutes so legitimate startup and load delays no longer return `WORKFLOW_TIMEOUT` while a mutating action may already have been accepted.

Closes #2654

## Changes

- Set `WORKFLOW_TOOL_REQUEST_TIMEOUT_MS` to `120_000`.
- Keep the existing timeout result, abort, late-settlement discard, no-retry, and fixture-only `requestTimeoutMs` override.
- Pin the new deadline in `test/unit/workflow-public-tool-timeout.test.ts` with fake timers (no two-minute wall wait).
- Update the user-facing deadline section and example JSON in `packages/coding-agent/docs/workflows.md`.
- Record the change under `packages/workflows/CHANGELOG.md` `[Unreleased]` `Changed`.

## Tests

- `npx vitest --run --project unit test/unit/workflow-public-tool-timeout.test.ts` (Crabbox): 6 passed
- `npx tsc --noEmit -p tsconfig.json` (Crabbox): clean
- `npx biome check --error-on-warnings` on the two TypeScript files (Crabbox): clean
- Docs grep: two-minute deadline and `after 120000ms` present; no leftover 30-second request-deadline copy

## Notes

Timeout results still return `WORKFLOW_TIMEOUT` with `timeoutMs: 120000`. Mutating actions keep the unknown-outcome warning that tells callers to inspect workflow status before retrying.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790236444&installation_model_id=10562&pr_number=2665&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2665&signature=ea37d2361509782d7530e825cc59ade5f030f1923c7872995a8da4b73be57a77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change raises the public `workflow` tool request deadline from 30 seconds to two minutes, updates the user-facing documentation, and records the change in the workflows changelog. A focused execution of the workflow timeout suite confirmed that requests remain pending through 119,999 ms, return `WORKFLOW_TIMEOUT` at 120,000 ms, abort supported delegated work, preserve caller cancellation, clear timers, and ignore late settlement. The potential failure where the new deadline did not propagate to the public tool boundary was disproved.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the public workflow timeout boundary and its cancellation behavior were exercised successfully at the exact two-minute deadline.

No defects remain in the final findings. The focused suite passed all six tests and directly covered the changed timeout constant, structured timeout result, abort propagation, caller cancellation, timer cleanup, and late-settlement handling.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- - Inspected workflow-tool-registration.ts to confirm WORKFLOW\_TOOL\_REQUEST\_TIMEOUT\_MS is used as the public registration default and that the timer resolves the structured timeout while aborting delegated work.
- - Ran npx vitest --run --project unit test/unit/workflow-public-tool-timeout.test.ts against both the direct parent worktree and the changed-worktree; both runs exited successfully with 6 of 6 tests passing.
- - Validated the boundary behavior: public actions remained pending at 119,999 ms and resolved at 120,000 ms with WORKFLOW\_TIMEOUT, while abort propagation, caller cancellation, timer cleanup, and late-success isolation continued to pass.
- - Compared against the direct parent worktree baseline; the before-run log shows exit code 0 with 6/6 tests passing at the prior 30-second configuration.
- - Gathered artifacts (shell script and before/after run logs) to enable review of the test invocation and results.

<a href="https://app.greptile.com/trex/runs/20542507/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(workflows): raise public workflow to..."](https://github.com/bastani-inc/atomic/commit/c69bf6aec6edcddbb961640ddd9d3f9dad1662f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56568096)</sub>

<!-- /greptile_comment -->