### PR TITLE
feat(subagents): render completion notifications as tool blocks

### DIFF
--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Foreground subagent completion, failure, and interruption notifications now render as status-colored tool blocks while preserving their result preview, expansion hint, duration, and session path.
+
 ## [0.9.16-alpha.2] - 2026-08-23
 
 ### Breaking Changes

--- a/packages/subagents/README.md
+++ b/packages/subagents/README.md
@@ -647,7 +647,7 @@ Metadata records timing, usage, typed status, termination cause, final model, at
 
 Session files are stored under a per-run session directory. With `context: "fork"`, each child starts from the parent’s current leaf through the session manager; this is a real session fork, not an injected summary.
 
-Foreground completions notify the originating session. The in-process status watch emits live lifecycle updates, and the extension consumes the terminal event to render completion notifications.
+Foreground completions notify the originating session. The in-process status watch emits live lifecycle updates, and the extension consumes the terminal event to render completion notifications. These notifications use tool blocks with the same background treatment as regular subagent tool blocks: success when the child completed, error when it failed, and pending when it was interrupted. Each block keeps the status glyph, agent name, outcome, duration, result preview, `ctrl+o` expand hint, and session file path.
 
 Foreground runs persist their session and user-facing artifacts beside the parent session:
 

--- a/packages/subagents/src/extension/index.ts
+++ b/packages/subagents/src/extension/index.ts
@@ -150,7 +150,7 @@ export function renderSubagentNotification(
 	message: { content: unknown; details?: unknown },
 	options: { expanded: boolean },
 	theme: ExtensionContext["ui"]["theme"],
-): Text {
+): Component {
 	const content = typeof message.content === "string" ? message.content : "";
 	const details = (message.details as SubagentNotifyDetails | undefined) ?? parseSubagentNotifyContent(content);
 	if (!details) return new Text(content, 0, 0);
@@ -180,7 +180,15 @@ export function renderSubagentNotification(
 	if (details.sessionLabel && details.sessionValue) {
 		text += `\n  ${theme.fg("muted", `${details.sessionLabel}: ${shortenPath(details.sessionValue)}`)}`;
 	}
-	return new Text(text, 0, 0);
+	const container = new Container();
+	container.addChild(new Spacer(1));
+	// Interrupted is the neutral terminal state, so it uses the pending background rather than success or error.
+	const boxTheme =
+		details.status === "completed" ? "toolSuccessBg" : details.status === "failed" ? "toolErrorBg" : "toolPendingBg";
+	const box = new Box(1, 1, (line: string) => theme.bg(boxTheme, line));
+	box.addChild(new Text(text, 0, 0));
+	container.addChild(box);
+	return container;
 }
 class SubagentControlNoticeComponent implements Component {
 	constructor(

--- a/test/unit/install-shell.test.ts
+++ b/test/unit/install-shell.test.ts
@@ -138,17 +138,31 @@ function createArchive(workspace: string, tag: string, asset: string): { path: s
 	const encodedTag = encodeURIComponent(tag);
 	const sourceRoot = join(workspace, `payload-${encodedTag}-${asset}`);
 	const payload = join(sourceRoot, "atomic");
+	const directories = [
+		sourceRoot,
+		payload,
+		join(payload, "builtin"),
+		join(payload, "node_modules"),
+		join(payload, "node_modules", "fixture"),
+	];
 	mkdirSync(join(payload, "builtin"), { recursive: true });
 	mkdirSync(join(payload, "node_modules", "fixture"), { recursive: true });
+	for (const directory of directories) chmodSync(directory, 0o755);
 	writeExecutable(
 		join(payload, "atomic"),
 		`#!/bin/sh\nversion='${tag}'\nif [ "\${ATOMIC_FIXTURE_FAIL_STAGED_VERSION:-}" = "$version" ]; then exit 17; fi\ncase "$0" in\n  *atomic-install.*) ;;\n  *) if [ "\${ATOMIC_FIXTURE_FAIL_FINAL_VERSION:-}" = "$version" ]; then exit 23; fi ;;\nesac\nif [ "\${1:-}" = --version ]; then printf '%s\\n' "$version"; exit 0; fi\nprintf '%s\\n' "$version:$*"\n`,
 	);
-	writeFileSync(join(payload, "package.json"), JSON.stringify({ name: "@bastani/atomic", version: tag }));
-	writeFileSync(join(payload, "app.js"), `fixture-${tag}`);
-	writeFileSync(join(payload, "builtin", "payload.txt"), `builtin-${tag}`);
-	writeFileSync(join(payload, "node_modules", "fixture", "payload.txt"), `modules-${tag}`);
-	writeFileSync(join(payload, "asset.txt"), asset);
+	const regularFiles = [
+		[join(payload, "package.json"), JSON.stringify({ name: "@bastani/atomic", version: tag })],
+		[join(payload, "app.js"), `fixture-${tag}`],
+		[join(payload, "builtin", "payload.txt"), `builtin-${tag}`],
+		[join(payload, "node_modules", "fixture", "payload.txt"), `modules-${tag}`],
+		[join(payload, "asset.txt"), asset],
+	] as const;
+	for (const [file, content] of regularFiles) {
+		writeFileSync(file, content);
+		chmodSync(file, 0o644);
+	}
 
 	const archive = join(workspace, `${encodedTag}-${asset}`);
 	const result = spawnSyncCollect([resolveExecutable("tar"), "-czf", archive, "-C", sourceRoot, "atomic"]);
@@ -157,6 +171,28 @@ function createArchive(workspace: string, tag: string, asset: string): { path: s
 	rmSync(sourceRoot, { recursive: true, force: true });
 	return { path: archive, checksum };
 }
+
+unixTest("fixture release archives pin payload modes independent of the ambient umask", () => {
+	const workspace = mkdtempSync(join(tmpdir(), "atomic-sh-archive-modes-"));
+	try {
+		const archive = createArchive(workspace, "1.0.0", "atomic-linux-x64.tar.gz");
+		const listing = spawnSyncCollect([resolveExecutable("tar"), "-tvzf", archive.path]);
+		assert.equal(listing.exitCode, 0, listing.stderr.toString());
+		const rows = listing.stdout.toString().split("\n");
+		for (const [member, mode] of [
+			["atomic/", "drwxr-xr-x"],
+			["atomic/builtin/", "drwxr-xr-x"],
+			["atomic/package.json", "-rw-r--r--"],
+			["atomic/atomic", "-rwxr-xr-x"],
+		] as const) {
+			const row = rows.find((candidate) => candidate.trimEnd().endsWith(` ${member}`));
+			assert.ok(row, `missing archive member ${member}`);
+			assert.equal(row.slice(0, 10), mode, member);
+		}
+	} finally {
+		rmSync(workspace, { recursive: true, force: true });
+	}
+});
 
 function addRelease(fixture: InstallerFixture, tag: string): FixtureRelease {
 	const assets = new Map<string, string>();

--- a/test/unit/subagents-notification-tool-block.test.ts
+++ b/test/unit/subagents-notification-tool-block.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { getKeybindings, setKeybindings } from "@earendil-works/pi-tui";
+import { afterEach, beforeEach, test } from "vitest";
+import { KeybindingsManager } from "../../packages/coding-agent/src/core/keybindings.ts";
+import { initTheme, theme } from "../../packages/coding-agent/src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../../packages/coding-agent/src/utils/ansi.ts";
+import { renderSubagentNotification } from "../../packages/subagents/src/extension/index.ts";
+import type { SubagentNotifyDetails } from "../../packages/subagents/src/runs/foreground/notify.ts";
+
+const originalKeybindings = getKeybindings();
+
+function render(details: SubagentNotifyDetails, expanded = false): { raw: string; plain: string } {
+	const raw = renderSubagentNotification({ content: "", details }, { expanded }, theme).render(100).join("\n");
+	return { raw, plain: stripAnsi(raw) };
+}
+
+function backgroundPrefix(token: "toolSuccessBg" | "toolErrorBg" | "toolPendingBg"): string {
+	const probe = "background-probe";
+	return theme.bg(token, probe).split(probe, 1)[0] ?? "";
+}
+
+beforeEach(() => {
+	initTheme("dark");
+	setKeybindings(new KeybindingsManager({ "app.tools.expand": "ctrl+o" }));
+});
+
+afterEach(() => setKeybindings(originalKeybindings));
+
+test("completion notifications render as status-colored tool blocks without losing content", () => {
+	const completed = render({
+		agent: "debugger",
+		status: "completed",
+		taskInfo: "task 1/2",
+		durationMs: 65_000,
+		resultPreview: "summary line\nadditional detail",
+		sessionLabel: "session file",
+		sessionValue: "/tmp/sessions/child.jsonl",
+	});
+	const failed = render({ agent: "debugger", status: "failed", resultPreview: "failure detail" });
+	const interrupted = render({ agent: "debugger", status: "interrupted", resultPreview: "stopped" });
+	const successBackground = backgroundPrefix("toolSuccessBg");
+	const errorBackground = backgroundPrefix("toolErrorBg");
+	const pendingBackground = backgroundPrefix("toolPendingBg");
+
+	assert.notEqual(successBackground, "");
+	assert.notEqual(errorBackground, "");
+	assert.notEqual(pendingBackground, "");
+	assert.notEqual(successBackground, errorBackground);
+	assert.notEqual(successBackground, pendingBackground);
+	assert.notEqual(errorBackground, pendingBackground);
+	assert.ok(completed.raw.includes(successBackground), "completed notification uses the success tool background");
+	assert.ok(failed.raw.includes(errorBackground), "failed notification uses the error tool background");
+	assert.ok(interrupted.raw.includes(pendingBackground), "interrupted notification uses the pending tool background");
+	assert.match(completed.plain, /✓ debugger completed · task 1\/2 · 1m 5s/);
+	assert.match(completed.plain, /⎿ {2}summary line/);
+	assert.match(completed.plain, /ctrl\+o full notification/);
+	assert.match(completed.plain, /session file: \/tmp\/sessions\/child\.jsonl/);
+	assert.match(failed.plain, /✗ debugger failed/);
+});
+
+test("tool-block rendering preserves collapsed and expanded preview behavior", () => {
+	const details: SubagentNotifyDetails = {
+		agent: "worker",
+		status: "completed",
+		resultPreview: "first line\nsecond line",
+	};
+	const collapsed = render(details);
+	const expanded = render(details, true);
+
+	assert.match(collapsed.plain, /first line/);
+	assert.doesNotMatch(collapsed.plain, /second line/);
+	assert.match(collapsed.plain, /ctrl\+o full notification/);
+	assert.match(expanded.plain, /first line/);
+	assert.match(expanded.plain, /second line/);
+	assert.doesNotMatch(expanded.plain, /full notification/);
+});


### PR DESCRIPTION
## Summary

Foreground subagent completion, failure, and interruption notifications previously rendered as plain text. They now render as status-colored tool blocks with the same background treatment as regular subagent tool calls, without dropping any of the existing notification content.

## Changes

- Wrap terminal foreground notifications in a tool-block container (`toolSuccessBg` / `toolErrorBg` / `toolPendingBg` for completed / failed / interrupted).
- Preserve the existing status glyph, agent name, outcome, duration, result preview, `ctrl+o` expand hint, and session file path.
- Document the new rendering in `packages/subagents/README.md` and note it under `[Unreleased]` in `packages/subagents/CHANGELOG.md`.

## Scope

Limited to `packages/subagents` plus its tests, changelog, and docs. No other packages were changed for the notification rendering. An install-shell fixture follow-up on this branch pins fake release-archive modes so restrictive runner umasks cannot change installer permission expectations.

## Tests

- Added `test/unit/subagents-notification-tool-block.test.ts` to assert status-specific tool backgrounds and that collapsed/expanded preview content is unchanged.
- Added `test/unit/install-shell.test.ts` coverage that fixture archive members keep their intended directory, regular-file, and executable modes.

## Validation

Implementation and regression coverage were validated on Crabbox remote runners (not in the local checkout). A previous remote-gate miss caused by a box without git metadata was fixed in the gate itself; this branch was re-verified after that fix.

## Notes

Do not merge from this request. CI remains the PR gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790253633&installation_model_id=10562&pr_number=2668&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2668&signature=36b9f81967a6a1340d2e2a3815e80b8a2295eb3c346b766ca112eea7bea56f58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Foreground subagent completion notifications now use status-colored tool blocks while preserving status details, result previews, expansion hints, and session paths. Direct rendering checks passed for completed, failed, and interrupted states in collapsed and expanded views. The installer archive-permission suite also passed, including deterministic fixture-mode coverage.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge based on direct coverage of notification rendering states and the related installer permission suite.

No defects were found. Direct assertions exercised all terminal statuses and both expanded and collapsed presentation, and the installer suite completed with 25 passing tests and one platform-specific skip.

**Files Needing Attention:** No files require follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran focused Vitest assertions against the foreground notification renderer after building the local AI workspace dependency; 2 of 2 assertions passed for completed, failed, and interrupted backgrounds and for collapsed and expanded completion content.
- Ran the changed POSIX installer test suite; 25 tests passed and one platform-specific test was skipped, including the archive fixture permission assertion.
- Tried a base-worktree renderer validation, but it could not start because linked package dependencies were unavailable, while HEAD checks completed successfully.
- Validated renderer and archive results after capture; the renderer reported exit code 0 with 2 passing assertions, and the archive reported exit code 0 with 25 passing tests.

<a href="https://app.greptile.com/trex/runs/20578257/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(subagents): describe tool-block com..."](https://github.com/bastani-inc/atomic/commit/de83c63ac021c5b3cfc94a3458b6b6f22c74901d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56640322)</sub>

<!-- /greptile_comment -->