### PR TITLE
fix(subagents): map parent abort onto interrupted recovery

### DIFF
--- a/packages/subagents/src/runs/inprocess/runner.ts
+++ b/packages/subagents/src/runs/inprocess/runner.ts
@@ -479,6 +479,7 @@ function createTestSession(sessionManager: SessionManager, spec: ChildSpec): Age
 						lastAssistantText = "";
 						appendAssistant([{ type: "thinking", thinking: "aborted mid-thought" }], "aborted");
 					}
+					for (const event of testOptions.events ?? []) for (const listener of listeners) listener(event);
 					return "";
 				}
 			}
@@ -561,7 +562,7 @@ function cancelledEnvelope(session: AgentSession | undefined, spec: ChildSpec, s
 			session?.messages as Parameters<typeof lastNonEmptyAssistantText>[0],
 			outputFor(session),
 		),
-		toolCount: session === undefined ? undefined : stats.toolCalls,
+		toolCount: stats.toolCalls,
 		sessionPath: session?.sessionFile ?? spec.sessionFile,
 		...(spec.progressArtifactPath ? { progressArtifactPath: spec.progressArtifactPath } : {}),
 		...(spec.outputArtifactPath ? { outputArtifactPath: spec.outputArtifactPath } : {}),
@@ -1040,7 +1041,7 @@ export class SubagentControlRuntime {
 					}
 				}
 				if (emission !== "none") emitProgress(emission === "force");
-				if (event.type === "model_fallback_start") {
+				if (event.type === "model_fallback_start" && !signals.abort.aborted) {
 					if (!attemptedModels.includes(event.to)) attemptedModels.push(event.to);
 					effectiveModelId = event.to;
 					progressState.model = event.to;

--- a/packages/subagents/src/runs/inprocess/runner.ts
+++ b/packages/subagents/src/runs/inprocess/runner.ts
@@ -45,6 +45,11 @@ import {
 	type MaxOutputConfig,
 	truncateOutput,
 } from "../../shared/types.js";
+import {
+	lastNonEmptyAssistantText,
+	PARENT_CANCEL_CAUSE,
+	recoverCancelledChildOutput,
+} from "../shared/cancellation-recovery.js";
 import { type ChildModePolicy, resolveChildModePolicy } from "./child-policy.js";
 import { createInProcessChildPromptBehavior, createInProcessChildSystemPromptTransform } from "./prompt-behavior.js";
 
@@ -79,6 +84,12 @@ export interface TestSessionOptions {
 	readonly sessionThinkingLevel?: string;
 	/** Test-only session events emitted in order after the initial agent_start event. */
 	readonly events?: readonly AgentSessionEvent[];
+	/** Seed an earlier assistant message so abort recovery can find real text. */
+	readonly seededAssistantText?: string;
+	/** After abort, append a thinking-only aborted message with no text. */
+	readonly thinkingOnlyOnAbort?: boolean;
+	/** Emit the fallback event before the prompt gate so abort can preserve live fallback metadata. */
+	readonly fallbackBeforeGate?: boolean;
 }
 
 export interface ChildSpec {
@@ -105,8 +116,13 @@ export interface ChildSpec {
 	 * candidate-advancement behavior main chat and workflow stages share.
 	 */
 	readonly fallbackModels?: readonly string[];
-	/** Live progress callback for the parent's tool-result rendering. */
 	readonly onProgress?: (progress: AgentProgress) => void;
+	/** Run-scoped progress.md path used to recover partial findings after parent abort. */
+	readonly progressPath?: string;
+	/** Persisted progress.md path to cite after parent cancellation. */
+	readonly progressArtifactPath?: string;
+	/** Persisted output artifact path to cite after parent cancellation. */
+	readonly outputArtifactPath?: string;
 }
 
 export interface ChildPolicy extends ChildModePolicy {
@@ -199,12 +215,14 @@ export type AttemptOutcome = (
 	  }
 	| {
 			readonly status: "interrupted";
+			readonly cause?: string;
 			readonly stats: AttemptStats;
 			readonly path: string;
 			readonly envelope: string;
 			readonly sessionFile?: string;
 			readonly model?: string;
 			readonly thinking?: string;
+			readonly attemptedModels?: readonly string[];
 	  }
 	| {
 			readonly status: "continued";
@@ -364,6 +382,11 @@ function createTestSession(sessionManager: SessionManager, spec: ChildSpec): Age
 	let lastAssistantText = "";
 	let aborted = false;
 	let settlePromptAbort: (() => void) | undefined;
+	const messages: Array<{
+		role: string;
+		content: Array<{ type: "text"; text: string } | { type: "thinking"; thinking: string }>;
+		stopReason?: string;
+	}> = [];
 	const promptAbort = new Promise<"aborted">((resolve, reject) => {
 		settlePromptAbort = () => {
 			if (testOptions.abortResolvesPrompt) resolve("aborted");
@@ -374,10 +397,35 @@ function createTestSession(sessionManager: SessionManager, spec: ChildSpec): Age
 	let assistantMessages = 0;
 	const zeroTokens = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
 	const zeroCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
+	const appendAssistant = (
+		content: Array<{ type: "text"; text: string } | { type: "thinking"; thinking: string }>,
+		stopReason: "stop" | "aborted",
+	): void => {
+		messages.push({ role: "assistant", content, stopReason });
+		sessionManager.appendMessage({
+			role: "assistant",
+			content,
+			api: "openai-responses",
+			provider: "openai",
+			model: "gpt-5.4",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: zeroCost,
+			},
+			stopReason,
+			timestamp: Date.now(),
+		});
+		assistantMessages += 1;
+	};
 	return {
 		sessionFile: sessionManager.getSessionFile(),
 		model: sessionModel,
 		thinkingLevel: testOptions.sessionThinkingLevel,
+		messages,
 		abort: async () => {
 			aborted = true;
 			settlePromptAbort?.();
@@ -387,22 +435,8 @@ function createTestSession(sessionManager: SessionManager, spec: ChildSpec): Age
 			return () => listeners.delete(listener);
 		},
 		prompt: async (text: string) => {
-			for (const listener of listeners) listener({ type: "agent_start" } as AgentSessionEvent);
-			if (aborted) throw new Error("aborted");
-			if (testOptions.promptLogPath) appendFileSync(testOptions.promptLogPath, `${text}\n---PROMPT---\n`, "utf8");
-			sessionManager.appendMessage({ role: "user", content: text, timestamp: Date.now() });
-			userMessages += 1;
-			if (testOptions.promptGate) {
-				const gateResult = await Promise.race([
-					testOptions.promptGate.then(() => "released" as const),
-					promptAbort,
-				]);
-				if (gateResult === "aborted") return "";
-			}
-			for (const event of testOptions.events ?? []) {
-				for (const listener of listeners) listener(event);
-			}
-			if (testOptions.fallbackModel) {
+			const emitFallback = (): void => {
+				if (!testOptions.fallbackModel) return;
 				for (const listener of listeners) {
 					listener({
 						type: "model_fallback_start",
@@ -424,29 +458,51 @@ function createTestSession(sessionManager: SessionManager, spec: ChildSpec): Age
 						args: {},
 					} as AgentSessionEvent);
 				}
+			};
+			for (const listener of listeners) listener({ type: "agent_start" } as AgentSessionEvent);
+			if (aborted) throw new Error("aborted");
+			if (testOptions.promptLogPath) appendFileSync(testOptions.promptLogPath, `${text}\n---PROMPT---\n`, "utf8");
+			sessionManager.appendMessage({ role: "user", content: text, timestamp: Date.now() });
+			userMessages += 1;
+			if (testOptions.seededAssistantText) {
+				lastAssistantText = testOptions.seededAssistantText;
+				appendAssistant([{ type: "text", text: lastAssistantText }], "stop");
 			}
+			if (testOptions.fallbackBeforeGate) emitFallback();
+			if (testOptions.promptGate) {
+				const gateResult = await Promise.race([
+					testOptions.promptGate.then(() => "released" as const),
+					promptAbort,
+				]);
+				if (gateResult === "aborted") {
+					if (testOptions.thinkingOnlyOnAbort) {
+						lastAssistantText = "";
+						appendAssistant([{ type: "thinking", thinking: "aborted mid-thought" }], "aborted");
+					}
+					return "";
+				}
+			}
+			for (const event of testOptions.events ?? []) {
+				for (const listener of listeners) listener(event);
+			}
+			if (!testOptions.fallbackBeforeGate) emitFallback();
 			lastAssistantText = testOptions.output ?? "done";
-			sessionManager.appendMessage({
-				role: "assistant",
-				content: [{ type: "text", text: lastAssistantText }],
-				api: "openai-responses",
-				provider: "openai",
-				model: "gpt-5.4",
-				usage: {
-					input: 0,
-					output: 0,
-					cacheRead: 0,
-					cacheWrite: 0,
-					totalTokens: 0,
-					cost: zeroCost,
-				},
-				stopReason: "stop",
-				timestamp: Date.now(),
-			});
-			assistantMessages += 1;
+			appendAssistant([{ type: "text", text: lastAssistantText }], "stop");
 			return lastAssistantText;
 		},
-		getLastAssistantText: () => lastAssistantText,
+		getLastAssistantText: () => {
+			const lastAssistant = [...messages].reverse().find((message) => {
+				if (message.role !== "assistant") return false;
+				if (message.stopReason === "aborted" && message.content.length === 0) return false;
+				return true;
+			});
+			if (!lastAssistant) return lastAssistantText || undefined;
+			let text = "";
+			for (const content of lastAssistant.content) {
+				if (content.type === "text") text += content.text ?? "";
+			}
+			return text.trim() || undefined;
+		},
 		getSessionStats: () => ({
 			sessionFile: sessionManager.getSessionFile(),
 			sessionId: sessionManager.getSessionId(),
@@ -496,6 +552,26 @@ function statsFor(session: AgentSession | undefined, fallbackSessionId: string):
 
 function outputFor(session: AgentSession | undefined): string {
 	return session?.getLastAssistantText() ?? "";
+}
+
+function cancelledEnvelope(session: AgentSession | undefined, spec: ChildSpec, stats: AttemptStats): string {
+	return recoverCancelledChildOutput({
+		progressPath: spec.progressPath,
+		assistantText: lastNonEmptyAssistantText(
+			session?.messages as Parameters<typeof lastNonEmptyAssistantText>[0],
+			outputFor(session),
+		),
+		toolCount: session === undefined ? undefined : stats.toolCalls,
+		sessionPath: session?.sessionFile ?? spec.sessionFile,
+		...(spec.progressArtifactPath ? { progressArtifactPath: spec.progressArtifactPath } : {}),
+		...(spec.outputArtifactPath ? { outputArtifactPath: spec.outputArtifactPath } : {}),
+	}).text;
+}
+
+function attemptStatus(termination: TerminationCauseName | undefined): "ok" | "error" | "interrupted" {
+	if (termination === "interrupt" || termination === PARENT_CANCEL_CAUSE) return "interrupted";
+	if (termination) return "error";
+	return "ok";
 }
 
 function boundedEnvelope(output: string, artifactPath?: string, maxOutput?: MaxOutputConfig): string {
@@ -754,26 +830,31 @@ export class SubagentControlRuntime {
 			const waitResult = await waitForExecutionCapacity(retryDelayMs, signals);
 			if (waitResult !== "retry") {
 				const stats = { ...EMPTY_STATS, sessionId: admitted.identity.path };
-				const status = waitResult === "interrupt" ? "interrupted" : "error";
-				this.native.publishChildStatus(admitted.identity.path, nativeStatus(status));
-				return status === "interrupted"
-					? {
-							status,
-							stats,
-							path: admitted.identity.path,
-							envelope: INTERRUPTED_ENVELOPE,
-							...(effectiveModelId === undefined ? {} : { model: effectiveModelId }),
-							...(effectiveThinking === undefined ? {} : { thinking: effectiveThinking }),
-						}
-					: {
-							status,
-							cause: waitResult,
-							stats,
-							path: admitted.identity.path,
-							envelope: boundedEnvelope(waitResult),
-							...(effectiveModelId === undefined ? {} : { model: effectiveModelId }),
-							...(effectiveThinking === undefined ? {} : { thinking: effectiveThinking }),
-						};
+				if (waitResult === "interrupt" || waitResult === PARENT_CANCEL_CAUSE) {
+					this.native.publishChildStatus(admitted.identity.path, nativeStatus("interrupted"));
+					return {
+						status: "interrupted",
+						...(waitResult === PARENT_CANCEL_CAUSE ? { cause: PARENT_CANCEL_CAUSE } : {}),
+						stats,
+						path: admitted.identity.path,
+						envelope:
+							waitResult === PARENT_CANCEL_CAUSE
+								? cancelledEnvelope(undefined, admitted.spec, stats)
+								: INTERRUPTED_ENVELOPE,
+						...(effectiveModelId === undefined ? {} : { model: effectiveModelId }),
+						...(effectiveThinking === undefined ? {} : { thinking: effectiveThinking }),
+					};
+				}
+				this.native.publishChildStatus(admitted.identity.path, nativeStatus("error"));
+				return {
+					status: "error",
+					cause: waitResult,
+					stats,
+					path: admitted.identity.path,
+					envelope: boundedEnvelope(waitResult),
+					...(effectiveModelId === undefined ? {} : { model: effectiveModelId }),
+					...(effectiveThinking === undefined ? {} : { thinking: effectiveThinking }),
+				};
 			}
 			retryDelayMs = Math.min(retryDelayMs * 2, CAPACITY_RETRY_MAX_DELAY_MS);
 		}
@@ -980,18 +1061,32 @@ export class SubagentControlRuntime {
 			const stats = statsFor(session, admitted.identity.path);
 			const sessionFile = session.sessionFile;
 			const output = outputFor(session);
-			const status: "ok" | "error" | "interrupted" =
-				termination === "interrupt" ? "interrupted" : termination ? "error" : "ok";
+			const status = attemptStatus(termination);
 			this.native.publishChildStatus(admitted.identity.path, nativeStatus(status));
 			this.native.finishChildAttempt(token, nativeStatus(status));
 			const envelope =
-				status === "interrupted"
-					? INTERRUPTED_ENVELOPE
-					: boundedEnvelope(output || termination || "(no output)", undefined);
+				termination === PARENT_CANCEL_CAUSE
+					? cancelledEnvelope(session, admitted.spec, stats)
+					: status === "interrupted"
+						? INTERRUPTED_ENVELOPE
+						: boundedEnvelope(output || termination || "(no output)", undefined);
 			if (status === "ok")
 				return {
 					status,
 					output,
+					stats,
+					path: admitted.identity.path,
+					envelope,
+					sessionFile,
+					...(effectiveModelId === undefined ? {} : { model: effectiveModelId }),
+					...(effectiveThinking === undefined ? {} : { thinking: effectiveThinking }),
+					...(attemptedModels.length > 1 ? { attemptedModels: [...attemptedModels] } : {}),
+					...skillReport,
+				};
+			if (status === "interrupted")
+				return {
+					status,
+					...(termination === PARENT_CANCEL_CAUSE ? { cause: PARENT_CANCEL_CAUSE } : {}),
 					stats,
 					path: admitted.identity.path,
 					envelope,
@@ -1010,42 +1105,47 @@ export class SubagentControlRuntime {
 				sessionFile,
 				...(effectiveModelId === undefined ? {} : { model: effectiveModelId }),
 				...(effectiveThinking === undefined ? {} : { thinking: effectiveThinking }),
-				...(status === "error" && attemptedModels.length > 1 ? { attemptedModels: [...attemptedModels] } : {}),
+				...(attemptedModels.length > 1 ? { attemptedModels: [...attemptedModels] } : {}),
 				...skillReport,
 			};
 		} catch (error) {
 			const stats = statsFor(session, admitted.identity.path);
 			const cause = error instanceof Error ? error.message : String(error);
-			const status: "interrupted" | "error" = termination === "interrupt" ? "interrupted" : "error";
+			const status = attemptStatus(termination) === "interrupted" ? "interrupted" : "error";
 			this.native.publishChildStatus(admitted.identity.path, nativeStatus(status));
 			try {
 				this.native.finishChildAttempt(token, nativeStatus(status));
 			} catch {
 				// Preserve the original failure when Rust already stamped termination.
 			}
-			return status === "interrupted"
-				? {
-						status,
-						stats,
-						path: admitted.identity.path,
-						envelope: INTERRUPTED_ENVELOPE,
-						sessionFile: session?.sessionFile,
-						...(effectiveModelId === undefined ? {} : { model: effectiveModelId }),
-						...(effectiveThinking === undefined ? {} : { thinking: effectiveThinking }),
-						...skillReport,
-					}
-				: {
-						status,
-						cause,
-						stats,
-						path: admitted.identity.path,
-						envelope: boundedEnvelope(cause),
-						sessionFile: session?.sessionFile,
-						...(effectiveModelId === undefined ? {} : { model: effectiveModelId }),
-						...(effectiveThinking === undefined ? {} : { thinking: effectiveThinking }),
-						...(attemptedModels.length > 1 ? { attemptedModels: [...attemptedModels] } : {}),
-						...skillReport,
-					};
+			if (status === "interrupted")
+				return {
+					status,
+					...(termination === PARENT_CANCEL_CAUSE ? { cause: PARENT_CANCEL_CAUSE } : {}),
+					stats,
+					path: admitted.identity.path,
+					envelope:
+						termination === PARENT_CANCEL_CAUSE
+							? cancelledEnvelope(session, admitted.spec, stats)
+							: INTERRUPTED_ENVELOPE,
+					sessionFile: session?.sessionFile,
+					...(effectiveModelId === undefined ? {} : { model: effectiveModelId }),
+					...(effectiveThinking === undefined ? {} : { thinking: effectiveThinking }),
+					...(attemptedModels.length > 1 ? { attemptedModels: [...attemptedModels] } : {}),
+					...skillReport,
+				};
+			return {
+				status,
+				cause,
+				stats,
+				path: admitted.identity.path,
+				envelope: boundedEnvelope(cause),
+				sessionFile: session?.sessionFile,
+				...(effectiveModelId === undefined ? {} : { model: effectiveModelId }),
+				...(effectiveThinking === undefined ? {} : { thinking: effectiveThinking }),
+				...(attemptedModels.length > 1 ? { attemptedModels: [...attemptedModels] } : {}),
+				...skillReport,
+			};
 		} finally {
 			signals.abort.removeEventListener("abort", abortListener);
 			signals.interrupt.removeEventListener("abort", interruptListener);

--- a/packages/subagents/src/runs/shared/cancellation-recovery.ts
+++ b/packages/subagents/src/runs/shared/cancellation-recovery.ts
@@ -64,7 +64,7 @@ function artifactLines(input: CancellationRecoveryInput): string[] {
 	if (input.sessionPath) lines.push(`Session: ${input.sessionPath}`);
 	const progressRef = existingPath(input.progressArtifactPath);
 	if (progressRef) lines.push(`Progress: ${progressRef}`);
-	if (input.outputArtifactPath) lines.push(`Output: ${input.outputArtifactPath}`);
+	if (existingPath(input.outputArtifactPath)) lines.push(`Output: ${input.outputArtifactPath}`);
 	return lines;
 }
 

--- a/packages/subagents/src/runs/shared/cancellation-recovery.ts
+++ b/packages/subagents/src/runs/shared/cancellation-recovery.ts
@@ -1,0 +1,111 @@
+import { existsSync, readFileSync } from "node:fs";
+import { INITIAL_PROGRESS_CONTENT } from "../../shared/progress-content.js";
+import { truncateOutput } from "../../shared/types-output.js";
+
+export { INITIAL_PROGRESS_CONTENT };
+
+export const PARENT_CANCEL_CAUSE = "abort";
+
+const PARTIAL_FINDINGS_MAX = { bytes: 32 * 1024, lines: 200 } as const;
+
+export type CancellationRecoverySource = "progress.md" | "assistant" | "none";
+
+export interface CancellationRecoveryInput {
+	readonly progressPath?: string;
+	readonly assistantText?: string;
+	readonly toolCount?: number;
+	readonly sessionPath?: string;
+	readonly outputArtifactPath?: string;
+	readonly progressArtifactPath?: string;
+}
+
+export interface CancellationRecovery {
+	readonly text: string;
+	readonly source: CancellationRecoverySource;
+}
+
+export function isParentCancellation(cause: string | undefined): boolean {
+	return cause === PARENT_CANCEL_CAUSE;
+}
+
+export function readModifiedProgress(progressPath: string | undefined): string | undefined {
+	if (!progressPath) return undefined;
+	try {
+		const content = readFileSync(progressPath, "utf8");
+		if (content.trim() === INITIAL_PROGRESS_CONTENT.trim()) return undefined;
+		const trimmed = content.trim();
+		return trimmed ? content : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function lastNonEmptyText(value: string | undefined): string | undefined {
+	const trimmed = value?.trim();
+	return trimmed ? value : undefined;
+}
+
+function existingPath(pathValue: string | undefined): string | undefined {
+	return pathValue && existsSync(pathValue) ? pathValue : undefined;
+}
+
+function boundPartial(text: string, artifactPath?: string): string {
+	return truncateOutput(text, PARTIAL_FINDINGS_MAX, existingPath(artifactPath)).text;
+}
+
+function afterLabel(toolCount: number | undefined): string {
+	return typeof toolCount === "number" && toolCount > 0
+		? ` after ${toolCount} tool call${toolCount === 1 ? "" : "s"}`
+		: "";
+}
+
+function artifactLines(input: CancellationRecoveryInput): string[] {
+	const lines: string[] = [];
+	if (input.sessionPath) lines.push(`Session: ${input.sessionPath}`);
+	const progressRef = existingPath(input.progressArtifactPath);
+	if (progressRef) lines.push(`Progress: ${progressRef}`);
+	if (input.outputArtifactPath) lines.push(`Output: ${input.outputArtifactPath}`);
+	return lines;
+}
+
+export function recoverCancelledChildOutput(input: CancellationRecoveryInput): CancellationRecovery {
+	const progress = readModifiedProgress(input.progressPath);
+	const assistant = lastNonEmptyText(input.assistantText);
+	const source: CancellationRecoverySource = progress ? "progress.md" : assistant ? "assistant" : "none";
+	const lines = [`Run cancelled by parent${afterLabel(input.toolCount)}.`, ""];
+	if (progress) {
+		lines.push("Partial findings from progress.md:", boundPartial(progress, input.progressArtifactPath), "");
+	} else if (assistant) {
+		lines.push("Partial findings from assistant history:", boundPartial(assistant), "");
+	}
+	lines.push("This is incomplete and has not been validated as a final answer.");
+	const refs = artifactLines(input);
+	if (refs.length) lines.push("", ...refs);
+	return { text: lines.join("\n"), source };
+}
+
+export function lastNonEmptyAssistantText(
+	messages: readonly { role?: string; content?: readonly { type?: string; text?: string }[] | string }[] | undefined,
+	fallback?: string,
+): string {
+	if (messages) {
+		for (let index = messages.length - 1; index >= 0; index--) {
+			const message = messages[index];
+			if (message?.role !== "assistant") continue;
+			if (typeof message.content === "string") {
+				if (message.content.trim()) return message.content;
+				continue;
+			}
+			const text = (message.content ?? [])
+				.filter((part) => part.type === "text" && part.text)
+				.map((part) => part.text)
+				.join("");
+			if (text.trim()) return text;
+		}
+	}
+	return lastNonEmptyText(fallback) ?? "";
+}
+
+export function presentCancelledStatus(status: string, cause?: string): string {
+	return status === "interrupted" && isParentCancellation(cause) ? "cancelled" : status;
+}

--- a/packages/subagents/src/runs/shared/cancellation-recovery.ts
+++ b/packages/subagents/src/runs/shared/cancellation-recovery.ts
@@ -45,12 +45,12 @@ function lastNonEmptyText(value: string | undefined): string | undefined {
 	return trimmed ? value : undefined;
 }
 
-function existingPath(pathValue: string | undefined): string | undefined {
+export function existingArtifactPath(pathValue: string | undefined): string | undefined {
 	return pathValue && existsSync(pathValue) ? pathValue : undefined;
 }
 
 function boundPartial(text: string, artifactPath?: string): string {
-	return truncateOutput(text, PARTIAL_FINDINGS_MAX, existingPath(artifactPath)).text;
+	return truncateOutput(text, PARTIAL_FINDINGS_MAX, existingArtifactPath(artifactPath)).text;
 }
 
 function afterLabel(toolCount: number | undefined): string {
@@ -61,10 +61,14 @@ function afterLabel(toolCount: number | undefined): string {
 
 function artifactLines(input: CancellationRecoveryInput): string[] {
 	const lines: string[] = [];
-	if (input.sessionPath) lines.push(`Session: ${input.sessionPath}`);
-	const progressRef = existingPath(input.progressArtifactPath);
-	if (progressRef) lines.push(`Progress: ${progressRef}`);
-	if (existingPath(input.outputArtifactPath)) lines.push(`Output: ${input.outputArtifactPath}`);
+	for (const [label, pathValue] of [
+		["Session", input.sessionPath],
+		["Progress", input.progressArtifactPath],
+		["Output", input.outputArtifactPath],
+	] as const) {
+		const existing = existingArtifactPath(pathValue);
+		if (existing) lines.push(`${label}: ${existing}`);
+	}
 	return lines;
 }
 

--- a/packages/subagents/src/shared/progress-content.ts
+++ b/packages/subagents/src/shared/progress-content.ts
@@ -1,0 +1,3 @@
+/** Canonical initial contents of a run-scoped progress.md template. */
+export const INITIAL_PROGRESS_CONTENT =
+	"# Progress\n\n## Status\nIn Progress\n\n## Tasks\n\n## Files Changed\n\n## Notes\n";

--- a/test/unit/subagents-foreground-intercom-detach.test.ts
+++ b/test/unit/subagents-foreground-intercom-detach.test.ts
@@ -186,7 +186,7 @@ describe("foreground intercom detach routing", () => {
 			gate.release();
 			for (let i = 0; i < 30 && recovered.length === 0; i++) await sleep(20);
 			assert.equal(recovered.length, 1);
-			assert.equal(recovered[0]?.status, "error");
+			assert.equal(recovered[0]?.status, "interrupted");
 			assert.equal(emitter.listenerCount(INTERCOM_DETACH_REQUEST_EVENT), 0);
 		});
 	});
@@ -210,7 +210,7 @@ describe("foreground intercom detach routing", () => {
 			controller.abort();
 			gate.release();
 			const result = await pending;
-			assert.equal(result.status, "error");
+			assert.equal(result.status, "interrupted");
 			assert.equal(result.detached, undefined);
 			assert.equal(emitter.listenerCount(INTERCOM_DETACH_REQUEST_EVENT), 0);
 		});

--- a/test/unit/subagents-parent-cancellation.test.ts
+++ b/test/unit/subagents-parent-cancellation.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "vitest";
+import {
+	INITIAL_PROGRESS_CONTENT,
+	isParentCancellation,
+	readModifiedProgress,
+	recoverCancelledChildOutput,
+} from "../../packages/subagents/src/runs/shared/cancellation-recovery.ts";
+
+test("an untouched progress template is not treated as recoverable findings", () => {
+	const root = mkdtempSync(join(tmpdir(), "atomic-cancel-progress-empty-"));
+	try {
+		const progressPath = join(root, "progress.md");
+		writeFileSync(progressPath, INITIAL_PROGRESS_CONTENT);
+		assert.equal(readModifiedProgress(progressPath), undefined);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("a modified progress.md is recovered as bounded labelled partial output", () => {
+	const root = mkdtempSync(join(tmpdir(), "atomic-cancel-progress-"));
+	try {
+		const progressPath = join(root, "progress.md");
+		writeFileSync(progressPath, "# Progress\n\n- Found auth middleware\n- Still unresolved: token refresh\n");
+		const recovered = recoverCancelledChildOutput({
+			progressPath,
+			assistantText: "later unused assistant text",
+			toolCount: 70,
+			sessionPath: "/tmp/session.jsonl",
+			outputArtifactPath: "/tmp/out.md",
+		});
+		assert.equal(recovered.source, "progress.md");
+		assert.match(recovered.text, /Run cancelled by parent after 70 tool calls/);
+		assert.match(recovered.text, /Partial findings from progress\.md/);
+		assert.match(recovered.text, /Found auth middleware/);
+		assert.match(recovered.text, /incomplete and has not been validated/);
+		assert.match(recovered.text, /Session: \/tmp\/session\.jsonl/);
+		assert.doesNotMatch(recovered.text, /Progress: /);
+		assert.match(recovered.text, /Output: \/tmp\/out\.md/);
+		assert.doesNotMatch(recovered.text, /\bcompleted\b/i);
+		assert.doesNotMatch(recovered.text, /^abort$/m);
+		assert.doesNotMatch(recovered.text, /full output at /);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("oversized ephemeral progress truncates without citing the deleted path", () => {
+	const root = mkdtempSync(join(tmpdir(), "atomic-cancel-progress-truncate-"));
+	try {
+		const progressPath = join(root, "progress.md");
+		writeFileSync(
+			progressPath,
+			`${Array.from({ length: 201 }, (_, index) => `- finding ${index + 1}`).join("\n")}\n`,
+		);
+		const recovered = recoverCancelledChildOutput({
+			progressPath,
+			toolCount: 70,
+		});
+		assert.equal(recovered.source, "progress.md");
+		assert.match(recovered.text, /Partial findings from progress\.md/);
+		assert.match(recovered.text, /TRUNCATED:/);
+		assert.doesNotMatch(recovered.text, /full output at /);
+		assert.doesNotMatch(recovered.text, /Progress: /);
+		assert.ok(!recovered.text.includes(progressPath));
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("oversized persisted progress cites the artifact path in the truncation marker", () => {
+	const root = mkdtempSync(join(tmpdir(), "atomic-cancel-progress-truncate-kept-"));
+	try {
+		const progressPath = join(root, "progress.md");
+		const progressArtifactPath = join(root, "kept", "progress.md");
+		writeFileSync(
+			progressPath,
+			`${Array.from({ length: 201 }, (_, index) => `- finding ${index + 1}`).join("\n")}\n`,
+		);
+		mkdirSync(join(root, "kept"), { recursive: true });
+		writeFileSync(progressArtifactPath, "kept\n");
+		const recovered = recoverCancelledChildOutput({
+			progressPath,
+			progressArtifactPath,
+			toolCount: 4,
+		});
+		assert.equal(recovered.source, "progress.md");
+		assert.match(recovered.text, /TRUNCATED:/);
+		assert.match(recovered.text, new RegExp(`full output at ${progressArtifactPath.replaceAll("/", "\\/")}`));
+		assert.match(recovered.text, new RegExp(`Progress: ${progressArtifactPath.replaceAll("/", "\\/")}`));
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("without progress updates, recovery uses the last non-empty assistant text", () => {
+	const recovered = recoverCancelledChildOutput({
+		assistantText: "Verified the login redirect.",
+		toolCount: 23,
+		sessionPath: "/tmp/session.jsonl",
+	});
+	assert.equal(recovered.source, "assistant");
+	assert.match(recovered.text, /Partial findings from assistant history/);
+	assert.match(recovered.text, /Verified the login redirect/);
+	assert.match(recovered.text, /incomplete and has not been validated/);
+});
+
+test("without recoverable content, recovery returns a cancellation notice and artifact refs", () => {
+	const recovered = recoverCancelledChildOutput({
+		toolCount: 0,
+		sessionPath: "/tmp/session.jsonl",
+		outputArtifactPath: "/tmp/out.md",
+		progressPath: "/tmp/progress.md",
+		progressArtifactPath: "/tmp/progress.md",
+	});
+	assert.equal(recovered.source, "none");
+	assert.match(recovered.text, /Run cancelled by parent/);
+	assert.doesNotMatch(recovered.text, /after 0 tool calls/);
+	assert.match(recovered.text, /Session: \/tmp\/session\.jsonl/);
+	assert.match(recovered.text, /Output: \/tmp\/out\.md/);
+	assert.doesNotMatch(recovered.text, /Progress: /);
+	assert.doesNotMatch(recovered.text, /^abort$/);
+	assert.equal(isParentCancellation("abort"), true);
+	assert.equal(isParentCancellation("interrupt"), false);
+});
+
+test("cancelled envelopes cite a progress artifact only when that file exists", () => {
+	const root = mkdtempSync(join(tmpdir(), "atomic-cancel-progress-exists-"));
+	try {
+		const missing = recoverCancelledChildOutput({
+			progressArtifactPath: join(root, "missing.md"),
+		});
+		assert.doesNotMatch(missing.text, /Progress: /);
+		const progressArtifactPath = join(root, "progress.md");
+		writeFileSync(progressArtifactPath, "# Progress\n\n- Kept finding\n");
+		const present = recoverCancelledChildOutput({
+			progressPath: progressArtifactPath,
+			progressArtifactPath,
+		});
+		assert.match(present.text, new RegExp(`Progress: ${progressArtifactPath.replaceAll("/", "\\/")}`));
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});

--- a/test/unit/subagents-parent-cancellation.test.ts
+++ b/test/unit/subagents-parent-cancellation.test.ts
@@ -10,6 +10,10 @@ import {
 	recoverCancelledChildOutput,
 } from "../../packages/subagents/src/runs/shared/cancellation-recovery.ts";
 
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 test("an untouched progress template is not treated as recoverable findings", () => {
 	const root = mkdtempSync(join(tmpdir(), "atomic-cancel-progress-empty-"));
 	try {
@@ -40,7 +44,7 @@ test("a modified progress.md is recovered as bounded labelled partial output", (
 		assert.match(recovered.text, /incomplete and has not been validated/);
 		assert.match(recovered.text, /Session: \/tmp\/session\.jsonl/);
 		assert.doesNotMatch(recovered.text, /Progress: /);
-		assert.match(recovered.text, /Output: \/tmp\/out\.md/);
+		assert.doesNotMatch(recovered.text, /Output: /);
 		assert.doesNotMatch(recovered.text, /\bcompleted\b/i);
 		assert.doesNotMatch(recovered.text, /^abort$/m);
 		assert.doesNotMatch(recovered.text, /full output at /);
@@ -73,27 +77,33 @@ test("without recoverable content, recovery returns a cancellation notice and ar
 	assert.match(recovered.text, /Run cancelled by parent/);
 	assert.doesNotMatch(recovered.text, /after 0 tool calls/);
 	assert.match(recovered.text, /Session: \/tmp\/session\.jsonl/);
-	assert.match(recovered.text, /Output: \/tmp\/out\.md/);
+	assert.doesNotMatch(recovered.text, /Output: /);
 	assert.doesNotMatch(recovered.text, /Progress: /);
 	assert.doesNotMatch(recovered.text, /^abort$/);
 	assert.equal(isParentCancellation("abort"), true);
 	assert.equal(isParentCancellation("interrupt"), false);
 });
 
-test("cancelled envelopes cite a progress artifact only when that file exists", () => {
+test("cancelled envelopes cite progress and output artifacts only when those files exist", () => {
 	const root = mkdtempSync(join(tmpdir(), "atomic-cancel-progress-exists-"));
 	try {
 		const missing = recoverCancelledChildOutput({
 			progressArtifactPath: join(root, "missing.md"),
+			outputArtifactPath: join(root, "missing-out.md"),
 		});
 		assert.doesNotMatch(missing.text, /Progress: /);
+		assert.doesNotMatch(missing.text, /Output: /);
 		const progressArtifactPath = join(root, "progress.md");
+		const outputArtifactPath = join(root, "out.md");
 		writeFileSync(progressArtifactPath, "# Progress\n\n- Kept finding\n");
+		writeFileSync(outputArtifactPath, "kept\n");
 		const present = recoverCancelledChildOutput({
 			progressPath: progressArtifactPath,
 			progressArtifactPath,
+			outputArtifactPath,
 		});
-		assert.match(present.text, new RegExp(`Progress: ${progressArtifactPath.replaceAll("/", "\\/")}`));
+		assert.match(present.text, new RegExp(`Progress: ${escapeRegExp(progressArtifactPath)}`));
+		assert.match(present.text, new RegExp(`Output: ${escapeRegExp(outputArtifactPath)}`));
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}

--- a/test/unit/subagents-parent-cancellation.test.ts
+++ b/test/unit/subagents-parent-cancellation.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "vitest";
@@ -44,54 +44,6 @@ test("a modified progress.md is recovered as bounded labelled partial output", (
 		assert.doesNotMatch(recovered.text, /\bcompleted\b/i);
 		assert.doesNotMatch(recovered.text, /^abort$/m);
 		assert.doesNotMatch(recovered.text, /full output at /);
-	} finally {
-		rmSync(root, { recursive: true, force: true });
-	}
-});
-
-test("oversized ephemeral progress truncates without citing the deleted path", () => {
-	const root = mkdtempSync(join(tmpdir(), "atomic-cancel-progress-truncate-"));
-	try {
-		const progressPath = join(root, "progress.md");
-		writeFileSync(
-			progressPath,
-			`${Array.from({ length: 201 }, (_, index) => `- finding ${index + 1}`).join("\n")}\n`,
-		);
-		const recovered = recoverCancelledChildOutput({
-			progressPath,
-			toolCount: 70,
-		});
-		assert.equal(recovered.source, "progress.md");
-		assert.match(recovered.text, /Partial findings from progress\.md/);
-		assert.match(recovered.text, /TRUNCATED:/);
-		assert.doesNotMatch(recovered.text, /full output at /);
-		assert.doesNotMatch(recovered.text, /Progress: /);
-		assert.ok(!recovered.text.includes(progressPath));
-	} finally {
-		rmSync(root, { recursive: true, force: true });
-	}
-});
-
-test("oversized persisted progress cites the artifact path in the truncation marker", () => {
-	const root = mkdtempSync(join(tmpdir(), "atomic-cancel-progress-truncate-kept-"));
-	try {
-		const progressPath = join(root, "progress.md");
-		const progressArtifactPath = join(root, "kept", "progress.md");
-		writeFileSync(
-			progressPath,
-			`${Array.from({ length: 201 }, (_, index) => `- finding ${index + 1}`).join("\n")}\n`,
-		);
-		mkdirSync(join(root, "kept"), { recursive: true });
-		writeFileSync(progressArtifactPath, "kept\n");
-		const recovered = recoverCancelledChildOutput({
-			progressPath,
-			progressArtifactPath,
-			toolCount: 4,
-		});
-		assert.equal(recovered.source, "progress.md");
-		assert.match(recovered.text, /TRUNCATED:/);
-		assert.match(recovered.text, new RegExp(`full output at ${progressArtifactPath.replaceAll("/", "\\/")}`));
-		assert.match(recovered.text, new RegExp(`Progress: ${progressArtifactPath.replaceAll("/", "\\/")}`));
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}

--- a/test/unit/subagents-parent-cancellation.test.ts
+++ b/test/unit/subagents-parent-cancellation.test.ts
@@ -10,10 +10,6 @@ import {
 	recoverCancelledChildOutput,
 } from "../../packages/subagents/src/runs/shared/cancellation-recovery.ts";
 
-function escapeRegExp(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 test("an untouched progress template is not treated as recoverable findings", () => {
 	const root = mkdtempSync(join(tmpdir(), "atomic-cancel-progress-empty-"));
 	try {
@@ -34,15 +30,15 @@ test("a modified progress.md is recovered as bounded labelled partial output", (
 			progressPath,
 			assistantText: "later unused assistant text",
 			toolCount: 70,
-			sessionPath: "/tmp/session.jsonl",
-			outputArtifactPath: "/tmp/out.md",
+			sessionPath: join(root, "session.jsonl"),
+			outputArtifactPath: join(root, "out.md"),
 		});
 		assert.equal(recovered.source, "progress.md");
 		assert.match(recovered.text, /Run cancelled by parent after 70 tool calls/);
 		assert.match(recovered.text, /Partial findings from progress\.md/);
 		assert.match(recovered.text, /Found auth middleware/);
 		assert.match(recovered.text, /incomplete and has not been validated/);
-		assert.match(recovered.text, /Session: \/tmp\/session\.jsonl/);
+		assert.doesNotMatch(recovered.text, /Session: /);
 		assert.doesNotMatch(recovered.text, /Progress: /);
 		assert.doesNotMatch(recovered.text, /Output: /);
 		assert.doesNotMatch(recovered.text, /\bcompleted\b/i);
@@ -57,7 +53,7 @@ test("without progress updates, recovery uses the last non-empty assistant text"
 	const recovered = recoverCancelledChildOutput({
 		assistantText: "Verified the login redirect.",
 		toolCount: 23,
-		sessionPath: "/tmp/session.jsonl",
+		sessionPath: join(tmpdir(), "atomic-cancel-absent", "session.jsonl"),
 	});
 	assert.equal(recovered.source, "assistant");
 	assert.match(recovered.text, /Partial findings from assistant history/);
@@ -68,15 +64,15 @@ test("without progress updates, recovery uses the last non-empty assistant text"
 test("without recoverable content, recovery returns a cancellation notice and artifact refs", () => {
 	const recovered = recoverCancelledChildOutput({
 		toolCount: 0,
-		sessionPath: "/tmp/session.jsonl",
-		outputArtifactPath: "/tmp/out.md",
-		progressPath: "/tmp/progress.md",
-		progressArtifactPath: "/tmp/progress.md",
+		sessionPath: join(tmpdir(), "atomic-cancel-absent", "session.jsonl"),
+		outputArtifactPath: join(tmpdir(), "atomic-cancel-absent", "out.md"),
+		progressPath: join(tmpdir(), "atomic-cancel-absent", "progress.md"),
+		progressArtifactPath: join(tmpdir(), "atomic-cancel-absent", "progress.md"),
 	});
 	assert.equal(recovered.source, "none");
 	assert.match(recovered.text, /Run cancelled by parent/);
 	assert.doesNotMatch(recovered.text, /after 0 tool calls/);
-	assert.match(recovered.text, /Session: \/tmp\/session\.jsonl/);
+	assert.doesNotMatch(recovered.text, /Session: /);
 	assert.doesNotMatch(recovered.text, /Output: /);
 	assert.doesNotMatch(recovered.text, /Progress: /);
 	assert.doesNotMatch(recovered.text, /^abort$/);
@@ -84,26 +80,23 @@ test("without recoverable content, recovery returns a cancellation notice and ar
 	assert.equal(isParentCancellation("interrupt"), false);
 });
 
-test("cancelled envelopes cite progress and output artifacts only when those files exist", () => {
-	const root = mkdtempSync(join(tmpdir(), "atomic-cancel-progress-exists-"));
+test("cancelled envelopes cite each artifact path only when that file exists", () => {
+	const root = mkdtempSync(join(tmpdir(), "atomic-cancel-refs-"));
 	try {
-		const missing = recoverCancelledChildOutput({
-			progressArtifactPath: join(root, "missing.md"),
-			outputArtifactPath: join(root, "missing-out.md"),
-		});
-		assert.doesNotMatch(missing.text, /Progress: /);
-		assert.doesNotMatch(missing.text, /Output: /);
-		const progressArtifactPath = join(root, "progress.md");
-		const outputArtifactPath = join(root, "out.md");
-		writeFileSync(progressArtifactPath, "# Progress\n\n- Kept finding\n");
-		writeFileSync(outputArtifactPath, "kept\n");
-		const present = recoverCancelledChildOutput({
-			progressPath: progressArtifactPath,
-			progressArtifactPath,
-			outputArtifactPath,
-		});
-		assert.match(present.text, new RegExp(`Progress: ${escapeRegExp(progressArtifactPath)}`));
-		assert.match(present.text, new RegExp(`Output: ${escapeRegExp(outputArtifactPath)}`));
+		const rows = [
+			["Session", "sessionPath", join(root, "session.jsonl")],
+			["Progress", "progressArtifactPath", join(root, "progress.md")],
+			["Output", "outputArtifactPath", join(root, "out.md")],
+		] as const;
+		for (const [label, key, pathValue] of rows) {
+			assert.doesNotMatch(recoverCancelledChildOutput({ [key]: pathValue }).text, new RegExp(`${label}: `));
+			writeFileSync(pathValue, "kept\n");
+			const present = recoverCancelledChildOutput({
+				[key]: pathValue,
+				...(key === "progressArtifactPath" ? { progressPath: pathValue } : {}),
+			});
+			assert.ok(present.text.includes(`${label}: ${pathValue}`));
+		}
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}


### PR DESCRIPTION
Stack 1/4 for #2635 (parent-cancelled subagents reported as failed with bare `abort` output).

Maps parent-propagated abort onto the existing interrupted/abort state (no new public status, per maintainer decision), makes it terminal and non-retryable with no model fallback, and introduces bounded recovery of partial findings: run-scoped progress.md, then last non-empty assistant text, then a clear cancellation notice citing only artifact files that actually exist.

Validation: `subagents-parent-cancellation` suite plus adjacent regression files green; per-segment tip build/tests verified. Stack: each PR ≤500 changed lines.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790270261&installation_model_id=10562&pr_number=2671&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2671&signature=ff9e5e0c57d86e3624e8a60ed61262bd773274280ca5d98adc23b5453ae8456e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds parent-cancellation recovery so interrupted child runs can return partial progress and artifact references. A focused foreground cancellation run showed that the foreground execution path does not pass the required progress and artifact paths into the child specification, causing persisted partial findings to be omitted from the returned cancellation message. This should be corrected before merge.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until foreground cancellation results retain partial progress and artifact references.

The behavior was reproduced through the real foreground in-process cancellation flow: a child wrote its only finding to progress.md before parent cancellation, but the returned envelope omitted that finding and both artifact references.

**Files Needing Attention:** packages/subagents/src/runs/foreground/inprocess-run-sync.ts needs to propagate the run-scoped progress and artifact paths into ChildSpec; packages/subagents/src/runs/inprocess/runner.ts consumes those fields during cancellation recovery.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Generated a focused foreground cancellation repro source for the P1 finding.
- Captured and inspected the observed foreground cancellation output from the repro run.
- Posted proof for the P1 finding in a review comment.
- Validated contract-level cancellation flow by evaluating envelope contents and status, noting an interrupted status with only the cancellation notice and session reference, and confirming that progress flags were false.

<a href="https://app.greptile.com/trex/runs/20631096/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/subagents/src/runs/foreground/inprocess-run-sync.ts`, line 259-321 ([link](https://github.com/bastani-inc/atomic/blob/1f6d6247275887706e1e539538e269cf847e72ed/packages/subagents/src/runs/foreground/inprocess-run-sync.ts#L259-L321)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Foreground cancellation drops partial progress**

   The foreground path creates a run-scoped `progress.md` and artifact paths, but does not pass `progressPath`, `progressArtifactPath`, or `outputArtifactPath` into `ChildSpec`. `cancelledEnvelope` relies on these fields to recover partial findings and include artifact references. When a parent aborts a child before it sends assistant text, callers receive only a generic cancellation message and session reference even though the child persisted useful findings in `progress.md`. Propagate the run-scoped progress and artifact paths when constructing `spec`.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Focused foreground parent-cancellation repro source](https://app.greptile.com/trex/artifacts/71a76368-b464-4592-bcb9-a784e8ed095d)**

   - The executable repro starts a foreground child, writes its only finding to run-scoped progress.md, aborts the parent, and asserts that the cancellation envelope lacks the finding and artifact references.

   **[Observed foreground parent-cancellation output](https://app.greptile.com/trex/artifacts/eb89d955-930c-48bb-a171-14e5e7e734aa)**

   - The successful repro output shows the progress file and its authorization-bypass finding existed while the cancellation envelope omitted the finding, progress reference, and output reference.

   <a href="https://app.greptile.com/trex/runs/20631096/artifacts?artifact=71a76368-b464-4592-bcb9-a784e8ed095d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/subagents/src/runs/foreground/inprocess-run-sync.ts
   Line: 259-321

   Comment:
   **Foreground cancellation drops partial progress**

   The foreground path creates a run-scoped `progress.md` and artifact paths, but does not pass `progressPath`, `progressArtifactPath`, or `outputArtifactPath` into `ChildSpec`. `cancelledEnvelope` relies on these fields to recover partial findings and include artifact references. When a parent aborts a child before it sends assistant text, callers receive only a generic cancellation message and session reference even though the child persisted useful findings in `progress.md`. Propagate the run-scoped progress and artifact paths when constructing `spec`.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Foreground cancellation envelope drops run-scoped progress and artifact references**

   - **Bug**
     - `packages/subagents/src/runs/foreground/inprocess-run-sync.ts:259-321` constructs `ChildSpec` without `progressPath`, `progressArtifactPath`, or `outputArtifactPath`, although `packages/subagents/src/runs/inprocess/runner.ts:558-569` consumes them to recover cancellation findings and cite artifacts. The executed parent-cancellation run preserved the progress file but returned an envelope without its sole finding or either artifact reference.
   - **Cause**
     - The foreground execution path creates and injects a run-scoped progress path but never propagates that path or the output artifact path into `ChildSpec`.
   - **Fix**
     - Pass the run-scoped progress path, persisted progress artifact path, and output artifact path through foreground run options into the constructed `ChildSpec`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/subagents/src/runs/foreground/inprocess-run-sync.ts:259-321
**Foreground cancellation drops partial progress**

The foreground path creates a run-scoped `progress.md` and artifact paths, but does not pass `progressPath`, `progressArtifactPath`, or `outputArtifactPath` into `ChildSpec`. `cancelledEnvelope` relies on these fields to recover partial findings and include artifact references. When a parent aborts a child before it sends assistant text, callers receive only a generic cancellation message and session reference even though the child persisted useful findings in `progress.md`. Propagate the run-scoped progress and artifact paths when constructing `spec`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(subagents): cite every cancelled art..."](https://github.com/bastani-inc/atomic/commit/1f6d6247275887706e1e539538e269cf847e72ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56744705)</sub>

<!-- /greptile_comment -->