### PR TITLE
fix(subagents): label parallel parent cancels instead of failures

### DIFF
--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Parent cancellation of a foreground in-process child now finishes as a terminal interrupted/abort outcome instead of `error` / failed. Parent receipts, Intercom summaries, and progress present the child as cancelled; persisted metadata keeps `status: "interrupted"` with `cause: "abort"` rather than a new public status. The run stays non-retryable, preserves any fallback metadata already recorded before abort, and recovers bounded partial findings from a modified run-scoped `progress.md`, then the last non-empty assistant text, then a cancellation notice with artifact references. Progress and Output paths are cited only when those files exist when the cancelled envelope is built. A queued child that never started does not claim "0 tool calls" ([#2635](https://github.com/bastani-inc/atomic/issues/2635)).
+- Parent cancellation of a foreground in-process child now finishes as a terminal interrupted/abort outcome instead of `error` / failed. Parent receipts, Intercom summaries, and progress present the child as cancelled; persisted metadata keeps `status: "interrupted"` with `cause: "abort"` rather than a new public status. The run stays non-retryable, preserves any fallback metadata already recorded before abort, and recovers bounded partial findings from a modified run-scoped `progress.md`, then the last non-empty assistant text, then a cancellation notice with artifact references. Progress and Output paths are cited only when those files exist when the cancelled envelope is built. A queued child that never started does not claim "0 tool calls"; a mixed completed-and-cancelled set reports `Status: cancelled` rather than `interrupted` ([#2635](https://github.com/bastani-inc/atomic/issues/2635)).
 
 ## [0.9.16-alpha.2] - 2026-08-23
 

--- a/packages/subagents/src/intercom/result-intercom.ts
+++ b/packages/subagents/src/intercom/result-intercom.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from "node:crypto";
 import { isStaleExtensionContextError } from "@bastani/atomic";
-import { PARENT_CANCEL_CAUSE, presentCancelledStatus } from "../runs/shared/cancellation-recovery.js";
+import {
+	existingArtifactPath,
+	PARENT_CANCEL_CAUSE,
+	presentCancelledStatus,
+} from "../runs/shared/cancellation-recovery.js";
 import {
 	type Details,
 	type IntercomEventBus,
@@ -75,6 +79,11 @@ function resolveGroupedStatus(children: SubagentResultIntercomChild[]): Subagent
 	return "failed";
 }
 
+function citedChildPath(child: SubagentResultIntercomChild, pathValue: string | undefined): string | undefined {
+	if (presentCancelledStatus(child.status, child.cause) !== "cancelled") return pathValue;
+	return existingArtifactPath(pathValue);
+}
+
 export interface GroupedResultIntercomMessageInput {
 	to: string;
 	runId: string;
@@ -116,8 +125,8 @@ function formatSubagentResultIntercomMessage(input: {
 		const child = input.children[index]!;
 		lines.push("", `${index + 1}. ${child.agent} — ${presentCancelledStatus(child.status, child.cause)}`);
 		if (child.intercomTarget) lines.push(`Run intercom target: ${child.intercomTarget}`);
-		if (child.artifactPath) lines.push(`Output artifact: ${child.artifactPath}`);
-		if (child.sessionPath) lines.push(`Session: ${child.sessionPath}`);
+		if (citedChildPath(child, child.artifactPath)) lines.push(`Output artifact: ${child.artifactPath}`);
+		if (citedChildPath(child, child.sessionPath)) lines.push(`Session: ${child.sessionPath}`);
 		lines.push("Summary:", child.summary);
 	}
 
@@ -138,7 +147,7 @@ export function buildSubagentResultIntercomPayload(
 		to: input.to,
 		runId: input.runId,
 		mode: input.mode,
-		status,
+		status: presentCancelledStatus(status, groupedParentCancelCause(children)) as SubagentResultStatus,
 		summary,
 		children,
 		...(firstChild?.agent ? { agent: firstChild.agent } : {}),
@@ -239,7 +248,7 @@ export function formatSubagentResultReceipt(input: {
 		`Children: ${formatStatusCounts(input.payload.children)}`,
 	];
 
-	const artifacts = input.payload.children.filter((child) => typeof child.artifactPath === "string");
+	const artifacts = input.payload.children.filter((child) => citedChildPath(child, child.artifactPath));
 	if (artifacts.length > 0) {
 		lines.push("Artifacts:");
 		for (const child of artifacts) {
@@ -255,7 +264,7 @@ export function formatSubagentResultReceipt(input: {
 		}
 	}
 
-	const sessions = input.payload.children.filter((child) => typeof child.sessionPath === "string");
+	const sessions = input.payload.children.filter((child) => citedChildPath(child, child.sessionPath));
 	if (sessions.length > 0) {
 		lines.push("Sessions:");
 		for (const child of sessions) {

--- a/packages/subagents/src/intercom/result-intercom.ts
+++ b/packages/subagents/src/intercom/result-intercom.ts
@@ -147,7 +147,7 @@ export function buildSubagentResultIntercomPayload(
 		to: input.to,
 		runId: input.runId,
 		mode: input.mode,
-		status: presentCancelledStatus(status, groupedParentCancelCause(children)) as SubagentResultStatus,
+		status,
 		summary,
 		children,
 		...(firstChild?.agent ? { agent: firstChild.agent } : {}),

--- a/packages/subagents/src/intercom/result-intercom.ts
+++ b/packages/subagents/src/intercom/result-intercom.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { isStaleExtensionContextError } from "@bastani/atomic";
+import { PARENT_CANCEL_CAUSE, presentCancelledStatus } from "../runs/shared/cancellation-recovery.js";
 import {
 	type Details,
 	type IntercomEventBus,
@@ -41,12 +42,26 @@ function countStatuses(children: SubagentResultIntercomChild[]): Record<Subagent
 	return counts;
 }
 
-function formatStatusCounts(counts: Record<SubagentResultStatus, number>): string {
+function formatStatusCounts(children: SubagentResultIntercomChild[]): string {
+	let completed = 0;
+	let failed = 0;
+	let interrupted = 0;
+	let cancelled = 0;
+	let detached = 0;
+	for (const child of children) {
+		const label = presentCancelledStatus(child.status, child.cause);
+		if (label === "cancelled") cancelled += 1;
+		else if (label === "completed") completed += 1;
+		else if (label === "failed") failed += 1;
+		else if (label === "interrupted") interrupted += 1;
+		else if (label === "detached") detached += 1;
+	}
 	const parts = [
-		counts.completed ? `${counts.completed} completed` : undefined,
-		counts.failed ? `${counts.failed} failed` : undefined,
-		counts.interrupted ? `${counts.interrupted} interrupted` : undefined,
-		counts.detached ? `${counts.detached} detached` : undefined,
+		completed ? `${completed} completed` : undefined,
+		failed ? `${failed} failed` : undefined,
+		cancelled ? `${cancelled} cancelled` : undefined,
+		interrupted ? `${interrupted} interrupted` : undefined,
+		detached ? `${detached} detached` : undefined,
 	].filter((part): part is string => Boolean(part));
 	return parts.length ? parts.join(", ") : "0 results";
 }
@@ -67,20 +82,28 @@ export interface GroupedResultIntercomMessageInput {
 	children: SubagentResultIntercomChild[];
 }
 
+function groupedParentCancelCause(children: SubagentResultIntercomChild[]): string | undefined {
+	if (children.length === 0) return undefined;
+	const labels = children.map((child) => presentCancelledStatus(child.status, child.cause));
+	if (labels.some((label) => label === "cancelled") && !labels.some((label) => label === "interrupted")) {
+		return PARENT_CANCEL_CAUSE;
+	}
+	return undefined;
+}
+
 function formatSubagentResultIntercomMessage(input: {
 	runId: string;
 	mode: SubagentRunMode;
 	status: SubagentResultStatus;
 	children: SubagentResultIntercomChild[];
 }): string {
-	const counts = countStatuses(input.children);
 	const lines: string[] = [
 		"subagent results",
 		"",
 		`Run: ${input.runId}`,
 		`Mode: ${input.mode}`,
-		`Status: ${input.status}`,
-		`Children: ${formatStatusCounts(counts)}`,
+		`Status: ${presentCancelledStatus(input.status, groupedParentCancelCause(input.children))}`,
+		`Children: ${formatStatusCounts(input.children)}`,
 	];
 	if (input.children.some((child) => child.intercomTarget)) {
 		lines.push(
@@ -91,7 +114,7 @@ function formatSubagentResultIntercomMessage(input: {
 
 	for (let index = 0; index < input.children.length; index++) {
 		const child = input.children[index]!;
-		lines.push("", `${index + 1}. ${child.agent} — ${child.status}`);
+		lines.push("", `${index + 1}. ${child.agent} — ${presentCancelledStatus(child.status, child.cause)}`);
 		if (child.intercomTarget) lines.push(`Run intercom target: ${child.intercomTarget}`);
 		if (child.artifactPath) lines.push(`Output artifact: ${child.artifactPath}`);
 		if (child.sessionPath) lines.push(`Session: ${child.sessionPath}`);
@@ -109,7 +132,7 @@ export function buildSubagentResultIntercomPayload(
 		summary: child.summary.trim() || "(no output)",
 	}));
 	const status = resolveGroupedStatus(children);
-	const summary = formatStatusCounts(countStatuses(children));
+	const summary = formatStatusCounts(children);
 	const firstChild = children[0];
 	const payload: SubagentResultIntercomPayload = {
 		to: input.to,
@@ -209,19 +232,18 @@ export function formatSubagentResultReceipt(input: {
 	runId: string;
 	payload: SubagentResultIntercomPayload;
 }): string {
-	const counts = countStatuses(input.payload.children);
 	const modeLabel = input.mode === "single" ? "single subagent result" : "parallel subagent results";
 	const lines = [
 		`Delivered ${modeLabel} via intercom.`,
 		`Run: ${input.runId}`,
-		`Children: ${formatStatusCounts(counts)}`,
+		`Children: ${formatStatusCounts(input.payload.children)}`,
 	];
 
 	const artifacts = input.payload.children.filter((child) => typeof child.artifactPath === "string");
 	if (artifacts.length > 0) {
 		lines.push("Artifacts:");
 		for (const child of artifacts) {
-			lines.push(`- ${child.agent} [${child.status}]: ${child.artifactPath}`);
+			lines.push(`- ${child.agent} [${presentCancelledStatus(child.status, child.cause)}]: ${child.artifactPath}`);
 		}
 	}
 
@@ -229,7 +251,7 @@ export function formatSubagentResultReceipt(input: {
 	if (intercomTargets.length > 0) {
 		lines.push("Run intercom targets (may be inactive after completion):");
 		for (const child of intercomTargets) {
-			lines.push(`- ${child.agent} [${child.status}]: ${child.intercomTarget}`);
+			lines.push(`- ${child.agent} [${presentCancelledStatus(child.status, child.cause)}]: ${child.intercomTarget}`);
 		}
 	}
 
@@ -237,7 +259,7 @@ export function formatSubagentResultReceipt(input: {
 	if (sessions.length > 0) {
 		lines.push("Sessions:");
 		for (const child of sessions) {
-			lines.push(`- ${child.agent} [${child.status}]: ${child.sessionPath}`);
+			lines.push(`- ${child.agent} [${presentCancelledStatus(child.status, child.cause)}]: ${child.sessionPath}`);
 		}
 	}
 

--- a/packages/subagents/src/runs/foreground/subagent-executor-parallel.ts
+++ b/packages/subagents/src/runs/foreground/subagent-executor-parallel.ts
@@ -21,6 +21,7 @@ import {
 	wrapForkTask,
 } from "../../shared/types.js";
 import { compactForegroundDetails, getSingleResultOutput } from "../../shared/utils.js";
+import { isParentCancellation } from "../shared/cancellation-recovery.js";
 import { sharedAutoGroupForSet } from "../shared/intercom-group.js";
 import { resolveModelCandidate } from "../shared/model-fallback.js";
 import { formatParallelResultContent } from "../shared/parallel-utils.js";
@@ -244,7 +245,7 @@ export async function runParallelPath(
 			if (result.artifactPaths) allArtifactPaths.push(result.artifactPaths);
 		}
 
-		const interrupted = results.find((result) => result.interrupted);
+		const interrupted = results.find((result) => result.interrupted && !isParentCancellation(result.cause));
 		const details = compactForegroundDetails({
 			mode: "parallel",
 			runId,
@@ -263,7 +264,12 @@ export async function runParallelPath(
 			markParentAskHandoff(yieldedResult, parentAsk);
 			return yieldedResult;
 		}
-		if (interrupted) {
+		if (
+			interrupted &&
+			!results.some(
+				(result) => isParentCancellation(result.cause) && (result.interrupted || result.status === "interrupted"),
+			)
+		) {
 			return {
 				content: [
 					{
@@ -312,6 +318,7 @@ export async function runParallelPath(
 				output: result.truncation?.text || getSingleResultOutput(result),
 				status: result.status,
 				error: result.error,
+				...(result.cause ? { cause: result.cause } : {}),
 			})),
 			(i, agent) => `=== Task ${i + 1}: ${agent} ===`,
 		);

--- a/packages/subagents/src/runs/foreground/subagent-executor-single.ts
+++ b/packages/subagents/src/runs/foreground/subagent-executor-single.ts
@@ -22,6 +22,7 @@ import {
 	wrapForkTask,
 } from "../../shared/types.js";
 import { compactForegroundDetails, getSingleResultOutput } from "../../shared/utils.js";
+import { isParentCancellation } from "../shared/cancellation-recovery.js";
 import { inheritedIntercomGroup, resolveChildIntercomGroup } from "../shared/intercom-group.js";
 import { currentModelFullId, resolveModelCandidate } from "../shared/model-fallback.js";
 import { recordRun } from "../shared/run-history.js";
@@ -193,6 +194,7 @@ export async function runSinglePath(
 			cwd: effectiveCwd,
 			signal,
 			interruptSignal: interruptController.signal,
+			...(progressDir ? { progressPath: path.join(progressDir, "progress.md") } : {}),
 			allowIntercomDetach: agentConfig.systemPrompt?.includes(INTERCOM_BRIDGE_MARKER) === true,
 			intercomEvents: deps.pi.events,
 			runId,
@@ -279,7 +281,7 @@ export async function runSinglePath(
 		truncation: r.truncation,
 	});
 
-	if (!r.detached && !r.interrupted) {
+	if (!r.detached && !(r.interrupted && !isParentCancellation(r.cause))) {
 		const intercomReceipt = await maybeBuildForegroundIntercomReceipt({
 			pi: deps.pi,
 			intercomBridge: data.intercomBridge,
@@ -321,6 +323,13 @@ export async function runSinglePath(
 					}),
 				},
 			],
+			details,
+		};
+	}
+
+	if (r.interrupted && isParentCancellation(r.cause)) {
+		return {
+			content: [{ type: "text", text: finalizedOutput.displayOutput || r.envelope || "Run cancelled by parent." }],
 			details,
 		};
 	}

--- a/packages/subagents/src/runs/shared/parallel-utils.ts
+++ b/packages/subagents/src/runs/shared/parallel-utils.ts
@@ -1,3 +1,5 @@
+import { isParentCancellation } from "./cancellation-recovery.js";
+
 export async function mapConcurrent<T, R>(
 	items: T[],
 	limit: number,
@@ -24,6 +26,7 @@ export interface ParallelTaskResult {
 	output: string;
 	status: import("../../shared/types.js").SubagentAttemptStatus;
 	error?: string;
+	cause?: string;
 	model?: string;
 	fastMode?: boolean;
 	attemptedModels?: string[];
@@ -46,13 +49,15 @@ export function aggregateParallelOutputs(
 						? "CONTINUED"
 						: r.status === "error"
 							? `FAILED${r.error ? `: ${r.error}` : ""}`
-							: r.error
-								? `WARNING: ${r.error}`
-								: !hasOutput && r.outputTargetPath && r.outputTargetExists === false
-									? `EMPTY OUTPUT (expected output file missing: ${r.outputTargetPath})`
-									: !hasOutput && !r.outputTargetPath
-										? "EMPTY OUTPUT (no textual response returned)"
-										: "";
+							: r.status === "interrupted" && isParentCancellation(r.cause)
+								? "CANCELLED"
+								: r.error
+									? `WARNING: ${r.error}`
+									: !hasOutput && r.outputTargetPath && r.outputTargetExists === false
+										? `EMPTY OUTPUT (expected output file missing: ${r.outputTargetPath})`
+										: !hasOutput && !r.outputTargetPath
+											? "EMPTY OUTPUT (no textual response returned)"
+											: "";
 			const body = status ? (hasOutput ? `${status}\n${r.output}` : status) : r.output;
 			return `${header}\n${body}`;
 		})

--- a/test/unit/subagents-parent-cancellation-parallel.test.ts
+++ b/test/unit/subagents-parent-cancellation-parallel.test.ts
@@ -1,6 +1,4 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionContext } from "@bastani/atomic";
 import { test } from "vitest";
@@ -12,14 +10,14 @@ import type { ExecutorDeps } from "../../packages/subagents/src/runs/foreground/
 import { clearSubagentControls } from "../../packages/subagents/src/runs/inprocess/control-registry.ts";
 import { formatParallelResultContent } from "../../packages/subagents/src/runs/shared/parallel-utils.ts";
 import type { SubagentState } from "../../packages/subagents/src/shared/types.ts";
-import { sleep } from "../helpers/runtime.ts";
+import { fileExistsSync, makeTempDirectory, removeTempDirectory, sleep } from "../helpers/runtime.ts";
 
 const PROMPT_TRIES = 2_400;
 const PROMPT_MS = 5;
 
 async function waitForPrompt(promptLogPath: string): Promise<void> {
-	for (let attempt = 0; attempt < PROMPT_TRIES && !existsSync(promptLogPath); attempt++) await sleep(PROMPT_MS);
-	assert.equal(existsSync(promptLogPath), true, "child prompt should start before abort");
+	for (let attempt = 0; attempt < PROMPT_TRIES && !fileExistsSync(promptLogPath); attempt++) await sleep(PROMPT_MS);
+	assert.equal(fileExistsSync(promptLogPath), true, "child prompt should start before abort");
 }
 
 function sampleAgent(): AgentConfig {
@@ -74,7 +72,7 @@ function executorContext(root: string): ExtensionContext {
 	} as unknown as ExtensionContext;
 }
 test("parallel parent abort reports each child cancelled instead of failed", async () => {
-	const root = mkdtempSync(join(tmpdir(), "atomic-cancel-parallel-"));
+	const root = makeTempDirectory("atomic-cancel-parallel-");
 	const gateA = Promise.withResolvers<void>();
 	const gateB = Promise.withResolvers<void>();
 	const controller = new AbortController();
@@ -145,7 +143,7 @@ test("parallel parent abort reports each child cancelled instead of failed", asy
 		gateA.resolve();
 		gateB.resolve();
 		clearSubagentControls();
-		rmSync(root, { recursive: true, force: true });
+		removeTempDirectory(root);
 	}
 });
 test("formatParallelResultContent labels parent-aborted children cancelled", () => {
@@ -172,7 +170,7 @@ test("formatParallelResultContent labels parent-aborted children cancelled", () 
 });
 
 test("parallel executor fall-through reports cancelled children instead of interrupt failure", async () => {
-	const root = mkdtempSync(join(tmpdir(), "atomic-cancel-parallel-exec-"));
+	const root = makeTempDirectory("atomic-cancel-parallel-exec-");
 	clearSubagentControls();
 	try {
 		const state: SubagentState = {
@@ -230,6 +228,6 @@ test("parallel executor fall-through reports cancelled children instead of inter
 		assert.notEqual(result.isError, true);
 	} finally {
 		clearSubagentControls();
-		rmSync(root, { recursive: true, force: true });
+		removeTempDirectory(root);
 	}
 });

--- a/test/unit/subagents-parent-cancellation-parallel.test.ts
+++ b/test/unit/subagents-parent-cancellation-parallel.test.ts
@@ -14,8 +14,11 @@ import { formatParallelResultContent } from "../../packages/subagents/src/runs/s
 import type { SubagentState } from "../../packages/subagents/src/shared/types.ts";
 import { sleep } from "../helpers/runtime.ts";
 
+const PROMPT_TRIES = 2_400;
+const PROMPT_MS = 5;
+
 async function waitForPrompt(promptLogPath: string): Promise<void> {
-	for (let attempt = 0; attempt < 200 && !existsSync(promptLogPath); attempt++) await sleep(5);
+	for (let attempt = 0; attempt < PROMPT_TRIES && !existsSync(promptLogPath); attempt++) await sleep(PROMPT_MS);
 	assert.equal(existsSync(promptLogPath), true, "child prompt should start before abort");
 }
 
@@ -70,7 +73,6 @@ function executorContext(root: string): ExtensionContext {
 		getSystemPrompt: () => "",
 	} as unknown as ExtensionContext;
 }
-
 test("parallel parent abort reports each child cancelled instead of failed", async () => {
 	const root = mkdtempSync(join(tmpdir(), "atomic-cancel-parallel-"));
 	const gateA = Promise.withResolvers<void>();
@@ -146,7 +148,6 @@ test("parallel parent abort reports each child cancelled instead of failed", asy
 		rmSync(root, { recursive: true, force: true });
 	}
 });
-
 test("formatParallelResultContent labels parent-aborted children cancelled", () => {
 	const text = formatParallelResultContent(
 		[

--- a/test/unit/subagents-parent-cancellation-parallel.test.ts
+++ b/test/unit/subagents-parent-cancellation-parallel.test.ts
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionContext } from "@bastani/atomic";
+import { test } from "vitest";
+import type { AgentConfig } from "../../packages/subagents/src/agents/agent-types.ts";
+import { buildSubagentResultIntercomPayload } from "../../packages/subagents/src/intercom/result-intercom.ts";
+import { runSingleInProcess } from "../../packages/subagents/src/runs/foreground/inprocess-run-sync.ts";
+import { createSubagentExecutor } from "../../packages/subagents/src/runs/foreground/subagent-executor.ts";
+import type { ExecutorDeps } from "../../packages/subagents/src/runs/foreground/subagent-executor-types.ts";
+import { clearSubagentControls } from "../../packages/subagents/src/runs/inprocess/control-registry.ts";
+import { formatParallelResultContent } from "../../packages/subagents/src/runs/shared/parallel-utils.ts";
+import type { SubagentState } from "../../packages/subagents/src/shared/types.ts";
+import { sleep } from "../helpers/runtime.ts";
+
+function sampleAgent(): AgentConfig {
+	return {
+		name: "analysis",
+		description: "analysis agent",
+		systemPrompt: "",
+		systemPromptMode: "replace",
+		inheritProjectContext: false,
+		inheritSkills: false,
+		source: "user",
+		filePath: "/tmp/analysis.md",
+	};
+}
+
+function cancelledExecutorResult(agentName: string, task: string) {
+	return {
+		agent: agentName,
+		task,
+		status: "interrupted" as const,
+		interrupted: true,
+		cause: "abort",
+		envelope: "Run cancelled by parent.\n\nThis is incomplete and has not been validated as a final answer.",
+		finalOutput: "Run cancelled by parent.\n\nThis is incomplete and has not been validated as a final answer.",
+		messages: [],
+		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 },
+	};
+}
+
+function executorContext(root: string): ExtensionContext {
+	return {
+		cwd: root,
+		mode: "tui",
+		hasUI: false,
+		ui: {},
+		model: undefined,
+		modelRegistry: { getAvailable: () => [] },
+		sessionManager: {
+			getSessionFile: () => join(root, "parent-session.jsonl"),
+			getSessionId: () => "parent-session",
+			getLeafId: () => null,
+			getEntries: () => [],
+		},
+		isIdle: () => true,
+		isProjectTrusted: () => true,
+		abort: () => {},
+		hasPendingMessages: () => false,
+		shutdown: () => {},
+		getContextUsage: () => undefined,
+		compact: () => {},
+		getSystemPrompt: () => "",
+	} as unknown as ExtensionContext;
+}
+
+test("parallel parent abort reports each child cancelled instead of failed", async () => {
+	const root = mkdtempSync(join(tmpdir(), "atomic-cancel-parallel-"));
+	const gateA = Promise.withResolvers<void>();
+	const gateB = Promise.withResolvers<void>();
+	const controller = new AbortController();
+	clearSubagentControls();
+	try {
+		const pending = Promise.all([
+			runSingleInProcess(root, sampleAgent(), "inspect fixture a", {
+				cwd: root,
+				runId: "cancel-parallel-parent",
+				index: 0,
+				sessionDir: join(root, "sessions", "a"),
+				signal: controller.signal,
+				testSession: { output: "too late a", promptGate: gateA.promise, abortResolvesPrompt: true },
+			}),
+			runSingleInProcess(root, sampleAgent(), "inspect fixture b", {
+				cwd: root,
+				runId: "cancel-parallel-parent",
+				index: 1,
+				sessionDir: join(root, "sessions", "b"),
+				signal: controller.signal,
+				testSession: { output: "too late b", promptGate: gateB.promise, abortResolvesPrompt: true },
+			}),
+		]);
+		await sleep(25);
+		controller.abort();
+		const results = await pending;
+		assert.deepEqual(
+			results.map((result) => result.status),
+			["interrupted", "interrupted"],
+		);
+		assert.deepEqual(
+			results.map((result) => result.cause),
+			["abort", "abort"],
+		);
+		for (const result of results) {
+			assert.equal(result.progress?.status, "interrupted");
+			assert.match(result.envelope ?? "", /Run cancelled by parent/);
+		}
+		const payload = buildSubagentResultIntercomPayload({
+			to: "orchestrator",
+			runId: "cancel-parallel-parent",
+			mode: "parallel",
+			children: results.map((result, index) => ({
+				agent: result.agent,
+				status: "interrupted",
+				cause: result.cause,
+				summary: result.envelope ?? "",
+				index,
+			})),
+		});
+		assert.equal(payload.status, "interrupted");
+		assert.match(payload.summary, /cancelled/);
+		assert.doesNotMatch(payload.summary, /failed/);
+		assert.match(payload.message, /cancelled/);
+		assert.doesNotMatch(payload.message, /failed/);
+	} finally {
+		gateA.resolve();
+		gateB.resolve();
+		clearSubagentControls();
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("formatParallelResultContent labels parent-aborted children cancelled", () => {
+	const text = formatParallelResultContent(
+		[
+			{
+				agent: "analysis",
+				output: "Run cancelled by parent.\n\nThis is incomplete and has not been validated as a final answer.",
+				status: "interrupted",
+				cause: "abort",
+			},
+			{
+				agent: "analysis",
+				output: "Run cancelled by parent.\n\nThis is incomplete and has not been validated as a final answer.",
+				status: "interrupted",
+				cause: "abort",
+			},
+		],
+		(index, agent) => `=== Task ${index + 1}: ${agent} ===`,
+	);
+	assert.match(text, /^0\/2 succeeded/);
+	assert.match(text, /CANCELLED/);
+	assert.doesNotMatch(text, /FAILED/);
+});
+
+test("parallel executor fall-through reports cancelled children instead of interrupt failure", async () => {
+	const root = mkdtempSync(join(tmpdir(), "atomic-cancel-parallel-exec-"));
+	clearSubagentControls();
+	try {
+		const state: SubagentState = {
+			baseCwd: root,
+			currentSessionId: "parent-session",
+			subagentInProgress: false,
+			foregroundControls: new Map(),
+			lastForegroundControlId: null,
+			pendingForegroundControlNotices: new Map(),
+			lastUiContext: null,
+		};
+		const execute = createSubagentExecutor({
+			pi: {
+				events: { on: () => () => {}, emit: () => {} },
+				getSessionName: () => "parent",
+			} as unknown as ExecutorDeps["pi"],
+			state,
+			config: { parallel: { concurrency: 4, maxTasks: 50 } },
+			tempArtifactsDir: join(root, "artifacts"),
+			getSubagentSessionRoot: () => join(root, "sessions"),
+			expandTilde: (value) => value,
+			discoverAgents: () => ({ agents: [sampleAgent()] }),
+			runtime: {
+				runSync: async (_cwd, _agents, agentName, task) => cancelledExecutorResult(agentName, task),
+			},
+		});
+		const result = await execute.execute(
+			"cancel-parallel-exec",
+			{
+				tasks: [
+					{ agent: "analysis", task: "inspect a" },
+					{ agent: "analysis", task: "inspect b" },
+				],
+				artifacts: false,
+			},
+			new AbortController().signal,
+			undefined,
+			executorContext(root),
+		);
+		const text = result.content
+			.filter((item): item is { type: "text"; text: string } => item.type === "text")
+			.map((item) => item.text)
+			.join("\n");
+		assert.doesNotMatch(text, /Parallel run ended after interrupt/);
+		assert.match(text, /CANCELLED/);
+		assert.match(text, /Run cancelled by parent/);
+		assert.deepEqual(
+			result.details?.results.map((child) => child.status),
+			["interrupted", "interrupted"],
+		);
+		assert.deepEqual(
+			result.details?.results.map((child) => child.cause),
+			["abort", "abort"],
+		);
+		assert.notEqual(result.isError, true);
+	} finally {
+		clearSubagentControls();
+		rmSync(root, { recursive: true, force: true });
+	}
+});

--- a/test/unit/subagents-parent-cancellation-parallel.test.ts
+++ b/test/unit/subagents-parent-cancellation-parallel.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionContext } from "@bastani/atomic";
@@ -13,6 +13,11 @@ import { clearSubagentControls } from "../../packages/subagents/src/runs/inproce
 import { formatParallelResultContent } from "../../packages/subagents/src/runs/shared/parallel-utils.ts";
 import type { SubagentState } from "../../packages/subagents/src/shared/types.ts";
 import { sleep } from "../helpers/runtime.ts";
+
+async function waitForPrompt(promptLogPath: string): Promise<void> {
+	for (let attempt = 0; attempt < 200 && !existsSync(promptLogPath); attempt++) await sleep(5);
+	assert.equal(existsSync(promptLogPath), true, "child prompt should start before abort");
+}
 
 function sampleAgent(): AgentConfig {
 	return {
@@ -80,7 +85,12 @@ test("parallel parent abort reports each child cancelled instead of failed", asy
 				index: 0,
 				sessionDir: join(root, "sessions", "a"),
 				signal: controller.signal,
-				testSession: { output: "too late a", promptGate: gateA.promise, abortResolvesPrompt: true },
+				testSession: {
+					output: "too late a",
+					promptGate: gateA.promise,
+					abortResolvesPrompt: true,
+					promptLogPath: join(root, "prompt-a.log"),
+				},
 			}),
 			runSingleInProcess(root, sampleAgent(), "inspect fixture b", {
 				cwd: root,
@@ -88,10 +98,16 @@ test("parallel parent abort reports each child cancelled instead of failed", asy
 				index: 1,
 				sessionDir: join(root, "sessions", "b"),
 				signal: controller.signal,
-				testSession: { output: "too late b", promptGate: gateB.promise, abortResolvesPrompt: true },
+				testSession: {
+					output: "too late b",
+					promptGate: gateB.promise,
+					abortResolvesPrompt: true,
+					promptLogPath: join(root, "prompt-b.log"),
+				},
 			}),
 		]);
-		await sleep(25);
+		await waitForPrompt(join(root, "prompt-a.log"));
+		await waitForPrompt(join(root, "prompt-b.log"));
 		controller.abort();
 		const results = await pending;
 		assert.deepEqual(

--- a/test/unit/subagents-parent-cancellation-parallel.test.ts
+++ b/test/unit/subagents-parent-cancellation-parallel.test.ts
@@ -139,7 +139,7 @@ test("parallel parent abort reports each child cancelled instead of failed", asy
 		assert.equal(payload.status, "interrupted");
 		assert.match(payload.summary, /cancelled/);
 		assert.doesNotMatch(payload.summary, /failed/);
-		assert.match(payload.message, /cancelled/);
+		assert.match(payload.message, /^Status: cancelled$/m);
 		assert.doesNotMatch(payload.message, /failed/);
 	} finally {
 		gateA.resolve();

--- a/test/unit/subagents-parent-cancellation.test.ts
+++ b/test/unit/subagents-parent-cancellation.test.ts
@@ -501,13 +501,9 @@ test("artifacts-disabled parent cancel still removes run-scoped progress storage
 					const pending = runSingleInProcess(cwd, agent, task, {
 						...options,
 						signal: childAbort.signal,
-						testSession: {
-							output: "must not complete",
-							promptGate: gate.promise,
-							abortResolvesPrompt: true,
-						},
+						testSession: abortSession(root, gate.promise),
 					});
-					await sleep(25);
+					await waitForPrompt(root);
 					childAbort.abort();
 					try {
 						return await pending;

--- a/test/unit/subagents-parent-cancellation.test.ts
+++ b/test/unit/subagents-parent-cancellation.test.ts
@@ -1,8 +1,11 @@
 import assert from "node:assert/strict";
 import { join } from "node:path";
+import type { ExtensionContext } from "@bastani/atomic";
 import { test } from "vitest";
 import type { AgentConfig } from "../../packages/subagents/src/agents/agent-types.ts";
 import { runSingleInProcess } from "../../packages/subagents/src/runs/foreground/inprocess-run-sync.ts";
+import { createSubagentExecutor } from "../../packages/subagents/src/runs/foreground/subagent-executor.ts";
+import type { ExecutorDeps } from "../../packages/subagents/src/runs/foreground/subagent-executor-types.ts";
 import { clearSubagentControls } from "../../packages/subagents/src/runs/inprocess/control-registry.ts";
 import {
 	INITIAL_PROGRESS_CONTENT,
@@ -10,7 +13,7 @@ import {
 	readModifiedProgress,
 	recoverCancelledChildOutput,
 } from "../../packages/subagents/src/runs/shared/cancellation-recovery.ts";
-import { DEFAULT_ARTIFACT_CONFIG } from "../../packages/subagents/src/shared/types.ts";
+import { DEFAULT_ARTIFACT_CONFIG, type SubagentState } from "../../packages/subagents/src/shared/types.ts";
 import { compactForegroundDetails } from "../../packages/subagents/src/shared/utils.ts";
 import { resultStatusLine } from "../../packages/subagents/src/tui/render-status-progress.ts";
 import {
@@ -461,4 +464,99 @@ test("compacted terminal progress keeps the parent-cancel cause", () => {
 	assert.equal(compacted.progress?.[0]?.status, "interrupted");
 	assert.equal(compacted.progress?.[0]?.cause, "abort");
 	assert.deepEqual(compacted.progress?.[0]?.recentTools, []);
+});
+
+test("artifacts-disabled parent cancel still removes run-scoped progress storage", async () => {
+	const root = mkdtempSync(join(tmpdir(), "atomic-cancel-progress-cleanup-"));
+	clearSubagentControls();
+	try {
+		const state: SubagentState = {
+			baseCwd: root,
+			currentSessionId: "parent-session",
+			subagentInProgress: false,
+			foregroundControls: new Map(),
+			lastForegroundControlId: null,
+			pendingForegroundControlNotices: new Map(),
+			lastUiContext: null,
+		};
+		const execute = createSubagentExecutor({
+			pi: {
+				events: { on: () => () => {}, emit: () => {} },
+				getSessionName: () => "parent",
+			} as unknown as ExecutorDeps["pi"],
+			state,
+			config: {},
+			tempArtifactsDir: join(root, "artifacts"),
+			getSubagentSessionRoot: () => join(root, "sessions"),
+			expandTilde: (value) => value,
+			discoverAgents: () => ({ agents: [sampleAgent()] }),
+			runtime: {
+				runSync: async (cwd, agents, agentName, task, options) => {
+					const agent = agents.find((candidate) => candidate.name === agentName) ?? sampleAgent();
+					if (options.progressPath) {
+						writeFileSync(options.progressPath, "# Progress\n\n- Recovered scratch finding\n");
+					}
+					const gate = Promise.withResolvers<void>();
+					const childAbort = new AbortController();
+					const pending = runSingleInProcess(cwd, agent, task, {
+						...options,
+						signal: childAbort.signal,
+						testSession: {
+							output: "must not complete",
+							promptGate: gate.promise,
+							abortResolvesPrompt: true,
+						},
+					});
+					await sleep(25);
+					childAbort.abort();
+					try {
+						return await pending;
+					} finally {
+						gate.resolve();
+					}
+				},
+			},
+		});
+		const result = await execute.execute(
+			"cancel-progress-cleanup",
+			{ agent: "analysis", task: "inspect fixture", progress: true, artifacts: false },
+			new AbortController().signal,
+			undefined,
+			{
+				cwd: root,
+				mode: "tui",
+				hasUI: false,
+				ui: {},
+				model: undefined,
+				modelRegistry: { getAvailable: () => [] },
+				sessionManager: {
+					getSessionFile: () => join(root, "parent-session.jsonl"),
+					getSessionId: () => "parent-session",
+					getLeafId: () => null,
+					getEntries: () => [],
+				},
+				isIdle: () => true,
+				isProjectTrusted: () => true,
+				abort: () => {},
+				hasPendingMessages: () => false,
+				shutdown: () => {},
+				getContextUsage: () => undefined,
+				compact: () => {},
+				getSystemPrompt: () => "",
+			} as unknown as ExtensionContext,
+		);
+		const runId = result.details?.runId;
+		assert.ok(runId);
+		const text = result.content
+			.filter((item): item is { type: "text"; text: string } => item.type === "text")
+			.map((item) => item.text)
+			.join("\n");
+		assert.match(text, /Partial findings from progress\.md/);
+		assert.match(text, /Recovered scratch finding/);
+		assert.doesNotMatch(text, /Progress: /);
+		assert.equal(existsSync(join(root, "subagent-artifacts", "progress", runId)), false);
+	} finally {
+		clearSubagentControls();
+		rmSync(root, { recursive: true, force: true });
+	}
 });

--- a/test/unit/subagents-parent-cancellation.test.ts
+++ b/test/unit/subagents-parent-cancellation.test.ts
@@ -26,6 +26,8 @@ import {
 	writeTextSync,
 } from "../helpers/runtime.ts";
 
+const PROMPT_TRIES = 2_400;
+const PROMPT_MS = 5;
 function abortSession(root: string, gate: Promise<void>) {
 	return {
 		output: "must not complete",
@@ -37,7 +39,7 @@ function abortSession(root: string, gate: Promise<void>) {
 
 async function waitForPrompt(root: string): Promise<void> {
 	const promptLogPath = join(root, "prompt.log");
-	for (let attempt = 0; attempt < 200 && !fileExistsSync(promptLogPath); attempt++) await sleep(5);
+	for (let attempt = 0; attempt < PROMPT_TRIES && !fileExistsSync(promptLogPath); attempt++) await sleep(PROMPT_MS);
 	assert.equal(fileExistsSync(promptLogPath), true, "child prompt should start before abort");
 }
 
@@ -349,7 +351,7 @@ test("parent abort keeps pre-cancel fallback metadata and does not start another
 				},
 			},
 		);
-		for (let attempt = 0; attempt < 200 && !sawFallback; attempt++) await sleep(5);
+		for (let attempt = 0; attempt < PROMPT_TRIES && !sawFallback; attempt++) await sleep(PROMPT_MS);
 		assert.equal(sawFallback, true, "fallback onUpdate should arrive before abort");
 		controller.abort();
 		const result = await pending;
@@ -467,7 +469,7 @@ test("compacted terminal progress keeps the parent-cancel cause", () => {
 });
 
 test("artifacts-disabled parent cancel still removes run-scoped progress storage", async () => {
-	const root = mkdtempSync(join(tmpdir(), "atomic-cancel-progress-cleanup-"));
+	const root = makeTempDirectory("atomic-cancel-progress-cleanup-");
 	clearSubagentControls();
 	try {
 		const state: SubagentState = {
@@ -494,7 +496,7 @@ test("artifacts-disabled parent cancel still removes run-scoped progress storage
 				runSync: async (cwd, agents, agentName, task, options) => {
 					const agent = agents.find((candidate) => candidate.name === agentName) ?? sampleAgent();
 					if (options.progressPath) {
-						writeFileSync(options.progressPath, "# Progress\n\n- Recovered scratch finding\n");
+						writeTextSync(options.progressPath, "# Progress\n\n- Recovered scratch finding\n");
 					}
 					const gate = Promise.withResolvers<void>();
 					const childAbort = new AbortController();
@@ -550,9 +552,9 @@ test("artifacts-disabled parent cancel still removes run-scoped progress storage
 		assert.match(text, /Partial findings from progress\.md/);
 		assert.match(text, /Recovered scratch finding/);
 		assert.doesNotMatch(text, /Progress: /);
-		assert.equal(existsSync(join(root, "subagent-artifacts", "progress", runId)), false);
+		assert.equal(fileExistsSync(join(root, "subagent-artifacts", "progress", runId)), false);
 	} finally {
 		clearSubagentControls();
-		rmSync(root, { recursive: true, force: true });
+		removeTempDirectory(root);
 	}
 });

--- a/test/unit/subagents-result-intercom.test.ts
+++ b/test/unit/subagents-result-intercom.test.ts
@@ -53,6 +53,7 @@ describe("subagent result intercom helpers", () => {
 				{ agent: "reviewer", status: "interrupted", cause: "abort", summary: "Run cancelled by parent." },
 			],
 		});
+		assert.equal(cancelled.status, "interrupted");
 		assert.match(cancelled.message, /^Status: cancelled$/m);
 		assert.match(cancelled.message, /Children: 2 cancelled/);
 
@@ -85,6 +86,7 @@ describe("subagent result intercom helpers", () => {
 				{ agent: "analysis", status: "interrupted", cause: "abort", summary: "Run cancelled by parent." },
 			],
 		});
+		assert.equal(payload.status, "interrupted");
 		assert.match(payload.message, /^Status: cancelled$/m);
 		assert.match(payload.message, /Children: 1 completed, 1 cancelled/);
 		assert.match(payload.message, /Output artifact: \/no\/out[\s\S]*Session: \/no\/sess/);

--- a/test/unit/subagents-result-intercom.test.ts
+++ b/test/unit/subagents-result-intercom.test.ts
@@ -81,12 +81,13 @@ describe("subagent result intercom helpers", () => {
 			runId: "mixed-complete-cancel",
 			mode: "parallel",
 			children: [
-				{ agent: "worker", status: "completed", summary: "done" },
+				{ agent: "worker", status: "completed", summary: "done", artifactPath: "/no/out", sessionPath: "/no/sess" },
 				{ agent: "analysis", status: "interrupted", cause: "abort", summary: "Run cancelled by parent." },
 			],
 		});
 		assert.match(payload.message, /^Status: cancelled$/m);
 		assert.match(payload.message, /Children: 1 completed, 1 cancelled/);
+		assert.match(payload.message, /Output artifact: \/no\/out[\s\S]*Session: \/no\/sess/);
 		assert.doesNotMatch(payload.message, /^Status: interrupted$/m);
 		assert.doesNotMatch(payload.message, / — interrupted$/m);
 	});

--- a/test/unit/subagents-result-intercom.test.ts
+++ b/test/unit/subagents-result-intercom.test.ts
@@ -42,4 +42,52 @@ describe("subagent result intercom helpers", () => {
 		assert.match(payload.message, /Children: 1 completed, 1 failed/);
 		assert.doesNotMatch(payload.message, /Nested subagents:/);
 	});
+
+	test("grouped intercom status is cancelled only when every child is interrupted with abort", () => {
+		const cancelled = buildSubagentResultIntercomPayload({
+			to: "orchestrator",
+			runId: "cancel",
+			mode: "parallel",
+			children: [
+				{ agent: "analysis", status: "interrupted", cause: "abort", summary: "Run cancelled by parent." },
+				{ agent: "reviewer", status: "interrupted", cause: "abort", summary: "Run cancelled by parent." },
+			],
+		});
+		assert.match(cancelled.message, /^Status: cancelled$/m);
+		assert.match(cancelled.message, /Children: 2 cancelled/);
+
+		const errorNamedAbort = buildSubagentResultIntercomPayload({
+			to: "orchestrator",
+			runId: "error-abort",
+			mode: "single",
+			children: [{ agent: "analysis", status: "failed", cause: "abort", summary: "abort" }],
+		});
+		assert.match(errorNamedAbort.message, /^Status: failed$/m);
+		assert.doesNotMatch(errorNamedAbort.message, /Status: cancelled/);
+
+		const empty = buildSubagentResultIntercomPayload({
+			to: "orchestrator",
+			runId: "empty",
+			mode: "parallel",
+			children: [],
+		});
+		assert.match(empty.message, /^Status: failed$/m);
+		assert.doesNotMatch(empty.message, /Status: cancelled/);
+	});
+
+	test("a mixed completed and parent-cancelled set reports Status: cancelled", () => {
+		const payload = buildSubagentResultIntercomPayload({
+			to: "orchestrator",
+			runId: "mixed-complete-cancel",
+			mode: "parallel",
+			children: [
+				{ agent: "worker", status: "completed", summary: "done" },
+				{ agent: "analysis", status: "interrupted", cause: "abort", summary: "Run cancelled by parent." },
+			],
+		});
+		assert.match(payload.message, /^Status: cancelled$/m);
+		assert.match(payload.message, /Children: 1 completed, 1 cancelled/);
+		assert.doesNotMatch(payload.message, /^Status: interrupted$/m);
+		assert.doesNotMatch(payload.message, / — interrupted$/m);
+	});
 });


### PR DESCRIPTION
Stack 3/4 for #2635.

Parallel sets: cancelled children are counted and labelled distinctly from failures in grouped receipts, mixed sets (user interrupt + parent cancels) present the cancellation summary (documented trade-off), prompt-start polling replaces fixed sleeps per the repo load-sensitivity rule, and the structured Intercom payload status stays `interrupted` while rendered text says cancelled (pinned by assertion).

Validation: parallel cancellation suite green at this tip.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790270264&installation_model_id=10562&pr_number=2673&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2673&signature=625b89c317e1a2abbe8dd88ce93b0ecc90324ead35b427a6a1fdacfad3fba2fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Parent-cancelled subagent runs preserve their interrupted status and abort cause while presenting cancelled messaging, recoverable partial output, and valid artifact references in parallel results and intercom delivery. Focused runtime coverage passed for concurrent child cancellation, rendering, recovery, and receipt generation.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains; the cancellation flow is safe to merge.

A shared parent abort was exercised against two active in-process child runs. Both retained the expected structured cancellation state without error fields, recovered available progress, rendered as cancelled rather than failed, and produced cancelled intercom status.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I built the local Pi AI and Atomic workspace prerequisites and then ran the focused cancellation and intercom suite successfully.
- I authored and executed a two-child in-process probe that starts real child runs, aborts their shared parent signal, and checks structured status and cause, partial recovery, artifact handling, grouped rendering, and intercom output.
- The probe observed both children as interrupted with cause abort, without error fields, and showed CANCELLED rendering with Status: cancelled in the intercom payload.
- After hydrating model data and rebuilding the local workspace, I reran the focused suite and confirmed the authored probe passed with two active children cancelled as interrupted with abort, no error field, intact recovery artifacts, and intercom Status: cancelled.

<a href="https://app.greptile.com/trex/runs/20647791/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(subagents): route parallel cancella..."](https://github.com/bastani-inc/atomic/commit/5c029c5dfda307546c37c98a1f6ce41544b2414a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56744722)</sub>

<!-- /greptile_comment -->