### PR TITLE
feat(coding-agent): scope model choices to sessions

### DIFF
--- a/packages/coding-agent/src/core/agent-session-methods.ts
+++ b/packages/coding-agent/src/core/agent-session-methods.ts
@@ -18,6 +18,7 @@ import type {
 	ExtensionBindings,
 	InterruptQueueHold,
 	ModelCycleResult,
+	ModelMutationOptions,
 	PromptOptions,
 	SessionStats,
 	ToolDefinitionEntry,
@@ -217,15 +218,24 @@ export interface AgentSessionMethodSurface extends AgentSessionQueuePauseControl
 		previousModel: Model<Api> | undefined,
 		source: "set" | "cycle" | "restore" | "fallback",
 	): Promise<void>;
-	setModel(model: Model<Api>): Promise<void>;
-	cycleModel(direction?: "forward" | "backward"): Promise<ModelCycleResult | undefined>;
-	_cycleScopedModel(direction: "forward" | "backward"): Promise<ModelCycleResult | undefined>;
-	_cycleAvailableModel(direction: "forward" | "backward"): Promise<ModelCycleResult | undefined>;
-	setThinkingLevel(level: ThinkingLevel): void;
-	cycleThinkingLevel(): ThinkingLevel | undefined;
+	setModel(model: Model<Api>, options?: ModelMutationOptions): Promise<void>;
+	cycleModel(
+		direction?: "forward" | "backward",
+		options?: ModelMutationOptions,
+	): Promise<ModelCycleResult | undefined>;
+	_cycleScopedModel(
+		direction: "forward" | "backward",
+		options: ModelMutationOptions,
+	): Promise<ModelCycleResult | undefined>;
+	_cycleAvailableModel(
+		direction: "forward" | "backward",
+		options: ModelMutationOptions,
+	): Promise<ModelCycleResult | undefined>;
+	setThinkingLevel(level: ThinkingLevel, options?: ModelMutationOptions): void;
+	cycleThinkingLevel(options?: ModelMutationOptions): ThinkingLevel | undefined;
 	getAvailableThinkingLevels(): ThinkingLevel[];
 	supportsThinking(): boolean;
-	_getThinkingLevelForModelSwitch(explicitLevel?: ThinkingLevel): ThinkingLevel;
+	_getThinkingLevelForModelSwitch(targetModel?: Model<Api>, explicitLevel?: ThinkingLevel): ThinkingLevel;
 	_clampThinkingLevel(level: ThinkingLevel, availableLevels: ThinkingLevel[]): ThinkingLevel;
 
 	_applyVerbatimCompaction(options: VerbatimCompactionApplyOptions): Promise<VerbatimCompactionResult | undefined>;

--- a/packages/coding-agent/src/core/agent-session-models.ts
+++ b/packages/coding-agent/src/core/agent-session-models.ts
@@ -217,6 +217,14 @@ export async function _cycleAvailableModel(
  * Saves to session and settings only if the level actually changes.
  */
 
+function persistThinkingLevel(session: AgentSession, level: ThinkingLevel): void {
+	if (session.model) {
+		session.settingsManager.setModelThinkingLevel(session.model.provider, session.model.id, level);
+		return;
+	}
+	session.settingsManager.setDefaultThinkingLevel(level);
+}
+
 export function setThinkingLevel(this: AgentSession, level: ThinkingLevel, options: ModelMutationOptions = {}): void {
 	const availableLevels = this.getAvailableThinkingLevels();
 	const effectiveLevel = availableLevels.includes(level) ? level : this._clampThinkingLevel(level, availableLevels);
@@ -227,7 +235,7 @@ export function setThinkingLevel(this: AgentSession, level: ThinkingLevel, optio
 
 	this.agent.state.thinkingLevel = effectiveLevel;
 
-	if (options.persist) this.settingsManager.setDefaultThinkingLevel(level);
+	if (options.persist) persistThinkingLevel(this, effectiveLevel);
 
 	if (isChanging) {
 		// A reasoning choice is not a model choice, so it leaves the selected

--- a/packages/coding-agent/src/core/agent-session-models.ts
+++ b/packages/coding-agent/src/core/agent-session-models.ts
@@ -3,7 +3,7 @@ import type { Api, Model } from "@bastani/pi-ai/compat";
 import { clampThinkingLevel, getSupportedThinkingLevels, modelsAreEqual } from "@bastani/pi-ai/compat";
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { AgentSessionInternalSurface as AgentSession } from "./agent-session-methods.ts";
-import { type ModelCycleResult, THINKING_LEVELS } from "./agent-session-types.ts";
+import { type ModelCycleResult, type ModelMutationOptions, THINKING_LEVELS } from "./agent-session-types.ts";
 import { formatNoApiKeyFoundMessage } from "./auth-guidance.ts";
 import { DEFAULT_THINKING_LEVEL } from "./defaults.ts";
 
@@ -92,18 +92,22 @@ export async function _emitModelSelect(
  * @throws Error if no auth is configured for the model
  */
 
-export async function setModel(this: AgentSession, model: Model<Api>): Promise<void> {
+export async function setModel(
+	this: AgentSession,
+	model: Model<Api>,
+	options: ModelMutationOptions = {},
+): Promise<void> {
 	if (!this._modelRuntime.hasConfiguredAuth(model.provider)) {
 		throw new Error(`No API key for ${model.provider}/${model.id}`);
 	}
 	this._clearFallbackModelScope?.();
 
 	const previousModel = this.model;
-	const thinkingLevel = this._getThinkingLevelForModelSwitch();
+	const thinkingLevel = this._getThinkingLevelForModelSwitch(model);
 	const nextModel = model;
 	this.agent.state.model = nextModel;
 	this.sessionManager.appendModelChange(nextModel.provider, nextModel.id);
-	this.settingsManager.setDefaultModelAndProvider(nextModel.provider, nextModel.id);
+	if (options.persist) this.settingsManager.setDefaultModelAndProvider(nextModel.provider, nextModel.id);
 
 	// Re-clamp thinking level for new model's capabilities
 	this.setThinkingLevel(thinkingLevel);
@@ -123,16 +127,18 @@ export async function setModel(this: AgentSession, model: Model<Api>): Promise<v
 export async function cycleModel(
 	this: AgentSession,
 	direction: "forward" | "backward" = "forward",
+	options: ModelMutationOptions = {},
 ): Promise<ModelCycleResult | undefined> {
 	if (this._scopedModels.length > 0) {
-		return this._cycleScopedModel(direction);
+		return this._cycleScopedModel(direction, options);
 	}
-	return this._cycleAvailableModel(direction);
+	return this._cycleAvailableModel(direction, options);
 }
 
 export async function _cycleScopedModel(
 	this: AgentSession,
 	direction: "forward" | "backward",
+	options: ModelMutationOptions,
 ): Promise<ModelCycleResult | undefined> {
 	const scopedModels = this._scopedModels.filter((scoped) =>
 		this._modelRuntime.hasConfiguredAuth(scoped.model.provider),
@@ -146,14 +152,14 @@ export async function _cycleScopedModel(
 	const len = scopedModels.length;
 	const nextIndex = direction === "forward" ? (currentIndex + 1) % len : (currentIndex - 1 + len) % len;
 	const next = scopedModels[nextIndex];
-	const thinkingLevel = this._getThinkingLevelForModelSwitch(next.thinkingLevel);
+	const thinkingLevel = this._getThinkingLevelForModelSwitch(next.model, next.thinkingLevel);
 	const nextModel = next.model;
 
 	// An explicit cycle finishes any active fallback lifecycle before switching.
 	this._clearFallbackModelScope?.();
 	this.agent.state.model = nextModel;
 	this.sessionManager.appendModelChange(nextModel.provider, nextModel.id);
-	this.settingsManager.setDefaultModelAndProvider(nextModel.provider, nextModel.id);
+	if (options.persist) this.settingsManager.setDefaultModelAndProvider(nextModel.provider, nextModel.id);
 
 	// Apply thinking level.
 	// - Explicit scoped model thinking level overrides current session level
@@ -171,6 +177,7 @@ export async function _cycleScopedModel(
 export async function _cycleAvailableModel(
 	this: AgentSession,
 	direction: "forward" | "backward",
+	options: ModelMutationOptions,
 ): Promise<ModelCycleResult | undefined> {
 	const availableModels = await this._modelRuntime.getAvailableSnapshot();
 	if (availableModels.length <= 1) return undefined;
@@ -183,12 +190,12 @@ export async function _cycleAvailableModel(
 	const nextIndex = direction === "forward" ? (currentIndex + 1) % len : (currentIndex - 1 + len) % len;
 	const selectedModel = availableModels[nextIndex];
 
-	const thinkingLevel = this._getThinkingLevelForModelSwitch();
+	const thinkingLevel = this._getThinkingLevelForModelSwitch(selectedModel);
 	// An explicit cycle finishes any active fallback lifecycle before switching.
 	this._clearFallbackModelScope?.();
 	this.agent.state.model = selectedModel;
 	this.sessionManager.appendModelChange(selectedModel.provider, selectedModel.id);
-	this.settingsManager.setDefaultModelAndProvider(selectedModel.provider, selectedModel.id);
+	if (options.persist) this.settingsManager.setDefaultModelAndProvider(selectedModel.provider, selectedModel.id);
 
 	// Re-clamp thinking level for new model's capabilities
 	this.setThinkingLevel(thinkingLevel);
@@ -210,7 +217,7 @@ export async function _cycleAvailableModel(
  * Saves to session and settings only if the level actually changes.
  */
 
-export function setThinkingLevel(this: AgentSession, level: ThinkingLevel): void {
+export function setThinkingLevel(this: AgentSession, level: ThinkingLevel, options: ModelMutationOptions = {}): void {
 	const availableLevels = this.getAvailableThinkingLevels();
 	const effectiveLevel = availableLevels.includes(level) ? level : this._clampThinkingLevel(level, availableLevels);
 
@@ -220,6 +227,8 @@ export function setThinkingLevel(this: AgentSession, level: ThinkingLevel): void
 
 	this.agent.state.thinkingLevel = effectiveLevel;
 
+	if (options.persist) this.settingsManager.setDefaultThinkingLevel(level);
+
 	if (isChanging) {
 		// A reasoning choice is not a model choice, so it leaves the selected
 		// fallback model in place. Keep the active lifecycle open until the turn
@@ -227,9 +236,6 @@ export function setThinkingLevel(this: AgentSession, level: ThinkingLevel): void
 		if (this._fallbackOriginModel !== undefined) this._fallbackOriginThinkingLevel = effectiveLevel;
 		this.sessionManager.appendThinkingLevelChange(effectiveLevel);
 		this._refreshBaseSystemPromptFromActiveTools();
-		if (this.supportsThinking() || effectiveLevel !== "off") {
-			this.settingsManager.setDefaultThinkingLevel(effectiveLevel);
-		}
 		this._emit({ type: "thinking_level_changed", level: effectiveLevel });
 		void this._extensionRunner.emit({
 			type: "thinking_level_select",
@@ -244,7 +250,7 @@ export function setThinkingLevel(this: AgentSession, level: ThinkingLevel): void
  * @returns New level, or undefined if model doesn't support thinking
  */
 
-export function cycleThinkingLevel(this: AgentSession): ThinkingLevel | undefined {
+export function cycleThinkingLevel(this: AgentSession, options: ModelMutationOptions = {}): ThinkingLevel | undefined {
 	if (!this.supportsThinking()) return undefined;
 
 	const levels = this.getAvailableThinkingLevels();
@@ -252,7 +258,7 @@ export function cycleThinkingLevel(this: AgentSession): ThinkingLevel | undefine
 	const nextIndex = (currentIndex + 1) % levels.length;
 	const nextLevel = levels[nextIndex];
 
-	this.setThinkingLevel(nextLevel);
+	this.setThinkingLevel(nextLevel, options);
 	return nextLevel;
 }
 
@@ -274,9 +280,17 @@ export function supportsThinking(this: AgentSession): boolean {
 	return !!this.model?.reasoning;
 }
 
-export function _getThinkingLevelForModelSwitch(this: AgentSession, explicitLevel?: ThinkingLevel): ThinkingLevel {
+export function _getThinkingLevelForModelSwitch(
+	this: AgentSession,
+	targetModel?: Model<Api>,
+	explicitLevel?: ThinkingLevel,
+): ThinkingLevel {
 	if (explicitLevel !== undefined) {
 		return explicitLevel;
+	}
+	if (targetModel) {
+		const perModel = this.settingsManager.getModelThinkingLevel(targetModel.provider, targetModel.id);
+		if (perModel !== undefined) return perModel;
 	}
 	if (!this.supportsThinking()) {
 		return this.settingsManager.getDefaultThinkingLevel() ?? DEFAULT_THINKING_LEVEL;

--- a/packages/coding-agent/src/core/agent-session-types.ts
+++ b/packages/coding-agent/src/core/agent-session-types.ts
@@ -186,6 +186,10 @@ export interface PromptOptions {
 	preflightResult?: (success: boolean) => void;
 }
 
+export interface ModelMutationOptions {
+	persist?: boolean;
+}
+
 export interface ModelCycleResult {
 	model: Model<Api>;
 	thinkingLevel: ThinkingLevel;

--- a/packages/coding-agent/src/core/model-resolver-initial.ts
+++ b/packages/coding-agent/src/core/model-resolver-initial.ts
@@ -51,6 +51,7 @@ export async function findInitialModel(options: {
 	defaultProvider?: string;
 	defaultModelId?: string;
 	defaultThinkingLevel?: ThinkingLevel;
+	modelThinkingLevels?: Record<string, ThinkingLevel>;
 	modelRuntime: ModelRuntime;
 }): Promise<InitialModelResult> {
 	const {
@@ -61,6 +62,7 @@ export async function findInitialModel(options: {
 		defaultProvider,
 		defaultModelId,
 		defaultThinkingLevel,
+		modelThinkingLevels,
 		modelRuntime,
 	} = options;
 
@@ -87,9 +89,11 @@ export async function findInitialModel(options: {
 	}
 
 	if (scopedModels.length > 0 && !isContinuing) {
+		const scopedModel = scopedModels[0];
+		const perModel = modelThinkingLevels?.[`${scopedModel.model.provider}/${scopedModel.model.id}`];
 		return {
-			model: scopedModels[0].model,
-			thinkingLevel: scopedModels[0].thinkingLevel ?? defaultThinkingLevel ?? DEFAULT_THINKING_LEVEL,
+			model: scopedModel.model,
+			thinkingLevel: scopedModel.thinkingLevel ?? perModel ?? defaultThinkingLevel ?? DEFAULT_THINKING_LEVEL,
 			fallbackMessage: undefined,
 		};
 	}
@@ -98,9 +102,9 @@ export async function findInitialModel(options: {
 		const found = modelRuntime.getModel(defaultProvider, defaultModelId);
 		if (found && modelRuntime.hasConfiguredAuth(found.provider)) {
 			model = found;
-			if (defaultThinkingLevel) {
-				thinkingLevel = defaultThinkingLevel;
-			}
+			const perModel = modelThinkingLevels?.[`${defaultProvider}/${defaultModelId}`];
+			if (perModel) thinkingLevel = perModel;
+			else if (defaultThinkingLevel) thinkingLevel = defaultThinkingLevel;
 			return { model, thinkingLevel, fallbackMessage: undefined };
 		}
 		if (!modelRuntime.getProvider(defaultProvider)) {

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -173,6 +173,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			defaultProvider: settingsManager.getDefaultProvider(),
 			defaultModelId: settingsManager.getDefaultModel(),
 			defaultThinkingLevel: settingsManager.getDefaultThinkingLevel(),
+			modelThinkingLevels: settingsManager.getAllModelThinkingLevels(),
 			modelRuntime,
 		});
 		model = result.model;
@@ -198,7 +199,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			: (settingsManager.getDefaultThinkingLevel() ?? DEFAULT_THINKING_LEVEL);
 	}
 
-	// Fall back to settings default
+	// Fall back to per-model override, then global default
+	if (thinkingLevel === undefined && model) {
+		thinkingLevel = settingsManager.getModelThinkingLevel(model.provider, model.id);
+	}
 	if (thinkingLevel === undefined) {
 		thinkingLevel = settingsManager.getDefaultThinkingLevel() ?? DEFAULT_THINKING_LEVEL;
 	}

--- a/packages/coding-agent/src/core/settings-manager-basic-accessors.ts
+++ b/packages/coding-agent/src/core/settings-manager-basic-accessors.ts
@@ -32,6 +32,17 @@ interface SettingsManagerBasicAccessors {
 	setShowCacheMissNotices(enabled: boolean): void;
 	getDefaultThinkingLevel(): "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | undefined;
 	setDefaultThinkingLevel(level: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max"): void;
+	getModelThinkingLevel(
+		provider: string,
+		modelId: string,
+	): "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | undefined;
+	getAllModelThinkingLevels(): Record<string, "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max">;
+	setModelThinkingLevel(
+		provider: string,
+		modelId: string,
+		level: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max",
+	): void;
+	removeModelThinkingLevel(provider: string, modelId: string): void;
 	getDefaultTools(): string[] | undefined;
 	getFallbackModels(): string[];
 	getTransport(): TransportSetting;
@@ -216,6 +227,32 @@ const basicAccessors: SettingsManagerBasicAccessors = {
 		const state = settingsInternals(this);
 		state.globalSettings.defaultThinkingLevel = level;
 		state.markModified("defaultThinkingLevel");
+		state.save();
+	},
+
+	getModelThinkingLevel(provider, modelId) {
+		return settingsInternals(this).settings.modelThinkingLevels?.[`${provider}/${modelId}`];
+	},
+
+	getAllModelThinkingLevels() {
+		return { ...(settingsInternals(this).settings.modelThinkingLevels ?? {}) };
+	},
+
+	setModelThinkingLevel(provider, modelId, level) {
+		const state = settingsInternals(this);
+		state.globalSettings.modelThinkingLevels ??= {};
+		state.globalSettings.modelThinkingLevels[`${provider}/${modelId}`] = level;
+		state.markModified("modelThinkingLevels");
+		state.save();
+	},
+
+	removeModelThinkingLevel(provider, modelId) {
+		const state = settingsInternals(this);
+		if (!state.globalSettings.modelThinkingLevels) return;
+		delete state.globalSettings.modelThinkingLevels[`${provider}/${modelId}`];
+		if (Object.keys(state.globalSettings.modelThinkingLevels).length === 0)
+			delete state.globalSettings.modelThinkingLevels;
+		state.markModified("modelThinkingLevels");
 		state.save();
 	},
 

--- a/packages/coding-agent/src/core/settings-types.ts
+++ b/packages/coding-agent/src/core/settings-types.ts
@@ -107,6 +107,7 @@ export interface Settings {
 	defaultProvider?: string;
 	defaultModel?: string;
 	defaultThinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+	modelThinkingLevels?: Record<string, "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max">;
 	fallbackModels?: string[]; // Ordered main-chat fallback models, optionally suffixed with :thinkingLevel
 	transport?: TransportSetting; // default: "auto"
 	steeringMode?: "all" | "one-at-a-time";

--- a/packages/coding-agent/test/suite/agent-session-cycle-controls.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-cycle-controls.test.ts
@@ -91,7 +91,7 @@ describe("AgentSession cycle fallback controls", () => {
 		expect(modelChanges(harness)).toEqual([`${current.provider}/${current.id}`]);
 	});
 
-	it("clears the lock after a real backward cycle changes and persists the model", async () => {
+	it("clears the lock after a real backward cycle changes the session model", async () => {
 		const harness = await createHarness({
 			models: [
 				{ id: "faux-1", name: "One", reasoning: true },
@@ -99,6 +99,7 @@ describe("AgentSession cycle fallback controls", () => {
 			],
 		});
 		harnesses.push(harness);
+		const previousDefault = harness.settingsManager.getDefaultModel();
 		const runtime = lockedRuntime(harness);
 
 		const response = await cycleHandler(
@@ -117,7 +118,7 @@ describe("AgentSession cycle fallback controls", () => {
 			data: { model: { provider: harness.getModel("faux-2")?.provider, id: "faux-2" } },
 		});
 		expect(harness.session.model?.id).toBe("faux-2");
-		expect(harness.settingsManager.getDefaultModel()).toBe("faux-2");
+		expect(harness.settingsManager.getDefaultModel()).toBe(previousDefault);
 		expect(modelChanges(harness)).toEqual([`${harness.getModel().provider}/faux-2`]);
 		expect(runtime.modelFallbackMessage).toBeUndefined();
 		expect(runtime.modelFallbackReason).toBeUndefined();
@@ -142,6 +143,7 @@ describe("AgentSession cycle fallback controls", () => {
 			],
 		});
 		harnesses.push(harness);
+		const previousDefault = harness.settingsManager.getDefaultModel();
 		await harness.session.bindExtensions({
 			shutdownHandler: () => {},
 			onError: (error) => extensionErrors.push(`${error.event}:${error.error}`),
@@ -155,7 +157,7 @@ describe("AgentSession cycle fallback controls", () => {
 		expect(hookCalls).toBe(1);
 		expect(extensionErrors).toEqual(["model_select:cycle selection rejected"]);
 		expect(harness.session.model?.id).toBe("faux-2");
-		expect(harness.settingsManager.getDefaultModel()).toBe("faux-2");
+		expect(harness.settingsManager.getDefaultModel()).toBe(previousDefault);
 		expect(modelChanges(harness)).toEqual([`${harness.getModel().provider}/faux-2`]);
 		expect(runtime.modelFallbackMessage).toBeUndefined();
 		expect(runtime.modelFallbackReason).toBeUndefined();


### PR DESCRIPTION
Stack 4/9. Session-scoped model and thinking-level changes (upstream #8356): ModelMutationOptions, per-model thinking storage + accessors, startup precedence. Enter selects for the session; persistence is explicit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790273427&installation_model_id=10562&pr_number=2678&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2678&signature=7a9da68a0c0af65a96ec2bc6fa5e3d6c03aa5bddf9d9296a457cb987cb9e539e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The change keeps ordinary model cycling scoped to the active session and stores persisted thinking preferences per active model using the effective supported level.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

No accepted P0 or P1 findings remain.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the general contract validation showing how the agent-session-models.ts logic chooses setModelThinkingLevel when a session model is active.
- Confirmed that, in the absence of a model, the code calls setDefaultThinkingLevel to apply a default level.
- Verified that effectiveLevel is computed by clamping capabilities and then persisted to storage.
- Inspected the authored validation test trex-pr2678-thinking-persistence.test.ts to confirm the persistence behavior described in the contract validation.

<a href="https://app.greptile.com/trex/runs/20650768/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(coding-agent): persist thinking per ..."](https://github.com/bastani-inc/atomic/commit/b7ef9d8b9481e330ee258d982c7cd78723deaf60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56766231)</sub>

<!-- /greptile_comment -->