### PR TITLE
feat(coding-agent): add thinking selectors and /thinking

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `/thinking` and a thinking-level selector. Enter applies the level to the current session; persist writes a per-model startup override. Settings can list, change, and clear those overrides.
+
 ### Fixed
 
 - Fixed Windows compiled binaries crashing with `ERR_INVALID_FILE_URL_PATH` when Return reached native modifier detection, including from the `/model` selector. Release app bundles keep only `pi-tui`'s native modifier loader runtime-relative, avoiding both the Linux build host's frozen module URL and Bun's inability to resolve a fully external `pi-tui` from a compiled split launcher, while retaining the staged Windows native helper for Shift+Enter handling.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fixed the thinking-level selector so a capability-clamped default still receives the default badge when the saved setting is higher than the active model supports.
 - Fixed Windows compiled binaries crashing with `ERR_INVALID_FILE_URL_PATH` when Return reached native modifier detection, including from the `/model` selector. Release app bundles keep only `pi-tui`'s native modifier loader runtime-relative, avoiding both the Linux build host's frozen module URL and Bun's inability to resolve a fully external `pi-tui` from a compiled split launcher, while retaining the staged Windows native helper for Shift+Enter handling.
 - Fixed `bundle:dev` and `start:fast` omitting the statically registered OAuth adapters. Development bundles now use the Bun entrypoint shared with compiled builds, so OpenAI Codex and xAI OAuth derivation and refresh no longer fail on unresolved runtime imports.
 - Fixed duplicate fullscreen right-click paste in VS Code-based terminals on Windows ([#8186](https://github.com/earendil-works/pi/issues/8186)).

--- a/packages/coding-agent/docs/models.md
+++ b/packages/coding-agent/docs/models.md
@@ -334,6 +334,8 @@ Example for a model where thinking cannot be disabled:
 
 Migration: older configs that used `compat.reasoningEffortMap` should move that mapping to model-level `thinkingLevelMap`. Use `null` for levels that should not appear in the UI.
 
+`/thinking` opens the thinking-level selector. Enter applies the level to the current session only. Persist (the selector's save action) writes `settings.modelThinkingLevels` for the active model instead of replacing the global `defaultThinkingLevel`. Settings → Default thinking level per model lists those overrides.
+
 ### Context Window
 
 `contextWindow` is the model's context size in tokens and drives local budgeting,

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -53,9 +53,9 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	private filteredModels: ModelItem[] = [];
 	private selectedIndex: number = 0;
 	private currentModel?: Model<Api>;
-	private settingsManager: SettingsManager;
+	private defaultModelKey?: string;
 	private modelRuntime: ModelRuntime;
-	private onSelectCallback: (model: Model<Api>) => void;
+	private onSelectCallback: (model: Model<Api>, persist: boolean) => void;
 	private onCancelCallback: () => void;
 	private errorMessage?: string;
 	private tui: TUI;
@@ -71,10 +71,10 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	constructor(
 		tui: TUI,
 		currentModel: Model<Api> | undefined,
-		settingsManager: SettingsManager,
+		_settingsManager: SettingsManager,
 		modelRuntime: ModelRuntime,
 		scopedModels: ReadonlyArray<ScopedModelItem>,
-		onSelect: (model: Model<Api>) => void,
+		onSelect: (model: Model<Api>, persist: boolean) => void,
 		onCancel: () => void,
 		initialSearchInput?: string,
 	) {
@@ -82,7 +82,9 @@ export class ModelSelectorComponent extends Container implements Focusable {
 
 		this.tui = tui;
 		this.currentModel = currentModel;
-		this.settingsManager = settingsManager;
+		const defaultProvider = _settingsManager.getDefaultProvider();
+		const defaultModel = _settingsManager.getDefaultModel();
+		this.defaultModelKey = defaultProvider && defaultModel ? `${defaultProvider}/${defaultModel}` : undefined;
 		this.modelRuntime = modelRuntime;
 		this.scopedModels = scopedModels;
 		this.scope = scopedModels.length > 0 ? "scoped" : "all";
@@ -113,7 +115,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		this.searchInput.onSubmit = () => {
 			// Enter on search input selects the first filtered item
 			if (this.filteredModels[this.selectedIndex]) {
-				this.handleSelect(this.filteredModels[this.selectedIndex].model);
+				this.handleSelect(this.filteredModels[this.selectedIndex].model, false);
 			}
 		};
 		this.addChild(this.searchInput);
@@ -196,12 +198,14 @@ export class ModelSelectorComponent extends Container implements Focusable {
 
 	private sortModels(models: ModelItem[]): ModelItem[] {
 		const sorted = [...models];
-		// Sort: current model first, then by provider
+		// Sort current first, saved default second, then by provider.
 		sorted.sort((a, b) => {
 			const aIsCurrent = modelsAreEqual(this.currentModel, a.model);
 			const bIsCurrent = modelsAreEqual(this.currentModel, b.model);
-			if (aIsCurrent && !bIsCurrent) return -1;
-			if (!aIsCurrent && bIsCurrent) return 1;
+			if (aIsCurrent !== bIsCurrent) return aIsCurrent ? -1 : 1;
+			const aIsDefault = `${a.provider}/${a.id}` === this.defaultModelKey;
+			const bIsDefault = `${b.provider}/${b.id}` === this.defaultModelKey;
+			if (aIsDefault !== bIsDefault) return aIsDefault ? -1 : 1;
 			return a.provider.localeCompare(b.provider);
 		});
 		return sorted;
@@ -231,8 +235,11 @@ export class ModelSelectorComponent extends Container implements Focusable {
 
 	private filterModels(query: string): void {
 		this.filteredModels = query
-			? fuzzyFilter(this.activeModels, query, ({ id, provider, model }) =>
-					getModelSelectorSearchText({ id, provider, name: model.name }),
+			? fuzzyFilter(
+					this.activeModels,
+					query,
+					({ id, provider, model }) =>
+						`${getModelSelectorSearchText({ id, provider, name: model.name })} ${`${provider}/${id}` === this.defaultModelKey ? "default" : ""}`,
 				)
 			: this.activeModels;
 		// When filtering by a query, move the selector to the top row so the best
@@ -259,18 +266,19 @@ export class ModelSelectorComponent extends Container implements Focusable {
 
 			const isSelected = i === this.selectedIndex;
 			const isCurrent = modelsAreEqual(this.currentModel, item.model);
+			const isDefault = `${item.provider}/${item.id}` === this.defaultModelKey;
 
 			let line = "";
 			if (isSelected) {
 				const prefix = theme.fg("accent", "→ ");
 				const modelText = `${item.id}`;
 				const providerBadge = theme.fg("muted", `[${item.provider}]`);
-				const checkmark = isCurrent ? theme.fg("success", " ✓") : "";
+				const checkmark = isCurrent ? theme.fg("success", " ✓") : isDefault ? theme.fg("muted", " · default") : "";
 				line = `${prefix + theme.fg("accent", modelText)} ${providerBadge}${checkmark}`;
 			} else {
 				const modelText = `  ${item.id}`;
 				const providerBadge = theme.fg("muted", `[${item.provider}]`);
-				const checkmark = isCurrent ? theme.fg("success", " ✓") : "";
+				const checkmark = isCurrent ? theme.fg("success", " ✓") : isDefault ? theme.fg("muted", " · default") : "";
 				line = `${modelText} ${providerBadge}${checkmark}`;
 			}
 
@@ -329,11 +337,16 @@ export class ModelSelectorComponent extends Container implements Focusable {
 			this.selectedIndex = this.selectedIndex === this.filteredModels.length - 1 ? 0 : this.selectedIndex + 1;
 			this.updateList();
 		}
+		// Ctrl+S persists the selected model as the startup default
+		else if (kb.matches(keyData, "app.models.save")) {
+			const selectedModel = this.filteredModels[this.selectedIndex];
+			if (selectedModel) this.handleSelect(selectedModel.model, true);
+		}
 		// Enter
 		else if (kb.matches(keyData, "tui.select.confirm")) {
 			const selectedModel = this.filteredModels[this.selectedIndex];
 			if (selectedModel) {
-				this.handleSelect(selectedModel.model);
+				this.handleSelect(selectedModel.model, false);
 			}
 		}
 		// Escape or Ctrl+C
@@ -349,11 +362,9 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		return true;
 	}
 
-	private handleSelect(model: Model<Api>): void {
+	private handleSelect(model: Model<Api>, persist: boolean): void {
 		this.dispose();
-		// Save as new default
-		this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
-		this.onSelectCallback(model);
+		this.onSelectCallback(model, persist);
 	}
 
 	getSearchInput(): Input {

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector-items.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector-items.ts
@@ -255,6 +255,10 @@ export function buildSettingsItems(config: SettingsConfig, callbacks: SettingsCa
 					: `${Object.keys(config.modelThinkingLevels ?? {}).length} configured`,
 			submenu: (_currentValue, done) => {
 				const levels: ThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
+				const thinkingCountLabel = () => {
+					const count = Object.keys(config.modelThinkingLevels ?? {}).length;
+					return count === 0 ? "none" : `${count} configured`;
+				};
 				const options = (config.availableDefaultModels ?? []).flatMap((model) => {
 					const key = `${model.provider}/${model.id}`;
 					const available = model.reasoning ? levels : (["off"] as ThinkingLevel[]);
@@ -281,13 +285,16 @@ export function buildSettingsItems(config: SettingsConfig, callbacks: SettingsCa
 						const slash = key.indexOf("/");
 						const provider = key.slice(0, slash);
 						const modelId = key.slice(slash + 1);
-						if (level) callbacks.onModelThinkingLevelChange?.(provider, modelId, level as ThinkingLevel);
-						else callbacks.onModelThinkingLevelRemove?.(provider, modelId);
-						done(
-							Object.keys(config.modelThinkingLevels ?? {}).length === 0
-								? "none"
-								: `${Object.keys(config.modelThinkingLevels ?? {}).length} configured`,
-						);
+						if (level) {
+							callbacks.onModelThinkingLevelChange?.(provider, modelId, level as ThinkingLevel);
+							config.modelThinkingLevels = { ...config.modelThinkingLevels, [key]: level as ThinkingLevel };
+						} else {
+							callbacks.onModelThinkingLevelRemove?.(provider, modelId);
+							const next = { ...config.modelThinkingLevels };
+							delete next[key];
+							config.modelThinkingLevels = next;
+						}
+						done(thinkingCountLabel());
 					},
 					() => done(),
 					undefined,

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector-items.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector-items.ts
@@ -2,7 +2,7 @@ import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { getCapabilities, type SettingItem } from "@earendil-works/pi-tui";
 import { formatHttpIdleTimeoutMs, HTTP_IDLE_TIMEOUT_CHOICES } from "../../../core/http-dispatcher.ts";
 import { keyDisplayText } from "./keybinding-hints.ts";
-import { DEFAULT_PROJECT_TRUST_LABELS, THINKING_DESCRIPTIONS } from "./settings-selector-options.ts";
+import { DEFAULT_PROJECT_TRUST_LABELS } from "./settings-selector-options.ts";
 import { SelectSubmenu, ThemeSubmenu, WarningSettingsSubmenu } from "./settings-selector-submenus.ts";
 import type { SettingsCallbacks, SettingsConfig } from "./settings-selector-types.ts";
 
@@ -246,26 +246,54 @@ export function buildSettingsItems(config: SettingsConfig, callbacks: SettingsCa
 				),
 		},
 		{
-			id: "thinking",
-			label: "Thinking level",
-			description: "Reasoning depth for thinking-capable models",
-			currentValue: config.thinkingLevel,
-			submenu: (currentValue, done) =>
-				new SelectSubmenu(
-					"Thinking Level",
-					"Select reasoning depth for thinking-capable models",
-					config.availableThinkingLevels.map((level) => ({
-						value: level,
-						label: level,
-						description: THINKING_DESCRIPTIONS[level],
-					})),
-					currentValue,
+			id: "model-thinking",
+			label: "Default thinking level per model",
+			description: "Search models and set a startup thinking override",
+			currentValue:
+				Object.keys(config.modelThinkingLevels ?? {}).length === 0
+					? "none"
+					: `${Object.keys(config.modelThinkingLevels ?? {}).length} configured`,
+			submenu: (_currentValue, done) => {
+				const levels: ThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
+				const options = (config.availableDefaultModels ?? []).flatMap((model) => {
+					const key = `${model.provider}/${model.id}`;
+					const available = model.reasoning ? levels : (["off"] as ThinkingLevel[]);
+					const items = available.map((level) => ({
+						value: `${key}\0${level}`,
+						label: `${model.id} [${model.provider}]`,
+						description: `${level}${config.modelThinkingLevels?.[key] === level ? " · default" : ""}`,
+					}));
+					if (config.modelThinkingLevels?.[key] !== undefined)
+						items.push({
+							value: `${key}\0`,
+							label: `${model.id} [${model.provider}]`,
+							description: "clear override",
+						});
+					return items;
+				});
+				return new SelectSubmenu(
+					"Per-Model Thinking Level",
+					"Select a model and thinking level",
+					options,
+					"",
 					(value) => {
-						callbacks.onThinkingLevelChange(value as ThinkingLevel);
-						done(value);
+						const [key, level] = value.split("\0");
+						const slash = key.indexOf("/");
+						const provider = key.slice(0, slash);
+						const modelId = key.slice(slash + 1);
+						if (level) callbacks.onModelThinkingLevelChange?.(provider, modelId, level as ThinkingLevel);
+						else callbacks.onModelThinkingLevelRemove?.(provider, modelId);
+						done(
+							Object.keys(config.modelThinkingLevels ?? {}).length === 0
+								? "none"
+								: `${Object.keys(config.modelThinkingLevels ?? {}).length} configured`,
+						);
 					},
 					() => done(),
-				),
+					undefined,
+					true,
+				);
+			},
 		},
 		{
 			id: "theme",

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector-submenus.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector-submenus.ts
@@ -1,5 +1,14 @@
 import type { Component, SelectItem, SelectListLayoutOptions, SettingItem } from "@earendil-works/pi-tui";
-import { Container, SelectList, SettingsList, Spacer, Text } from "@earendil-works/pi-tui";
+import {
+	Container,
+	fuzzyFilter,
+	getKeybindings,
+	Input,
+	SelectList,
+	SettingsList,
+	Spacer,
+	Text,
+} from "@earendil-works/pi-tui";
 import type { WarningSettings } from "../../../core/settings-manager.ts";
 import {
 	getSelectListTheme,
@@ -65,6 +74,12 @@ export class WarningSettingsSubmenu extends Container {
 
 export class SelectSubmenu extends Container {
 	private selectList: SelectList;
+	private readonly allOptions: SelectItem[];
+	private readonly currentValue: string;
+	private readonly onSelectValue: (value: string) => void;
+	private readonly onCancelValue: () => void;
+	private searchInput?: Input;
+	private listChildIndex = 0;
 
 	constructor(
 		title: string,
@@ -74,14 +89,25 @@ export class SelectSubmenu extends Container {
 		onSelect: (value: string) => void,
 		onCancel: () => void,
 		onSelectionChange?: (value: string) => void,
+		searchable = false,
 	) {
 		super();
+		this.allOptions = options;
+		this.currentValue = currentValue;
+		this.onSelectValue = onSelect;
+		this.onCancelValue = onCancel;
 
 		this.addChild(new Text(theme.bold(theme.fg("accent", title)), 0, 0));
 
 		if (description) {
 			this.addChild(new Spacer(1));
 			this.addChild(new Text(theme.fg("muted", description), 0, 0));
+		}
+
+		if (searchable) {
+			this.addChild(new Spacer(1));
+			this.searchInput = new Input();
+			this.addChild(this.searchInput);
 		}
 
 		this.addChild(new Spacer(1));
@@ -110,6 +136,7 @@ export class SelectSubmenu extends Container {
 			};
 		}
 
+		this.listChildIndex = this.children.length;
 		this.addChild(this.selectList);
 
 		this.addChild(new Spacer(1));
@@ -117,7 +144,37 @@ export class SelectSubmenu extends Container {
 	}
 
 	handleInput(data: string): boolean {
-		this.selectList.handleInput(data);
+		if (!this.searchInput) {
+			this.selectList.handleInput(data);
+			return true;
+		}
+		const kb = getKeybindings();
+		if (
+			kb.matches(data, "tui.select.up") ||
+			kb.matches(data, "tui.select.down") ||
+			kb.matches(data, "tui.select.confirm") ||
+			kb.matches(data, "tui.select.cancel")
+		) {
+			this.selectList.handleInput(data);
+			return true;
+		}
+		this.searchInput.handleInput(data);
+		const query = this.searchInput.getValue();
+		const options = query
+			? fuzzyFilter(this.allOptions, query, (item) => `${item.label} ${item.description ?? ""}`)
+			: this.allOptions;
+		const list = new SelectList(
+			options,
+			Math.min(options.length, 10),
+			getSelectListTheme(),
+			SETTINGS_SUBMENU_SELECT_LIST_LAYOUT,
+		);
+		const currentIndex = options.findIndex((item) => item.value === this.currentValue);
+		if (currentIndex !== -1) list.setSelectedIndex(currentIndex);
+		list.onSelect = (item) => this.onSelectValue(item.value);
+		list.onCancel = this.onCancelValue;
+		this.children[this.listChildIndex] = list;
+		this.selectList = list;
 		return true;
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector-types.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector-types.ts
@@ -1,4 +1,4 @@
-import type { Transport } from "@bastani/pi-ai/compat";
+import type { Api, Model, Transport } from "@bastani/pi-ai/compat";
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { ScrollViewScrollbar } from "@earendil-works/pi-tui";
 import type {
@@ -27,6 +27,8 @@ export interface SettingsConfig {
 	bashInterceptorEnabled: boolean;
 	thinkingLevel: ThinkingLevel;
 	availableThinkingLevels: ThinkingLevel[];
+	availableDefaultModels?: Model<Api>[];
+	modelThinkingLevels?: Record<string, ThinkingLevel>;
 	currentTheme: string;
 	terminalTheme: TerminalTheme;
 	availableThemes: string[];
@@ -64,6 +66,8 @@ export interface SettingsCallbacks {
 	onHttpIdleTimeoutChange: (timeoutMs: number) => void;
 	onBashInterceptorEnabledChange: (enabled: boolean) => void;
 	onThinkingLevelChange: (level: ThinkingLevel) => void;
+	onModelThinkingLevelChange?: (provider: string, modelId: string, level: ThinkingLevel) => void;
+	onModelThinkingLevelRemove?: (provider: string, modelId: string) => void;
 	onThemeChange: (theme: string) => void;
 	onThemePreview?: (theme: string) => void;
 	onHideThinkingBlockChange: (hidden: boolean) => void;

--- a/packages/coding-agent/src/modes/interactive/components/thinking-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/thinking-selector.ts
@@ -1,13 +1,22 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
-import { Container, type SelectItem, SelectList, type SelectListLayoutOptions } from "@earendil-works/pi-tui";
-import { getSelectListTheme } from "../theme/theme.ts";
+import {
+	Container,
+	type Focusable,
+	fuzzyFilter,
+	getKeybindings,
+	Input,
+	matchesKey,
+	type SelectItem,
+	SelectList,
+	type SelectListLayoutOptions,
+	Spacer,
+	Text,
+} from "@earendil-works/pi-tui";
+import { getSelectListTheme, theme } from "../theme/theme.ts";
 import { DynamicBorder } from "./dynamic-border.ts";
+import { keyDisplayText } from "./keybinding-hints.ts";
 
-const THINKING_SELECT_LIST_LAYOUT: SelectListLayoutOptions = {
-	minPrimaryColumnWidth: 12,
-	maxPrimaryColumnWidth: 32,
-};
-
+const THINKING_SELECT_LIST_LAYOUT: SelectListLayoutOptions = { minPrimaryColumnWidth: 12, maxPrimaryColumnWidth: 32 };
 const LEVEL_DESCRIPTIONS: Record<ThinkingLevel, string> = {
 	off: "No reasoning",
 	minimal: "Very brief reasoning (~1k tokens)",
@@ -18,55 +27,95 @@ const LEVEL_DESCRIPTIONS: Record<ThinkingLevel, string> = {
 	max: "Maximum reasoning",
 };
 
-/**
- * Component that renders a thinking level selector with borders
- */
-export class ThinkingSelectorComponent extends Container {
+export class ThinkingSelectorComponent extends Container implements Focusable {
+	private searchInput: Input;
 	private selectList: SelectList;
+	private selectListChildIndex: number;
+	private allItems: SelectItem[];
+	private readonly onSelectLevel: (level: ThinkingLevel) => void;
+	private readonly onCancelSelect: () => void;
+	private readonly onSelectAsDefault?: (level: ThinkingLevel) => void;
+	private _focused = false;
+
+	get focused(): boolean {
+		return this._focused;
+	}
+	set focused(value: boolean) {
+		this._focused = value;
+		this.searchInput.focused = value;
+	}
 
 	constructor(
 		currentLevel: ThinkingLevel,
 		availableLevels: ThinkingLevel[],
-		onSelect: (level: ThinkingLevel) => void,
-		onCancel: () => void,
+		onSelectLevel: (level: ThinkingLevel) => void,
+		onCancelSelect: () => void,
+		onSelectAsDefault?: (level: ThinkingLevel) => void,
+		defaultThinkingLevel?: ThinkingLevel,
 	) {
 		super();
-
-		const thinkingLevels: SelectItem[] = availableLevels.map((level) => ({
+		this.onSelectLevel = onSelectLevel;
+		this.onCancelSelect = onCancelSelect;
+		this.onSelectAsDefault = onSelectAsDefault;
+		this.allItems = availableLevels.map((level) => ({
 			value: level,
 			label: level,
-			description: LEVEL_DESCRIPTIONS[level],
+			description:
+				level === defaultThinkingLevel ? `${LEVEL_DESCRIPTIONS[level]} · default` : LEVEL_DESCRIPTIONS[level],
 		}));
-
-		// Add top border
 		this.addChild(new DynamicBorder());
-
-		// Create selector
-		this.selectList = new SelectList(
-			thinkingLevels,
-			thinkingLevels.length,
-			getSelectListTheme(),
-			THINKING_SELECT_LIST_LAYOUT,
-		);
-
-		// Preselect current level
-		const currentIndex = thinkingLevels.findIndex((item) => item.value === currentLevel);
-		if (currentIndex !== -1) {
-			this.selectList.setSelectedIndex(currentIndex);
-		}
-
-		this.selectList.onSelect = (item) => {
-			onSelect(item.value as ThinkingLevel);
-		};
-
-		this.selectList.onCancel = () => {
-			onCancel();
-		};
-
+		this.addChild(new Spacer(1));
+		this.addChild(new Text("Thinking Level", 0, 0));
+		this.addChild(new Text(`${keyDisplayText("app.thinking.cycle")} cycles thinking levels in-session`, 0, 0));
+		this.addChild(new Spacer(1));
+		this.searchInput = new Input();
+		this.searchInput.onSubmit = () => this.selectList.handleInput("\r");
+		this.addChild(this.searchInput);
+		this.addChild(new Spacer(1));
+		this.selectList = this.buildSelectList(this.allItems, currentLevel);
+		this.selectListChildIndex = this.children.length;
 		this.addChild(this.selectList);
-
-		// Add bottom border
+		this.addChild(new Text(theme.fg("dim", "  Enter to select · Ctrl+S to set as default · Esc to cancel"), 0, 0));
 		this.addChild(new DynamicBorder());
+	}
+
+	private buildSelectList(items: SelectItem[], preselect?: ThinkingLevel): SelectList {
+		const list = new SelectList(items, Math.max(1, items.length), getSelectListTheme(), THINKING_SELECT_LIST_LAYOUT);
+		const index = items.findIndex((item) => item.value === preselect);
+		if (index !== -1) list.setSelectedIndex(index);
+		list.onSelect = (item) => this.onSelectLevel(item.value as ThinkingLevel);
+		list.onCancel = () => this.onCancelSelect();
+		return list;
+	}
+
+	private applyFilter(query: string): void {
+		const items = query
+			? fuzzyFilter(this.allItems, query, (item) => `${item.label} ${item.description ?? ""}`)
+			: this.allItems;
+		const selected = this.selectList.getSelectedItem()?.value as ThinkingLevel | undefined;
+		const list = this.buildSelectList(items, selected);
+		this.children[this.selectListChildIndex] = list;
+		this.selectList = list;
+	}
+
+	handleInput(keyData: string): void {
+		if (matchesKey(keyData, "ctrl+s") && this.onSelectAsDefault) {
+			const item = this.selectList.getSelectedItem();
+			if (item) this.onSelectAsDefault(item.value as ThinkingLevel);
+			return;
+		}
+		const kb = getKeybindings();
+		if (
+			kb.matches(keyData, "tui.select.up") ||
+			kb.matches(keyData, "tui.select.down") ||
+			kb.matches(keyData, "tui.select.confirm") ||
+			kb.matches(keyData, "tui.select.cancel")
+		) {
+			this.selectList.handleInput(keyData);
+			return;
+		}
+		this.searchInput.handleInput(keyData);
+		this.applyFilter(this.searchInput.getValue());
 	}
 
 	getSelectList(): SelectList {

--- a/packages/coding-agent/src/modes/interactive/interactive-input-handling.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-input-handling.ts
@@ -296,6 +296,11 @@ InteractiveModeBase.prototype.setupEditorSubmitHandler = function (this: Interac
 				await this.handleModelCommand(searchTerm);
 				return;
 			}
+			if (text === "/thinking" || text.startsWith("/thinking ")) {
+				this.editor.setText("");
+				this.handleThinkingCommand(text.startsWith("/thinking ") ? text.slice(10).trim() : undefined);
+				return;
+			}
 			if (text === "/export" || text.startsWith("/export ")) {
 				await this.handleExportCommand(text);
 				this.editor.setText("");

--- a/packages/coding-agent/src/modes/interactive/interactive-input-handling.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-input-handling.ts
@@ -298,6 +298,7 @@ InteractiveModeBase.prototype.setupEditorSubmitHandler = function (this: Interac
 			}
 			if (text === "/thinking" || text.startsWith("/thinking ")) {
 				this.editor.setText("");
+				await this.ensureDeferredStartupComplete();
 				this.handleThinkingCommand(text.startsWith("/thinking ") ? text.slice(10).trim() : undefined);
 				return;
 			}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-deps.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-deps.ts
@@ -164,6 +164,7 @@ export { ScopedModelsSelectorComponent } from "./components/scoped-models-select
 export { SessionSelectorComponent } from "./components/session-selector.ts";
 export { SettingsSelectorComponent } from "./components/settings-selector.ts";
 export { SkillInvocationMessageComponent } from "./components/skill-invocation-message.ts";
+export { ThinkingSelectorComponent } from "./components/thinking-selector.ts";
 export { ToolExecutionComponent } from "./components/tool-execution.ts";
 export { TreeSelectorComponent } from "./components/tree-selector.ts";
 export { TrustSelectorComponent } from "./components/trust-selector.ts";

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-surface.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-surface.ts
@@ -1,3 +1,4 @@
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 /** Method surface installed onto InteractiveModeBase by sibling modules. */
 
 import type { MarkdownTransformer } from "../../core/extensions/types.ts";
@@ -325,6 +326,9 @@ declare module "./interactive-mode-base.ts" {
 		showFastModeSelector(): void;
 		showSettingsSelector(): void;
 		handleModelCommand(searchTerm?: string): Promise<void>;
+		handleThinkingCommand(searchTerm?: string): void;
+		selectThinkingLevel(level: ThinkingLevel, persist: boolean): void;
+		showThinkingSelector(): void;
 		findExactModelMatch(searchTerm: string): Promise<Model<Api> | undefined>;
 		getModelCandidates(): Promise<Model<Api>[]>;
 		updateAvailableProviderCount(): Promise<void>;

--- a/packages/coding-agent/src/modes/interactive/interactive-model-routing.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-model-routing.ts
@@ -1,3 +1,4 @@
+import { clampThinkingLevel } from "@bastani/pi-ai/compat";
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { boundedInteractiveModelRefresh } from "../../core/bounded-model-refresh.ts";
 import { isOfflineModeEnabled } from "../../core/package-manager-env.ts";
@@ -14,6 +15,19 @@ import {
 } from "./interactive-mode-deps.ts";
 import { ANTHROPIC_SUBSCRIPTION_AUTH_WARNING, isAnthropicSubscriptionAuthKey } from "./interactive-mode-helpers.ts";
 import { refreshModelCatalogs } from "./model-catalog-refresh.ts";
+
+export function resolveThinkingSelectorDefault(
+	rawDefault: ThinkingLevel | undefined,
+	availableLevels: readonly ThinkingLevel[],
+	model: Model<Api> | undefined,
+): ThinkingLevel | undefined {
+	if (rawDefault === undefined) return undefined;
+	if (availableLevels.includes(rawDefault)) return rawDefault;
+	if (!model) return availableLevels.includes("off") ? "off" : availableLevels[0];
+	const clamped = clampThinkingLevel(model, rawDefault) as ThinkingLevel;
+	if (availableLevels.includes(clamped)) return clamped;
+	return availableLevels.includes("off") ? "off" : availableLevels[0];
+}
 
 InteractiveModeBase.prototype.handleModelCommand = async function (
 	this: InteractiveModeBase,
@@ -372,18 +386,19 @@ InteractiveModeBase.prototype.showThinkingSelector = function (this: Interactive
 			done();
 		};
 		const model = this.session.model;
-		const modelDefault =
+		const availableLevels = this.session.getAvailableThinkingLevels();
+		const rawDefault =
 			model === undefined
 				? this.settingsManager.getDefaultThinkingLevel()
 				: (this.settingsManager.getModelThinkingLevel(model.provider, model.id) ??
 					this.settingsManager.getDefaultThinkingLevel());
 		const selector = new ThinkingSelectorComponent(
 			this.session.thinkingLevel,
-			this.session.getAvailableThinkingLevels(),
+			availableLevels,
 			(level) => select(level, false),
 			() => done(),
 			(level) => select(level, true),
-			modelDefault,
+			resolveThinkingSelectorDefault(rawDefault, availableLevels, model),
 		);
 		return { component: selector, focus: selector };
 	});

--- a/packages/coding-agent/src/modes/interactive/interactive-model-routing.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-model-routing.ts
@@ -29,6 +29,27 @@ export function resolveThinkingSelectorDefault(
 	return availableLevels.includes("off") ? "off" : availableLevels[0];
 }
 
+/**
+ * The saved level the active session would start from, in the precedence
+ * `findInitialModel` uses: a scoped `--models "id:level"` entry wins over a
+ * persisted per-model override, which wins over the global default. Matching
+ * it keeps the selector badge from advertising a level the session never used.
+ */
+export function resolveSessionThinkingDefault(
+	model: Model<Api> | undefined,
+	scopedModels: ReadonlyArray<{ model: Model<Api>; thinkingLevel?: ThinkingLevel }>,
+	settings: {
+		getModelThinkingLevel(provider: string, modelId: string): ThinkingLevel | undefined;
+		getDefaultThinkingLevel(): ThinkingLevel | undefined;
+	},
+): ThinkingLevel | undefined {
+	if (model === undefined) return settings.getDefaultThinkingLevel();
+	const scopedLevel = scopedModels.find(
+		(scoped) => scoped.model.provider === model.provider && scoped.model.id === model.id,
+	)?.thinkingLevel;
+	return scopedLevel ?? settings.getModelThinkingLevel(model.provider, model.id) ?? settings.getDefaultThinkingLevel();
+}
+
 InteractiveModeBase.prototype.handleModelCommand = async function (
 	this: InteractiveModeBase,
 	searchTerm?: string,
@@ -387,11 +408,7 @@ InteractiveModeBase.prototype.showThinkingSelector = function (this: Interactive
 		};
 		const model = this.session.model;
 		const availableLevels = this.session.getAvailableThinkingLevels();
-		const rawDefault =
-			model === undefined
-				? this.settingsManager.getDefaultThinkingLevel()
-				: (this.settingsManager.getModelThinkingLevel(model.provider, model.id) ??
-					this.settingsManager.getDefaultThinkingLevel());
+		const rawDefault = resolveSessionThinkingDefault(model, this.session.scopedModels, this.settingsManager);
 		const selector = new ThinkingSelectorComponent(
 			this.session.thinkingLevel,
 			availableLevels,

--- a/packages/coding-agent/src/modes/interactive/interactive-model-routing.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-model-routing.ts
@@ -1,3 +1,4 @@
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { boundedInteractiveModelRefresh } from "../../core/bounded-model-refresh.ts";
 import { isOfflineModeEnabled } from "../../core/package-manager-env.ts";
 import { InteractiveModeBase } from "./interactive-mode-base.ts";
@@ -8,6 +9,7 @@ import {
 	ModelSelectorComponent,
 	resolveModelScopeFromModels,
 	ScopedModelsSelectorComponent,
+	ThinkingSelectorComponent,
 	UserMessageSelectorComponent,
 } from "./interactive-mode-deps.ts";
 import { ANTHROPIC_SUBSCRIPTION_AUTH_WARNING, isAnthropicSubscriptionAuthKey } from "./interactive-mode-helpers.ts";
@@ -134,9 +136,9 @@ InteractiveModeBase.prototype.showModelSelector = function (
 			this.settingsManager,
 			this.session.modelRuntime,
 			this.session.scopedModels,
-			async (model) => {
+			async (model, persist) => {
 				try {
-					await this.session.setModel(model);
+					await this.session.setModel(model, { persist });
 					this.footer.invalidate();
 					this.updateEditorBorderColor();
 					done();
@@ -334,5 +336,49 @@ InteractiveModeBase.prototype.showUserMessageSelector = async function (this: In
 			initialSelectedId,
 		);
 		return { component: selector, focus: selector.getMessageList() };
+	});
+};
+
+InteractiveModeBase.prototype.handleThinkingCommand = function (this: InteractiveModeBase, searchTerm?: string): void {
+	if (!searchTerm) {
+		this.showThinkingSelector();
+		return;
+	}
+	const levels = this.session.getAvailableThinkingLevels();
+	const normalized = searchTerm.trim().toLowerCase();
+	const level = levels.find((candidate) => candidate === normalized);
+	if (!level) {
+		this.showError(`Unknown thinking level "${searchTerm}". Available levels: ${levels.join(", ")}.`);
+		return;
+	}
+	this.selectThinkingLevel(level, false);
+};
+
+InteractiveModeBase.prototype.selectThinkingLevel = function (
+	this: InteractiveModeBase,
+	level: ThinkingLevel,
+	persist: boolean,
+): void {
+	this.session.setThinkingLevel(level, { persist });
+	this.footer.invalidate();
+	this.updateEditorBorderColor();
+	this.showStatus(persist ? `Default thinking level: ${level}` : `Thinking level: ${level}`);
+};
+
+InteractiveModeBase.prototype.showThinkingSelector = function (this: InteractiveModeBase): void {
+	this.showSelector((done) => {
+		const select = (level: ThinkingLevel, persist: boolean) => {
+			this.selectThinkingLevel(level, persist);
+			done();
+		};
+		const selector = new ThinkingSelectorComponent(
+			this.session.thinkingLevel,
+			this.session.getAvailableThinkingLevels(),
+			(level) => select(level, false),
+			() => done(),
+			(level) => select(level, true),
+			this.settingsManager.getDefaultThinkingLevel(),
+		);
+		return { component: selector, focus: selector };
 	});
 };

--- a/packages/coding-agent/src/modes/interactive/interactive-model-routing.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-model-routing.ts
@@ -371,13 +371,19 @@ InteractiveModeBase.prototype.showThinkingSelector = function (this: Interactive
 			this.selectThinkingLevel(level, persist);
 			done();
 		};
+		const model = this.session.model;
+		const modelDefault =
+			model === undefined
+				? this.settingsManager.getDefaultThinkingLevel()
+				: (this.settingsManager.getModelThinkingLevel(model.provider, model.id) ??
+					this.settingsManager.getDefaultThinkingLevel());
 		const selector = new ThinkingSelectorComponent(
 			this.session.thinkingLevel,
 			this.session.getAvailableThinkingLevels(),
 			(level) => select(level, false),
 			() => done(),
 			(level) => select(level, true),
-			this.settingsManager.getDefaultThinkingLevel(),
+			modelDefault,
 		);
 		return { component: selector, focus: selector };
 	});

--- a/packages/coding-agent/src/modes/interactive/interactive-selectors.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-selectors.ts
@@ -95,6 +95,8 @@ InteractiveModeBase.prototype.showSettingsSelector = function (this: Interactive
 				bashInterceptorEnabled: this.settingsManager.getBashInterceptorEnabled(),
 				thinkingLevel: this.session.thinkingLevel,
 				availableThinkingLevels: this.session.getAvailableThinkingLevels(),
+				availableDefaultModels: [...this.session.modelRuntime.getAvailableSnapshot()],
+				modelThinkingLevels: this.settingsManager.getAllModelThinkingLevels(),
 				currentTheme: this.themeController.getThemeSelection() || "dark",
 				terminalTheme: this.themeController.getTerminalTheme(),
 				availableThemes: getAvailableThemes(),
@@ -170,6 +172,12 @@ InteractiveModeBase.prototype.showSettingsSelector = function (this: Interactive
 					this.session.setThinkingLevel(level);
 					this.footer.invalidate();
 					this.updateEditorBorderColor();
+				},
+				onModelThinkingLevelChange: (provider, modelId, level) => {
+					this.settingsManager.setModelThinkingLevel(provider, modelId, level);
+				},
+				onModelThinkingLevelRemove: (provider, modelId) => {
+					this.settingsManager.removeModelThinkingLevel(provider, modelId);
 				},
 				onThemeChange: (themeSetting) => {
 					this.settingsManager.setTheme(themeSetting);

--- a/packages/coding-agent/test/interactive-catalog-startup-selector-refresh.test.ts
+++ b/packages/coding-agent/test/interactive-catalog-startup-selector-refresh.test.ts
@@ -79,7 +79,11 @@ function openSelector(modelRuntime: ModelRuntime): ModelSelectorComponent {
 	return new ModelSelectorComponent(
 		{ requestRender: () => {} } as unknown as TUI,
 		model,
-		{ setDefaultModelAndProvider: () => {} } as unknown as SettingsManager,
+		{
+			setDefaultModelAndProvider: () => {},
+			getDefaultProvider: () => undefined,
+			getDefaultModel: () => undefined,
+		} as unknown as SettingsManager,
 		modelRuntime,
 		[],
 		() => {},

--- a/packages/coding-agent/test/interactive-selectors-tui-mode.test.ts
+++ b/packages/coding-agent/test/interactive-selectors-tui-mode.test.ts
@@ -57,6 +57,7 @@ function openSettingsSelector() {
 				getAvailableThinkingLevels: () => ["off"],
 				isStreaming: false,
 				isCompacting: false,
+				modelRuntime: { getAvailableSnapshot: () => [] },
 			},
 		},
 		renderer,

--- a/packages/coding-agent/test/model-registry-hot-reload.test.ts
+++ b/packages/coding-agent/test/model-registry-hot-reload.test.ts
@@ -62,7 +62,11 @@ describe("model config hot reload", () => {
 			refresh,
 		} as unknown as ModelRuntime;
 		const tui = { requestRender: vi.fn() } as unknown as TUI;
-		const settings = { setDefaultModelAndProvider: vi.fn() } as unknown as SettingsManager;
+		const settings = {
+			setDefaultModelAndProvider: vi.fn(),
+			getDefaultProvider: () => undefined,
+			getDefaultModel: () => undefined,
+		} as unknown as SettingsManager;
 		const openPicker = () =>
 			new ModelSelectorComponent(
 				tui,

--- a/packages/coding-agent/test/model-selector-refresh-status.test.ts
+++ b/packages/coding-agent/test/model-selector-refresh-status.test.ts
@@ -39,7 +39,11 @@ function createSelector(refresh: ModelRuntime["refresh"]): ModelSelectorComponen
 	return new ModelSelectorComponent(
 		{ requestRender: () => {} } as unknown as TUI,
 		model,
-		{ setDefaultModelAndProvider: () => {} } as unknown as SettingsManager,
+		{
+			setDefaultModelAndProvider: () => {},
+			getDefaultProvider: () => undefined,
+			getDefaultModel: () => undefined,
+		} as unknown as SettingsManager,
 		runtime,
 		[],
 		() => {},

--- a/packages/coding-agent/test/thinking-selector-default.test.ts
+++ b/packages/coding-agent/test/thinking-selector-default.test.ts
@@ -2,7 +2,10 @@ import { type Api, clampThinkingLevel, type Model } from "@bastani/pi-ai/compat"
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { beforeAll, expect, test } from "vitest";
 import { ThinkingSelectorComponent } from "../src/modes/interactive/components/thinking-selector.ts";
-import { resolveThinkingSelectorDefault } from "../src/modes/interactive/interactive-model-routing.ts";
+import {
+	resolveSessionThinkingDefault,
+	resolveThinkingSelectorDefault,
+} from "../src/modes/interactive/interactive-model-routing.ts";
 import { initTheme } from "../src/modes/interactive/theme/theme.ts";
 
 beforeAll(() => {
@@ -70,4 +73,43 @@ test("selector badges the clamped default rather than leaving no item marked", (
 
 	expect(renderedLines(unclamped).some((line) => line.includes("default"))).toBe(false);
 	expect(renderedLines(clamped).some((line) => line.includes("default"))).toBe(true);
+});
+
+function reasoningModel(id = "big"): Model<Api> {
+	return { ...nonReasoningModel(), id, name: id, reasoning: true } as Model<Api>;
+}
+
+const savedLevels = (perModel?: ThinkingLevel, global?: ThinkingLevel) => ({
+	getModelThinkingLevel: () => perModel,
+	getDefaultThinkingLevel: () => global,
+});
+
+test("a scoped model level outranks the global default", () => {
+	const model = reasoningModel();
+	// `--models "big:high"` with a global default of low: startup runs at high.
+	expect(resolveSessionThinkingDefault(model, [{ model, thinkingLevel: "high" }], savedLevels(undefined, "low"))).toBe(
+		"high",
+	);
+});
+
+test("a scoped model level outranks a persisted per-model override", () => {
+	const model = reasoningModel();
+	expect(resolveSessionThinkingDefault(model, [{ model, thinkingLevel: "high" }], savedLevels("medium", "low"))).toBe(
+		"high",
+	);
+});
+
+test("a scoped entry for a different model does not leak its level", () => {
+	const active = reasoningModel("active");
+	const other = reasoningModel("other");
+	expect(
+		resolveSessionThinkingDefault(active, [{ model: other, thinkingLevel: "high" }], savedLevels(undefined, "low")),
+	).toBe("low");
+});
+
+test("falls back to the per-model override, then the global default", () => {
+	const model = reasoningModel();
+	expect(resolveSessionThinkingDefault(model, [], savedLevels("medium", "low"))).toBe("medium");
+	expect(resolveSessionThinkingDefault(model, [], savedLevels(undefined, "low"))).toBe("low");
+	expect(resolveSessionThinkingDefault(model, [{ model }], savedLevels(undefined, "low"))).toBe("low");
 });

--- a/packages/coding-agent/test/thinking-selector-default.test.ts
+++ b/packages/coding-agent/test/thinking-selector-default.test.ts
@@ -1,0 +1,73 @@
+import { type Api, clampThinkingLevel, type Model } from "@bastani/pi-ai/compat";
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+import { beforeAll, expect, test } from "vitest";
+import { ThinkingSelectorComponent } from "../src/modes/interactive/components/thinking-selector.ts";
+import { resolveThinkingSelectorDefault } from "../src/modes/interactive/interactive-model-routing.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+
+beforeAll(() => {
+	initTheme("dark");
+});
+
+function nonReasoningModel(): Model<Api> {
+	return {
+		id: "tiny",
+		name: "tiny",
+		api: "openai-completions",
+		provider: "openai",
+		baseUrl: "https://example.test",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1024,
+		maxTokens: 256,
+	} as Model<Api>;
+}
+
+function renderedLines(selector: ThinkingSelectorComponent): string[] {
+	return selector.getSelectList().render(80);
+}
+
+test("keeps a saved default that the active model supports", () => {
+	expect(resolveThinkingSelectorDefault("high", ["off", "low", "medium", "high"], undefined)).toBe("high");
+});
+
+test("clamps an unsupported global default to the startup-effective level", () => {
+	const model = nonReasoningModel();
+	expect(clampThinkingLevel(model, "high")).toBe("off");
+	expect(resolveThinkingSelectorDefault("high", ["off"], model)).toBe("off");
+});
+
+test("clamps an unsupported per-model default the same way", () => {
+	const model = nonReasoningModel();
+	expect(resolveThinkingSelectorDefault("high" as ThinkingLevel, ["off"], model)).toBe("off");
+});
+
+test("leaves the badge unset when no saved default exists", () => {
+	expect(resolveThinkingSelectorDefault(undefined, ["off"], nonReasoningModel())).toBeUndefined();
+});
+
+test("selector badges the clamped default rather than leaving no item marked", () => {
+	const rawDefault: ThinkingLevel = "high";
+	const available: ThinkingLevel[] = ["off"];
+	const model = nonReasoningModel();
+	const unclamped = new ThinkingSelectorComponent(
+		"off",
+		available,
+		() => {},
+		() => {},
+		() => {},
+		rawDefault,
+	);
+	const clamped = new ThinkingSelectorComponent(
+		"off",
+		available,
+		() => {},
+		() => {},
+		() => {},
+		resolveThinkingSelectorDefault(rawDefault, available, model),
+	);
+
+	expect(renderedLines(unclamped).some((line) => line.includes("default"))).toBe(false);
+	expect(renderedLines(clamped).some((line) => line.includes("default"))).toBe(true);
+});

--- a/test/unit/status-writer.test.ts
+++ b/test/unit/status-writer.test.ts
@@ -185,7 +185,7 @@ describe("createStatusWriter — statusFile:true", () => {
 			startedAt: 1000,
 		});
 
-		await sleep(50);
+		await writer.flush();
 		writer.unsubscribe();
 
 		const raw = await readFile(filePath, "utf8");
@@ -210,7 +210,7 @@ describe("createStatusWriter — statusFile:true", () => {
 		});
 		s.recordRunEnd("r-terminal", "completed", { x: 1 });
 
-		await sleep(50);
+		await writer.flush();
 		writer.unsubscribe();
 
 		const parsed = JSON.parse(await readFile(filePath, "utf8")) as {
@@ -233,7 +233,7 @@ describe("createStatusWriter — statusFile:true", () => {
 			startedAt: Date.now(),
 		});
 
-		await sleep(50);
+		await writer.flush();
 
 		// Unsubscribe BEFORE the next store update
 		writer.unsubscribe();
@@ -294,7 +294,7 @@ describe("createStatusWriter — statusFile:true", () => {
 			stages: [],
 			startedAt: Date.now(),
 		});
-		await sleep(50);
+		await writer.flush();
 
 		const raw = await readFile(filePath, "utf8");
 		assert.ok(JSON.parse(raw));


### PR DESCRIPTION
Stack 5/9. /thinking command (ordered after /tree), Ctrl+S-persists-default in the model selector, searchable per-model thinking overrides, default badges and default-aware search/ordering in both selectors (upstream #8399 series). Atomic adaptation: one searchable combined model/level list instead of upstream's stepped picker (documented in the matrix).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790273429&installation_model_id=10562&pr_number=2679&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2679&signature=281dabbfd39478fe41c1702cd951fe62c3ad6a62a14e3c895590b6e97a780d57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->













<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update adds searchable model and thinking controls, per-model startup overrides, and documentation for the new commands. A resumed session can still display a `/thinking` default badge that conflicts with the thinking level restored for that session.

<h3>Confidence Score: 4/5</h3>

Not ready to merge until the thinking selector represents restored session state consistently.

A restored session can initialize with one thinking level while `/thinking` labels a different current settings value as its default.

**Files Needing Attention:** packages/coding-agent/src/modes/interactive/interactive-model-routing.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and attached the repro source and test output artifacts.
- T-Rex produced an additional proof for another posted P1 finding described in the review comment.
- T-Rex executed the restored-session-thinking-default-repro test using bun x vitest and confirmed the test passed, validating the mismatch described in the PR.

<a href="https://app.greptile.com/trex/runs/20675645/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/src/modes/interactive/interactive-model-routing.ts:411-418
**Restored thinking level is excluded from the default badge**

Resuming a session restores its recorded, capability-clamped thinking level, but this selector derives its default badge only from scoped, per-model, or global settings. For example, a session restored with `low` while the current global setting is `high` selects `low` as the active session level but labels `high` as the default in `/thinking`. Use the restored session level when it supplied the session’s initial level so the selector reflects the active session’s startup behavior.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (7): Last reviewed commit: ["fix(coding-agent): badge the scoped leve..."](https://github.com/bastani-inc/atomic/commit/893fd4aaa67240f60424ce3e71e2518910f921a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56766238)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->