### PR TITLE
feat(coding-agent): port skills, packages, and llama fixes

### DIFF
--- a/packages/coding-agent/docs/llama-cpp.md
+++ b/packages/coding-agent/docs/llama-cpp.md
@@ -35,7 +35,7 @@ Run:
 /login llama.cpp
 ```
 
-Enter the router URL and optional API key. The default URL is `http://127.0.0.1:8080`. The same values can be supplied without `/login`:
+Enter the router URL and optional API key. The default URL is `http://127.0.0.1:8080`. If the router uses `--no-models-autoload`, login only stores the connection; use `/llama` to load a model, then `/model` to select it. The same values can be supplied without `/login`:
 
 ```bash
 export LLAMA_BASE_URL=http://127.0.0.1:8080

--- a/packages/coding-agent/docs/skills.md
+++ b/packages/coding-agent/docs/skills.md
@@ -34,9 +34,10 @@ Atomic loads skills from:
 - CLI: `--skill <path>` (repeatable, additive even with `--no-skills`)
 
 Discovery rules:
-- In `~/.atomic/agent/skills/` and `.atomic/skills/` (plus legacy `~/.pi/agent/skills/` and `.pi/skills/`), direct root `.md` files are discovered as individual skills
+- In `~/.atomic/agent/skills/` and `.atomic/skills/` (plus legacy `~/.pi/agent/skills/` and `.pi/skills/`), direct root `.md` files are discovered as individual skills when they have valid skill frontmatter with a non-empty `description`
 - In all skill locations, directories containing `SKILL.md` are discovered recursively
 - In `~/.agents/skills/` and project `.agents/skills/`, root `.md` files are ignored
+- Root Markdown files other than `SKILL.md` that do not look like skills are ignored silently
 
 Disable discovery with `--no-skills` (explicit `--skill` paths still load).
 
@@ -211,7 +212,7 @@ Atomic validates skills against the Agent Skills standard. Most issues produce w
 
 Unknown frontmatter fields are ignored.
 
-**Exception:** Skills with missing description are not loaded.
+Declared skills with missing descriptions are not loaded. Malformed `SKILL.md` files and `SKILL.md` files without a description produce warnings and are not loaded. Other Markdown files without valid skill frontmatter are ignored.
 
 Name collisions (the same name from different real files) produce diagnostics and keep the existing first-winner precedence for `/skill:name`. Atomic also retains the other files as source-qualified candidates as described in [Skill Commands](#skill-commands).
 

--- a/packages/coding-agent/src/core/package-manager-npm.ts
+++ b/packages/coding-agent/src/core/package-manager-npm.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
-import { maxSatisfying, rcompare, satisfies } from "semver";
+import { gt, maxSatisfying, rcompare, satisfies } from "semver";
 import { APP_NAME, CONFIG_DIR_NAME, getProjectConfigDirs } from "../config.ts";
 import { markPathIgnoredByCloudSync } from "../utils/paths.ts";
 import { runCommand, runCommandCapture, runCommandSync } from "./package-manager-command.ts";
@@ -253,7 +253,7 @@ export async function npmHasAvailableUpdate(
 			source.version ? source.spec : source.name,
 			source.range,
 		);
-		return targetVersion !== installedVersion;
+		return gt(targetVersion, installedVersion);
 	} catch {
 		return false;
 	}

--- a/packages/coding-agent/src/core/package-manager-operations.ts
+++ b/packages/coding-agent/src/core/package-manager-operations.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs";
+import { gt } from "semver";
 import { runWithConcurrency } from "./package-manager-command.ts";
 import { GIT_UPDATE_CONCURRENCY, UPDATE_CHECK_CONCURRENCY } from "./package-manager-constants.ts";
 import { isOfflineModeEnabled } from "./package-manager-env.ts";
@@ -196,7 +197,7 @@ async function shouldUpdateNpmSource(
 			source.version ? source.spec : source.name,
 			source.range,
 		);
-		return targetVersion !== installedVersion;
+		return gt(targetVersion, installedVersion);
 	} catch {
 		return true;
 	}

--- a/packages/coding-agent/src/core/package-manager-resource-files.ts
+++ b/packages/coding-agent/src/core/package-manager-resource-files.ts
@@ -137,7 +137,12 @@ async function collectSkillEntries(
 			const info = await getEntryInfo(dir, entry.name, entry.isDirectory(), entry.isFile(), entry.isSymbolicLink());
 			if (!info) continue;
 			const relPath = toPosixPath(relative(root, info.fullPath));
-			if (mode === "pi" && dir === root && info.isFile && entry.name.endsWith(".md") && !ig.ignores(relPath)) {
+			const shouldIncludeMarkdownFile =
+				info.isFile &&
+				entry.name.endsWith(".md") &&
+				!ig.ignores(relPath) &&
+				((mode === "pi" && dir === root) || (mode === "agents" && dir !== root));
+			if (shouldIncludeMarkdownFile) {
 				entries.push(info.fullPath);
 				continue;
 			}

--- a/packages/coding-agent/src/core/skills.ts
+++ b/packages/coding-agent/src/core/skills.ts
@@ -116,10 +116,10 @@ function validateName(name: string): string[] {
 /**
  * Validate description per Agent Skills spec.
  */
-function validateDescription(description: string | undefined): string[] {
+function validateDescription(description: unknown): string[] {
 	const errors: string[] = [];
 
-	if (!description || description.trim() === "") {
+	if (typeof description !== "string" || description.trim() === "") {
 		errors.push("description is required");
 	} else if (description.length > MAX_DESCRIPTION_LENGTH) {
 		errors.push(`description exceeds ${MAX_DESCRIPTION_LENGTH} characters (${description.length})`);
@@ -281,49 +281,69 @@ function loadSkillFromFile(
 	source: string,
 ): { skill: Skill | null; diagnostics: ResourceDiagnostic[] } {
 	const diagnostics: ResourceDiagnostic[] = [];
+	const isDeclaredSkill = basename(filePath) === "SKILL.md";
 
+	let rawContent: string;
 	try {
-		const rawContent = readFileSync(filePath, "utf-8");
-		const { frontmatter } = parseFrontmatter<SkillFrontmatter>(rawContent);
-		const skillDir = dirname(filePath);
-		const parentDirName = basename(skillDir);
-
-		// Validate description
-		const descErrors = validateDescription(frontmatter.description);
-		for (const error of descErrors) {
-			diagnostics.push({ type: "warning", message: error, path: filePath });
-		}
-
-		// Use name from frontmatter, or fall back to parent directory name
-		const name = frontmatter.name || parentDirName;
-
-		// Validate name
-		const nameErrors = validateName(name);
-		for (const error of nameErrors) {
-			diagnostics.push({ type: "warning", message: error, path: filePath });
-		}
-
-		// Still load the skill even with warnings (unless description is completely missing)
-		if (!frontmatter.description || frontmatter.description.trim() === "") {
-			return { skill: null, diagnostics };
-		}
-
-		return {
-			skill: {
-				name,
-				description: frontmatter.description,
-				filePath,
-				baseDir: skillDir,
-				sourceInfo: createSkillSourceInfo(filePath, skillDir, source),
-				disableModelInvocation: frontmatter["disable-model-invocation"] === true,
-			},
-			diagnostics,
-		};
+		rawContent = readFileSync(filePath, "utf-8");
 	} catch (error) {
-		const message = error instanceof Error ? error.message : "failed to parse skill file";
+		const message = error instanceof Error ? error.message : "failed to read skill file";
 		diagnostics.push({ type: "warning", message, path: filePath });
 		return { skill: null, diagnostics };
 	}
+
+	let frontmatter: SkillFrontmatter;
+	try {
+		({ frontmatter } = parseFrontmatter<SkillFrontmatter>(rawContent));
+	} catch (error) {
+		if (isDeclaredSkill) {
+			const message = error instanceof Error ? error.message : "failed to parse skill file";
+			diagnostics.push({ type: "warning", message, path: filePath });
+		}
+		return { skill: null, diagnostics };
+	}
+
+	const description = frontmatter.description;
+	const hasDescription = typeof description === "string" && description.trim() !== "";
+	if (!isDeclaredSkill && !hasDescription) {
+		return { skill: null, diagnostics };
+	}
+
+	const skillDir = dirname(filePath);
+	const parentDirName = basename(skillDir);
+
+	// Validate description
+	const descErrors = validateDescription(description);
+	for (const error of descErrors) {
+		diagnostics.push({ type: "warning", message: error, path: filePath });
+	}
+
+	// Use name from frontmatter, or fall back to parent directory name
+	const frontmatterName = typeof frontmatter.name === "string" ? frontmatter.name : undefined;
+	const name = frontmatterName || parentDirName;
+
+	// Validate name
+	const nameErrors = validateName(name);
+	for (const error of nameErrors) {
+		diagnostics.push({ type: "warning", message: error, path: filePath });
+	}
+
+	// Still load the skill even with warnings, unless description is missing or empty.
+	if (!hasDescription) {
+		return { skill: null, diagnostics };
+	}
+
+	return {
+		skill: {
+			name,
+			description,
+			filePath,
+			baseDir: skillDir,
+			sourceInfo: createSkillSourceInfo(filePath, skillDir, source),
+			disableModelInvocation: frontmatter["disable-model-invocation"] === true,
+		},
+		diagnostics,
+	};
 }
 
 /**

--- a/packages/coding-agent/src/extensions/llama/client.ts
+++ b/packages/coding-agent/src/extensions/llama/client.ts
@@ -28,6 +28,10 @@ export interface LlamaModelsResponse {
 	object?: string;
 }
 
+export interface LlamaServerProps {
+	models_autoload?: boolean;
+}
+
 export interface LlamaModelEvent {
 	model: string;
 	event: string;
@@ -187,6 +191,13 @@ export class LlamaClient {
 		const data = (payload as { data: unknown[] }).data;
 		if (!data.every(isModelInfo)) throw new Error("Server is not running in llama.cpp router mode");
 		return data;
+	}
+
+	async props(options: { signal?: AbortSignal } = {}): Promise<LlamaServerProps> {
+		const payload = await this.request("/props", { signal: options.signal });
+		if (typeof payload !== "object" || payload === null) return {};
+		const { models_autoload: modelsAutoload } = payload as Record<string, unknown>;
+		return typeof modelsAutoload === "boolean" ? { models_autoload: modelsAutoload } : {};
 	}
 
 	async load(model: string, signal?: AbortSignal): Promise<void> {

--- a/packages/coding-agent/src/extensions/llama/client.ts
+++ b/packages/coding-agent/src/extensions/llama/client.ts
@@ -58,6 +58,12 @@ function isModelInfo(value: unknown): value is LlamaModelInfo {
 	return typeof candidate.id === "string" && typeof candidate.status?.value === "string";
 }
 
+function isLlamaServerProps(value: unknown): value is LlamaServerProps {
+	if (typeof value !== "object" || value === null) return false;
+	const modelsAutoload = (value as LlamaServerProps).models_autoload;
+	return modelsAutoload === undefined || typeof modelsAutoload === "boolean";
+}
+
 function linkSignal(source: AbortSignal | undefined, target: AbortController): () => void {
 	if (!source) return () => {};
 	if (source.aborted) {
@@ -195,9 +201,8 @@ export class LlamaClient {
 
 	async props(options: { signal?: AbortSignal } = {}): Promise<LlamaServerProps> {
 		const payload = await this.request("/props", { signal: options.signal });
-		if (typeof payload !== "object" || payload === null) return {};
-		const { models_autoload: modelsAutoload } = payload as Record<string, unknown>;
-		return typeof modelsAutoload === "boolean" ? { models_autoload: modelsAutoload } : {};
+		if (!isLlamaServerProps(payload)) return {};
+		return typeof payload.models_autoload === "boolean" ? { models_autoload: payload.models_autoload } : {};
 	}
 
 	async load(model: string, signal?: AbortSignal): Promise<void> {

--- a/packages/coding-agent/src/extensions/llama/index.ts
+++ b/packages/coding-agent/src/extensions/llama/index.ts
@@ -53,6 +53,8 @@ export default function llamaExtension(pi: ExtensionAPI): void {
 		provider.setCatalog(current, client.serverUrl);
 		const result = await ctx.modelRegistry.refresh({
 			providers: [LLAMA_PROVIDER_ID],
+			// /llama already contacted the configured llama.cpp server, so keep this refresh live even in PI_OFFLINE.
+			allowNetwork: true,
 			signal,
 		});
 		if (result.aborted) throw new Error("Model catalog refresh timed out.");

--- a/packages/coding-agent/src/extensions/llama/provider.ts
+++ b/packages/coding-agent/src/extensions/llama/provider.ts
@@ -25,6 +25,24 @@ async function resolveServerUrl(
 	return configured ? normalizeLlamaServerUrl(configured) : undefined;
 }
 
+function modelIsSelectable(model: LlamaModelInfo, routerAutoload = false): boolean {
+	if (model.status.value === "loaded" || model.status.value === "sleeping") return true;
+	return routerAutoload && model.status.value === "unloaded" && !model.status.failed && model.source === "preset";
+}
+
+async function routerAutoloadEnabled(
+	client: LlamaClient,
+	catalog: readonly LlamaModelInfo[],
+	signal: AbortSignal,
+): Promise<boolean> {
+	if (!catalog.some((model) => model.status.value === "unloaded" && model.source === "preset")) return false;
+	try {
+		return (await client.props({ signal })).models_autoload === true;
+	} catch {
+		return false;
+	}
+}
+
 function toPiModel(model: LlamaModelInfo, serverUrl: string): Model<"openai-completions"> {
 	const reportedContextWindow = model.meta?.n_ctx ?? model.meta?.n_ctx_train;
 	const contextWindow = reportedContextWindow && reportedContextWindow > 0 ? reportedContextWindow : 128000;
@@ -52,20 +70,26 @@ function toPiModel(model: LlamaModelInfo, serverUrl: string): Model<"openai-comp
 
 export interface LlamaProviderController {
 	provider: Provider<"openai-completions">;
-	setCatalog(models: readonly LlamaModelInfo[], serverUrl: string): void;
+	setCatalog(models: readonly LlamaModelInfo[], serverUrl: string, options?: { routerAutoload?: boolean }): void;
 }
 
 export function createLlamaProvider(): LlamaProviderController {
 	let models: readonly Model<"openai-completions">[] = [];
 
-	// Shared by the exported setCatalog and by refreshModels. refreshModels must
-	// compute the list before publishing so the assignment happens inside the
-	// generation-checked `update` callback rather than before it.
-	const toCatalog = (catalog: readonly LlamaModelInfo[], serverUrl: string): readonly Model<"openai-completions">[] =>
-		catalog.filter((model) => model.status.value === "loaded").map((model) => toPiModel(model, serverUrl));
+	// Keep catalog assignment inside generation-checked publication callbacks.
+	const toCatalog = (
+		catalog: readonly LlamaModelInfo[],
+		serverUrl: string,
+		routerAutoload = false,
+	): readonly Model<"openai-completions">[] =>
+		catalog.filter((model) => modelIsSelectable(model, routerAutoload)).map((model) => toPiModel(model, serverUrl));
 
-	const setCatalog = (catalog: readonly LlamaModelInfo[], serverUrl: string): void => {
-		models = toCatalog(catalog, serverUrl);
+	const setCatalog = (
+		catalog: readonly LlamaModelInfo[],
+		serverUrl: string,
+		options: { routerAutoload?: boolean } = {},
+	): void => {
+		models = toCatalog(catalog, serverUrl, options.routerAutoload === true);
 	};
 
 	const provider: Provider<"openai-completions"> = {
@@ -136,9 +160,12 @@ export function createLlamaProvider(): LlamaProviderController {
 			if (!context.allowNetwork || context.signal.aborted || context.credential?.type !== "api_key") return;
 			const serverUrl = credentialServerUrl(context.credential);
 			if (!serverUrl) return;
-			const catalog = await new LlamaClient(serverUrl, context.credential.key).list({ signal: context.signal });
+			const client = new LlamaClient(serverUrl, context.credential.key);
+			const catalog = await client.list({ signal: context.signal });
 			if (context.signal.aborted) return;
-			const refreshed = toCatalog(catalog, serverUrl);
+			const routerAutoload = await routerAutoloadEnabled(client, catalog, context.signal);
+			if (context.signal.aborted) return;
+			const refreshed = toCatalog(catalog, serverUrl, routerAutoload);
 			await context.publish({
 				persist: { models: refreshed, checkedAt: Date.now() },
 				update: () => {

--- a/packages/coding-agent/src/modes/interactive/interactive-deferred-startup.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-deferred-startup.ts
@@ -1,4 +1,5 @@
 import { modelsAreEqual } from "@bastani/pi-ai/compat";
+import { loadAllHighlightLanguages } from "../../utils/syntax-highlight.ts";
 import { InteractiveModeBase } from "./interactive-mode-base.ts";
 import {
 	type Container,
@@ -81,6 +82,7 @@ InteractiveModeBase.prototype.completeDeferredStartup = async function (this: In
 		void this.updateAvailableProviderCount().catch(() => {});
 		this.updateEditorBorderColor();
 		this.ui.requestRender();
+		void loadAllHighlightLanguages().then(() => this.ui.requestRender());
 	} catch (error) {
 		// Same ownership rule as the success path: this catch swallows the error,
 		// so prompt preflight continues and must keep its indicator.

--- a/packages/coding-agent/src/utils/highlight-js.d.ts
+++ b/packages/coding-agent/src/utils/highlight-js.d.ts
@@ -1,0 +1,36 @@
+interface HighlightJsResult {
+	value: string;
+}
+
+interface HighlightJsOptions {
+	language: string;
+	ignoreIllegals?: boolean;
+}
+
+interface HighlightJsLanguageDefinition {
+	readonly name?: string;
+}
+
+type HighlightJsLanguageFactory = (hljs: HighlightJsApi) => HighlightJsLanguageDefinition;
+
+interface HighlightJsApi {
+	highlight(code: string, options: HighlightJsOptions): HighlightJsResult;
+	highlightAuto(code: string, languageSubset?: string[]): HighlightJsResult;
+	getLanguage(name: string): HighlightJsLanguageDefinition | undefined;
+	registerLanguage(name: string, language: HighlightJsLanguageFactory): void;
+}
+
+declare module "highlight.js/lib/core.js" {
+	const hljs: HighlightJsApi;
+	export default hljs;
+}
+
+declare module "highlight.js/lib/index.js" {
+	const hljs: HighlightJsApi;
+	export default hljs;
+}
+
+declare module "highlight.js/lib/languages/*.js" {
+	const language: HighlightJsLanguageFactory;
+	export default language;
+}

--- a/packages/coding-agent/src/utils/highlight-js.d.ts
+++ b/packages/coding-agent/src/utils/highlight-js.d.ts
@@ -1,3 +1,5 @@
+/// <reference lib="dom" />
+
 interface HighlightJsResult {
 	value: string;
 }

--- a/packages/coding-agent/src/utils/syntax-highlight.ts
+++ b/packages/coding-agent/src/utils/syntax-highlight.ts
@@ -1,5 +1,72 @@
-import hljs from "highlight.js";
+/// <reference path="./highlight-js.d.ts" />
+import hljs from "highlight.js/lib/core.js";
+import bash from "highlight.js/lib/languages/bash.js";
+import c from "highlight.js/lib/languages/c.js";
+import cpp from "highlight.js/lib/languages/cpp.js";
+import csharp from "highlight.js/lib/languages/csharp.js";
+import dart from "highlight.js/lib/languages/dart.js";
+import go from "highlight.js/lib/languages/go.js";
+import groovy from "highlight.js/lib/languages/groovy.js";
+import java from "highlight.js/lib/languages/java.js";
+import javascript from "highlight.js/lib/languages/javascript.js";
+import kotlin from "highlight.js/lib/languages/kotlin.js";
+import lua from "highlight.js/lib/languages/lua.js";
+import nix from "highlight.js/lib/languages/nix.js";
+import perl from "highlight.js/lib/languages/perl.js";
+import php from "highlight.js/lib/languages/php.js";
+import python from "highlight.js/lib/languages/python.js";
+import ruby from "highlight.js/lib/languages/ruby.js";
+import rust from "highlight.js/lib/languages/rust.js";
+import scala from "highlight.js/lib/languages/scala.js";
+import swift from "highlight.js/lib/languages/swift.js";
+import typescript from "highlight.js/lib/languages/typescript.js";
 import { decodeHtmlEntityAt } from "./html.ts";
+
+const eagerLanguages = {
+	python,
+	java,
+	go,
+	javascript,
+	cpp,
+	typescript,
+	php,
+	ruby,
+	c,
+	csharp,
+	nix,
+	bash,
+	rust,
+	scala,
+	kotlin,
+	swift,
+	dart,
+	groovy,
+	perl,
+	lua,
+};
+
+for (const [name, language] of Object.entries(eagerLanguages)) {
+	hljs.registerLanguage(name, language);
+}
+
+let allLanguagesPromise: Promise<void> | undefined;
+
+export function loadAllHighlightLanguages(): Promise<void> {
+	if (!allLanguagesPromise) {
+		allLanguagesPromise = new Promise((resolve) => {
+			setImmediate(() => {
+				void import("highlight.js/lib/index.js").then(
+					() => resolve(),
+					() => {
+						// Eager languages and plaintext fallback remain available.
+						resolve();
+					},
+				);
+			});
+		});
+	}
+	return allLanguagesPromise;
+}
 
 export type HighlightFormatter = (text: string) => string;
 export type HighlightTheme = Partial<Record<string, HighlightFormatter>>;

--- a/packages/coding-agent/test/llama-extension.test.ts
+++ b/packages/coding-agent/test/llama-extension.test.ts
@@ -138,7 +138,7 @@ describe("llama.cpp extension", () => {
 		expect(() => normalizeLlamaServerUrl("file:///tmp/llama")).toThrow("http or https");
 	});
 
-	it("exposes only loaded models with router metadata", () => {
+	it("exposes loaded and sleeping models with router metadata", () => {
 		const controller = createLlamaProvider();
 		controller.setCatalog(
 			[
@@ -148,6 +148,7 @@ describe("llama.cpp extension", () => {
 					architecture: { input_modalities: ["text", "image"] },
 					meta: { n_ctx: 65536, n_ctx_train: 131072 },
 				},
+				{ id: "sleeping", status: { value: "sleeping" } },
 				{ id: "unloaded", status: { value: "unloaded" } },
 				{ id: "loading", status: { value: "loading" } },
 			],
@@ -162,10 +163,14 @@ describe("llama.cpp extension", () => {
 				maxTokens: 65536,
 				input: ["text", "image"],
 			}),
+			expect.objectContaining({
+				id: "sleeping",
+				baseUrl: "http://localhost:8080/v1",
+			}),
 		]);
 	});
 
-	it("persists and restores loaded models for cache-only startup refreshes", async () => {
+	it("persists and restores selectable models for cache-only startup refreshes", async () => {
 		let cachedEntry: ModelsStoreEntry | undefined;
 		const refreshContext = (allowNetwork: boolean): RefreshModelsContext => ({
 			credential: { type: "api_key", key: "local", env: { LLAMA_BASE_URL: url } },
@@ -183,6 +188,7 @@ describe("llama.cpp extension", () => {
 				json(response, {
 					data: [
 						{ id: "loaded", status: { value: "loaded" }, meta: { n_ctx: 32768 } },
+						{ id: "sleeping", status: { value: "sleeping" }, meta: { n_ctx: 32768 } },
 						{ id: "unloaded", status: { value: "unloaded" } },
 					],
 				});
@@ -192,14 +198,16 @@ describe("llama.cpp extension", () => {
 		});
 
 		const first = createLlamaProvider();
+
 		await first.provider.refreshModels?.(refreshContext(true));
-		expect(first.provider.getModels().map((model) => model.id)).toEqual(["loaded"]);
-		expect(cachedEntry?.models.map((model) => model.id)).toEqual(["loaded"]);
+		expect(first.provider.getModels().map((model) => model.id)).toEqual(["loaded", "sleeping"]);
+		expect(cachedEntry?.models.map((model) => model.id)).toEqual(["loaded", "sleeping"]);
 
 		const second = createLlamaProvider();
 		await second.provider.refreshModels?.(refreshContext(false));
 		expect(second.provider.getModels()).toEqual([
 			expect.objectContaining({ id: "loaded", baseUrl: `${url}/v1`, contextWindow: 32768 }),
+			expect.objectContaining({ id: "sleeping", baseUrl: `${url}/v1`, contextWindow: 32768 }),
 		]);
 	});
 

--- a/packages/coding-agent/test/syntax-highlight.test.ts
+++ b/packages/coding-agent/test/syntax-highlight.test.ts
@@ -1,9 +1,46 @@
 import { resetCapabilitiesCache, setCapabilities } from "@earendil-works/pi-tui";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { highlightCode, initTheme } from "../src/modes/interactive/theme/theme.ts";
-import { highlight, renderHighlightedHtml, supportsLanguage } from "../src/utils/syntax-highlight.ts";
+import {
+	highlight,
+	loadAllHighlightLanguages,
+	renderHighlightedHtml,
+	supportsLanguage,
+} from "../src/utils/syntax-highlight.ts";
+
+const eagerLanguages = [
+	"python",
+	"java",
+	"go",
+	"javascript",
+	"cpp",
+	"typescript",
+	"php",
+	"ruby",
+	"c",
+	"csharp",
+	"nix",
+	"bash",
+	"rust",
+	"scala",
+	"kotlin",
+	"swift",
+	"dart",
+	"groovy",
+	"perl",
+	"lua",
+];
+const eagerLanguagesLoadedAtStartup = eagerLanguages.every(supportsLanguage);
+const uncommonLanguageLoadedAtStartup = supportsLanguage("ada");
 
 describe("syntax highlight renderer", () => {
+	it("loads the twenty most common languages at startup and defers the rest", async () => {
+		expect(eagerLanguagesLoadedAtStartup).toBe(true);
+		expect(uncommonLanguageLoadedAtStartup).toBe(false);
+		await loadAllHighlightLanguages();
+		expect(supportsLanguage("ada")).toBe(true);
+	});
+
 	it("renders highlighted spans with the provided theme", () => {
 		const rendered = renderHighlightedHtml('<span class="hljs-keyword">const</span> value', {
 			keyword: (text) => `[keyword:${text}]`,


### PR DESCRIPTION
Stack 6/9. Root .md files no longer load as skills (#8012), nested markdown skills (#8255), semver-correct package upgrade comparison (#8239), llama.cpp: sleeping models (#8235), guidance-as-no-default (#8236), offline catalog refresh (#8238), autoload presets (#8558), plus deferred syntax-grammar loading for startup cost. Note: upstream's glob-dependency removal is intentionally deferred (breaks ambient type resolution in the local toolchain; documented in the matrix).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790273432&installation_model_id=10562&pr_number=2680&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2680&signature=061ea847d132ec8bb22a79230b9e4cc48432dff8e74e5e42bd6e79c87eb08c84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->













<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update improves Cloudflare model catalog resilience by making tool-capable Workers AI models available through the AI Gateway compatibility endpoint when upstream gateway metadata is absent. It also includes supporting model metadata, dependency updates, documentation, and focused coverage. No blocking failure remains.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The Cloudflare fallback behavior produces the expected gateway model contract for omitted upstream gateway entries, and no accepted blocking finding remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before capture, the old generator produced no Cloudflare AI Gateway provider/model for the omitted gateway entry.
- After capture, the fallback generated workers-ai/@cf/example/derived using openai-completions, the Cloudflare /compat URL, and the expected compatibility contract.
- The focused test suite ran and passed, including tests for omitted and mis-tagged default-model scenarios.
- Artifacts summarizing the baseline output, current fallback output, and focused generator test results were prepared for review.

<a href="https://app.greptile.com/trex/runs/20675646/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (7): Last reviewed commit: ["fix(coding-agent): restore DOM types for..."](https://github.com/bastani-inc/atomic/commit/4df020602ddf11e72f17419697353c13915a1073) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56766276)</sub>

<!-- /greptile_comment -->