### PR TITLE
fix(coding-agent): port extension, event, and input robustness fixes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fixed the thinking-level selector so a capability-clamped default still receives the default badge when the saved setting is higher than the active model supports.
+- Failed extension loads now roll back provider registrations applied during that load instead of leaving an earlier provider in the runtime.
 - Fixed Windows compiled binaries crashing with `ERR_INVALID_FILE_URL_PATH` when Return reached native modifier detection, including from the `/model` selector. Release app bundles keep only `pi-tui`'s native modifier loader runtime-relative, avoiding both the Linux build host's frozen module URL and Bun's inability to resolve a fully external `pi-tui` from a compiled split launcher, while retaining the staged Windows native helper for Shift+Enter handling.
 - Fixed `bundle:dev` and `start:fast` omitting the statically registered OAuth adapters. Development bundles now use the Bun entrypoint shared with compiled builds, so OpenAI Codex and xAI OAuth derivation and refresh no longer fail on unresolved runtime imports.
 - Fixed duplicate fullscreen right-click paste in VS Code-based terminals on Windows ([#8186](https://github.com/earendil-works/pi/issues/8186)).

--- a/packages/coding-agent/examples/extensions/border-status-editor.ts
+++ b/packages/coding-agent/examples/extensions/border-status-editor.ts
@@ -87,7 +87,7 @@ export default function (pi: ExtensionAPI) {
 		activeTui?.requestRender();
 	});
 
-	pi.on("agent_end", () => {
+	pi.on("agent_settled", () => {
 		isWorking = false;
 		stopSpinner();
 		activeTui?.requestRender();

--- a/packages/coding-agent/examples/extensions/git-checkpoint.ts
+++ b/packages/coding-agent/examples/extensions/git-checkpoint.ts
@@ -46,7 +46,7 @@ export default function (pi: ExtensionAPI) {
 		}
 	});
 
-	pi.on("agent_end", async () => {
+	pi.on("agent_settled", async () => {
 		// Clear checkpoints after agent completes
 		checkpoints.clear();
 	});

--- a/packages/coding-agent/examples/extensions/notify.ts
+++ b/packages/coding-agent/examples/extensions/notify.ts
@@ -49,7 +49,7 @@ function notify(title: string, body: string): void {
 }
 
 export default function (pi: ExtensionAPI) {
-	pi.on("agent_end", async () => {
+	pi.on("agent_settled", async () => {
 		notify("Pi", "Ready for input");
 	});
 }

--- a/packages/coding-agent/examples/extensions/titlebar-spinner.ts
+++ b/packages/coding-agent/examples/extensions/titlebar-spinner.ts
@@ -48,7 +48,7 @@ export default function (pi: ExtensionAPI) {
 		startAnimation(ctx);
 	});
 
-	pi.on("agent_end", async (_event, ctx) => {
+	pi.on("agent_settled", async (_event, ctx) => {
 		stopAnimation(ctx);
 	});
 

--- a/packages/coding-agent/examples/rpc-extension-ui.ts
+++ b/packages/coding-agent/examples/rpc-extension-ui.ts
@@ -390,7 +390,7 @@ async function main() {
 			return;
 		}
 
-		if (data.type === "agent_end") {
+		if (data.type === "agent_settled") {
 			isStreaming = false;
 			hideLoading();
 			outputLog.append("");

--- a/packages/coding-agent/examples/sdk/README.md
+++ b/packages/coding-agent/examples/sdk/README.md
@@ -139,7 +139,7 @@ session.subscribe((event) => {
     case "tool_execution_end":
       console.log(`Result: ${event.result}`);
       break;
-    case "agent_end":
+    case "agent_settled":
       console.log("Done");
       break;
   }

--- a/packages/coding-agent/src/cli/file-processor.ts
+++ b/packages/coding-agent/src/cli/file-processor.ts
@@ -9,6 +9,7 @@ import { resolve } from "path";
 import { resolveReadPath } from "../core/tools/path-utils.ts";
 import { processImage } from "../utils/image-process.ts";
 import { detectSupportedImageMimeTypeFromFile } from "../utils/mime.ts";
+import { stripBom } from "../utils/text.ts";
 
 export interface ProcessedFiles {
 	text: string;
@@ -73,7 +74,7 @@ export async function processFileArguments(fileArgs: string[], options?: Process
 		} else {
 			// Handle text file
 			try {
-				const content = await readFile(absolutePath, "utf-8");
+				const content = stripBom(await readFile(absolutePath, "utf-8"));
 				text += `<file name="${absolutePath}">\n${content}\n</file>\n`;
 			} catch (error: unknown) {
 				const message = error instanceof Error ? error.message : String(error);

--- a/packages/coding-agent/src/core/agent-session-export.ts
+++ b/packages/coding-agent/src/core/agent-session-export.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import type { AssistantMessage } from "@bastani/pi-ai/compat";
@@ -146,7 +147,11 @@ export async function exportToHtml(
  * @returns The resolved output file path.
  */
 
-export function exportToJsonl(this: AgentSession, outputPath?: string): string {
+export function exportToJsonl(
+	this: AgentSession,
+	outputPath?: string,
+	options: { includeShareContext?: boolean } = {},
+): string {
 	const filePath = resolvePath(
 		outputPath ?? `session-${new Date().toISOString().replace(/[:.]/g, "-")}.jsonl`,
 		process.cwd(),
@@ -173,6 +178,24 @@ export function exportToJsonl(this: AgentSession, outputPath?: string): string {
 		const linear = { ...entry, parentId: prevId };
 		lines.push(JSON.stringify(linear));
 		prevId = entry.id;
+	}
+	if (options.includeShareContext) {
+		const shareEntry = {
+			type: "custom",
+			id: randomUUID(),
+			parentId: prevId,
+			timestamp: new Date().toISOString(),
+			customType: "atomic.share",
+			data: {
+				systemPrompt: this.systemPrompt,
+				tools: this.agent.state.tools.map(({ name, description, parameters }) => ({
+					name,
+					description,
+					parameters,
+				})),
+			},
+		};
+		lines.push(JSON.stringify(shareEntry));
 	}
 
 	writeFileSync(filePath, `${lines.join("\n")}\n`);

--- a/packages/coding-agent/src/core/agent-session-methods.ts
+++ b/packages/coding-agent/src/core/agent-session-methods.ts
@@ -315,7 +315,7 @@ export interface AgentSessionMethodSurface extends AgentSessionQueuePauseControl
 	getSessionStats(): SessionStats;
 	getContextUsage(): ContextUsage | undefined;
 	exportToHtml(outputPath?: string, options?: { themeName?: string }): Promise<string>;
-	exportToJsonl(outputPath?: string): string;
+	exportToJsonl(outputPath?: string, options?: { includeShareContext?: boolean }): string;
 	getLastAssistantText(): string | undefined;
 	createReplacedSessionContext(): ReplacedSessionContext;
 	sealWorkflowStageGeneration(): void;

--- a/packages/coding-agent/src/core/auth-storage-backends.ts
+++ b/packages/coding-agent/src/core/auth-storage-backends.ts
@@ -1,4 +1,4 @@
-import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
 import { getAgentDir } from "../config.ts";
@@ -114,8 +114,9 @@ export class FileAuthStorageBackend implements AuthStorageBackend {
 		const dir = dirname(path);
 		const tempPath = join(dir, `.${`auth.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}`}.tmp`);
 		try {
+			const existingMode = existsSync(path) ? statSync(path).mode & 0o777 : 0o600;
 			writeFileSync(tempPath, content, AUTH_FILE_WRITE_OPTIONS);
-			chmodSync(tempPath, 0o600);
+			chmodSync(tempPath, existingMode);
 			renameSync(tempPath, path);
 		} catch (error) {
 			try {

--- a/packages/coding-agent/src/core/auth-storage-backends.ts
+++ b/packages/coding-agent/src/core/auth-storage-backends.ts
@@ -1,4 +1,4 @@
-import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
 import { getAgentDir } from "../config.ts";
@@ -114,9 +114,8 @@ export class FileAuthStorageBackend implements AuthStorageBackend {
 		const dir = dirname(path);
 		const tempPath = join(dir, `.${`auth.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}`}.tmp`);
 		try {
-			const existingMode = existsSync(path) ? statSync(path).mode & 0o777 : 0o600;
 			writeFileSync(tempPath, content, AUTH_FILE_WRITE_OPTIONS);
-			chmodSync(tempPath, existingMode);
+			chmodSync(tempPath, 0o600);
 			renameSync(tempPath, path);
 		} catch (error) {
 			try {

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -6,6 +6,7 @@
 import type { AuthOperationOptions, Credential, CredentialInfo, CredentialStore } from "@bastani/pi-ai";
 import { join } from "path";
 import { getAgentConfigPaths, getAgentDir } from "../config.ts";
+import { stripBom } from "../utils/text.ts";
 import {
 	type AuthStorageBackend,
 	FileAuthStorageBackend,
@@ -50,7 +51,7 @@ export class AuthStorage implements CredentialStore {
 		if (!content) {
 			return {};
 		}
-		return JSON.parse(content) as AuthStorageData;
+		return JSON.parse(stripBom(content)) as AuthStorageData;
 	}
 
 	/**
@@ -146,7 +147,7 @@ export class ReadOnlyAuthStorage implements CredentialStore {
 		let parsed: unknown;
 		try {
 			const content = this.storage.read();
-			parsed = content === undefined ? {} : JSON.parse(content);
+			parsed = content === undefined ? {} : JSON.parse(stripBom(content));
 		} catch (error) {
 			// The no-refresh path must not turn a corrupt auth file into an empty
 			// credential set. Surface invalid state without touching the file.
@@ -229,7 +230,7 @@ export function readStoredCredential(providerId: string, authPath?: string | str
 	try {
 		let credential: Credential | undefined;
 		storage.withLock((content) => {
-			credential = content ? (JSON.parse(content) as AuthStorageData)[providerId] : undefined;
+			credential = content ? (JSON.parse(stripBom(content)) as AuthStorageData)[providerId] : undefined;
 			return { result: undefined };
 		});
 		return credential;

--- a/packages/coding-agent/src/core/extensions/api-types.ts
+++ b/packages/coding-agent/src/core/extensions/api-types.ts
@@ -157,11 +157,9 @@ export interface ExtensionAPI {
 	/** Register a CLI flag. */
 	registerFlag(
 		name: string,
-		options: {
-			description?: string;
-			type: "boolean" | "string";
-			default?: boolean | string;
-		},
+		options:
+			| { description?: string; type: "boolean"; default?: boolean }
+			| { description?: string; type: "string"; default?: string },
 	): void;
 
 	/** Get the value of a registered CLI flag. */

--- a/packages/coding-agent/src/core/extensions/loader-api.ts
+++ b/packages/coding-agent/src/core/extensions/loader-api.ts
@@ -38,7 +38,7 @@ export function createExtensionAPI(
 	resourceLoaderInheritanceSnapshotProvider?: ResourceLoaderInheritanceSnapshotProvider,
 ): { api: ExtensionAPI; commit: () => void; discard: () => void } {
 	const workflowResources = normalizeWorkflowResourceProvider(workflowResourceProvider);
-	const pendingRuntimeChanges: Array<() => void> = [];
+	const pendingRuntimeChanges: Array<{ apply: () => void; rollback: () => void }> = [];
 	const loadingUnsubscribers: Array<() => void> = [];
 	const initialFlagValues = new Map(runtime.flagValues);
 	const initialFlagOwners = new Map(runtime.flagOwners);
@@ -49,9 +49,9 @@ export function createExtensionAPI(
 			throw new Error(`Extension "${extension.path}" failed to load and its API is no longer active.`);
 		runtime.assertActive();
 	};
-	const applyRuntimeChange = (change: () => void) => {
+	const applyRuntimeChange = (change: { apply: () => void; rollback: () => void }) => {
 		if (state === "loading") pendingRuntimeChanges.push(change);
-		else if (state === "active") change();
+		else if (state === "active") change.apply();
 		else assertActive();
 	};
 	// Successive load generations of one session each build a new facade over
@@ -267,15 +267,37 @@ export function createExtensionAPI(
 			assertActive();
 			if (typeof nameOrProvider === "string") {
 				if (!config) throw new Error("Provider config is required");
-				applyRuntimeChange(() => runtime.registerProvider(nameOrProvider, config, extension.path));
+				const name = nameOrProvider;
+				applyRuntimeChange({
+					apply: () => runtime.registerProvider(name, config, extension.path),
+					rollback: () => runtime.unregisterProvider(name, extension.path),
+				});
 			} else {
-				applyRuntimeChange(() => runtime.registerProvider(nameOrProvider, extension.path));
+				const provider = nameOrProvider;
+				applyRuntimeChange({
+					apply: () => runtime.registerProvider(provider, extension.path),
+					rollback: () => runtime.unregisterProvider(provider.id, extension.path),
+				});
 			}
 		},
 
 		unregisterProvider(name: string) {
 			assertActive();
-			applyRuntimeChange(() => runtime.unregisterProvider(name, extension.path));
+			const prior = runtime.pendingProviderRegistrations.filter((registration) =>
+				"provider" in registration ? registration.provider.id === name : registration.name === name,
+			);
+			applyRuntimeChange({
+				apply: () => runtime.unregisterProvider(name, extension.path),
+				rollback: () => {
+					for (const registration of prior) {
+						if ("provider" in registration) {
+							runtime.registerProvider(registration.provider, registration.extensionPath);
+						} else {
+							runtime.registerProvider(registration.name, registration.config, registration.extensionPath);
+						}
+					}
+				},
+			});
 		},
 
 		events,
@@ -285,10 +307,25 @@ export function createExtensionAPI(
 		api,
 		commit: () => {
 			if (state !== "loading") return;
-			for (const change of pendingRuntimeChanges) change();
-			state = "active";
-			pendingRuntimeChanges.length = 0;
-			loadingUnsubscribers.length = 0;
+			const applied: Array<{ apply: () => void; rollback: () => void }> = [];
+			try {
+				for (const change of pendingRuntimeChanges) {
+					change.apply();
+					applied.push(change);
+				}
+				state = "active";
+				pendingRuntimeChanges.length = 0;
+				loadingUnsubscribers.length = 0;
+			} catch (error) {
+				for (const change of applied.reverse()) {
+					try {
+						change.rollback();
+					} catch {
+						// Best-effort undo of provider ops already applied in this commit.
+					}
+				}
+				throw error;
+			}
 		},
 		discard: () => {
 			if (state !== "loading") return;

--- a/packages/coding-agent/src/core/extensions/loader-api.ts
+++ b/packages/coding-agent/src/core/extensions/loader-api.ts
@@ -287,7 +287,10 @@ export function createExtensionAPI(
 				"provider" in registration ? registration.provider.id === name : registration.name === name,
 			);
 			applyRuntimeChange({
-				apply: () => runtime.unregisterProvider(name, extension.path),
+				// Explicit unregistration stays name-wide: its rollback below
+				// restores every prior registration, so a narrower removal here
+				// would re-register entries that were never taken away.
+				apply: () => runtime.unregisterProvider(name),
 				rollback: () => {
 					for (const registration of prior) {
 						if ("provider" in registration) {

--- a/packages/coding-agent/src/core/extensions/loader-api.ts
+++ b/packages/coding-agent/src/core/extensions/loader-api.ts
@@ -36,19 +36,36 @@ export function createExtensionAPI(
 	eventBus: EventBus,
 	workflowResourceProvider: WorkflowResourceProviderInput = emptyWorkflowResourceProvider,
 	resourceLoaderInheritanceSnapshotProvider?: ResourceLoaderInheritanceSnapshotProvider,
-): ExtensionAPI {
+): { api: ExtensionAPI; commit: () => void; discard: () => void } {
 	const workflowResources = normalizeWorkflowResourceProvider(workflowResourceProvider);
+	const pendingRuntimeChanges: Array<() => void> = [];
+	const loadingUnsubscribers: Array<() => void> = [];
+	const initialFlagValues = new Map(runtime.flagValues);
+	const initialFlagOwners = new Map(runtime.flagOwners);
+	const initialFlagOwnerOrigins = new Map(runtime.flagOwnerOrigins);
+	let state: "loading" | "active" | "failed" = "loading";
+	const assertActive = () => {
+		if (state === "failed")
+			throw new Error(`Extension "${extension.path}" failed to load and its API is no longer active.`);
+		runtime.assertActive();
+	};
+	const applyRuntimeChange = (change: () => void) => {
+		if (state === "loading") pendingRuntimeChanges.push(change);
+		else change();
+	};
 	// Successive load generations of one session each build a new facade over
 	// the same shared bus; mapping the facade back to that bus lets
 	// session-scoped state re-bind across module re-evaluation.
 	const events: EventBus = {
 		emit(channel, data) {
-			runtime.assertActive();
+			assertActive();
 			eventBus.emit(channel, data);
 		},
 		on(channel, handler) {
-			runtime.assertActive();
-			return runtime.trackEventBusSubscription(eventBus.on(channel, handler));
+			assertActive();
+			const unsubscribe = runtime.trackEventBusSubscription(eventBus.on(channel, handler));
+			if (state === "loading") loadingUnsubscribers.push(unsubscribe);
+			return unsubscribe;
 		},
 	};
 	registerCanonicalEventBus(events, eventBus);
@@ -249,19 +266,38 @@ export function createExtensionAPI(
 			runtime.assertActive();
 			if (typeof nameOrProvider === "string") {
 				if (!config) throw new Error("Provider config is required");
-				runtime.registerProvider(nameOrProvider, config, extension.path);
+				applyRuntimeChange(() => runtime.registerProvider(nameOrProvider, config, extension.path));
 			} else {
-				runtime.registerProvider(nameOrProvider, extension.path);
+				applyRuntimeChange(() => runtime.registerProvider(nameOrProvider, extension.path));
 			}
 		},
 
 		unregisterProvider(name: string) {
 			runtime.assertActive();
-			runtime.unregisterProvider(name, extension.path);
+			applyRuntimeChange(() => runtime.unregisterProvider(name, extension.path));
 		},
 
 		events,
 	} as ExtensionAPI;
 
-	return api;
+	return {
+		api,
+		commit: () => {
+			if (state !== "loading") return;
+			for (const change of pendingRuntimeChanges) change();
+			state = "active";
+			pendingRuntimeChanges.length = 0;
+			loadingUnsubscribers.length = 0;
+		},
+		discard: () => {
+			if (state !== "loading") return;
+			state = "failed";
+			for (const unsubscribe of loadingUnsubscribers) unsubscribe();
+			pendingRuntimeChanges.length = 0;
+			loadingUnsubscribers.length = 0;
+			runtime.flagValues = initialFlagValues;
+			runtime.flagOwners = initialFlagOwners;
+			runtime.flagOwnerOrigins = initialFlagOwnerOrigins;
+		},
+	};
 }

--- a/packages/coding-agent/src/core/extensions/loader-api.ts
+++ b/packages/coding-agent/src/core/extensions/loader-api.ts
@@ -51,7 +51,8 @@ export function createExtensionAPI(
 	};
 	const applyRuntimeChange = (change: () => void) => {
 		if (state === "loading") pendingRuntimeChanges.push(change);
-		else change();
+		else if (state === "active") change();
+		else assertActive();
 	};
 	// Successive load generations of one session each build a new facade over
 	// the same shared bus; mapping the facade back to that bus lets
@@ -71,14 +72,14 @@ export function createExtensionAPI(
 	registerCanonicalEventBus(events, eventBus);
 	const api = {
 		on(event: string, handler: HandlerFn): void {
-			runtime.assertActive();
+			assertActive();
 			const list = extension.handlers.get(event) ?? [];
 			list.push(handler);
 			extension.handlers.set(event, list);
 		},
 
 		registerTool(tool: ToolDefinition): void {
-			runtime.assertActive();
+			assertActive();
 			if (runtime.canRegisterResource?.(extension, "tool", tool.name) === false) return;
 			const registration = { definition: tool, sourceInfo: extension.sourceInfo };
 			if (runtime.stageToolRegistration?.(extension, tool.name, registration)) return;
@@ -88,7 +89,7 @@ export function createExtensionAPI(
 		},
 
 		registerCommand(name: string, options: Omit<RegisteredCommand, "name" | "sourceInfo">): void {
-			runtime.assertActive();
+			assertActive();
 			if (runtime.canRegisterResource?.(extension, "command", name) === false) return;
 			const registration = { name, sourceInfo: extension.sourceInfo, ...options };
 			if (runtime.stageCommandRegistration?.(extension, name, registration)) return;
@@ -102,7 +103,7 @@ export function createExtensionAPI(
 				handler: (ctx: ExtensionContext) => Promise<void> | void;
 			},
 		): void {
-			runtime.assertActive();
+			assertActive();
 			if (runtime.canRegisterResource?.(extension, "shortcut", shortcut) === false) return;
 			const registration = { shortcut, extensionPath: extension.path, ...options };
 			if (runtime.stageShortcutRegistration?.(extension, shortcut, registration)) return;
@@ -117,7 +118,7 @@ export function createExtensionAPI(
 				default?: boolean | string;
 			},
 		): void {
-			runtime.assertActive();
+			assertActive();
 			if (options.default !== undefined && typeof options.default !== options.type) {
 				throw new Error(
 					`Invalid default for flag "${name}": expected ${options.type}, got ${typeof options.default}`,
@@ -150,120 +151,120 @@ export function createExtensionAPI(
 		},
 
 		registerMessageRenderer<T>(customType: string, renderer: MessageRenderer<T>): void {
-			runtime.assertActive();
+			assertActive();
 			extension.messageRenderers.set(customType, renderer as MessageRenderer);
 		},
 
 		registerMarkdownTransformer(transformer: MarkdownTransformer): void {
-			runtime.assertActive();
+			assertActive();
 			extension.markdownTransformer = transformer;
 		},
 
 		registerEntryRenderer<T>(customType: string, renderer: EntryRenderer<T>): void {
-			runtime.assertActive();
+			assertActive();
 			extension.entryRenderers.set(customType, renderer as EntryRenderer);
 		},
 
 		getFlag(name: string): boolean | string | undefined {
-			runtime.assertActive();
+			assertActive();
 			const pendingDefault = runtime.getPendingFlagDefault?.(extension.path, name);
 			if (!extension.flags.has(name) && pendingDefault === undefined) return undefined;
 			return runtime.flagValues.get(name) ?? pendingDefault;
 		},
 
 		getWorkflowResources() {
-			runtime.assertActive();
+			assertActive();
 			return [...workflowResources.get()];
 		},
 
 		async refreshWorkflowResources() {
-			runtime.assertActive();
+			assertActive();
 			const refreshed = await workflowResources.refresh?.();
 			return [...(refreshed ?? workflowResources.get())];
 		},
 
 		getResourceLoaderInheritanceSnapshot() {
-			runtime.assertActive();
+			assertActive();
 			return resourceLoaderInheritanceSnapshotProvider?.() ?? {};
 		},
 
 		sendMessage(message, options): void | Promise<void> {
-			runtime.assertActive();
+			assertActive();
 			return runtime.sendMessage(message, options);
 		},
 
 		sendMessages(messages, options): void | Promise<void> {
-			runtime.assertActive();
+			assertActive();
 			return runtime.sendMessages(messages, options);
 		},
 
 		sendUserMessage(content, options): void {
-			runtime.assertActive();
+			assertActive();
 			runtime.sendUserMessage(content, options);
 		},
 
 		appendEntry(customType: string, data?: unknown): void {
-			runtime.assertActive();
+			assertActive();
 			runtime.appendEntry(customType, data);
 		},
 
 		setSessionName(name: string): void {
-			runtime.assertActive();
+			assertActive();
 			runtime.setSessionName(name);
 		},
 
 		getSessionName(): string | undefined {
-			runtime.assertActive();
+			assertActive();
 			return runtime.getSessionName();
 		},
 
 		setLabel(entryId: string, label: string | undefined): void {
-			runtime.assertActive();
+			assertActive();
 			runtime.setLabel(entryId, label);
 		},
 
 		exec(command: string, args: string[], options?: ExecOptions) {
-			runtime.assertActive();
+			assertActive();
 			return execCommand(command, args, options?.cwd ?? cwd, options);
 		},
 
 		getActiveTools(): string[] {
-			runtime.assertActive();
+			assertActive();
 			return runtime.getActiveToolsAfterRegistration?.(extension) ?? runtime.getActiveTools();
 		},
 
 		getAllTools() {
-			runtime.assertActive();
+			assertActive();
 			return runtime.getAllToolsAfterRegistration?.(extension) ?? runtime.getAllTools();
 		},
 
 		setActiveTools(toolNames: string[]): void {
-			runtime.assertActive();
+			assertActive();
 			if (!runtime.setActiveToolsAfterRegistration?.(extension, toolNames)) runtime.setActiveTools(toolNames);
 		},
 
 		getCommands() {
-			runtime.assertActive();
+			assertActive();
 			return runtime.getCommandsAfterRegistration?.(extension) ?? runtime.getCommands();
 		},
 
 		setModel(model) {
-			runtime.assertActive();
+			assertActive();
 			return runtime.setModel(model);
 		},
 
 		getThinkingLevel() {
-			runtime.assertActive();
+			assertActive();
 			return runtime.getThinkingLevel();
 		},
 
 		setThinkingLevel(level) {
-			runtime.assertActive();
+			assertActive();
 			runtime.setThinkingLevel(level);
 		},
 
 		registerProvider(nameOrProvider: string | Provider, config?: ProviderConfig) {
-			runtime.assertActive();
+			assertActive();
 			if (typeof nameOrProvider === "string") {
 				if (!config) throw new Error("Provider config is required");
 				applyRuntimeChange(() => runtime.registerProvider(nameOrProvider, config, extension.path));
@@ -273,7 +274,7 @@ export function createExtensionAPI(
 		},
 
 		unregisterProvider(name: string) {
-			runtime.assertActive();
+			assertActive();
 			applyRuntimeChange(() => runtime.unregisterProvider(name, extension.path));
 		},
 

--- a/packages/coding-agent/src/core/extensions/loader-api.ts
+++ b/packages/coding-agent/src/core/extensions/loader-api.ts
@@ -101,6 +101,11 @@ export function createExtensionAPI(
 			},
 		): void {
 			runtime.assertActive();
+			if (options.default !== undefined && typeof options.default !== options.type) {
+				throw new Error(
+					`Invalid default for flag "${name}": expected ${options.type}, got ${typeof options.default}`,
+				);
+			}
 			if (runtime.canRegisterResource?.(extension, "flag", name) === false) return;
 			const registration = { name, extensionPath: extension.path, ...options };
 			if (runtime.stageFlagRegistration?.(extension, name, registration, options.default)) return;

--- a/packages/coding-agent/src/core/extensions/loader-core.ts
+++ b/packages/coding-agent/src/core/extensions/loader-core.ts
@@ -64,7 +64,7 @@ async function loadExtension(
 		}
 
 		const extension = createExtension(extensionPath, resolvedPath);
-		const api = createExtensionAPI(
+		const transaction = createExtensionAPI(
 			extension,
 			runtime,
 			cwd,
@@ -73,7 +73,13 @@ async function loadExtension(
 			resourceLoaderInheritanceSnapshotProvider,
 		);
 		const factorySpan = startTimingSpan(`loadExtensions.${extensionPath}.factory`, "extensions");
-		await factory(api);
+		try {
+			await factory(transaction.api);
+			transaction.commit();
+		} catch (error) {
+			transaction.discard();
+			throw error;
+		}
 		endTimingSpan(factorySpan);
 
 		return { extension, error: null };
@@ -97,7 +103,7 @@ export async function loadExtensionFromFactory(
 ): Promise<Extension> {
 	const extension = createExtension(extensionPath, extensionPath);
 	const resolvedCwd = resolvePath(cwd);
-	const api = createExtensionAPI(
+	const transaction = createExtensionAPI(
 		extension,
 		runtime,
 		resolvedCwd,
@@ -105,7 +111,13 @@ export async function loadExtensionFromFactory(
 		workflowResourceProvider,
 		resourceLoaderInheritanceSnapshotProvider,
 	);
-	await factory(api);
+	try {
+		await factory(transaction.api);
+		transaction.commit();
+	} catch (error) {
+		transaction.discard();
+		throw error;
+	}
 	return extension;
 }
 

--- a/packages/coding-agent/src/core/extensions/loader-runtime.ts
+++ b/packages/coding-agent/src/core/extensions/loader-runtime.ts
@@ -243,10 +243,16 @@ export function createExtensionRuntime(): ExtensionRuntime {
 				});
 			}
 		},
-		unregisterProvider: (name) => {
-			runtime.pendingProviderRegistrations = runtime.pendingProviderRegistrations.filter((registration) =>
-				"provider" in registration ? registration.provider.id !== name : registration.name !== name,
-			);
+		unregisterProvider: (name, extensionPath) => {
+			runtime.pendingProviderRegistrations = runtime.pendingProviderRegistrations.filter((registration) => {
+				const matchesName =
+					"provider" in registration ? registration.provider.id === name : registration.name === name;
+				if (!matchesName) return true;
+				// A transactional rollback owns only what its own extension
+				// registered. Without this, a later extension reusing a provider
+				// name would drop an earlier extension's working registration.
+				return extensionPath !== undefined && registration.extensionPath !== extensionPath;
+			});
 		},
 	};
 	return runtime;

--- a/packages/coding-agent/src/core/extensions/ui-types.ts
+++ b/packages/coding-agent/src/core/extensions/ui-types.ts
@@ -258,8 +258,8 @@ export interface ExtensionUIContext {
 	/** Set a custom footer component, or undefined to restore the built-in footer.
 	 *
 	 * The factory receives a FooterDataProvider for data not otherwise accessible:
-	 * git branch and extension statuses from setStatus(). Token stats, model info,
-	 * etc. are available via ctx.sessionManager and ctx.model.
+	 * git branch and extension statuses from setStatus(). Context usage is on
+	 * ctx.getContextUsage(), token stats on ctx.sessionManager.getEntries(), and model info on ctx.model.
 	 */
 	setFooter(
 		factory:

--- a/packages/coding-agent/src/core/footer-data-provider.ts
+++ b/packages/coding-agent/src/core/footer-data-provider.ts
@@ -103,7 +103,7 @@ function shouldPollGitHead(repoDir: string): boolean {
 
 /**
  * Provides git branch and extension statuses - data not otherwise accessible to extensions.
- * Token stats, model info available via ctx.sessionManager and ctx.model.
+ * Context usage is on ctx.getContextUsage(), token stats on ctx.sessionManager.getEntries(), and model info on ctx.model.
  */
 export class FooterDataProvider {
 	private cwd: string;

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -9,6 +9,7 @@ import {
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { getAgentDir } from "../config.ts";
+import { stripBom } from "../utils/text.ts";
 
 export interface AppKeybindings {
 	"app.interrupt": true;
@@ -336,7 +337,7 @@ function orderKeybindingsConfig(config: Record<string, unknown>): Record<string,
 function loadRawConfig(path: string): Record<string, unknown> | undefined {
 	if (!existsSync(path)) return undefined;
 	try {
-		const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+		const parsed = JSON.parse(stripBom(readFileSync(path, "utf-8"))) as unknown;
 		return isRecord(parsed) ? parsed : undefined;
 	} catch {
 		return undefined;

--- a/packages/coding-agent/src/core/model-config.ts
+++ b/packages/coding-agent/src/core/model-config.ts
@@ -6,6 +6,7 @@ import { Compile } from "typebox/compile";
 import type { TLocalizedValidationError } from "typebox/error";
 import { stripJsonComments } from "../utils/json.ts";
 import { normalizePath } from "../utils/paths.ts";
+import { stripBom } from "../utils/text.ts";
 
 const PercentileCutoffsSchema = Type.Object({
 	p50: Type.Optional(Type.Number()),
@@ -261,7 +262,7 @@ export class ModelConfig {
 
 		let parsed: unknown;
 		try {
-			parsed = JSON.parse(stripJsonComments(content));
+			parsed = JSON.parse(stripJsonComments(stripBom(content)));
 		} catch (error) {
 			return new ModelConfig(
 				new Map(),

--- a/packages/coding-agent/src/core/models-store.ts
+++ b/packages/coding-agent/src/core/models-store.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import type { ModelsStore, ModelsStoreEntry } from "@bastani/pi-ai";
 import { getAgentDir } from "../config.ts";
+import { stripBom } from "../utils/text.ts";
 import { type AuthStorageBackend, FileAuthStorageBackend } from "./auth-storage-backends.ts";
 
 type StoredModels = Record<string, ModelsStoreEntry>;
@@ -30,7 +31,7 @@ export class FileModelsStore implements ModelsStore {
 	}
 
 	private parse(content: string | undefined): StoredModels {
-		return content ? (JSON.parse(content) as StoredModels) : {};
+		return content ? (JSON.parse(stripBom(content)) as StoredModels) : {};
 	}
 
 	async read(providerId: string): Promise<ModelsStoreEntry | undefined> {

--- a/packages/coding-agent/src/core/package-manager-git.ts
+++ b/packages/coding-agent/src/core/package-manager-git.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync
 import { basename, dirname, join, resolve, sep } from "node:path";
 import { APP_NAME, getProjectConfigDirs } from "../config.ts";
 import type { GitSource } from "../utils/git.ts";
+import { stripBom } from "../utils/text.ts";
 import { runCommand, runCommandCapture } from "./package-manager-command.ts";
 import { NETWORK_TIMEOUT_MS } from "./package-manager-constants.ts";
 import { isOfflineModeEnabled } from "./package-manager-env.ts";
@@ -81,7 +82,7 @@ function hasMissingGitDependencies(targetDir: string): boolean {
 	const packageJsonPath = join(targetDir, "package.json");
 	if (!existsSync(packageJsonPath)) return false;
 	try {
-		const manifest = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as { dependencies?: unknown };
+		const manifest = JSON.parse(stripBom(readFileSync(packageJsonPath, "utf-8"))) as { dependencies?: unknown };
 		if (!manifest.dependencies || typeof manifest.dependencies !== "object" || Array.isArray(manifest.dependencies)) {
 			return false;
 		}

--- a/packages/coding-agent/src/core/package-manager-manifest.ts
+++ b/packages/coding-agent/src/core/package-manager-manifest.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { APP_NAME } from "../config.ts";
+import { stripBom } from "../utils/text.ts";
 import type { PiManifest, ResourceType } from "./package-manager-types.ts";
 
 const MANIFEST_ENTRY_FIELDS = ["extensions", "skills", "prompts", "themes", "workflows", "workflow"] as const;
@@ -29,7 +30,7 @@ export function getManifestFromPackageJson(pkg: unknown): PiManifest | null {
 export function readPiManifestFile(packageJsonPath: string): PiManifest | null {
 	try {
 		const content = readFileSync(packageJsonPath, "utf-8");
-		const pkg = JSON.parse(content) as Record<string, unknown>;
+		const pkg = JSON.parse(stripBom(content)) as Record<string, unknown>;
 		return getManifestFromPackageJson(pkg);
 	} catch {
 		return null;

--- a/packages/coding-agent/src/core/package-manager-npm.ts
+++ b/packages/coding-agent/src/core/package-manager-npm.ts
@@ -3,6 +3,7 @@ import { basename, dirname, join } from "node:path";
 import { gt, maxSatisfying, rcompare, satisfies } from "semver";
 import { APP_NAME, CONFIG_DIR_NAME, getProjectConfigDirs } from "../config.ts";
 import { markPathIgnoredByCloudSync } from "../utils/paths.ts";
+import { stripBom } from "../utils/text.ts";
 import { runCommand, runCommandCapture, runCommandSync } from "./package-manager-command.ts";
 import { NETWORK_TIMEOUT_MS } from "./package-manager-constants.ts";
 import { isOfflineModeEnabled } from "./package-manager-env.ts";
@@ -264,7 +265,7 @@ export function getInstalledNpmVersion(installedPath: string): string | undefine
 	if (!existsSync(packageJsonPath)) return undefined;
 	try {
 		const content = readFileSync(packageJsonPath, "utf-8");
-		const pkg = JSON.parse(content) as { version?: string };
+		const pkg = JSON.parse(stripBom(content)) as { version?: string };
 		return pkg.version;
 	} catch {
 		return undefined;

--- a/packages/coding-agent/src/core/remote-catalog-provider.ts
+++ b/packages/coding-agent/src/core/remote-catalog-provider.ts
@@ -4,6 +4,7 @@ import { fetchWithRetry } from "../utils/management-http.ts";
 import { getPiUserAgent } from "../utils/pi-user-agent.ts";
 
 const DEFAULT_CATALOG_BASE_URL = "https://pi.dev";
+const REMOTE_CATALOG_ATTEMPT_TIMEOUT_MS = 4_000;
 export const REMOTE_CATALOG_REFRESH_INTERVAL_MS = 4 * 60 * 60 * 1000;
 
 function mergeModels(baseline: readonly Model<Api>[], dynamic: readonly Model<Api>[]): Model<Api>[] {
@@ -82,14 +83,18 @@ export function withRemoteCatalog(
 			// leave the overlay empty.
 			const validator = stored?.models.length ? stored.etag : undefined;
 			const url = new URL(`/api/models/providers/${encodeURIComponent(provider.id)}`, catalogBaseUrl);
-			const response = await fetchWithRetry(url, {
-				headers: {
-					accept: "application/json",
-					"User-Agent": getPiUserAgent(VERSION),
-					...(validator ? { "if-none-match": validator } : {}),
+			const response = await fetchWithRetry(
+				url,
+				{
+					headers: {
+						accept: "application/json",
+						"User-Agent": getPiUserAgent(VERSION),
+						...(validator ? { "if-none-match": validator } : {}),
+					},
+					signal: context.signal,
 				},
-				signal: context.signal,
-			});
+				{ attemptTimeoutMs: REMOTE_CATALOG_ATTEMPT_TIMEOUT_MS },
+			);
 			if (context.signal.aborted) return;
 			const checkedAt = Date.now();
 			// Unchanged: dynamicModels already holds the stored overlay, so only the

--- a/packages/coding-agent/src/core/resource-loader-context-files.ts
+++ b/packages/coding-agent/src/core/resource-loader-context-files.ts
@@ -3,6 +3,7 @@ import { basename, dirname, join, sep } from "node:path";
 import chalk from "chalk";
 import { getAgentDir, getAgentDirs } from "../config.ts";
 import { canonicalizePath, resolvePath } from "../utils/paths.ts";
+import { stripBom } from "../utils/text.ts";
 import { findGitPaths } from "./footer-data-provider.ts";
 
 export function resolvePromptInput(input: string | undefined, description: string): string | undefined {
@@ -12,7 +13,7 @@ export function resolvePromptInput(input: string | undefined, description: strin
 
 	if (existsSync(input)) {
 		try {
-			return readFileSync(input, "utf-8");
+			return stripBom(readFileSync(input, "utf-8"));
 		} catch (error) {
 			console.error(chalk.yellow(`Warning: Could not read ${description} file ${input}: ${error}`));
 			return input;
@@ -45,7 +46,7 @@ function loadContextFileFromDir(dir: string): { path: string; content: string } 
 				if (!statSync(filePath).isFile()) continue;
 				return {
 					path: filePath,
-					content: readFileSync(filePath, "utf-8"),
+					content: stripBom(readFileSync(filePath, "utf-8")),
 				};
 			} catch (error) {
 				console.error(chalk.yellow(`Warning: Could not read ${filePath}: ${error}`));

--- a/packages/coding-agent/src/modes/interactive/interactive-slash-commands.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-slash-commands.ts
@@ -12,6 +12,7 @@ import {
 	fs,
 	getChangelogPath,
 	getShareViewerUrl,
+	hyperlink,
 	Markdown,
 	MissingSessionCwdError,
 	normalizeChangelogLinks,
@@ -312,7 +313,7 @@ InteractiveModeBase.prototype.handleShareCommand = async function (this: Interac
 
 		// Create the preview URL
 		const previewUrl = getShareViewerUrl(gistId);
-		this.showStatus(`Share URL: ${previewUrl}\nGist: ${gistUrl}`);
+		this.showStatus(`Share URL: ${hyperlink(previewUrl, previewUrl)}\nGist: ${hyperlink(gistUrl, gistUrl)}`);
 	} catch (error: unknown) {
 		if (!loader.signal.aborted) {
 			restoreEditor();

--- a/packages/coding-agent/src/modes/interactive/interactive-slash-commands.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-slash-commands.ts
@@ -235,10 +235,11 @@ InteractiveModeBase.prototype.handleShareCommand = async function (this: Interac
 		return;
 	}
 
-	// Export to a temp file
-	const tmpFile = path.join(os.tmpdir(), "session.html");
+	// Share an export-only JSONL copy carrying context for the viewer. The
+	// persisted session is not mutated.
+	const tmpFile = path.join(os.tmpdir(), "session.jsonl");
 	try {
-		await this.session.exportToHtml(tmpFile, { themeName: theme.name });
+		this.session.exportToJsonl(tmpFile, { includeShareContext: true });
 	} catch (error: unknown) {
 		this.showError(`Failed to export session: ${error instanceof Error ? error.message : "Unknown error"}`);
 		return;

--- a/packages/coding-agent/src/modes/interactive/theme/theme-parse.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme-parse.ts
@@ -1,3 +1,4 @@
+import { stripBom } from "../../../utils/text.ts";
 import type { ThemeJson } from "./theme-schema.ts";
 import { validateThemeJson } from "./theme-schema.ts";
 
@@ -53,7 +54,7 @@ export function parseThemeJson(label: string, json: unknown): ThemeJson {
 export function parseThemeJsonContent(label: string, content: string): ThemeJson {
 	let json: unknown;
 	try {
-		json = JSON.parse(content);
+		json = JSON.parse(stripBom(content));
 	} catch (error) {
 		throw new Error(`Failed to parse theme ${label}: ${error}`);
 	}

--- a/packages/coding-agent/src/modes/json-event.ts
+++ b/packages/coding-agent/src/modes/json-event.ts
@@ -2,58 +2,53 @@ import type { Usage } from "@bastani/pi-ai";
 import type { AgentSessionEvent } from "../core/agent-session.ts";
 
 type WithoutPartial<T> = T extends { partial: unknown } ? Omit<T, "partial"> : T;
-
-type ToJsonEvent<T> = T extends {
-	type: "message_update";
-	assistantMessageEvent: infer TAssistantMessageEvent;
-}
-	? {
-			type: "message_update";
-			usage: Usage;
-			endTurn?: boolean;
-			assistantMessageEvent: WithoutPartial<TAssistantMessageEvent>;
-		}
-	: T;
-
-/** Session event shape emitted by the JSON and RPC stdout protocols. */
-export type JsonAgentSessionEvent = ToJsonEvent<AgentSessionEvent>;
+type ToJsonAssistantMessageEvent<T> = T extends { type: "toolcall_start"; partial: unknown }
+	? WithoutPartial<T> & { id?: string; toolName?: string }
+	: WithoutPartial<T>;
 
 type MessageUpdateEvent = Extract<AgentSessionEvent, { type: "message_update" }>;
-type JsonMessageUpdateEvent = Extract<JsonAgentSessionEvent, { type: "message_update" }>;
+type JsonMessageUpdateEvent = {
+	type: "message_update";
+	usage: Usage;
+	endTurn?: boolean;
+	assistantMessageEvent: ToJsonAssistantMessageEvent<MessageUpdateEvent["assistantMessageEvent"]>;
+};
 
-/**
- * Remove cumulative assistant snapshots from streaming wire events.
- * `message_start` provides the initial message, deltas build it, and
- * `message_end` provides the final authoritative message. Cumulative usage
- * and the provider's end-of-turn signal remain available because their size
- * is constant.
- */
+/** Session event shape emitted by the JSON and RPC stdout protocols. */
+export type JsonAgentSessionEvent = Exclude<AgentSessionEvent, { type: "message_update" }> | JsonMessageUpdateEvent;
+
+function toJsonAssistantMessageEvent(
+	event: MessageUpdateEvent["assistantMessageEvent"],
+): JsonMessageUpdateEvent["assistantMessageEvent"] {
+	if (event.type === "toolcall_start") {
+		const toolCall = event.partial.content[event.contentIndex];
+		if (toolCall?.type !== "toolCall") {
+			throw new Error(`toolcall_start content at index ${event.contentIndex} is not a tool call`);
+		}
+		const { partial: _partial, ...deltaEvent } = event;
+		return { ...deltaEvent, id: toolCall.id, toolName: toolCall.name };
+	}
+	if (!("partial" in event)) return event;
+	const { partial: _partial, ...deltaEvent } = event;
+	return deltaEvent;
+}
+
+/** Remove cumulative assistant snapshots while retaining constant-size metadata. */
 export function toJsonEvent(event: MessageUpdateEvent): JsonMessageUpdateEvent;
 export function toJsonEvent(event: AgentSessionEvent): JsonAgentSessionEvent;
 export function toJsonEvent(event: AgentSessionEvent): JsonAgentSessionEvent {
-	if (event.type !== "message_update") {
-		return event;
-	}
-	if (event.message.role !== "assistant") {
-		throw new Error("message_update message is not an assistant message");
-	}
-
-	const assistantMessageEvent = event.assistantMessageEvent;
-	const usage = event.message.usage;
-	const endTurn = event.message.endTurn;
-	if (!("partial" in assistantMessageEvent)) {
-		return withEndTurn({ type: "message_update", usage, assistantMessageEvent }, endTurn);
-	}
-
-	const { partial: _partial, ...deltaEvent } = assistantMessageEvent;
-	return withEndTurn({ type: "message_update", usage, assistantMessageEvent: deltaEvent }, endTurn);
+	if (event.type !== "message_update") return event;
+	if (event.message.role !== "assistant") throw new Error("message_update message is not an assistant message");
+	return withEndTurn(
+		{
+			type: "message_update",
+			usage: event.message.usage,
+			assistantMessageEvent: toJsonAssistantMessageEvent(event.assistantMessageEvent),
+		},
+		event.message.endTurn,
+	);
 }
 
-/**
- * Carry the provider's end-of-turn signal only when the provider reported one.
- * A present-but-undefined key would make "the provider said nothing" look like
- * a reported value, so an unreported signal leaves the key off the frame.
- */
 function withEndTurn(update: JsonMessageUpdateEvent, endTurn: boolean | undefined): JsonMessageUpdateEvent {
 	if (endTurn === undefined) return update;
 	return { ...update, endTurn };

--- a/packages/coding-agent/src/utils/frontmatter.ts
+++ b/packages/coding-agent/src/utils/frontmatter.ts
@@ -1,4 +1,5 @@
 import { parse } from "yaml";
+import { stripBom } from "./text.ts";
 
 type ParsedFrontmatter<T extends Record<string, unknown>> = {
 	frontmatter: T;
@@ -8,7 +9,7 @@ type ParsedFrontmatter<T extends Record<string, unknown>> = {
 const normalizeNewlines = (value: string): string => value.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 
 const extractFrontmatter = (content: string): { yamlString: string | null; body: string } => {
-	const normalized = normalizeNewlines(content);
+	const normalized = normalizeNewlines(stripBom(content));
 
 	if (!normalized.startsWith("---")) {
 		return { yamlString: null, body: normalized };

--- a/packages/coding-agent/src/utils/management-http.ts
+++ b/packages/coding-agent/src/utils/management-http.ts
@@ -9,6 +9,8 @@ export interface FetchRetryOptions {
 	retryOnStatus?: boolean;
 	/** Overall timeout shared by all attempts. */
 	timeoutMs?: number;
+	/** Per-attempt timeout; timed-out attempts remain retryable. */
+	attemptTimeoutMs?: number;
 }
 
 /**
@@ -35,14 +37,17 @@ export async function fetchWithRetry(
 	const parentSignal = init?.signal;
 	const timeoutSignal =
 		options.timeoutMs !== undefined && options.timeoutMs > 0 ? AbortSignal.timeout(options.timeoutMs) : undefined;
-	const signal = timeoutSignal
-		? parentSignal
-			? AbortSignal.any([parentSignal, timeoutSignal])
-			: timeoutSignal
-		: parentSignal;
+	const attemptTimeoutMs =
+		options.attemptTimeoutMs && options.attemptTimeoutMs > 0 ? options.attemptTimeoutMs : undefined;
 
 	for (let attempt = 0; ; attempt += 1) {
-		signal?.throwIfAborted();
+		parentSignal?.throwIfAborted();
+		timeoutSignal?.throwIfAborted();
+		const attemptTimeoutSignal = attemptTimeoutMs ? AbortSignal.timeout(attemptTimeoutMs) : undefined;
+		const signals = [parentSignal, timeoutSignal, attemptTimeoutSignal].filter(
+			(signal): signal is AbortSignal => signal !== undefined,
+		);
+		const signal = signals.length > 1 ? AbortSignal.any(signals) : signals[0];
 		try {
 			const response = await fetch(input, signal ? { ...init, signal } : init);
 			const shouldRetry = retryOnStatus && RETRYABLE_STATUS_CODES.has(response.status) && attempt < maxRetries;
@@ -54,10 +59,15 @@ export async function fetchWithRetry(
 				// to do if cancelling its body also fails.
 			}
 		} catch (error) {
+			const attemptTimedOut =
+				attemptTimeoutSignal?.aborted === true && !parentSignal?.aborted && !timeoutSignal?.aborted;
 			if (
 				parentSignal?.aborted ||
 				timeoutSignal?.aborted ||
-				(error instanceof Error && error.name === "AbortError" && timeoutSignal === undefined) ||
+				(error instanceof Error &&
+					error.name === "AbortError" &&
+					!attemptTimedOut &&
+					timeoutSignal === undefined) ||
 				attempt >= maxRetries
 			) {
 				throw error;

--- a/packages/coding-agent/src/utils/text.ts
+++ b/packages/coding-agent/src/utils/text.ts
@@ -1,0 +1,9 @@
+/** Split a leading UTF-8 byte order mark from decoded text. */
+export function splitBom(content: string): { bom: string; text: string } {
+	return content.startsWith("\uFEFF") ? { bom: "\uFEFF", text: content.slice(1) } : { bom: "", text: content };
+}
+
+/** Remove a leading UTF-8 byte order mark from decoded text. */
+export function stripBom(content: string): string {
+	return splitBom(content).text;
+}

--- a/packages/coding-agent/test/1955-registration-batching.test.ts
+++ b/packages/coding-agent/test/1955-registration-batching.test.ts
@@ -41,7 +41,7 @@ for (const origin of ["inherited-pi", "bundled"] as const) {
 			for (const name of candidate.tools.keys()) registryTools.add(name);
 			activeTools = [...new Set([...activeTools, ...additions])];
 		};
-		const pi = createExtensionAPI(candidate, runtime, "/tmp", createEventBus());
+		const { api: pi } = createExtensionAPI(candidate, runtime, "/tmp", createEventBus());
 		let sawTool = false;
 		let sawCommand = false;
 		let sawActiveTool = false;
@@ -77,7 +77,7 @@ for (const origin of ["inherited-pi", "bundled"] as const) {
 test("preserves constrainedSampling own-property state in staged inherited inspection", () => {
 	const runtime = createExtensionRuntime();
 	const candidate = extension("sampling", "inherited-pi");
-	const pi = createExtensionAPI(candidate, runtime, "/tmp", createEventBus());
+	const { api: pi } = createExtensionAPI(candidate, runtime, "/tmp", createEventBus());
 	const grammar = {
 		type: "grammar" as const,
 		variants: { openai_lark: 'start: "α" | "β"\n', openai_regex: "^(a|a)$" },
@@ -118,7 +118,7 @@ test("keeps original event order while committing only the bundled collision win
 	const trace: string[] = [];
 	let inheritedObserved: boolean | string | undefined;
 	for (const candidate of [inherited, bundled]) {
-		const pi = createExtensionAPI(candidate, runtime, "/tmp", createEventBus());
+		const { api: pi } = createExtensionAPI(candidate, runtime, "/tmp", createEventBus());
 		pi.on("session_start", async () => {
 			trace.push(candidate.sourceInfo.configurationOrigin ?? "missing");
 			pi.registerFlag("shared", { type: "string", default: candidate.path });
@@ -154,7 +154,7 @@ test("preserves first-registration views across pending inherited duplicates", a
 	let secondView: Array<boolean | string | undefined> = [];
 	let secondCommands: string[] = [];
 	for (const candidate of extensions) {
-		const pi = createExtensionAPI(candidate, runtime, "/tmp", createEventBus());
+		const { api: pi } = createExtensionAPI(candidate, runtime, "/tmp", createEventBus());
 		pi.on("session_start", async () => {
 			pi.registerFlag("shared", { type: "string", default: candidate.path });
 			pi.registerTool({
@@ -192,8 +192,8 @@ for (const origin of ["inherited-pi", "atomic"] as const) {
 		const first = extension(`${origin}-first`, origin);
 		const second = extension(`${origin}-second`, origin);
 		let observed: boolean | string | undefined;
-		const firstApi = createExtensionAPI(first, runtime, "/tmp", createEventBus());
-		const secondApi = createExtensionAPI(second, runtime, "/tmp", createEventBus());
+		const { api: firstApi } = createExtensionAPI(first, runtime, "/tmp", createEventBus());
+		const { api: secondApi } = createExtensionAPI(second, runtime, "/tmp", createEventBus());
 		firstApi.on("session_start", async () => firstApi.registerFlag("later-default", { type: "string" }));
 		secondApi.on("session_start", async () => {
 			secondApi.registerFlag("later-default", { type: "string", default: "ready" });
@@ -229,8 +229,8 @@ test("replays the latest mixed-origin active-tool selection after staged commit"
 	runtime.refreshTools = () => {
 		activeTools = [...new Set([...activeTools, ...extensions.flatMap((candidate) => [...candidate.tools.keys()])])];
 	};
-	const inheritedApi = createExtensionAPI(inherited, runtime, "/tmp", createEventBus());
-	const bundledApi = createExtensionAPI(bundled, runtime, "/tmp", createEventBus());
+	const { api: inheritedApi } = createExtensionAPI(inherited, runtime, "/tmp", createEventBus());
+	const { api: bundledApi } = createExtensionAPI(bundled, runtime, "/tmp", createEventBus());
 	inheritedApi.on("session_start", async () => {
 		inheritedApi.registerTool({
 			name: "inherited-tool",

--- a/packages/coding-agent/test/extension-provider-rollback.test.ts
+++ b/packages/coding-agent/test/extension-provider-rollback.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "vitest";
+import { createEventBus } from "../src/core/event-bus.ts";
+import { createExtensionAPI } from "../src/core/extensions/loader-api.ts";
+import { createExtensionRuntime } from "../src/core/extensions/loader-runtime.ts";
+import type { Extension, ProviderConfig } from "../src/core/extensions/types.ts";
+
+function extension(path: string): Extension {
+	return {
+		path,
+		resolvedPath: path,
+		sourceInfo: { path, source: "test", scope: "user", origin: "top-level", configurationOrigin: "bundled" },
+		handlers: new Map(),
+		tools: new Map(),
+		messageRenderers: new Map(),
+		entryRenderers: new Map(),
+		commands: new Map(),
+		flags: new Map(),
+		shortcuts: new Map(),
+	};
+}
+
+const providerConfig: ProviderConfig = {
+	baseUrl: "https://provider.test/v1",
+	apiKey: "provider-test-key",
+	api: "openai-completions",
+	models: [
+		{
+			id: "instant-model",
+			name: "Instant Model",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 1, output: 2, cacheRead: 0.5, cacheWrite: 0.75 },
+			contextWindow: 128000,
+			maxTokens: 4096,
+		},
+	],
+};
+
+test("rolls back providers applied before a failed commit", () => {
+	const runtime = createExtensionRuntime();
+	const originalRegister = runtime.registerProvider.bind(runtime);
+	let calls = 0;
+	runtime.registerProvider = ((nameOrProvider, configOrPath, extensionPath) => {
+		calls += 1;
+		if (calls === 2) throw new Error("second provider failed");
+		originalRegister(nameOrProvider, configOrPath, extensionPath);
+	}) as typeof runtime.registerProvider;
+
+	const { api, commit, discard } = createExtensionAPI(extension("multi"), runtime, "/tmp", createEventBus());
+	api.registerProvider("first", providerConfig);
+	api.registerProvider("second", { ...providerConfig, baseUrl: "https://provider-two.test/v1" });
+
+	expect(() => commit()).toThrow("second provider failed");
+	discard();
+	expect(
+		runtime.pendingProviderRegistrations.map((registration) =>
+			"provider" in registration ? registration.provider.id : registration.name,
+		),
+	).toEqual([]);
+});

--- a/packages/coding-agent/test/extension-provider-rollback.test.ts
+++ b/packages/coding-agent/test/extension-provider-rollback.test.ts
@@ -58,3 +58,35 @@ test("rolls back providers applied before a failed commit", () => {
 		),
 	).toEqual([]);
 });
+
+test("rollback keeps an earlier extension's provider of the same name", () => {
+	const runtime = createExtensionRuntime();
+
+	// An earlier extension owns "shared-provider" and stays committed.
+	const earlier = createExtensionAPI(extension("earlier"), runtime, "/tmp", createEventBus());
+	earlier.api.registerProvider("shared-provider", providerConfig);
+	earlier.commit();
+
+	const originalRegister = runtime.registerProvider.bind(runtime);
+	let calls = 0;
+	runtime.registerProvider = ((nameOrProvider, configOrPath, extensionPath) => {
+		calls += 1;
+		if (calls === 2) throw new Error("later provider failed");
+		originalRegister(nameOrProvider, configOrPath, extensionPath);
+	}) as typeof runtime.registerProvider;
+
+	// A later extension reuses the same provider name, then fails mid-commit.
+	const later = createExtensionAPI(extension("later"), runtime, "/tmp", createEventBus());
+	later.api.registerProvider("shared-provider", { ...providerConfig, baseUrl: "https://later.test/v1" });
+	later.api.registerProvider("later-only", { ...providerConfig, baseUrl: "https://later-two.test/v1" });
+
+	expect(() => later.commit()).toThrow("later provider failed");
+	later.discard();
+
+	// The failing extension's registration is gone; the earlier owner survives.
+	const shared = runtime.pendingProviderRegistrations.filter(
+		(registration) => !("provider" in registration) && registration.name === "shared-provider",
+	);
+	expect(shared).toHaveLength(1);
+	expect(shared[0] && "extensionPath" in shared[0] ? shared[0].extensionPath : undefined).toBe("earlier");
+});

--- a/packages/coding-agent/test/extension-stale-context.test.ts
+++ b/packages/coding-agent/test/extension-stale-context.test.ts
@@ -28,7 +28,7 @@ function extension(): Extension {
 
 test("exported predicate recognizes a real stale extension API error", () => {
 	const runtime = createExtensionRuntime();
-	const pi = createExtensionAPI(extension(), runtime, "/tmp", createEventBus());
+	const { api: pi } = createExtensionAPI(extension(), runtime, "/tmp", createEventBus());
 
 	pi.registerMarkdownTransformer((markdown) => markdown);
 	runtime.invalidate();


### PR DESCRIPTION
Stack 7/9. Extension flag type validation (#8123), failed-factory state discard (#8424), footer API doc clarification (#8482), agent_settled example fixes (#8242), tool metadata at stream start in JSON events (#7953), export-only atomic.share context entry (no Radius upload — intentionally rejected), share-link cleanup, model-catalog retry, UTF-8 BOM normalization across remaining readers, preserved managed-state file permissions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790273432&installation_model_id=10562&pr_number=2681&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2681&signature=8a9d0a5dd93d7f3dae7964c798d5809655e08ac135e701e1e6f6b12a083ab03e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->













<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update makes extension provider registration transactional, preserves provider ownership during rollback, restricts rewritten credential files to their owner, and adds bounded retry behavior for slow model-catalog requests.

<h3>Confidence Score: 5/5</h3>

Safe to merge: no blocking failure remains in the exercised credential, extension rollback, or catalog retry paths.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Uploaded and ran the runtime validation for auth.json permissions, observing the baseline 0644 state and the final 0600 state with credentials present.
- Executed the focused extension-provider transaction runtime validation, capturing before and after states that show registration behavior and confirming that no product files were modified.
- Ran the delayed catalog endpoint validation script to exercise per-attempt timeouts and cancellation logic; observed no retries after cancellation and deterministic termination.

<a href="https://app.greptile.com/trex/runs/20675659/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (7): Last reviewed commit: ["fix(coding-agent): scope provider rollba..."](https://github.com/bastani-inc/atomic/commit/1a7efb7cb6c070373ec9fdac94d098fd3d8ee475) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56766277)</sub>

<!-- /greptile_comment -->