### PR TITLE
feat(coding-agent): add Windows tools and startup diagnostics

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,11 +5,13 @@
 ### Added
 
 - Added `/thinking` and a thinking-level selector. Enter applies the level to the current session; persist writes a per-model startup override. Settings can list, change, and clear those overrides.
+- Added a Windows `powershell` tool, registered by default only when `pwsh.exe` or `powershell.exe` is on `PATH`.
 
 ### Fixed
 
 - Fixed the thinking-level selector so a capability-clamped default still receives the default badge when the saved setting is higher than the active model supports.
 - Failed extension loads now roll back provider registrations applied during that load instead of leaving an earlier provider in the runtime.
+- PowerShell cancellation now terminates the Windows process tree and returns without waiting on descendant-held stdout or stderr.
 - Fixed Windows compiled binaries crashing with `ERR_INVALID_FILE_URL_PATH` when Return reached native modifier detection, including from the `/model` selector. Release app bundles keep only `pi-tui`'s native modifier loader runtime-relative, avoiding both the Linux build host's frozen module URL and Bun's inability to resolve a fully external `pi-tui` from a compiled split launcher, while retaining the staged Windows native helper for Shift+Enter handling.
 - Fixed `bundle:dev` and `start:fast` omitting the statically registered OAuth adapters. Development bundles now use the Bun entrypoint shared with compiled builds, so OpenAI Codex and xAI OAuth derivation and refresh no longer fail on unresolved runtime imports.
 - Fixed duplicate fullscreen right-click paste in VS Code-based terminals on Windows ([#8186](https://github.com/earendil-works/pi/issues/8186)).

--- a/packages/coding-agent/docs/windows.md
+++ b/packages/coding-agent/docs/windows.md
@@ -51,3 +51,7 @@ On Windows, Atomic canonicalizes paths before starting native filesystem watcher
 When self-update starts on Windows, Atomic first cleans any previous `.atomic-native-quarantine` directory under the global package root. If native add-ons from the current install are loaded by the running process, Atomic moves those files into a per-run quarantine directory and copies them back into place before invoking the package manager. This lets the package manager replace native dependency files that Windows would otherwise keep locked.
 
 If Atomic cannot safely self-update the current installation, it exits with a clear message instead of guessing. The message explains that the install is unsupported, unmanaged, or not writable; prints the detected executable path when available; and tells you to update Atomic with the package manager, wrapper, source checkout, or release artifact that originally installed it. Archive installs are not managed by `atomic update`; rerun the PowerShell installer to replace `current` with the requested release. Standalone Bun binaries direct users to the current [Atomic releases](https://github.com/bastani-inc/atomic/releases/latest), never upstream Pi artifacts.
+
+### Optional PowerShell tool
+
+On native Windows, add `powershell` to `defaultTools` to use PowerShell 7 (`pwsh.exe`) or Windows PowerShell (`powershell.exe`). The `bash` tool and `!`/`!!` shortcuts continue to use Bash. Both `ATOMIC_*` and legacy `PI_*` session variables are available.

--- a/packages/coding-agent/docs/windows.md
+++ b/packages/coding-agent/docs/windows.md
@@ -52,6 +52,6 @@ When self-update starts on Windows, Atomic first cleans any previous `.atomic-na
 
 If Atomic cannot safely self-update the current installation, it exits with a clear message instead of guessing. The message explains that the install is unsupported, unmanaged, or not writable; prints the detected executable path when available; and tells you to update Atomic with the package manager, wrapper, source checkout, or release artifact that originally installed it. Archive installs are not managed by `atomic update`; rerun the PowerShell installer to replace `current` with the requested release. Standalone Bun binaries direct users to the current [Atomic releases](https://github.com/bastani-inc/atomic/releases/latest), never upstream Pi artifacts.
 
-### Optional PowerShell tool
+### PowerShell tool
 
-On native Windows, add `powershell` to `defaultTools` to use PowerShell 7 (`pwsh.exe`) or Windows PowerShell (`powershell.exe`). The `bash` tool and `!`/`!!` shortcuts continue to use Bash. Both `ATOMIC_*` and legacy `PI_*` session variables are available.
+On native Windows, Atomic registers the `powershell` tool by default when PowerShell 7 (`pwsh.exe`) or Windows PowerShell (`powershell.exe`) is on `PATH`. If neither executable is available, the tool is omitted so the agent is not offered a command that cannot run. Add `powershell` to `defaultTools` to enable it explicitly when you want it active alongside a narrower built-in selection. The `bash` tool and `!`/`!!` shortcuts continue to use Bash. Both `ATOMIC_*` and legacy `PI_*` session variables are available.

--- a/packages/coding-agent/src/core/agent-session-tool-registry.ts
+++ b/packages/coding-agent/src/core/agent-session-tool-registry.ts
@@ -4,7 +4,7 @@ import type { ToolDefinitionEntry } from "./agent-session-types.ts";
 import { ExtensionRunner, type ToolDefinition, wrapRegisteredTools } from "./extensions/index.ts";
 import { ModelRegistry } from "./model-registry.ts";
 import { createSyntheticSourceInfo } from "./source-info.ts";
-import { createAllToolDefinitions, defaultToolNames } from "./tools/index.ts";
+import { createAllToolDefinitions, getDefaultToolNames } from "./tools/index.ts";
 import { resolveSessionTempDirPath } from "./tools/session-temp-dir.ts";
 import { createToolDefinitionFromAgentTool } from "./tools/tool-definition-wrapper.ts";
 
@@ -127,7 +127,7 @@ export function _buildRuntime(
 		if (this._excludedToolNames?.has(name)) return false;
 		return true;
 	};
-	const activeBuiltinTools = (options.activeToolNames ?? [...defaultToolNames]).filter(isAllowedBuiltinTool);
+	const activeBuiltinTools = (options.activeToolNames ?? [...getDefaultToolNames()]).filter(isAllowedBuiltinTool);
 	const baseToolDefinitions = this._baseToolsOverride
 		? Object.fromEntries(
 				Object.entries(this._baseToolsOverride).map(([name, tool]) => [
@@ -191,7 +191,7 @@ export function _buildRuntime(
 
 	const defaultActiveToolNames = this._baseToolsOverride
 		? Object.keys(this._baseToolsOverride)
-		: [...defaultToolNames];
+		: [...getDefaultToolNames()];
 	const baseActiveToolNames = options.activeToolNames ?? defaultActiveToolNames;
 	this._refreshToolRegistry({
 		activeToolNames: baseActiveToolNames,

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -57,12 +57,33 @@ export interface AppKeybindings {
 
 export type AppKeybinding = keyof AppKeybindings;
 
+export function useWindowsKeybindings(
+	platform: NodeJS.Platform = process.platform,
+	env: NodeJS.ProcessEnv = process.env,
+): boolean {
+	return platform === "win32" || (platform === "linux" && Boolean(env.WSL_DISTRO_NAME || env.WSL_INTEROP));
+}
+
 declare module "@earendil-works/pi-tui" {
 	interface Keybindings extends AppKeybindings {}
 }
 
+const windowsKeybindings = useWindowsKeybindings();
+
 export const KEYBINDINGS = {
 	...TUI_KEYBINDINGS,
+	"tui.editor.undo": {
+		...TUI_KEYBINDINGS["tui.editor.undo"],
+		defaultKeys: process.platform === "win32" ? "ctrl+z" : windowsKeybindings ? "alt+z" : "ctrl+-",
+	},
+	"tui.altScreen.previousPrompt": {
+		...TUI_KEYBINDINGS["tui.altScreen.previousPrompt"],
+		defaultKeys: windowsKeybindings ? "ctrl+up" : ["ctrl+shift+up", "ctrl+up"],
+	},
+	"tui.altScreen.nextPrompt": {
+		...TUI_KEYBINDINGS["tui.altScreen.nextPrompt"],
+		defaultKeys: windowsKeybindings ? "ctrl+down" : ["ctrl+shift+down", "ctrl+down"],
+	},
 	// Unbind pi-tui 0.84.2's transcript-search defaults. Atomic no longer
 	// exposes a find box over the transcript or an attached stage chat.
 	"tui.altScreen.search": { defaultKeys: [], description: "Search the rendered transcript (disabled)" },
@@ -85,7 +106,7 @@ export const KEYBINDINGS = {
 		description: "Cycle to next model",
 	},
 	"app.model.cycleBackward": {
-		defaultKeys: "shift+ctrl+p",
+		defaultKeys: windowsKeybindings ? "alt+p" : "shift+ctrl+p",
 		description: "Cycle to previous model",
 	},
 	"app.model.select": { defaultKeys: "ctrl+l", description: "Open model selector" },
@@ -103,15 +124,15 @@ export const KEYBINDINGS = {
 		description: "Open external editor",
 	},
 	"app.message.followUp": {
-		defaultKeys: "alt+enter",
+		defaultKeys: windowsKeybindings ? "ctrl+q" : "alt+enter",
 		description: "Queue follow-up message",
 	},
 	"app.message.dequeue": {
-		defaultKeys: "alt+up",
+		defaultKeys: windowsKeybindings ? "alt+q" : "alt+up",
 		description: "Restore queued messages",
 	},
 	"app.clipboard.pasteImage": {
-		defaultKeys: process.platform === "win32" ? "alt+v" : "ctrl+v",
+		defaultKeys: windowsKeybindings ? "alt+v" : "ctrl+v",
 		description: "Paste image from clipboard (text fallback)",
 	},
 	"app.session.new": { defaultKeys: [], description: "Start a new session" },
@@ -171,7 +192,7 @@ export const KEYBINDINGS = {
 		description: "Toggle all models for provider",
 	},
 	"app.models.reorderUp": {
-		defaultKeys: "alt+up",
+		defaultKeys: windowsKeybindings ? "alt+q" : "alt+up",
 		description: "Move model up in order",
 	},
 	"app.models.reorderDown": {

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -35,7 +35,7 @@ import type { CreateAgentSessionOptions, CreateAgentSessionResult } from "./sdk-
 import { getDefaultSessionDir, SessionManager } from "./session-manager.ts";
 import { SettingsManager } from "./settings-manager.ts";
 import { time } from "./timings.ts";
-import { defaultToolNames } from "./tools/index.ts";
+import { getDefaultToolNames } from "./tools/index.ts";
 
 export type { ModelFallbackReason } from "./model-resolver-types.ts";
 export * from "./sdk-exports.ts";
@@ -224,7 +224,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		? [...options.tools]
 		: options.noTools
 			? []
-			: [...(configuredDefaultToolNames ?? defaultToolNames)];
+			: [...(configuredDefaultToolNames ?? getDefaultToolNames())];
 
 	let agent: Agent;
 

--- a/packages/coding-agent/src/core/settings-diagnostics.ts
+++ b/packages/coding-agent/src/core/settings-diagnostics.ts
@@ -1,0 +1,14 @@
+import type { AgentSessionRuntimeDiagnostic } from "./agent-session-services.ts";
+
+/** Remove duplicate diagnostics while preserving first-observed startup order. */
+export function deduplicateDiagnostics(
+	diagnostics: readonly AgentSessionRuntimeDiagnostic[],
+): AgentSessionRuntimeDiagnostic[] {
+	const seen = new Set<string>();
+	return diagnostics.filter((diagnostic) => {
+		const key = `${diagnostic.type}\0${diagnostic.message}`;
+		if (seen.has(key)) return false;
+		seen.add(key);
+		return true;
+	});
+}

--- a/packages/coding-agent/src/core/settings-manager-core.ts
+++ b/packages/coding-agent/src/core/settings-manager-core.ts
@@ -86,12 +86,20 @@ export class SettingsManager {
 		const projectLoad = SettingsManager.tryLoadFromStorage(storage, "project", projectTrusted);
 		const initialErrors: SettingsError[] = [];
 		if (globalLoad.error) {
-			initialErrors.push({ scope: "global", error: globalLoad.error });
+			initialErrors.push({
+				scope: "global",
+				path: (globalLoad.error as Error & { path?: string }).path,
+				error: globalLoad.error,
+			});
 		} else {
 			initialErrors.push(...SettingsManager.validateLoadedSettings("global", globalLoad.settings));
 		}
 		if (projectLoad.error) {
-			initialErrors.push({ scope: "project", error: projectLoad.error });
+			initialErrors.push({
+				scope: "project",
+				path: (projectLoad.error as Error & { path?: string }).path,
+				error: projectLoad.error,
+			});
 		} else {
 			initialErrors.push(...SettingsManager.validateLoadedSettings("project", projectLoad.settings));
 		}

--- a/packages/coding-agent/src/core/settings-storage.ts
+++ b/packages/coding-agent/src/core/settings-storage.ts
@@ -73,9 +73,14 @@ export class FileSettingsStorage implements SettingsStorage {
 		for (let i = readPaths.length - 1; i >= 0; i--) {
 			const readPath = readPaths[i]!;
 			if (!existsSync(readPath)) continue;
-			const parsed = parseJsonFileContent(readFileSync(readPath, "utf-8")) as Settings;
-			merged = deepMergeSettings(merged, parsed);
-			found = true;
+			try {
+				const parsed = parseJsonFileContent(readFileSync(readPath, "utf-8")) as Settings;
+				merged = deepMergeSettings(merged, parsed);
+				found = true;
+			} catch (error) {
+				if (error instanceof Error) (error as Error & { path?: string }).path = readPath;
+				throw error;
+			}
 		}
 		return found ? JSON.stringify(merged, null, 2) : undefined;
 	}

--- a/packages/coding-agent/src/core/settings-types.ts
+++ b/packages/coding-agent/src/core/settings-types.ts
@@ -176,5 +176,6 @@ export interface SettingsStorage {
 
 export interface SettingsError {
 	scope: SettingsScope;
+	path?: string;
 	error: Error;
 }

--- a/packages/coding-agent/src/core/tools/index.ts
+++ b/packages/coding-agent/src/core/tools/index.ts
@@ -129,10 +129,14 @@ export type ToolName =
 	| "ask_user_question"
 	| "todo";
 export type BuiltinToolMap<T> = Omit<Record<ToolName, T>, "powershell"> & { powershell?: T };
+// The universe of built-in tool names, matching the `ToolName` union exactly.
+// Availability is decided per platform in `getDefaultToolNames()` and
+// `createAllToolDefinitions()`; this set stays static so a name is never
+// "unknown" merely because the host cannot run it.
 export const allToolNames: Set<ToolName> = new Set([
 	"read",
 	"bash",
-	...(isPowerShellAvailable() ? (["powershell"] as const satisfies readonly ToolName[]) : []),
+	"powershell",
 	"edit",
 	"write",
 	"find",
@@ -142,17 +146,28 @@ export const allToolNames: Set<ToolName> = new Set([
 	"todo",
 ]);
 
-export const defaultToolNames: readonly ToolName[] = [
-	"read",
-	"bash",
-	...(isPowerShellAvailable() ? (["powershell"] as const satisfies readonly ToolName[]) : []),
-	"edit",
-	"write",
-	"find",
-	"search",
-	"ask_user_question",
-	"todo",
-];
+/**
+ * Built-in tools enabled at startup.
+ *
+ * `powershell` is conditional: it is Windows-only and additionally needs a
+ * resolvable `pwsh.exe`/`powershell.exe`. That probe reads PATH, so it runs per
+ * call rather than at module load, and callers can decide it explicitly through
+ * `powerShellAvailable` instead of depending on the host running the process.
+ */
+export function getDefaultToolNames(options?: { powerShellAvailable?: boolean }): readonly ToolName[] {
+	const powerShell = options?.powerShellAvailable ?? isPowerShellAvailable();
+	return [
+		"read",
+		"bash",
+		...(powerShell ? (["powershell"] as const satisfies readonly ToolName[]) : []),
+		"edit",
+		"write",
+		"find",
+		"search",
+		"ask_user_question",
+		"todo",
+	];
+}
 
 export interface ToolsOptions {
 	read?: ReadToolOptions;

--- a/packages/coding-agent/src/core/tools/index.ts
+++ b/packages/coding-agent/src/core/tools/index.ts
@@ -40,6 +40,17 @@ export {
 	lsToolSystemPromptContribution,
 } from "./ls.ts";
 export {
+	createLocalPowerShellOperations,
+	createPowerShellTool,
+	createPowerShellToolDefinition,
+	type PowerShellOperations,
+	type PowerShellSpawnContext,
+	type PowerShellSpawnHook,
+	type PowerShellToolDetails,
+	type PowerShellToolInput,
+	type PowerShellToolOptions,
+} from "./powershell.ts";
+export {
 	createReadTool,
 	createReadToolDefinition,
 	type ReadOperations,
@@ -96,6 +107,7 @@ import { createEditTool, createEditToolDefinition, type EditToolOptions } from "
 import { createFindTool, createFindToolDefinition, type FindToolOptions } from "./find.ts";
 import { createHashlineSnapshotStore, type HashlineSnapshotStore } from "./hashline.ts";
 import { createLsTool, createLsToolDefinition, type LsToolOptions } from "./ls.ts";
+import { createPowerShellTool, createPowerShellToolDefinition, type PowerShellToolOptions } from "./powershell.ts";
 import { createReadTool, createReadToolDefinition, type ReadToolOptions } from "./read.ts";
 import { createSearchTool, createSearchToolDefinition, type SearchToolOptions } from "./search.ts";
 import { createTodoToolDefinition } from "./todos.ts";
@@ -104,10 +116,21 @@ import { createWriteTool, createWriteToolDefinition, type WriteToolOptions } fro
 
 export type Tool = AgentTool<TSchema, unknown>;
 export type ToolDef = ToolDefinition<TSchema, unknown>;
-export type ToolName = "read" | "bash" | "edit" | "write" | "find" | "search" | "ls" | "ask_user_question" | "todo";
+export type ToolName =
+	| "read"
+	| "bash"
+	| "powershell"
+	| "edit"
+	| "write"
+	| "find"
+	| "search"
+	| "ls"
+	| "ask_user_question"
+	| "todo";
 export const allToolNames: Set<ToolName> = new Set([
 	"read",
 	"bash",
+	"powershell",
 	"edit",
 	"write",
 	"find",
@@ -120,6 +143,7 @@ export const allToolNames: Set<ToolName> = new Set([
 export const defaultToolNames: readonly ToolName[] = [
 	"read",
 	"bash",
+	"powershell",
 	"edit",
 	"write",
 	"find",
@@ -131,6 +155,7 @@ export const defaultToolNames: readonly ToolName[] = [
 export interface ToolsOptions {
 	read?: ReadToolOptions;
 	bash?: BashToolOptions;
+	powershell?: PowerShellToolOptions;
 	write?: WriteToolOptions;
 	edit?: EditToolOptions;
 	find?: FindToolOptions;
@@ -148,6 +173,8 @@ export function createToolDefinition(toolName: ToolName, cwd: string, options?: 
 			return createReadToolDefinition(cwd, { ...options?.read, hashlineStore });
 		case "bash":
 			return createBashToolDefinition(cwd, options?.bash);
+		case "powershell":
+			return createPowerShellToolDefinition(cwd, options?.powershell);
 		case "edit":
 			return createEditToolDefinition(cwd, { ...options?.edit, hashlineStore });
 		case "write":
@@ -174,6 +201,8 @@ export function createTool(toolName: ToolName, cwd: string, options?: ToolsOptio
 			return createReadTool(cwd, { ...options?.read, hashlineStore });
 		case "bash":
 			return createBashTool(cwd, options?.bash);
+		case "powershell":
+			return createPowerShellTool(cwd, options?.powershell);
 		case "edit":
 			return createEditTool(cwd, { ...options?.edit, hashlineStore });
 		case "write":
@@ -220,6 +249,7 @@ export function createAllToolDefinitions(cwd: string, options?: ToolsOptions): R
 	return {
 		read: createReadToolDefinition(cwd, { ...options?.read, hashlineStore }),
 		bash: createBashToolDefinition(cwd, options?.bash),
+		powershell: createPowerShellToolDefinition(cwd, options?.powershell),
 		edit: createEditToolDefinition(cwd, { ...options?.edit, hashlineStore }),
 		write: createWriteToolDefinition(cwd, { ...options?.write, hashlineStore }),
 		find: createFindToolDefinition(cwd, options?.find),
@@ -257,6 +287,7 @@ export function createAllTools(cwd: string, options?: ToolsOptions): Record<Tool
 	return {
 		read: createReadTool(cwd, { ...options?.read, hashlineStore }),
 		bash: createBashTool(cwd, options?.bash),
+		powershell: createPowerShellTool(cwd, options?.powershell),
 		edit: createEditTool(cwd, { ...options?.edit, hashlineStore }),
 		write: createWriteTool(cwd, { ...options?.write, hashlineStore }),
 		find: createFindTool(cwd, options?.find),

--- a/packages/coding-agent/src/core/tools/index.ts
+++ b/packages/coding-agent/src/core/tools/index.ts
@@ -143,7 +143,7 @@ export const allToolNames: Set<ToolName> = new Set([
 export const defaultToolNames: readonly ToolName[] = [
 	"read",
 	"bash",
-	"powershell",
+	...(process.platform === "win32" ? (["powershell"] as const satisfies readonly ToolName[]) : []),
 	"edit",
 	"write",
 	"find",

--- a/packages/coding-agent/src/core/tools/index.ts
+++ b/packages/coding-agent/src/core/tools/index.ts
@@ -100,6 +100,7 @@ export {
 
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import type { TSchema } from "typebox";
+import { isPowerShellAvailable } from "../../utils/shell.ts";
 import type { ToolDefinition } from "../extensions/types.ts";
 import { createAskUserQuestionToolDefinition } from "./ask-user-question/index.ts";
 import { type BashToolOptions, createBashTool, createBashToolDefinition } from "./bash.ts";
@@ -127,10 +128,11 @@ export type ToolName =
 	| "ls"
 	| "ask_user_question"
 	| "todo";
+export type BuiltinToolMap<T> = Omit<Record<ToolName, T>, "powershell"> & { powershell?: T };
 export const allToolNames: Set<ToolName> = new Set([
 	"read",
 	"bash",
-	"powershell",
+	...(isPowerShellAvailable() ? (["powershell"] as const satisfies readonly ToolName[]) : []),
 	"edit",
 	"write",
 	"find",
@@ -143,7 +145,7 @@ export const allToolNames: Set<ToolName> = new Set([
 export const defaultToolNames: readonly ToolName[] = [
 	"read",
 	"bash",
-	...(process.platform === "win32" ? (["powershell"] as const satisfies readonly ToolName[]) : []),
+	...(isPowerShellAvailable() ? (["powershell"] as const satisfies readonly ToolName[]) : []),
 	"edit",
 	"write",
 	"find",
@@ -244,12 +246,11 @@ export function createReadOnlyToolDefinitions(cwd: string, options?: ToolsOption
 	];
 }
 
-export function createAllToolDefinitions(cwd: string, options?: ToolsOptions): Record<ToolName, ToolDef> {
+export function createAllToolDefinitions(cwd: string, options?: ToolsOptions): BuiltinToolMap<ToolDef> {
 	const hashlineStore = options?.hashlineStore ?? createHashlineSnapshotStore();
-	return {
+	const definitions: BuiltinToolMap<ToolDef> = {
 		read: createReadToolDefinition(cwd, { ...options?.read, hashlineStore }),
 		bash: createBashToolDefinition(cwd, options?.bash),
-		powershell: createPowerShellToolDefinition(cwd, options?.powershell),
 		edit: createEditToolDefinition(cwd, { ...options?.edit, hashlineStore }),
 		write: createWriteToolDefinition(cwd, { ...options?.write, hashlineStore }),
 		find: createFindToolDefinition(cwd, options?.find),
@@ -258,6 +259,10 @@ export function createAllToolDefinitions(cwd: string, options?: ToolsOptions): R
 		ask_user_question: createAskUserQuestionToolDefinition(),
 		todo: createTodoToolDefinition(cwd),
 	};
+	if (isPowerShellAvailable()) {
+		definitions.powershell = createPowerShellToolDefinition(cwd, options?.powershell);
+	}
+	return definitions;
 }
 
 export function createCodingTools(cwd: string, options?: ToolsOptions): Tool[] {
@@ -282,12 +287,11 @@ export function createReadOnlyTools(cwd: string, options?: ToolsOptions): Tool[]
 	];
 }
 
-export function createAllTools(cwd: string, options?: ToolsOptions): Record<ToolName, Tool> {
+export function createAllTools(cwd: string, options?: ToolsOptions): BuiltinToolMap<Tool> {
 	const hashlineStore = options?.hashlineStore ?? createHashlineSnapshotStore();
-	return {
+	const tools: BuiltinToolMap<Tool> = {
 		read: createReadTool(cwd, { ...options?.read, hashlineStore }),
 		bash: createBashTool(cwd, options?.bash),
-		powershell: createPowerShellTool(cwd, options?.powershell),
 		edit: createEditTool(cwd, { ...options?.edit, hashlineStore }),
 		write: createWriteTool(cwd, { ...options?.write, hashlineStore }),
 		find: createFindTool(cwd, options?.find),
@@ -296,4 +300,8 @@ export function createAllTools(cwd: string, options?: ToolsOptions): Record<Tool
 		ask_user_question: wrapToolDefinition(createAskUserQuestionToolDefinition()),
 		todo: wrapToolDefinition(createTodoToolDefinition(cwd)),
 	};
+	if (isPowerShellAvailable()) {
+		tools.powershell = createPowerShellTool(cwd, options?.powershell);
+	}
+	return tools;
 }

--- a/packages/coding-agent/src/core/tools/powershell.ts
+++ b/packages/coding-agent/src/core/tools/powershell.ts
@@ -1,0 +1,60 @@
+import { getPowerShellConfig } from "../../utils/shell.ts";
+import {
+	type BashOperations,
+	type BashToolDetails,
+	type BashToolInput,
+	type BashToolOptions,
+	createBashToolDefinition,
+} from "./bash.ts";
+import { wrapToolDefinition } from "./tool-definition-wrapper.ts";
+
+const UTF8_OUTPUT_PREFIX = "try { [Console]::OutputEncoding=[System.Text.Encoding]::UTF8 } catch {}\n";
+export const powershellToolSystemPromptContribution = {
+	snippet: "Execute PowerShell commands.",
+	guidelines: ["You can inspect ATOMIC_* or PI_* environment variables for current model and session details."],
+} as const;
+export type PowerShellOperations = BashOperations;
+export type PowerShellToolDetails = BashToolDetails;
+export type PowerShellToolInput = BashToolInput;
+export interface PowerShellToolOptions extends Pick<BashToolOptions, "exposeSessionEnvironment" | "spawnHook"> {
+	operations?: BashOperations;
+}
+export function createLocalPowerShellOperations(): PowerShellOperations {
+	return {
+		exec: async (command, cwd, options) => {
+			const { shell, args } = getPowerShellConfig();
+			const { spawn } = await import("node:child_process");
+			return new Promise((resolve, reject) => {
+				const child = spawn(shell, [...args, `${UTF8_OUTPUT_PREFIX}${command}`], {
+					cwd,
+					env: options.env,
+					windowsHide: true,
+				});
+				child.stdout.on("data", (data: Buffer) => options.onData(data, "stdout"));
+				child.stderr.on("data", (data: Buffer) => options.onData(data, "stderr"));
+				child.once("error", reject);
+				child.once("close", (exitCode) => resolve({ exitCode }));
+				options.signal?.addEventListener("abort", () => child.kill(), { once: true });
+			});
+		},
+	};
+}
+export function createPowerShellToolDefinition(cwd: string, options: PowerShellToolOptions = {}) {
+	const definition = createBashToolDefinition(cwd, {
+		...options,
+		operations: options.operations ?? createLocalPowerShellOperations(),
+	});
+	return {
+		...definition,
+		name: "powershell",
+		label: "powershell",
+		description: "Execute a PowerShell command in the session workspace.",
+		promptSnippet: powershellToolSystemPromptContribution.snippet,
+		promptGuidelines: [...powershellToolSystemPromptContribution.guidelines],
+	};
+}
+export function createPowerShellTool(cwd: string, options?: PowerShellToolOptions) {
+	return wrapToolDefinition(createPowerShellToolDefinition(cwd, options));
+}
+export type PowerShellSpawnContext = never;
+export type PowerShellSpawnHook = NonNullable<BashToolOptions["spawnHook"]>;

--- a/packages/coding-agent/src/core/tools/powershell.ts
+++ b/packages/coding-agent/src/core/tools/powershell.ts
@@ -24,17 +24,49 @@ export function createLocalPowerShellOperations(): PowerShellOperations {
 		exec: async (command, cwd, options) => {
 			const { shell, args } = getPowerShellConfig();
 			const { spawn } = await import("node:child_process");
+			if (options.signal?.aborted) throw new Error("aborted");
 			return new Promise((resolve, reject) => {
 				const child = spawn(shell, [...args, `${UTF8_OUTPUT_PREFIX}${command}`], {
 					cwd,
 					env: options.env,
 					windowsHide: true,
 				});
+				let timedOut = false;
+				let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+				const onAbort = () => {
+					child.kill();
+				};
+				if (options.timeout !== undefined && options.timeout > 0) {
+					timeoutHandle = setTimeout(() => {
+						timedOut = true;
+						child.kill();
+					}, options.timeout * 1000);
+				}
+				const finish = (handler: () => void) => {
+					if (timeoutHandle) clearTimeout(timeoutHandle);
+					options.signal?.removeEventListener("abort", onAbort);
+					handler();
+				};
 				child.stdout.on("data", (data: Buffer) => options.onData(data, "stdout"));
 				child.stderr.on("data", (data: Buffer) => options.onData(data, "stderr"));
-				child.once("error", reject);
-				child.once("close", (exitCode) => resolve({ exitCode }));
-				options.signal?.addEventListener("abort", () => child.kill(), { once: true });
+				child.once("error", (error) => finish(() => reject(error)));
+				child.once("close", (exitCode) => {
+					finish(() => {
+						if (options.signal?.aborted) {
+							reject(new Error("aborted"));
+							return;
+						}
+						if (timedOut) {
+							reject(new Error(`timeout:${options.timeout}`));
+							return;
+						}
+						resolve({ exitCode });
+					});
+				});
+				if (options.signal) {
+					if (options.signal.aborted) onAbort();
+					else options.signal.addEventListener("abort", onAbort, { once: true });
+				}
 			});
 		},
 	};

--- a/packages/coding-agent/src/core/tools/powershell.ts
+++ b/packages/coding-agent/src/core/tools/powershell.ts
@@ -1,4 +1,10 @@
-import { getPowerShellConfig } from "../../utils/shell.ts";
+import { waitForChildProcess } from "../../utils/child-process.ts";
+import {
+	getPowerShellConfig,
+	killProcessTree,
+	trackDetachedChildPid,
+	untrackDetachedChildPid,
+} from "../../utils/shell.ts";
 import {
 	type BashOperations,
 	type BashToolDetails,
@@ -25,49 +31,39 @@ export function createLocalPowerShellOperations(): PowerShellOperations {
 			const { shell, args } = getPowerShellConfig();
 			const { spawn } = await import("node:child_process");
 			if (options.signal?.aborted) throw new Error("aborted");
-			return new Promise((resolve, reject) => {
-				const child = spawn(shell, [...args, `${UTF8_OUTPUT_PREFIX}${command}`], {
-					cwd,
-					env: options.env,
-					windowsHide: true,
-				});
-				let timedOut = false;
-				let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-				const onAbort = () => {
-					child.kill();
-				};
+			const child = spawn(shell, [...args, `${UTF8_OUTPUT_PREFIX}${command}`], {
+				cwd,
+				env: options.env,
+				windowsHide: true,
+			});
+			if (child.pid) trackDetachedChildPid(child.pid);
+			let timedOut = false;
+			let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+			const onAbort = () => {
+				if (child.pid) killProcessTree(child.pid);
+			};
+			try {
 				if (options.timeout !== undefined && options.timeout > 0) {
 					timeoutHandle = setTimeout(() => {
 						timedOut = true;
-						child.kill();
+						if (child.pid) killProcessTree(child.pid);
 					}, options.timeout * 1000);
 				}
-				const finish = (handler: () => void) => {
-					if (timeoutHandle) clearTimeout(timeoutHandle);
-					options.signal?.removeEventListener("abort", onAbort);
-					handler();
-				};
-				child.stdout.on("data", (data: Buffer) => options.onData(data, "stdout"));
-				child.stderr.on("data", (data: Buffer) => options.onData(data, "stderr"));
-				child.once("error", (error) => finish(() => reject(error)));
-				child.once("close", (exitCode) => {
-					finish(() => {
-						if (options.signal?.aborted) {
-							reject(new Error("aborted"));
-							return;
-						}
-						if (timedOut) {
-							reject(new Error(`timeout:${options.timeout}`));
-							return;
-						}
-						resolve({ exitCode });
-					});
-				});
+				child.stdout?.on("data", (data: Buffer) => options.onData(data, "stdout"));
+				child.stderr?.on("data", (data: Buffer) => options.onData(data, "stderr"));
 				if (options.signal) {
 					if (options.signal.aborted) onAbort();
 					else options.signal.addEventListener("abort", onAbort, { once: true });
 				}
-			});
+				const exitCode = await waitForChildProcess(child);
+				if (options.signal?.aborted) throw new Error("aborted");
+				if (timedOut) throw new Error(`timeout:${options.timeout}`);
+				return { exitCode };
+			} finally {
+				if (child.pid) untrackDetachedChildPid(child.pid);
+				if (timeoutHandle) clearTimeout(timeoutHandle);
+				options.signal?.removeEventListener("abort", onAbort);
+			}
 		},
 	};
 }

--- a/packages/coding-agent/src/main-stdio.ts
+++ b/packages/coding-agent/src/main-stdio.ts
@@ -29,9 +29,11 @@ export function collectSettingsDiagnostics(
 	settingsManager: SettingsManager,
 	context: string,
 ): AgentSessionRuntimeDiagnostic[] {
-	return settingsManager.drainErrors().map(({ scope, error }) => ({
+	return settingsManager.drainErrors().map(({ scope, path, error }) => ({
 		type: "warning",
-		message: `(${context}, ${scope} settings) ${error.message}`,
+		message: path
+			? `(${context}) Invalid settings file ${path}: ${error.message}`
+			: `(${context}, ${scope} settings) ${error.message}`,
 	}));
 }
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -55,6 +55,7 @@ import { flushRawStdout, restoreStdout, takeOverStdout, writeRawStdout } from ".
 import { formatBorrowedExtensionSourceTrustPrompt, resolveProjectTrusted } from "./core/project-trust.ts";
 import { getMissingSessionCwdIssue, MissingSessionCwdError } from "./core/session-cwd.ts";
 import { SessionManager } from "./core/session-manager.ts";
+import { deduplicateDiagnostics } from "./core/settings-diagnostics.ts";
 import { SettingsManager } from "./core/settings-manager.ts";
 import { endTimingSpan, printTimings, resetTimings, startTimingSpan, time } from "./core/timings.ts";
 import { hasProjectTrustInputs, ProjectTrustStore } from "./core/trust-manager.ts";
@@ -396,7 +397,7 @@ export async function main(argv: string[], options?: MainOptions) {
 	}
 
 	const startupSettingsManager = SettingsManager.create(cwd, agentDir, { projectTrusted: startupProjectTrusted });
-	reportDiagnostics(collectSettingsDiagnostics(startupSettingsManager, "startup session lookup"));
+	const startupSettingsDiagnostics = collectSettingsDiagnostics(startupSettingsManager, "startup session lookup");
 
 	// --use-theme steers this run only: the override lives in the startup
 	// manager's effective settings and never reaches its global settings file.
@@ -655,6 +656,7 @@ export async function main(argv: string[], options?: MainOptions) {
 	applyHttpProxySettings(settingsManager.getGlobalSettings().httpProxy);
 	configureHttpDispatcher(settingsManager.getHttpIdleTimeoutMs());
 	if (parsed.help) {
+		reportDiagnostics(startupSettingsDiagnostics);
 		const extensionFlags = resourceLoader
 			.getExtensions()
 			.extensions.flatMap((extension) => Array.from(extension.flags.values()));
@@ -666,6 +668,7 @@ export async function main(argv: string[], options?: MainOptions) {
 	}
 
 	if (parsed.listModels !== undefined) {
+		reportDiagnostics(startupSettingsDiagnostics);
 		const searchPattern = typeof parsed.listModels === "string" ? parsed.listModels : undefined;
 		if (shouldRestoreStdoutForMetadata) {
 			restoreStdout();
@@ -701,8 +704,10 @@ export async function main(argv: string[], options?: MainOptions) {
 
 	const scopedModels = [...session.scopedModels];
 	time("resolveModelScope");
-	reportDiagnostics(runtime.diagnostics);
-	if (runtime.diagnostics.some((diagnostic) => diagnostic.type === "error")) {
+	const startupDiagnostics = deduplicateDiagnostics([...startupSettingsDiagnostics, ...runtime.diagnostics]);
+	const hasRuntimeErrors = runtime.diagnostics.some((diagnostic) => diagnostic.type === "error");
+	if (appMode !== "interactive" || hasRuntimeErrors) reportDiagnostics(startupDiagnostics);
+	if (hasRuntimeErrors) {
 		startupEarlyInputCapture?.consume();
 		process.exit(1);
 	}
@@ -738,6 +743,7 @@ export async function main(argv: string[], options?: MainOptions) {
 
 		const interactiveMode = new InteractiveMode(runtime, {
 			migratedProviders,
+			startupDiagnostics,
 			modelFallbackMessage,
 			autoTrustOnReloadCwd,
 			initialMessage,

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-types.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-types.ts
@@ -1,4 +1,5 @@
 import type { Terminal } from "@earendil-works/pi-tui";
+import type { AgentSessionRuntimeDiagnostic } from "../../core/agent-session-services.ts";
 import type { EarlyInputCapture } from "../../main-early-input.ts";
 import type { ImageContent } from "./interactive-mode-deps.ts";
 
@@ -18,6 +19,8 @@ export type CompactionQueuedMessage = {
 export interface InteractiveModeOptions {
 	/** Providers that were migrated to auth.json (shows warning) */
 	migratedProviders?: string[];
+	/** Diagnostics collected before the interactive transcript was initialized. */
+	startupDiagnostics?: AgentSessionRuntimeDiagnostic[];
 	/** Warning message if session model couldn't be restored */
 	modelFallbackMessage?: string;
 	/** Cwd to persist as trusted after reload/shutdown if it gains trust inputs during an implicitly trusted session. */

--- a/packages/coding-agent/src/modes/interactive/interactive-startup.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-startup.ts
@@ -324,7 +324,13 @@ InteractiveModeBase.prototype.run = async function (this: InteractiveModeBase): 
 	}, 500);
 
 	// Show startup warnings
-	const { migratedProviders, initialMessage, initialImages, initialMessages } = this.options;
+	const { migratedProviders, startupDiagnostics, initialMessage, initialImages, initialMessages } = this.options;
+
+	for (const diagnostic of startupDiagnostics ?? []) {
+		if (diagnostic.type === "error") this.showError(diagnostic.message);
+		else if (diagnostic.type === "warning") this.showWarning(diagnostic.message);
+		else this.showStatus(diagnostic.message);
+	}
 
 	if (migratedProviders && migratedProviders.length > 0) {
 		this.showWarning(`Migrated credentials to auth.json: ${migratedProviders.join(", ")}`);

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -23,11 +23,11 @@ function getBashShellConfig(shell: string): ShellConfig {
 /**
  * Find bash executable on PATH (cross-platform)
  */
-function findBashOnPath(): string | null {
+function findExecutableOnPath(executable: string): string | null {
 	if (process.platform === "win32") {
 		// Windows: Use 'where' and verify file exists (where can return non-existent paths)
 		try {
-			const result = spawnSync("where", ["bash.exe"], {
+			const result = spawnSync("where", [executable], {
 				encoding: "utf-8",
 				timeout: 5000,
 				env: createChildProcessEnvironment(),
@@ -46,7 +46,7 @@ function findBashOnPath(): string | null {
 
 	// Unix: Use 'which' and trust its output (handles Termux and special filesystems)
 	try {
-		const result = spawnSync("which", ["bash"], {
+		const result = spawnSync("which", [executable], {
 			encoding: "utf-8",
 			timeout: 5000,
 			env: createChildProcessEnvironment(),
@@ -98,7 +98,7 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
 		}
 
 		// 3. Fallback: search bash.exe on PATH (Cygwin, MSYS2, WSL, etc.)
-		const bashOnPath = findBashOnPath();
+		const bashOnPath = findExecutableOnPath("bash.exe");
 		if (bashOnPath) {
 			return getBashShellConfig(bashOnPath);
 		}
@@ -117,12 +117,21 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
 		return getBashShellConfig("/bin/bash");
 	}
 
-	const bashOnPath = findBashOnPath();
+	const bashOnPath = findExecutableOnPath("bash");
 	if (bashOnPath) {
 		return getBashShellConfig(bashOnPath);
 	}
 
 	return { shell: "sh", args: ["-c"] };
+}
+
+export const POWERSHELL_ARGS = ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command"] as const;
+
+export function getPowerShellConfig(): ShellConfig {
+	if (process.platform !== "win32") throw new Error("The powershell tool is only available on Windows.");
+	const shell = findExecutableOnPath("pwsh.exe") ?? findExecutableOnPath("powershell.exe");
+	if (!shell) throw new Error("No PowerShell executable found. Install PowerShell or add it to PATH.");
+	return { shell, args: [...POWERSHELL_ARGS] };
 }
 
 export function getShellEnv(): NodeJS.ProcessEnv {

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -134,6 +134,15 @@ export function getPowerShellConfig(): ShellConfig {
 	return { shell, args: [...POWERSHELL_ARGS] };
 }
 
+export function isPowerShellAvailable(): boolean {
+	try {
+		getPowerShellConfig();
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 export function getShellEnv(): NodeJS.ProcessEnv {
 	const binDir = getBinDir();
 	const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === "path") ?? "PATH";

--- a/packages/coding-agent/test/interactive-fullscreen-input.test.ts
+++ b/packages/coding-agent/test/interactive-fullscreen-input.test.ts
@@ -125,6 +125,11 @@ describe("fullscreen input navigation", () => {
 			new KeybindingsManager({
 				"tui.altScreen.halfPageUp": "ctrl+u",
 				"tui.altScreen.halfPageDown": "ctrl+d",
+				// Pinned so this covers marked-message navigation itself. The
+				// platform defaults diverge (Windows drops ctrl+shift+arrow), and
+				// keybindings.test.ts owns that default-resolution contract.
+				"tui.altScreen.previousPrompt": "ctrl+shift+up",
+				"tui.altScreen.nextPrompt": "ctrl+shift+down",
 			}),
 		);
 		const terminal = new RecordingTerminal();

--- a/packages/coding-agent/test/powershell-tool.test.ts
+++ b/packages/coding-agent/test/powershell-tool.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "vitest";
+import { allToolNames, defaultToolNames } from "../src/core/tools/index.ts";
+import { createLocalPowerShellOperations } from "../src/core/tools/powershell.ts";
+import { isPowerShellAvailable } from "../src/utils/shell.ts";
+
+test("omits PowerShell from default and registered tools when no executable is available", () => {
+	expect(allToolNames.has("powershell")).toBe(isPowerShellAvailable());
+	expect(defaultToolNames.includes("powershell")).toBe(isPowerShellAvailable());
+});
+
+test("pre-aborted signals reject without running a command", async () => {
+	const ops = createLocalPowerShellOperations();
+	const controller = new AbortController();
+	controller.abort();
+	await expect(
+		ops.exec("Write-Output hi", process.cwd(), {
+			onData: () => {},
+			signal: controller.signal,
+		}),
+	).rejects.toThrow(/aborted|only available on Windows|No PowerShell executable found/);
+});
+
+test("abort settles promptly instead of waiting on descendant-held streams", async () => {
+	if (!isPowerShellAvailable()) return;
+
+	const ops = createLocalPowerShellOperations();
+	const controller = new AbortController();
+	const started = Date.now();
+	const run = ops.exec("Start-Sleep -Seconds 20", process.cwd(), {
+		onData: () => {},
+		signal: controller.signal,
+	});
+	controller.abort();
+	await expect(run).rejects.toThrow(/aborted/);
+	expect(Date.now() - started).toBeLessThan(2000);
+});

--- a/packages/coding-agent/test/powershell-tool.test.ts
+++ b/packages/coding-agent/test/powershell-tool.test.ts
@@ -1,11 +1,21 @@
 import { expect, test } from "vitest";
-import { allToolNames, defaultToolNames } from "../src/core/tools/index.ts";
+import { allToolNames, getDefaultToolNames } from "../src/core/tools/index.ts";
 import { createLocalPowerShellOperations } from "../src/core/tools/powershell.ts";
 import { isPowerShellAvailable } from "../src/utils/shell.ts";
 
-test("omits PowerShell from default and registered tools when no executable is available", () => {
-	expect(allToolNames.has("powershell")).toBe(isPowerShellAvailable());
-	expect(defaultToolNames.includes("powershell")).toBe(isPowerShellAvailable());
+test("powershell is always a known tool name, on every platform", () => {
+	// The name universe is platform-independent, so a shared settings.json that
+	// lists `powershell` is never rejected as unknown on a non-Windows host.
+	expect(allToolNames.has("powershell")).toBe(true);
+});
+
+test("powershell is a startup default only when an executable resolves", () => {
+	expect(getDefaultToolNames({ powerShellAvailable: true })).toContain("powershell");
+	expect(getDefaultToolNames({ powerShellAvailable: false })).not.toContain("powershell");
+});
+
+test("the resolved default set follows the host probe", () => {
+	expect(getDefaultToolNames()).toEqual(getDefaultToolNames({ powerShellAvailable: isPowerShellAvailable() }));
 });
 
 test("pre-aborted signals reject without running a command", async () => {

--- a/packages/coding-agent/test/suite/regressions/5109-exclude-tools.test.ts
+++ b/packages/coding-agent/test/suite/regressions/5109-exclude-tools.test.ts
@@ -1,11 +1,19 @@
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
+import { defaultToolNames } from "../../../src/core/tools/index.ts";
 import type { ExtensionFactory } from "../../../src/index.ts";
 import { createHarness } from "../harness.ts";
 
 function toolNames(tools: Array<{ name: string }>): string[] {
 	return tools.map((tool) => tool.name).sort();
 }
+
+/**
+ * `powershell` is a conditional default: it registers only on Windows with a
+ * resolvable executable. Deriving it keeps this regression about exclusion
+ * filtering instead of hard-coding one platform's default tool set.
+ */
+const conditionalDefaults = defaultToolNames.includes("powershell") ? ["powershell"] : [];
 
 describe("regression #5109: exclude tools", () => {
 	const extensionFactories: ExtensionFactory[] = [
@@ -50,16 +58,19 @@ describe("regression #5109: exclude tools", () => {
 			expect(allToolNames).not.toContain("ask_question");
 			expect(allToolNames).toContain("bash");
 			expect(allToolNames).toContain("dynamic_tool");
-			expect(harness.session.getActiveToolNames().sort()).toEqual([
-				"ask_user_question",
-				"bash",
-				"dynamic_tool",
-				"edit",
-				"find",
-				"search",
-				"todo",
-				"write",
-			]);
+			expect(harness.session.getActiveToolNames().sort()).toEqual(
+				[
+					"ask_user_question",
+					"bash",
+					"dynamic_tool",
+					"edit",
+					"find",
+					"search",
+					"todo",
+					"write",
+					...conditionalDefaults,
+				].sort(),
+			);
 			expect(harness.session.systemPrompt).not.toContain("- read:");
 			expect(harness.session.systemPrompt).not.toContain("ask_question");
 			expect(harness.session.systemPrompt).toContain("- dynamic_tool: Run dynamic test behavior");

--- a/packages/coding-agent/test/suite/regressions/5109-exclude-tools.test.ts
+++ b/packages/coding-agent/test/suite/regressions/5109-exclude-tools.test.ts
@@ -1,6 +1,6 @@
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
-import { defaultToolNames } from "../../../src/core/tools/index.ts";
+import { getDefaultToolNames } from "../../../src/core/tools/index.ts";
 import type { ExtensionFactory } from "../../../src/index.ts";
 import { createHarness } from "../harness.ts";
 
@@ -13,7 +13,7 @@ function toolNames(tools: Array<{ name: string }>): string[] {
  * resolvable executable. Deriving it keeps this regression about exclusion
  * filtering instead of hard-coding one platform's default tool set.
  */
-const conditionalDefaults = defaultToolNames.includes("powershell") ? ["powershell"] : [];
+const conditionalDefaults = getDefaultToolNames().includes("powershell") ? ["powershell"] : [];
 
 describe("regression #5109: exclude tools", () => {
 	const extensionFactories: ExtensionFactory[] = [

--- a/packages/coding-agent/test/suite/regressions/no-builtin-tools-preserves-extension-tools.test.ts
+++ b/packages/coding-agent/test/suite/regressions/no-builtin-tools-preserves-extension-tools.test.ts
@@ -12,7 +12,7 @@ import { DefaultResourceLoader } from "../../../src/core/resource-loader.ts";
 import { createAgentSession } from "../../../src/core/sdk.ts";
 import { SessionManager } from "../../../src/core/session-manager.ts";
 import { SettingsManager } from "../../../src/core/settings-manager.ts";
-import { allToolNames } from "../../../src/core/tools/index.ts";
+import { getDefaultToolNames } from "../../../src/core/tools/index.ts";
 
 describe("noTools builtin mode keeps extension tools enabled", () => {
 	let tempDir: string;
@@ -87,7 +87,7 @@ describe("noTools builtin mode keeps extension tools enabled", () => {
 				"edit",
 				"find",
 				"ls",
-				...(allToolNames.has("powershell") ? (["powershell"] as const) : []),
+				...(getDefaultToolNames().includes("powershell") ? (["powershell"] as const) : []),
 				"read",
 				"search",
 				"todo",

--- a/packages/coding-agent/test/suite/regressions/no-builtin-tools-preserves-extension-tools.test.ts
+++ b/packages/coding-agent/test/suite/regressions/no-builtin-tools-preserves-extension-tools.test.ts
@@ -12,6 +12,7 @@ import { DefaultResourceLoader } from "../../../src/core/resource-loader.ts";
 import { createAgentSession } from "../../../src/core/sdk.ts";
 import { SessionManager } from "../../../src/core/session-manager.ts";
 import { SettingsManager } from "../../../src/core/settings-manager.ts";
+import { allToolNames } from "../../../src/core/tools/index.ts";
 
 describe("noTools builtin mode keeps extension tools enabled", () => {
 	let tempDir: string;
@@ -78,7 +79,21 @@ describe("noTools builtin mode keeps extension tools enabled", () => {
 				.getAllTools()
 				.map((tool) => tool.name)
 				.sort(),
-		).toEqual(["ask_user_question", "bash", "dynamic_tool", "edit", "find", "ls", "read", "search", "todo", "write"]);
+		).toEqual(
+			[
+				"ask_user_question",
+				"bash",
+				"dynamic_tool",
+				"edit",
+				"find",
+				"ls",
+				...(allToolNames.has("powershell") ? (["powershell"] as const) : []),
+				"read",
+				"search",
+				"todo",
+				"write",
+			].sort(),
+		);
 		expect(session.getActiveToolNames()).toEqual(["dynamic_tool"]);
 		expect(session.systemPrompt).toContain("- dynamic_tool: Run dynamic test behavior");
 		expect(session.systemPrompt).not.toContain("- read:");

--- a/test/unit/default-tools-setting.test.ts
+++ b/test/unit/default-tools-setting.test.ts
@@ -216,6 +216,7 @@ describe("defaultTools setting", () => {
 				"edit",
 				"find",
 				"ls",
+				...(allToolNames.has("powershell") ? (["powershell"] as const) : []),
 				"read",
 				"sdk_tool",
 				"search",

--- a/test/unit/default-tools-setting.test.ts
+++ b/test/unit/default-tools-setting.test.ts
@@ -14,7 +14,8 @@ import {
 } from "../../packages/coding-agent/src/core/sdk.js";
 import { SessionManager } from "../../packages/coding-agent/src/core/session-manager.js";
 import { SettingsManager } from "../../packages/coding-agent/src/core/settings-manager.js";
-import { allToolNames, defaultToolNames } from "../../packages/coding-agent/src/core/tools/index.js";
+import { allToolNames, getDefaultToolNames } from "../../packages/coding-agent/src/core/tools/index.js";
+import { isPowerShellAvailable } from "../../packages/coding-agent/src/utils/shell.js";
 import {
 	fileExistsSync,
 	makeDirectorySync,
@@ -22,6 +23,13 @@ import {
 	removePathSync,
 	writeTextSync,
 } from "../helpers/runtime.js";
+
+/**
+ * Built-ins that this host can actually construct. Every name is registrable
+ * except `powershell`, which additionally requires a resolvable executable, so
+ * it is absent on non-Windows hosts even though the name is always valid.
+ */
+const registrableToolNames = [...allToolNames].filter((name) => name !== "powershell" || isPowerShellAvailable());
 
 const tempDirs: string[] = [];
 
@@ -142,7 +150,7 @@ describe("defaultTools setting", () => {
 				// "read" is the only initially active built-in; the others stay
 				// registered (reachable via /tools) but inactive.
 				assert.ok(active.includes("read"));
-				for (const builtin of allToolNames) {
+				for (const builtin of registrableToolNames) {
 					assert.ok(registered.includes(builtin), `expected built-in '${builtin}' to stay registered`);
 					if (builtin !== "read") {
 						assert.equal(
@@ -216,7 +224,7 @@ describe("defaultTools setting", () => {
 				"edit",
 				"find",
 				"ls",
-				...(allToolNames.has("powershell") ? (["powershell"] as const) : []),
+				...(getDefaultToolNames().includes("powershell") ? (["powershell"] as const) : []),
 				"read",
 				"sdk_tool",
 				"search",
@@ -272,7 +280,7 @@ describe("defaultTools setting", () => {
 	test("an unset setting keeps the standard built-in defaults; an empty list keeps none", async () => {
 		const unsetSession = await createSession(undefined);
 		try {
-			assert.deepEqual(unsetSession.getActiveToolNames(), [...defaultToolNames]);
+			assert.deepEqual(unsetSession.getActiveToolNames(), [...getDefaultToolNames()]);
 		} finally {
 			unsetSession.dispose();
 		}
@@ -280,7 +288,7 @@ describe("defaultTools setting", () => {
 		const emptySession = await createSession([], {}, [staticExtensionTool("static_tool")]);
 		try {
 			assert.deepEqual(emptySession.getActiveToolNames(), ["static_tool"]);
-			for (const builtin of allToolNames) {
+			for (const builtin of registrableToolNames) {
 				assert.ok(
 					emptySession
 						.getAllTools()
@@ -309,7 +317,7 @@ describe("defaultTools setting", () => {
 			try {
 				assert.deepEqual(
 					session.getActiveToolNames(),
-					[...defaultToolNames],
+					[...getDefaultToolNames()],
 					`expected malformed defaultTools ${raw} to fall back to the standard defaults`,
 				);
 			} finally {

--- a/test/unit/structured-output-tool.test.ts
+++ b/test/unit/structured-output-tool.test.ts
@@ -10,7 +10,7 @@ import {
 	createAllToolDefinitions,
 	createAllTools,
 	createStructuredOutputTool,
-	defaultToolNames,
+	getDefaultToolNames,
 	STRUCTURED_OUTPUT_TOOL_NAME,
 	type StructuredOutputCapture,
 } from "../../packages/coding-agent/src/core/tools/index.js";
@@ -251,7 +251,7 @@ describe("structured_output factory tool", () => {
 
 	test("is exported as an opt-in factory but not registered as a builtin", () => {
 		assert.equal(allToolNames.has("structured_output" as never), false);
-		assert.equal(defaultToolNames.includes("structured_output" as never), false);
+		assert.equal(getDefaultToolNames().includes("structured_output" as never), false);
 		assert.equal(typeof createStructuredOutputToolFromEntrypoint, "function");
 		assert.equal(STRUCTURED_OUTPUT_TOOL_NAME_FROM_ENTRYPOINT, STRUCTURED_OUTPUT_TOOL_NAME);
 


### PR DESCRIPTION
Stack 8/9. Settings errors carry layered .atomic/.pi paths, deduplicated path-aware diagnostics, startup diagnostics routed into the transcript (fullscreen-safe), optional Windows-only PowerShell tool (#8512, pwsh.exe then powershell.exe, !/!! stay on Bash), Windows/WSL keybinding defaults (transcript-search bindings deliberately kept unbound per Atomic policy).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790273435&installation_model_id=10562&pr_number=2682&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2682&signature=9e9437e18164297373989c6dc482ee250ad2f4cf620fe4c2c356d6f1a8fb9961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->















<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds Windows-aware PowerShell availability, platform-derived defaults, layered settings diagnostics, and interactive startup notice delivery. One malformed settings file is currently shown twice during interactive startup because diagnostics collected during session lookup and runtime creation are treated as different notices.

<h3>Confidence Score: 4/5</h3>

Settings startup feedback needs a small correction before merge so users receive one notice per malformed settings file.

The reproduced duplicate notice affects interactive startup feedback but does not expose data or alter settings behavior.

**Files Needing Attention:** packages/coding-agent/src/core/settings-diagnostics.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex captured a Linux environment without PowerShell to justify using a process-boundary mock for Windows behavior.
- T-Rex executed and recorded focused PowerShell and stdio tests, capturing the exact command, working directory, and successful result.
- T-Rex captured the review script source and its results, which validate all four claims against mocked processes and boundary.
- T-Rex produced a proof for a posted P1 finding, and linked it to the review harness artifacts showing startup diagnostic reproduction.
- T-Rex demonstrated startup diagnostics by using a malformed settings.json, exercising the two real startup paths, and showing two distinct warnings with preserved full paths after deduplicateDiagnostics.

<a href="https://app.greptile.com/trex/runs/20681847/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **One invalid settings file appears twice in interactive startup notices**

   - **Bug**
     - `main.ts` combines diagnostics from the startup session lookup and runtime creation, then passes them to the interactive notice surface. For a malformed settings file both managers produce a warning for the same absolute file path, but users receive two notices rather than one.
   - **Cause**
     - `deduplicateDiagnostics()` uses `${type}\0${message}` as its identity. The otherwise identical file diagnostics have messages prefixed with different context strings: `(startup session lookup)` and `(runtime creation)`, so they cannot deduplicate.
   - **Fix**
     - Deduplicate settings-file diagnostics by stable identity such as diagnostic type plus normalized settings-file path/error, or normalize the context out before deduplicating while retaining a single useful context in the displayed message. Add a test that constructs both startup managers against one malformed file and asserts a single interactive notice.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/src/core/settings-diagnostics.ts:9
**Startup diagnostic deduplication includes transient context**

A malformed settings file is collected once during startup session lookup and again during runtime creation. Both diagnostics refer to the same file and parse failure, but their context prefixes differ, so the `${type}\0${message}` key treats them as distinct and interactive users receive the same warning twice. Deduplicate settings-file diagnostics using a stable identity such as the normalized path and underlying error, while retaining one useful display context.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (8): Last reviewed commit: ["refactor(coding-agent): resolve PowerShe..."](https://github.com/bastani-inc/atomic/commit/8170eab23f1cd42797f9cd231b535a2b169c1bb0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56766309)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->