### PR TITLE
docs(coding-agent): finalize the pi 0.84.3 port

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,8 +4,20 @@
 
 ### Added
 
-- Added `/thinking` and a thinking-level selector. Enter applies the level to the current session; persist writes a per-model startup override. Settings can list, change, and clear those overrides.
-- Added a Windows `powershell` tool, registered by default only when `pwsh.exe` or `powershell.exe` is on `PATH`.
+- Added `/thinking [level]` plus searchable model and per-model thinking selectors. Selectors show saved defaults, search by model/provider/default state, order the current and default models first, and use `Ctrl+S` to persist a startup default while Enter changes only the current session ([#8399](https://github.com/earendil-works/pi/issues/8399)).
+- Added a Windows PowerShell tool that prefers PowerShell 7 and falls back to Windows PowerShell when `pwsh.exe` or `powershell.exe` is on `PATH`. The tool is omitted when neither executable is available. Bash remains the shell for `!`/`!!`, plus Windows/WSL-friendly default keybindings ([#8512](https://github.com/earendil-works/pi/issues/8512)).
+- Added path-aware, deduplicated settings diagnostics and routed startup diagnostics into the fullscreen transcript so alternate-screen startup cannot hide configuration errors.
+- Added export-only `atomic.share` context records containing the system prompt and tool schemas. Session sharing keeps private-Gist transport and Atomic viewer URLs; no persisted session is mutated and no Radius upload is introduced.
+
+### Changed
+
+- Updated the external pi runtime dependencies to 0.84.3, inheriting the matching agent/client/protocol updates and TUI fixes for narrow-width padding and wrapped Markdown-table link colors ([#8252](https://github.com/earendil-works/pi/issues/8252), [#8335](https://github.com/earendil-works/pi/issues/8335)).
+- Model and thinking-level changes are session-scoped by default; saved per-model thinking overrides determine startup behavior, and persistence is now explicit through `Ctrl+S` ([#8356](https://github.com/earendil-works/pi/issues/8356)).
+- Skill discovery silently ignores ordinary root Markdown files without skill frontmatter, continues diagnosing malformed declared skills, and loads nested Markdown skills from packages ([#8012](https://github.com/earendil-works/pi/issues/8012), [#8255](https://github.com/earendil-works/pi/issues/8255)).
+- llama.cpp catalogs now expose sleeping models, refresh local-router catalogs even in offline mode, detect autoload support and offer presets, and explain when `/llama` is required after login ([#8235](https://github.com/earendil-works/pi/issues/8235), [#8236](https://github.com/earendil-works/pi/issues/8236), [#8238](https://github.com/earendil-works/pi/issues/8238), [#8558](https://github.com/earendil-works/pi/issues/8558)).
+- Deferred uncommon syntax grammars until after first render to reduce interactive startup work while keeping common languages available immediately.
+- Extension examples whose intent is final settlement now listen for `agent_settled`; JSON mode exposes tool-call ID and tool name at stream start; session-share links use canonical terminal hyperlinks and perform GitHub authentication preflight before export ([#8242](https://github.com/earendil-works/pi/issues/8242), [#7953](https://github.com/earendil-works/pi/issues/7953)).
+- Compaction now reports truthful aggregate planner usage notices, including multi-attempt Verbatim planning, when cache-miss notices are enabled.
 
 ### Fixed
 
@@ -17,11 +29,16 @@
 - Fixed duplicate fullscreen right-click paste in VS Code-based terminals on Windows ([#8186](https://github.com/earendil-works/pi/issues/8186)).
 - Fixed padded text exceeding narrow terminal widths ([#8252](https://github.com/earendil-works/pi/issues/8252)).
 - Fixed wrapped Markdown table links leaking color into borders and neighboring cells, including tables inside blockquotes ([#8335](https://github.com/earendil-works/pi/issues/8335)).
-- Compaction failures and cancellations now emit `session_compact_failed` to extensions with their trigger, error, abort/retry state, and whether an extension supplied the compacted text ([#8241](https://github.com/earendil-works/pi/issues/8241)).
+- Compaction failures and cancellations now emit `session_compact_failed` to extensions and expose public failure details with their trigger, error, abort/retry state, and whether an extension supplied the compacted text ([#8241](https://github.com/earendil-works/pi/issues/8241)).
 - Automatic compaction now estimates message size when providers report all-zero usage instead of silently skipping the threshold check ([#8328](https://github.com/earendil-works/pi/issues/8328)).
 - Branch and session summaries reject tool calls, and their requests explicitly disable tools; planner requests do the same while retaining validated truncated-range recovery.
 - Branch and session summaries reject token-cap-truncated prose instead of persisting incomplete checkpoints ([#7048](https://github.com/earendil-works/pi/issues/7048)).
 - Branch summaries record the source leaf rather than the navigation destination.
+- Fixed package updates comparing versions for inequality and potentially downgrading a newer installed package; upgrades now use semantic-version ordering ([#8239](https://github.com/earendil-works/pi/issues/8239)).
+- Fixed extension flags accepting runtime defaults whose value did not match the declared boolean/string type, and failed extension factories leaking partially registered commands, tools, flags, and inherited resources into later loads ([#8123](https://github.com/earendil-works/pi/issues/8123), [#8424](https://github.com/earendil-works/pi/issues/8424)).
+- Fixed hung authenticated model-catalog attempts consuming the whole request budget without retrying by applying a per-attempt timeout before retrying.
+- Fixed UTF-8 BOMs breaking auth, model, keybinding, frontmatter, package, resource, theme, and CLI text inputs while preserving BOM-aware hashline edits.
+- Fixed atomic managed-state rewrites resetting existing file permissions. Credential files are always rewritten as `0600` so a world-readable `auth.json` cannot leak replacement secrets.
 
 ## [0.9.16-alpha.4] - 2026-08-23
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -492,7 +492,7 @@ Upstream Pi's minimal-core rationale is documented in the [original blog post](h
 ## CLI Reference
 
 ```bash
-atomic [options] [@files...] [messages...]
+atomic [options] [--] [@files...] [messages...]
 ```
 
 ### Package Commands
@@ -596,6 +596,7 @@ Combine `--no-*` with explicit flags to load exactly what you need, ignoring set
 | `--append-system-prompt <text>` | Append to system prompt |
 | `--offline` | Disable startup network operations, including update checks, package updates, and telemetry |
 | `--verbose` | Force verbose startup |
+| `--` | Stop option parsing; remaining arguments are prompts or `@file` inputs |
 | `-h`, `--help` | Show help |
 | `-v`, `--version` | Show version |
 
@@ -617,6 +618,9 @@ atomic "List all .ts files in src/"
 
 # Non-interactive
 atomic -p "Summarize this codebase"
+
+# Prompt beginning with a dash
+atomic -p -- "- Summarize these points"
 
 # Non-interactive with piped stdin
 cat README.md | atomic -p "Summarize this text"

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -894,7 +894,7 @@ Events are streamed to stdout as JSON lines. Most events do not include an `id`;
 | `message_start` | Message begins |
 | `message_update` | Streaming update (text/thinking/toolcall deltas) |
 | `message_end` | Message completes |
-| `tool_execution_start` | Tool begins execution |
+| `tool_execution_start` | Tool begins execution; includes `toolCallId`, `toolName`, and initial arguments |
 | `tool_execution_update` | Tool execution progress (streaming output) |
 | `tool_execution_end` | Tool completes |
 | `bash_execution_update` | Correlated direct-bash stdout/stderr delta |

--- a/packages/coding-agent/docs/windows.md
+++ b/packages/coding-agent/docs/windows.md
@@ -22,13 +22,13 @@ After the script is fetched, it enables TLS 1.2 for its own GitHub requests and 
 
 The installer adds the bin directory to the User PATH and the current PowerShell process. Restart the terminal when it finishes so other processes see the new PATH. A custom `ATOMIC_BIN_DIR` containing `;` cannot be one Windows PATH entry, so the installer leaves PATH untouched and prints a direct-run command for `atomic.cmd` instead. If the bin directory already holds a same-stem launcher that `PATHEXT` resolves before `atomic.cmd`, such as a stale `atomic.exe` from an older Node-based install, the installer reports it and stops before downloading anything; remove that entry and rerun. Because the shim is `atomic.cmd`, `PATHEXT` must include `.CMD` for bare `atomic` to resolve; if it does not, the installer says so and stops rather than reporting a success you could not use. An unexpected regular `current` entry under `ATOMIC_INSTALL_DIR`, or a regular `atomic-current` entry under `ATOMIC_BIN_DIR`, is reported and left untouched instead of being moved or deleted. A pinned `-Ref` is honored literally: if GitHub answers with a different release tag, the install stops before downloading anything. Package-manager installation remains available but requires Node.js; see the [Quickstart](/quickstart#package-managers).
 
-After installation, Atomic requires a bash shell for its shell tool. Checked locations (in order):
+By default, Atomic uses a Bash shell for the `bash` tool and `!`/`!!` shortcuts. If you use those surfaces, Atomic checks these locations in order:
 
 1. Custom path from `~/.atomic/agent/settings.json` (legacy `~/.pi/agent/settings.json` also supported)
 2. Git Bash (`C:\Program Files\Git\bin\bash.exe`)
 3. `bash.exe` on PATH (Cygwin, MSYS2, WSL)
 
-For most users, [Git for Windows](https://git-scm.com/download/win) is sufficient.
+For users who want the default Bash surfaces, [Git for Windows](https://git-scm.com/download/win) is sufficient. Native Windows users can instead enable the optional PowerShell tool described below; `!`/`!!` remain Bash-only.
 
 ## Custom Shell Path
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -259,7 +259,7 @@ export function printHelp(extensionFlags?: ExtensionFlag[]): void {
 	console.log(`${chalk.bold(APP_NAME)} - AI coding assistant with read, bash, edit, write, find, search, ask_user_question, todo tools
 
 ${chalk.bold("Usage:")}
-  ${APP_NAME} [options] [@files...] [messages...]
+  ${APP_NAME} [options] [--] [@files...] [messages...]
 
 ${chalk.bold("Commands:")}
   ${APP_NAME} install <source> [-l]     Install extension source and add to settings
@@ -312,6 +312,7 @@ ${chalk.bold("Options:")}
   --approve, -a                  Trust project-local files for this run
   --no-approve, -na              Ignore project-local files for this run
   --offline                      Disable startup network operations (same as ${ENV_OFFLINE}=1)
+  --                             End option parsing; treat remaining arguments as messages/files
   --help, -h                     Show this help
   --version, -v                  Show version number
 
@@ -338,6 +339,9 @@ ${chalk.bold("Examples:")}
 
   # Non-interactive mode (process and exit)
   ${APP_NAME} -p "List all .ts files in src/"
+
+  # Prompt beginning with a dash
+  ${APP_NAME} -p -- "- Summarize these points"
 
   # Multiple messages (interactive)
   ${APP_NAME} "Read package.json" "What dependencies do we have?"

--- a/research/pi-0.84.3-port-matrix.md
+++ b/research/pi-0.84.3-port-matrix.md
@@ -6,10 +6,10 @@ branch: pi-0.84.3/00-port-matrix
 repository: atomic-monorepo
 topic: Pi v0.84.2..upstream-main (v0.84.3 + 4) upstream commit and file port matrix
 tags: [implementation, evidence, pi-0.84.3, port-matrix]
-status: in_progress
+status: completed
 last_updated: 2026-08-25
-last_updated_by: Claude Opus 5
-port_outcome: in progress — S1 shipped dependency-carried outcomes; S2 shipped compaction correctness; S3–S8 remain planned
+last_updated_by: Claude Fable 5
+port_outcome: shipped on the pi-0.84.3/* stack
 breaking_changes_allowed: false
 compatibility_context: Preserve Atomic public SDK, branding, CLI names and paths, legacy PI_*/.pi aliases, providers, isolated runtime, fullscreen-only renderer, Verbatim Compaction, versionless 0.0.0 manifests, and Atomic's Bun-compiled release/CI pipeline.
 ---
@@ -161,7 +161,7 @@ default-thinking settings rows are replaced by a searchable per-model thinking o
 | `f0a2880f29` | Revert token-estimate removal | **equivalent** | Restores the state Atomic already has. |
 | `496185f6e4` | `/thinking` command | **ported (adapted)** | S4. Atomic has `components/thinking-selector.ts` but no `/thinking` in `core/slash-commands.ts`, no autocomplete entry, and no routing in `interactive-input-handling.ts`. Port the final `/thinking <level>` form; omit the superseded `--default` parser. |
 | `9c8070fbe4` | Ctrl+S persists `/model` | **ported (adapted)** | S4. Atomic's model selector always persists on Enter; split into session-only Enter and persisting Ctrl+S callbacks. |
-| `ee29aa118b` | Searchable default model and thinking level | **ported (adapted)** | S4. Atomic's top-level `SettingsList` search is on, but `SelectSubmenu` is not searchable. Port only the surviving per-model thinking submenu. |
+| `ee29aa118b` | Searchable default model and thinking level | **ported (adapted); shipped S4** | Atomic shipped one searchable combined model/level editor rather than upstream's stepped model-then-level picker, preserving per-model overrides with a simpler Atomic settings surface. |
 | `a669db3c33` | Show `modelid [provider]` like `/model` | **ported (adapted)** | S4. Atomic's `/model` already renders id plus provider badge; the settings-side per-model picker and wider layout are new. |
 | `1d3503fb9b` | Show and search saved defaults (#8399) | **ported (adapted)** | S4. Neither Atomic selector has a default badge or default-aware search. |
 | `768184923a` | Narrow default-model query matching | **ported** | S4. Ships with the selector port; no standalone Atomic analogue. |
@@ -176,7 +176,7 @@ default-thinking settings rows are replaced by a searchable per-model thinking o
 | `8c2529daeb` | Don't load root `.md` files as skills (#8012) | **ported**, S5 | `src/core/skills.ts:264` still routes every root `.md` through `loadSkillFromFile`, and line 279 diagnoses undeclared files. Silently skip non-`SKILL.md` files without frontmatter; keep diagnostics for malformed declared skills. Doc delta in `docs/skills.md`. |
 | `5e11f65865` | Load nested markdown skills (#8255) | **ported**, S5 | `src/core/package-manager-resource-files.ts:140` includes loose Markdown only for `mode === "pi" && dir === root`; nested Agents-format Markdown is dropped. |
 | `080932e53c` | Use `semver.gt` for version comparison (#8239) | **ported**, S5 | `package-manager-operations.ts:199` and `package-manager-npm.ts:256` both compare with `!==`, so a newer installed package can be downgraded. |
-| `f8f03460a0` | Reduce workspace dependency tree | **ported (adapted)**, S5 | Only the coding-agent half: replace the `glob` dependency with deterministic `node:fs` globbing in `package-manager-resource-collector.ts`, drop the direct dependency, regenerate lock/shrinkwrap. The `packages/{ai,agent,evals,telemetry}` manifest hunks are **not applicable** — Atomic must not touch its vendored fork and ships none of the others in upstream's shape. |
+| `f8f03460a0` | Reduce workspace dependency tree | **intentionally deferred** | The coding-agent `glob` removal was attempted in S5, but removing the dependency broke ambient type resolution in Atomic's local toolchain. The dependency and existing collector remain; upstream workspace-package manifest hunks remain not applicable to Atomic's vendored/package layout. |
 | `a1f955e9f4` | Remove redundant development dependencies | **ported; shipped**, S1 | Removed coding-agent's redundant `@types/diff` and `@types/ms` during S1's lock regeneration. Atomic had no root `jiti` duplicate. |
 | `955a543b31` | Expose sleeping llama.cpp models (#8235) | **ported (adapted)**, S5 | `src/extensions/llama/provider.ts:64-65` filters sleeping models out even though `index.ts` and the UI already recognize them. |
 | `a1bc0ec790` | llama.cpp guidance as no default (#8236) | **ported (adapted)**, S5 | Atomic's split `interactive-auth-login.ts:36-47` offers no llama-specific guidance; `docs/llama-cpp.md` needs the matching note. |
@@ -197,8 +197,8 @@ default-thinking settings rows are replaced by a searchable per-model thinking o
 | `830a0a59e9` | Expose tool metadata at stream start (#7953) | **ported (adapted)**, S6 | `src/modes/json-event.ts:41-49` strips `partial` generically and loses the starting tool call's `id`/`toolName`; the adaptation must keep Atomic's `withEndTurn` (`:52-59`) and cumulative `usage`. Docs in `docs/json.md` + `docs/rpc.md`. |
 | `460191cfcf` | Include context in Radius session shares | **ported (adapted)**, S6 | Only the export half: emit an export-only, Atomic-branded `atomic.share` custom entry carrying system prompt and tool schemas from `agent-session-export.ts`, without mutating the persisted session. The Radius upload half is rejected — see `686f3487f5`. |
 | `f4585b8bec` | Simplify session sharing links | **ported (adapted)**, S6 | Atomic prints plain Gist/pi.dev URLs and runs the `gh auth status` preflight before export. Take the canonical-hyperlink and preflight-ordering cleanup; keep `ATOMIC_SHARE_VIEWER_URL` with its legacy `PI_SHARE_VIEWER_URL` alias. |
-| `686f3487f5` | Share via Radius artifacts under experimental (#8443) | **intentionally rejected** | Uploading session artifacts — including the system prompt and tool schemas — to upstream's hosted Radius service is an upstream product surface. Atomic keeps private-Gist sharing under its own branding and viewer variable. |
-| `77f2d1235e` | Only share via Radius if logged in | **intentionally rejected** | Same boundary: silently routing `/share` to a hosted upstream service whenever a Radius credential happens to exist is exactly the behavior Atomic declines. |
+| `686f3487f5` | Share via Radius artifacts under experimental (#8443) | **intentionally rejected; confirmed S6** | Uploading session artifacts — including the system prompt and tool schemas — to upstream's hosted Radius service remains outside Atomic's product boundary. Atomic ships only an export-time `atomic.share` context record and retains private-Gist sharing. |
+| `77f2d1235e` | Only share via Radius if logged in | **intentionally rejected; confirmed S6** | Atomic does not silently route `/share` to an upstream-hosted service when a Radius credential exists; S6 preserved the existing private-Gist transport and Atomic viewer URL. |
 | `df018b6020` | Retry hung model catalog requests | **ported**, S6 | `src/utils/management-http.ts:9-11` exposes only an overall `timeoutMs` and reuses one combined signal, so a hung attempt can never be retried; `remote-catalog-provider.ts:85` needs the 4 s per-attempt limit. |
 | `1355cd36e0` | Normalize UTF-8 BOMs in text inputs | **ported (adapted)**, S6 | Partly present: `src/utils/json.ts:9-15` already provides `stripJsonBom`/`parseJsonFileContent` for settings and trust, and `test/hashline-tools.test.ts:513` proves hashline edits preserve a file's BOM. Port the remaining readers (auth, models, model config, keybindings, frontmatter, package manager, resource loader, theme, CLI file processor) without disturbing either. |
 | `c49906ec77` | Preserve managed state file permissions | **ported (adapted)**, S6 | `auth-storage-backends.ts:113-119` writes a temp file, chmods `0600`, and renames over the target, so simply dropping the chmod would still replace the inode and its mode. Carry the existing target mode onto the replacement while keeping `0600` as the creation default. |


### PR DESCRIPTION
Stack 9/9. [--] end-of-options in README + CLI help, comprehensive [Unreleased] changelog entries for the whole port, and port-matrix outcome finalization (shipped statuses, documented deviations).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790273437&installation_model_id=10562&pr_number=2683&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2683&signature=e0f7cb82e17e87d7e312d7bfe464fb4ffd5797c8c0a1f746b07c61afd36cf8a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

















<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update completes the pi 0.84.3 documentation across the CLI reference, release notes, RPC documentation, Windows guidance, and port matrix. The documented `--` behavior was exercised with a dash-prefixed prompt and matches the parser and generated CLI help.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The focused end-of-options tests passed, and direct parsing confirmed that `atomic -p -- "- Summarize these points"` preserves the dash-prefixed prompt without producing an unknown-option diagnostic. Generated help and README guidance agree with that behavior.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused test suite for args-end-of-options and directly invoked parseArgs with \["-p", "--", "- Summarize these points"\], and all seven focused tests passed with the parser retaining the dash-prefixed message as the sole output and with no file arguments, unknown flags, or diagnostics.
- Verified that the capture shows the parent revision had already parsed the focused command correctly, and that the capture contains the full focused test output, the parser result, generated help lines, and documentation excerpts, with no source changes made.
- Recorded two runtime-log artifacts to support review, including the focused test run log and the full capture log accessible via URLs.

<a href="https://app.greptile.com/trex/runs/20681844/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (9): Last reviewed commit: ["docs(coding-agent): finalize pi 0.84.3 p..."](https://github.com/bastani-inc/atomic/commit/f3e2e381697d295a45d7b82d44c831f77903a61e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56766328)</sub>

<!-- /greptile_comment -->