### PR TITLE
feat(coding-agent): port upstream post-0.84.3 fixes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added a Windows PowerShell tool that prefers PowerShell 7 and falls back to Windows PowerShell when `pwsh.exe` or `powershell.exe` is on `PATH`. The tool is omitted when neither executable is available. Bash remains the shell for `!`/`!!`, plus Windows/WSL-friendly default keybindings ([#8512](https://github.com/earendil-works/pi/issues/8512)).
 - Added path-aware, deduplicated settings diagnostics and routed startup diagnostics into the fullscreen transcript so alternate-screen startup cannot hide configuration errors.
 - Added export-only `atomic.share` context records containing the system prompt and tool schemas. Session sharing keeps private-Gist transport and Atomic viewer URLs; no persisted session is mutated and no Radius upload is introduced.
+- Added RPC `clear_queue` to retrieve and remove queued steering and follow-up messages ([#8432](https://github.com/earendil-works/pi/issues/8432)).
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added path-aware, deduplicated settings diagnostics and routed startup diagnostics into the fullscreen transcript so alternate-screen startup cannot hide configuration errors.
 - Added export-only `atomic.share` context records containing the system prompt and tool schemas. Session sharing keeps private-Gist transport and Atomic viewer URLs; no persisted session is mutated and no Radius upload is introduced.
 - Added RPC `clear_queue` to retrieve and remove queued steering and follow-up messages ([#8432](https://github.com/earendil-works/pi/issues/8432)).
+- Exported `detectSupportedImageMimeTypeFromFile` from the public coding-agent API ([#8600](https://github.com/earendil-works/pi/pull/8600)).
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Fixed hung authenticated model-catalog attempts consuming the whole request budget without retrying by applying a per-attempt timeout before retrying.
 - Fixed UTF-8 BOMs breaking auth, model, keybinding, frontmatter, package, resource, theme, and CLI text inputs while preserving BOM-aware hashline edits.
 - Fixed atomic managed-state rewrites resetting existing file permissions. Credential files are always rewritten as `0600` so a world-readable `auth.json` cannot leak replacement secrets.
+- Fixed extension messages sent with `triggerTurn: false` while the agent is running being inserted between a tool call and its result; they are now appended after the turn's tool results ([#8537](https://github.com/earendil-works/pi/issues/8537)).
 
 ## [0.9.16-alpha.4] - 2026-08-23
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Fixed hung authenticated model-catalog attempts consuming the whole request budget without retrying by applying a per-attempt timeout before retrying.
 - Fixed UTF-8 BOMs breaking auth, model, keybinding, frontmatter, package, resource, theme, and CLI text inputs while preserving BOM-aware hashline edits.
 - Fixed atomic managed-state rewrites resetting existing file permissions. Credential files are always rewritten as `0600` so a world-readable `auth.json` cannot leak replacement secrets.
+- Fixed explicitly persisted default models disappearing from non-empty model scopes; persisted defaults are now added to both the active and saved scope.
 - Fixed extension messages sent with `triggerTurn: false` while the agent is running being inserted between a tool call and its result; they are now appended after the turn's tool results ([#8537](https://github.com/earendil-works/pi/issues/8537)).
 
 ## [0.9.16-alpha.4] - 2026-08-23

--- a/packages/coding-agent/docs/custom-provider.md
+++ b/packages/coding-agent/docs/custom-provider.md
@@ -373,7 +373,7 @@ interface OAuthCredentials {
 
 ## Custom Streaming API
 
-For providers with non-standard APIs, implement `streamSimple`. Study the existing streaming implementations before writing your own:
+For providers with non-standard APIs, implement `streamSimple`. Study the existing API implementations before writing your own:
 
 **Reference implementations:**
 

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -138,6 +138,29 @@ Response:
 {"type": "response", "command": "abort", "success": true}
 ```
 
+#### clear_queue
+
+Remove queued steering and follow-up messages and return their text.
+
+```json
+{"type": "clear_queue"}
+```
+
+Response:
+```json
+{
+  "type": "response",
+  "command": "clear_queue",
+  "success": true,
+  "data": {
+    "steering": ["Change direction"],
+    "followUp": ["Summarize when finished"]
+  }
+}
+```
+
+To implement interactive Esc behavior, send `clear_queue` before `abort`, then restore the returned text in the client editor. `abort` continues queued messages when they remain in the session.
+
 #### new_session
 
 Start a fresh session. Can be cancelled by a `session_before_switch` extension event handler.

--- a/packages/coding-agent/src/core/agent-session-custom-message-commit.ts
+++ b/packages/coding-agent/src/core/agent-session-custom-message-commit.ts
@@ -30,6 +30,8 @@ export async function commitAdmittedCustomMessage<T>(
 			} else {
 				self._queueAgentMessage(appMessage, delivery);
 			}
+		} else if (self.isStreaming) {
+			self._pendingCustomMessages.push(appMessage);
 		} else {
 			self._appendCustomMessage(appMessage);
 		}
@@ -44,6 +46,8 @@ export async function commitAdmittedCustomMessage<T>(
 		options.deliverAs === undefined
 	) {
 		self._appendCustomMessage(appMessage);
+	} else if (self.isStreaming && options?.triggerTurn === false) {
+		self._pendingCustomMessages.push(appMessage);
 	} else if (self.isStreaming && useProtectedReconciliation) {
 		await queueProtectedStreamingCustomMessage(
 			self,
@@ -115,6 +119,8 @@ export async function commitAdmittedCustomMessages<T>(
 			} else {
 				for (const item of appMessages) self._queueAgentMessage(item, delivery);
 			}
+		} else if (self.isStreaming) {
+			self._pendingCustomMessages.push(...appMessages);
 		} else {
 			for (const item of appMessages) self._appendCustomMessage(item);
 		}
@@ -125,6 +131,8 @@ export async function commitAdmittedCustomMessages<T>(
 		options.deliverAs === undefined
 	) {
 		for (const item of appMessages) self._appendCustomMessage(item);
+	} else if (self.isStreaming && options?.triggerTurn === false) {
+		self._pendingCustomMessages.push(...appMessages);
 	} else if (self.isStreaming && useProtectedReconciliation) {
 		await queueProtectedStreamingCustomMessages(self, appMessages, delivery);
 	} else if (self.isStreaming && options?.persistWhenStreaming === true) {

--- a/packages/coding-agent/src/core/agent-session-events.ts
+++ b/packages/coding-agent/src/core/agent-session-events.ts
@@ -178,6 +178,7 @@ export async function _processAgentEvent(this: AgentSession, event: AgentEvent):
 			retryConsumedProtectedStreamingCustomMessages(this);
 		}
 	}
+	if (event.type === "turn_end") this._flushPendingCustomMessages();
 
 	// Handle session persistence
 	if (event.type === "message_end") {

--- a/packages/coding-agent/src/core/agent-session-message-queue.ts
+++ b/packages/coding-agent/src/core/agent-session-message-queue.ts
@@ -204,6 +204,14 @@ export function _appendCustomMessage<T>(this: AgentSession, message: CustomMessa
 	this._emit({ type: "message_start", message });
 	this._emit({ type: "message_end", message });
 }
+
+/** Append context-only custom messages once the current turn's tool results are in history. */
+export function _flushPendingCustomMessages(this: AgentSession): void {
+	if (this._pendingCustomMessages.length === 0) return;
+	const pending = this._pendingCustomMessages;
+	this._pendingCustomMessages = [];
+	for (const message of pending) this._appendCustomMessage(message);
+}
 export function _enqueueInterruptCustomMessage<T>(
 	this: AgentSession,
 	message: CustomMessage<T>,
@@ -441,6 +449,7 @@ export const agentSessionMessageQueueMethods = {
 	sendCustomMessages,
 	closeWorkflowStageGeneration,
 	_appendCustomMessage,
+	_flushPendingCustomMessages,
 	_enqueueInterruptCustomMessage,
 	_sendInterruptCustomMessageNow,
 	_ensureActiveInterruptQueueHold,

--- a/packages/coding-agent/src/core/agent-session-methods.ts
+++ b/packages/coding-agent/src/core/agent-session-methods.ts
@@ -194,6 +194,7 @@ export interface AgentSessionMethodSurface extends AgentSessionQueuePauseControl
 	_commitAdmittedCustomMessage<T>(message: CustomMessage<T>, options?: SendMessageOptions): Promise<void>;
 	_commitAdmittedCustomMessages<T>(messages: CustomMessage<T>[], options?: SendMessagesOptions): Promise<void>;
 	_appendCustomMessage<T>(message: CustomMessage<T>): void;
+	_flushPendingCustomMessages(): void;
 	_enqueueInterruptCustomMessage<T>(message: CustomMessage<T>, options?: SendMessageOptions): Promise<void>;
 	_sendInterruptCustomMessageNow<T>(message: CustomMessage<T>, options?: SendMessageOptions): Promise<void>;
 	_ensureActiveInterruptQueueHold(): InterruptQueueHold;
@@ -442,6 +443,7 @@ export interface AgentSessionInternalSurface extends AgentSessionMethodSurface, 
 	_workflowStageDeliveryForwardTarget: AgentSessionInternalSurface | undefined;
 	_activeInterruptAbortMessage: string | undefined;
 	_pendingNextTurnMessages: CustomMessage[];
+	_pendingCustomMessages: CustomMessage[];
 	_protectedStreamingCustomMessages: Array<{
 		message: CustomMessage;
 		delivery: "steer" | "followUp";

--- a/packages/coding-agent/src/core/agent-session-models.ts
+++ b/packages/coding-agent/src/core/agent-session-models.ts
@@ -86,6 +86,19 @@ export async function _emitModelSelect(
 	});
 }
 
+function addPersistedDefaultToNonEmptyScope(session: AgentSession, model: Model<Api>): void {
+	if (session._scopedModels.length === 0) return;
+	if (session._scopedModels.some((scoped) => modelsAreEqual(scoped.model, model))) return;
+
+	session._scopedModels = [...session._scopedModels, { model }];
+	const enabledModels = session.settingsManager.getEnabledModels();
+	if (!enabledModels?.length) return;
+
+	const modelReference = `${model.provider}/${model.id}`;
+	if (enabledModels.some((pattern) => pattern.toLowerCase() === modelReference.toLowerCase())) return;
+	session.settingsManager.setEnabledModels([...enabledModels, modelReference]);
+}
+
 /**
  * Set model directly.
  * Validates that auth is configured, saves to session and settings.
@@ -107,7 +120,10 @@ export async function setModel(
 	const nextModel = model;
 	this.agent.state.model = nextModel;
 	this.sessionManager.appendModelChange(nextModel.provider, nextModel.id);
-	if (options.persist) this.settingsManager.setDefaultModelAndProvider(nextModel.provider, nextModel.id);
+	if (options.persist) {
+		this.settingsManager.setDefaultModelAndProvider(nextModel.provider, nextModel.id);
+		addPersistedDefaultToNonEmptyScope(this, nextModel);
+	}
 
 	// Re-clamp thinking level for new model's capabilities
 	this.setThinkingLevel(thinkingLevel);
@@ -159,7 +175,10 @@ export async function _cycleScopedModel(
 	this._clearFallbackModelScope?.();
 	this.agent.state.model = nextModel;
 	this.sessionManager.appendModelChange(nextModel.provider, nextModel.id);
-	if (options.persist) this.settingsManager.setDefaultModelAndProvider(nextModel.provider, nextModel.id);
+	if (options.persist) {
+		this.settingsManager.setDefaultModelAndProvider(nextModel.provider, nextModel.id);
+		addPersistedDefaultToNonEmptyScope(this, nextModel);
+	}
 
 	// Apply thinking level.
 	// - Explicit scoped model thinking level overrides current session level
@@ -195,7 +214,10 @@ export async function _cycleAvailableModel(
 	this._clearFallbackModelScope?.();
 	this.agent.state.model = selectedModel;
 	this.sessionManager.appendModelChange(selectedModel.provider, selectedModel.id);
-	if (options.persist) this.settingsManager.setDefaultModelAndProvider(selectedModel.provider, selectedModel.id);
+	if (options.persist) {
+		this.settingsManager.setDefaultModelAndProvider(selectedModel.provider, selectedModel.id);
+		addPersistedDefaultToNonEmptyScope(this, selectedModel);
+	}
 
 	// Re-clamp thinking level for new model's capabilities
 	this.setThinkingLevel(thinkingLevel);

--- a/packages/coding-agent/src/core/agent-session-prompt.ts
+++ b/packages/coding-agent/src/core/agent-session-prompt.ts
@@ -127,8 +127,9 @@ export async function prompt(this: AgentSession, text: string, options?: PromptO
 		// Close the completed fallback lifecycle before validating credentials for
 		// the next idle prompt. The selected fallback remains the session model.
 		if (typeof this._settleFallbackModelScope === "function") await this._settleFallbackModelScope();
-		// Flush any pending bash messages before the new prompt
+		// Flush context-only messages deferred until the previous turn's tool results were appended.
 		this._flushPendingBashMessages();
+		this._flushPendingCustomMessages();
 
 		// Validate model
 		if (!this.model) {
@@ -253,6 +254,7 @@ export async function _runAgentPrompt(
 	} finally {
 		this._systemPromptOverride = undefined;
 		await this._agentEventQueue;
+		this._flushPendingCustomMessages();
 		if (typeof this._extensionRunner?.emit === "function") {
 			await this._extensionRunner.emit({ type: "agent_settled" });
 		}

--- a/packages/coding-agent/src/core/agent-session-transfer.ts
+++ b/packages/coding-agent/src/core/agent-session-transfer.ts
@@ -33,6 +33,7 @@ export function transferWorkflowStageDeliveriesTo(this: AgentSession, target: ob
 	};
 	transferProtectedStreamingCustomMessages(source, next, sourceQueues);
 	next._pendingNextTurnMessages.unshift(...source._pendingNextTurnMessages.splice(0));
+	next._pendingCustomMessages.unshift(...source._pendingCustomMessages.splice(0));
 	next._steeringMessages = [...source._steeringMessages.splice(0), ...next._steeringMessages];
 	next._followUpMessages = [...source._followUpMessages.splice(0), ...next._followUpMessages];
 	source._activeInterruptQueueHold = undefined;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -113,6 +113,8 @@ class AgentSessionBase {
 	protected _workflowStageDeliveryForwardTarget: AgentSessionInternalSurface | undefined = undefined;
 	protected _activeInterruptAbortMessage: string | undefined = undefined;
 	protected _pendingNextTurnMessages: CustomMessage[] = [];
+	/** Context-only custom messages queued during a run, flushed after the current turn's tool results. */
+	protected _pendingCustomMessages: CustomMessage[] = [];
 	protected _protectedStreamingCustomMessages: Array<{
 		message: CustomMessage;
 		delivery: "steer" | "followUp";

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -481,5 +481,6 @@ export { createGitEnvironment, GIT_LOCAL_ENV_VARS } from "./utils/git-env.ts";
 export { convertToPng } from "./utils/image-convert.ts";
 export { formatDimensionNote, type ResizedImage, resizeImage } from "./utils/image-resize.ts";
 export { INTERACTIVE_ENGINE_ENV_VARS, scrubInteractiveEngineEnv } from "./utils/interactive-engine-env.ts";
+export { detectSupportedImageMimeTypeFromFile } from "./utils/mime.ts";
 // Shell utilities
 export { getShellConfig } from "./utils/shell.ts";

--- a/packages/coding-agent/src/modes/interactive/interactive-model-routing.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-model-routing.ts
@@ -174,6 +174,7 @@ InteractiveModeBase.prototype.showModelSelector = function (
 			async (model, persist) => {
 				try {
 					await this.session.setModel(model, { persist });
+					await this.updateAvailableProviderCount();
 					this.footer.invalidate();
 					this.updateEditorBorderColor();
 					done();

--- a/packages/coding-agent/src/modes/rpc/rpc-client-api.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client-api.ts
@@ -47,6 +47,9 @@ export abstract class RpcClientApi {
 	async abort(): Promise<void> {
 		await this.request({ type: "abort" });
 	}
+	async clearQueue(): Promise<{ steering: string[]; followUp: string[] }> {
+		return this.data(await this.request({ type: "clear_queue" }));
+	}
 	async newSession(parentSession?: string): Promise<{ cancelled: boolean }> {
 		return this.data(await this.request({ type: "new_session", parentSession }));
 	}

--- a/packages/coding-agent/test/model-persisted-default-scope.test.ts
+++ b/packages/coding-agent/test/model-persisted-default-scope.test.ts
@@ -1,0 +1,86 @@
+import { getModel, streamSimple } from "@bastani/pi-ai/compat";
+import { Agent } from "@earendil-works/pi-agent-core";
+import { afterEach, describe, expect, test } from "vitest";
+import { AgentSession } from "../src/core/agent-session.ts";
+import { AuthStorage } from "../src/core/auth-storage.ts";
+import { SessionManager } from "../src/core/session-manager.ts";
+import { SettingsManager } from "../src/core/settings-manager.ts";
+import { createInMemoryModelRegistry, getModelRuntime } from "./model-runtime-test-utils.ts";
+import { createTestResourceLoader } from "./utilities.ts";
+
+const sonnet = getModel("anthropic", "claude-sonnet-4-5")!;
+const opus = getModel("anthropic", "claude-opus-4-8")!;
+
+describe("persisted default model scoping", () => {
+	const sessions: AgentSession[] = [];
+
+	afterEach(() => {
+		for (const session of sessions.splice(0)) session.dispose();
+	});
+
+	async function createSession(options: { scoped: boolean; persistedScope?: string[] }) {
+		const settingsManager = SettingsManager.inMemory(
+			options.persistedScope ? { enabledModels: options.persistedScope } : {},
+		);
+		const authStorage = AuthStorage.inMemory({ anthropic: { type: "api_key", key: "test-key" } });
+		const modelRuntime = getModelRuntime(await createInMemoryModelRegistry(authStorage));
+		const agent = new Agent({
+			initialState: { model: sonnet, systemPrompt: "test", tools: [] },
+			streamFn: streamSimple,
+		});
+		const session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settingsManager,
+			cwd: process.cwd(),
+			modelRuntime,
+			resourceLoader: createTestResourceLoader(),
+			scopedModels: options.scoped ? [{ model: sonnet }] : [],
+		});
+		sessions.push(session);
+		return { session, settingsManager };
+	}
+
+	test("adds a persisted default to an existing scoped model list", async () => {
+		const { session, settingsManager } = await createSession({
+			scoped: true,
+			persistedScope: [`${sonnet.provider}/${sonnet.id}`],
+		});
+
+		await session.setModel(opus, { persist: true });
+
+		expect(settingsManager.getDefaultProvider()).toBe(opus.provider);
+		expect(settingsManager.getDefaultModel()).toBe(opus.id);
+		expect(session.scopedModels.map((scoped) => `${scoped.model.provider}/${scoped.model.id}`)).toEqual([
+			`${sonnet.provider}/${sonnet.id}`,
+			`${opus.provider}/${opus.id}`,
+		]);
+		expect(settingsManager.getEnabledModels()).toEqual([
+			`${sonnet.provider}/${sonnet.id}`,
+			`${opus.provider}/${opus.id}`,
+		]);
+	});
+
+	test("does not create a scoped model list when all models are available", async () => {
+		const { session, settingsManager } = await createSession({ scoped: false });
+
+		await session.setModel(opus, { persist: true });
+
+		expect(session.scopedModels).toEqual([]);
+		expect(settingsManager.getEnabledModels()).toBeUndefined();
+	});
+
+	test("keeps session-only model changes out of scope", async () => {
+		const { session, settingsManager } = await createSession({
+			scoped: true,
+			persistedScope: [`${sonnet.provider}/${sonnet.id}`],
+		});
+
+		await session.setModel(opus, { persist: false });
+
+		expect(session.scopedModels.map((scoped) => `${scoped.model.provider}/${scoped.model.id}`)).toEqual([
+			`${sonnet.provider}/${sonnet.id}`,
+		]);
+		expect(settingsManager.getEnabledModels()).toEqual([`${sonnet.provider}/${sonnet.id}`]);
+	});
+});

--- a/packages/coding-agent/test/paused-queued-late-admission.test.ts
+++ b/packages/coding-agent/test/paused-queued-late-admission.test.ts
@@ -205,9 +205,6 @@ describe("paused queue late admission gate", () => {
 			{ triggerTurn: false },
 		);
 
-		const overlappingHistory = harness.session.messages.filter(
-			(message) => message.role === "custom" && message.customType.startsWith("overlap-history-"),
-		);
 		const paused = harness.session as AgentSession & {
 			readonly _activeInterruptQueueHold?: {
 				readonly steering: readonly object[];
@@ -222,6 +219,12 @@ describe("paused queue late admission gate", () => {
 		await Promise.all([active, aborting]);
 		const released = await harness.session.resumeQueuedMessages();
 
+		// Non-trigger custom arrivals during a streaming turn are held until the
+		// turn settles, so they cannot land between a tool call and its result.
+		// They must still reach history in order once it does.
+		const overlappingHistory = harness.session.messages.filter(
+			(message) => message.role === "custom" && message.customType.startsWith("overlap-history-"),
+		);
 		expect(overlappingHistory.map((message) => message.details)).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
 		expect(heldDuringAbort).toBe(0);
 		expect(released).toBe(false);

--- a/packages/coding-agent/test/rpc-client-clear-queue.test.ts
+++ b/packages/coding-agent/test/rpc-client-clear-queue.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { RpcClientApi, type RpcCommandBody } from "../src/modes/rpc/rpc-client-api.ts";
+import type { RpcResponse } from "../src/modes/rpc/rpc-types.ts";
+
+class QueueClient extends RpcClientApi {
+	lastCommand: RpcCommandBody | undefined;
+
+	protected request(command: RpcCommandBody): Promise<RpcResponse> {
+		this.lastCommand = command;
+		return Promise.resolve({
+			type: "response",
+			command: "clear_queue",
+			success: true,
+			data: { steering: ["Change direction"], followUp: ["Summarize when finished"] },
+		});
+	}
+
+	protected data<T>(response: RpcResponse): T {
+		if (!("data" in response)) throw new Error("Expected RPC response data");
+		return response.data as T;
+	}
+}
+
+describe("RpcClient clearQueue", () => {
+	it("sends the clear_queue RPC command", async () => {
+		const client = new QueueClient();
+
+		const result = await client.clearQueue();
+
+		expect(client.lastCommand).toEqual({ type: "clear_queue" });
+		expect(result).toEqual({ steering: ["Change direction"], followUp: ["Summarize when finished"] });
+	});
+});

--- a/packages/coding-agent/test/rpc-prompt-response-semantics.test.ts
+++ b/packages/coding-agent/test/rpc-prompt-response-semantics.test.ts
@@ -445,4 +445,58 @@ describe("RPC prompt response semantics", () => {
 			await cleanup();
 		}
 	});
+
+	it("returns and clears queued steering and follow-up messages", async () => {
+		const { lineHandler, cleanup } = await startRpcMode({ withAuth: true, responseDelayMs: 500 });
+
+		try {
+			lineHandler(JSON.stringify({ id: "clear-start", type: "prompt", message: "Start" }));
+			await vi.waitFor(() => {
+				expect(getPromptResponses(rpcIo.outputLines, "clear-start")).toHaveLength(1);
+			});
+
+			lineHandler(
+				JSON.stringify({
+					id: "clear-steering",
+					type: "prompt",
+					message: "Change direction",
+					streamingBehavior: "steer",
+				}),
+			);
+			await vi.waitFor(() => {
+				expect(getPromptResponses(rpcIo.outputLines, "clear-steering")).toHaveLength(1);
+			});
+
+			lineHandler(
+				JSON.stringify({
+					id: "clear-follow-up",
+					type: "prompt",
+					message: "Summarize when finished",
+					streamingBehavior: "followUp",
+				}),
+			);
+			await vi.waitFor(() => {
+				expect(getPromptResponses(rpcIo.outputLines, "clear-follow-up")).toHaveLength(1);
+			});
+
+			lineHandler(JSON.stringify({ id: "clear", type: "clear_queue" }));
+			await vi.waitFor(() => {
+				expect(parseOutputLines(rpcIo.outputLines)).toContainEqual({
+					id: "clear",
+					type: "response",
+					command: "clear_queue",
+					success: true,
+					data: {
+						steering: ["Change direction"],
+						followUp: ["Summarize when finished"],
+					},
+				});
+			});
+
+			await sleep(600);
+			expect(parseOutputLines(rpcIo.outputLines).filter((record) => record.type === "agent_start")).toHaveLength(1);
+		} finally {
+			await cleanup();
+		}
+	});
 });

--- a/packages/coding-agent/test/suite/regressions/8537-custom-message-tool-result-ordering.test.ts
+++ b/packages/coding-agent/test/suite/regressions/8537-custom-message-tool-result-ordering.test.ts
@@ -1,0 +1,144 @@
+import type { AgentMessage, AgentTool } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import { convertToLlm } from "../../../src/core/messages.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+function roles(messages: AgentMessage[]): string[] {
+	return messages.map((message) => message.role);
+}
+
+describe("#8537 custom messages injected during tool execution", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("appends the message after the turn's tool results instead of between call and result", async () => {
+		let notify: (() => Promise<void>) | undefined;
+		const slowTool: AgentTool = {
+			name: "wait",
+			label: "Wait",
+			description: "Wait for a background task",
+			parameters: Type.Object({}),
+			execute: async () => {
+				// A background task (e.g. a subagent reply) notifies the session while the
+				// tool is still running.
+				await notify?.();
+				return { content: [{ type: "text", text: "tool done" }], details: {} };
+			},
+		};
+
+		const harness = await createHarness({ tools: [slowTool] });
+		harnesses.push(harness);
+		notify = () =>
+			harness.session.sendCustomMessage(
+				{ customType: "subagent-reply", content: "subagent replied", display: true },
+				{ triggerTurn: false },
+			);
+
+		harness.setResponses([
+			fauxAssistantMessage([fauxToolCall("wait", {})], { stopReason: "toolUse" }),
+			fauxAssistantMessage("done"),
+		]);
+
+		await harness.session.prompt("hi");
+
+		expect(roles(harness.session.messages)).toEqual(["user", "assistant", "toolResult", "custom", "assistant"]);
+	});
+
+	it("keeps session entries and message events in the same order as agent state", async () => {
+		let notify: (() => Promise<void>) | undefined;
+		const slowTool: AgentTool = {
+			name: "wait",
+			label: "Wait",
+			description: "Wait for a background task",
+			parameters: Type.Object({}),
+			execute: async () => {
+				await notify?.();
+				return { content: [{ type: "text", text: "tool done" }], details: {} };
+			},
+		};
+
+		const harness = await createHarness({ tools: [slowTool] });
+		harnesses.push(harness);
+		notify = () =>
+			harness.session.sendCustomMessage(
+				{ customType: "subagent-reply", content: "subagent replied", display: true },
+				{ triggerTurn: false },
+			);
+
+		harness.setResponses([
+			fauxAssistantMessage([fauxToolCall("wait", {})], { stopReason: "toolUse" }),
+			fauxAssistantMessage("done"),
+		]);
+
+		await harness.session.prompt("hi");
+
+		const entryKinds = harness.sessionManager
+			.getBranch()
+			.flatMap((entry) =>
+				entry.type === "message" ? [entry.message.role] : entry.type === "custom_message" ? ["custom"] : [],
+			);
+		expect(entryKinds).toEqual(["user", "assistant", "toolResult", "custom", "assistant"]);
+
+		// message events must never describe a message the session tree does not contain yet
+		const messageStarts = harness.events.flatMap((event) =>
+			event.type === "message_start" ? [event.message.role] : [],
+		);
+		expect(messageStarts).toEqual(["user", "assistant", "toolResult", "custom", "assistant"]);
+	});
+
+	it("produces an llm history where every tool result follows its tool call", async () => {
+		let notify: (() => Promise<void>) | undefined;
+		const slowTool: AgentTool = {
+			name: "wait",
+			label: "Wait",
+			description: "Wait for a background task",
+			parameters: Type.Object({}),
+			execute: async () => {
+				await notify?.();
+				return { content: [{ type: "text", text: "tool done" }], details: {} };
+			},
+		};
+
+		const harness = await createHarness({ tools: [slowTool] });
+		harnesses.push(harness);
+		notify = () =>
+			harness.session.sendCustomMessage(
+				{ customType: "subagent-reply", content: "subagent replied", display: true },
+				{ triggerTurn: false },
+			);
+
+		harness.setResponses([
+			fauxAssistantMessage([fauxToolCall("wait", {})], { stopReason: "toolUse" }),
+			fauxAssistantMessage("done"),
+			fauxAssistantMessage("second turn"),
+		]);
+
+		await harness.session.prompt("hi");
+		await harness.session.prompt("and now?");
+
+		const llmMessages = convertToLlm(harness.session.messages);
+		const openToolCallIds = new Set<string>();
+		for (const message of llmMessages) {
+			if (message.role === "assistant") {
+				openToolCallIds.clear();
+				for (const block of message.content) {
+					if (block.type === "toolCall") openToolCallIds.add(block.id);
+				}
+				continue;
+			}
+			if (message.role === "toolResult") {
+				expect(openToolCallIds.has(message.toolCallId)).toBe(true);
+				openToolCallIds.delete(message.toolCallId);
+				continue;
+			}
+			openToolCallIds.clear();
+		}
+	});
+});

--- a/test/unit/agent-session-prompt-start.test.ts
+++ b/test/unit/agent-session-prompt-start.test.ts
@@ -8,6 +8,8 @@ describe("AgentSession prompt-start handshake", () => {
 		const events: string[] = [];
 		let streaming = false;
 		const session = {
+			_pendingCustomMessages: [],
+			_flushPendingCustomMessages() {},
 			agent: {
 				prompt() {
 					events.push("agent.prompt");
@@ -50,6 +52,8 @@ describe("AgentSession prompt-start handshake", () => {
 	test("does not report prompt ownership when agent.prompt throws synchronously", async () => {
 		let promptStarted = false;
 		const session = {
+			_pendingCustomMessages: [],
+			_flushPendingCustomMessages() {},
 			agent: {
 				prompt() {
 					throw new Error("startup failed");
@@ -76,6 +80,8 @@ describe("AgentSession prompt-start handshake", () => {
 	test("does not report prompt ownership when startup rejects before streaming", async () => {
 		let promptStarted = false;
 		const session = {
+			_pendingCustomMessages: [],
+			_flushPendingCustomMessages() {},
 			agent: { prompt: () => Promise.reject(new Error("startup rejected")) },
 			isStreaming: false,
 			abortSessionSummary: () => {},
@@ -104,6 +110,8 @@ describe("AgentSession workflow delivery authorization", () => {
 		let sideEffects = 0;
 		const delivered: string[] = [];
 		const session = {
+			_pendingCustomMessages: [],
+			_flushPendingCustomMessages() {},
 			isStreaming: false,
 			abortSessionSummary: () => {},
 			promptTemplates: [],

--- a/test/unit/agent-session-stage-admission.test.ts
+++ b/test/unit/agent-session-stage-admission.test.ts
@@ -33,6 +33,7 @@ function harness(withRouter = true) {
 		async _enqueueInterruptCustomMessage() {},
 		async _runAgentPrompt() {},
 		agent: { state: { streamingMessage: undefined, messages: [] }, async waitForIdle() {} },
+		_pendingCustomMessages: [],
 		_agentEventQueue: Promise.resolve(),
 	};
 	const send = (content: string, key: string) =>
@@ -147,6 +148,7 @@ describe("AgentSession workflow-stage admission", () => {
 				if (typeof message.content === "string") processed.push(message.content);
 			},
 			agent: { async waitForIdle() {} },
+			_pendingCustomMessages: [],
 			_agentEventQueue: Promise.resolve(),
 		};
 
@@ -211,8 +213,10 @@ describe("AgentSession workflow-stage admission", () => {
 			timestamp: 1,
 		};
 		const restored: object[] = [];
+		const carried = { customType: "carried", content: "carried" };
 		const target = {
 			_pendingNextTurnMessages: [] as object[],
+			_pendingCustomMessages: [] as object[],
 			_queuedMessagesPaused: false,
 			_activeInterruptQueueHold: undefined,
 			_steeringMessages: [] as string[],
@@ -227,6 +231,7 @@ describe("AgentSession workflow-stage admission", () => {
 		const source = {
 			_activeInterruptQueueHold: undefined,
 			_pendingNextTurnMessages: [notification],
+			_pendingCustomMessages: [carried] as object[],
 			_queuedMessagesPaused: false,
 			_steeringMessages: [] as string[],
 			_followUpMessages: [] as string[],
@@ -237,5 +242,8 @@ describe("AgentSession workflow-stage admission", () => {
 		transferWorkflowStageDeliveriesTo.call(source as never, target);
 		assert.deepEqual(restored, [notification]);
 		assert.deepEqual(target._pendingNextTurnMessages, [notification]);
+		// Context-only custom messages move with the rest of the delivery state.
+		assert.deepEqual(target._pendingCustomMessages, [carried]);
+		assert.deepEqual(source._pendingCustomMessages, []);
 	});
 });

--- a/test/unit/workflow-idle-prompt-start-race.test.ts
+++ b/test/unit/workflow-idle-prompt-start-race.test.ts
@@ -64,6 +64,8 @@ test("production prompt wiring holds idle admission until the first agent turn s
 			emitBeforeAgentStart: async () => undefined,
 		},
 		_flushPendingBashMessages() {},
+		_pendingCustomMessages: [],
+		_flushPendingCustomMessages() {},
 		model: { provider: "test", id: "test" },
 		_modelRuntime: { hasConfiguredAuth: () => true },
 		_findLastAssistantMessage: () => undefined,


### PR DESCRIPTION
Stack 10 on the pi 0.84.3 port (#2675-#2683). Ports upstream main through 8fa7eebd23: image MIME detector export (#8600), custom messages appended after the turn's tool results (with regression test), provider doc links, RPC queue clearing (with docs), and persisted-default retention in model scopes (reconciled with this stack's session-scoped model storage). ToolExecution*Event export (#6847) skipped as already-equivalent in Atomic's public API. 51/51 focused tests pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790274162&installation_model_id=10562&pr_number=2685&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2685&signature=76db106667344f3a3dbb568814287259db1e3c3d3cae0b981daa024252784bc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->















<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update expands coding-agent capabilities and documentation, refreshes the Pi runtime dependencies, and makes Cloudflare’s default Kimi model available through both Workers AI and AI Gateway when upstream catalog metadata is incomplete.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

No accepted blocking findings remain.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the focused Cloudflare catalog generator test against the prior generator and observed all three mocked Kimi metadata scenarios fail because the Workers AI and AI Gateway entries were absent.
- I then ran the same harness against the current generator and observed all three scenarios pass, including omitted metadata and tool\_call: false inputs for Workers AI and AI Gateway.
- The executable harness invokes scripts/generate-models.ts --json-only with mocked models.dev responses and reads the generated provider catalogs, demonstrating that the current implementation retains Kimi and only derives tool-capable Gateway entries.
- I inspected the before/after log artifacts to confirm the outcomes: the before output showed failures and undefined Kimi IDs/base URLs, while the after output showed all three scenarios passing.

<a href="https://app.greptile.com/trex/runs/20681867/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (8): Last reviewed commit: ["test(coding-agent): cover deferred custo..."](https://github.com/bastani-inc/atomic/commit/747eff29c6b187152a6efa0a760ccabc8b78d228) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56771161)</sub>

<!-- /greptile_comment -->