### PR TITLE
fix(coding-agent): register the thinking slash command

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 ### Fixed
 
+- Fixed `/thinking` being absent from slash-command autocomplete and added completions for the active model's available thinking levels.
+
 - Fixed the thinking-level selector so a capability-clamped default still receives the default badge when the saved setting is higher than the active model supports.
 - Failed extension loads now roll back provider registrations applied during that load instead of leaving an earlier provider in the runtime.
 - PowerShell cancellation now terminates the Windows process tree and returns without waiting on descendant-held stdout or stderr.

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -315,6 +315,7 @@ export function getBundledWorkflowArgumentCompletions(argumentPrefix: string): A
 export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "settings", description: "Open settings menu" },
 	{ name: "model", description: "Select model (opens selector UI)" },
+	{ name: "thinking", description: "Set thinking level", argumentHint: "<level>" },
 	{ name: "scoped-models", description: "Enable/disable models for ctrl+p cycling" },
 	{ name: "fast", description: "Configure Codex fast mode for chat and workflows" },
 	{ name: "export", description: "Export session (HTML default, or specify path: .html/.jsonl)" },

--- a/packages/coding-agent/src/modes/interactive/interactive-autocomplete.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-autocomplete.ts
@@ -288,6 +288,15 @@ InteractiveModeBase.prototype.createBaseAutocompleteProvider = function (
 		};
 	}
 
+	const thinkingCommand = slashCommands.find((command) => command.name === "thinking");
+	if (thinkingCommand) {
+		thinkingCommand.getArgumentCompletions = (prefix: string): AutocompleteItem[] | null => {
+			const levels = fuzzyFilter(this.session.getAvailableThinkingLevels(), prefix, (level) => level);
+			if (levels.length === 0) return null;
+			return levels.map((level) => ({ value: level, label: level }));
+		};
+	}
+
 	const loginCommand = slashCommands.find((command) => command.name === "login");
 	if (loginCommand) {
 		loginCommand.getArgumentCompletions = (prefix: string) =>

--- a/test/unit/slash-commands.test.ts
+++ b/test/unit/slash-commands.test.ts
@@ -11,6 +11,14 @@ describe("built-in slash commands", () => {
 		assert.equal(command.description, `Exit ${APP_NAME}`);
 	});
 
+	test("lists /thinking with its level argument", () => {
+		const command = BUILTIN_SLASH_COMMANDS.find((item) => item.name === "thinking");
+
+		assert.ok(command, "expected /thinking to be listed as a built-in command");
+		assert.equal(command.description, "Set thinking level");
+		assert.equal(command.argumentHint, "<level>");
+	});
+
 	test("removes /context-compact and keeps /compact as the compaction command", () => {
 		const contextCommand = BUILTIN_SLASH_COMMANDS.find((item) => item.name === "context-compact");
 		const compactCommand = BUILTIN_SLASH_COMMANDS.find((item) => item.name === "compact");


### PR DESCRIPTION
Adds the missing `/thinking` built-in slash-command registration and dynamic level completions. The submit handler was already present, but autocomplete is generated exclusively from `BUILTIN_SLASH_COMMANDS`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790285262&installation_model_id=10562&pr_number=2687&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2687&signature=977e6911420e83a2a3b1ccea7e827597cd93814d21af1d5186a6c9256989c797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `/thinking <level>` to interactive slash-command autocomplete and sources its argument suggestions from the active model's available thinking levels. It also adds command metadata coverage and documents the correction.

## T-Rex validation blocked

The focused autocomplete harness could not load the coding-agent runtime because the local `@bastani/pi-ai` package has no resolvable built entry point. Its required build is blocked by missing generated AI provider model data, so the interactive completion assertions did not run.

<h3>Confidence Score: 5/5</h3>

No product defect was confirmed in the changed command registration or completion wiring.

The final finding set is empty. Source inspection shows the command is registered with its level hint and completion values are retrieved from the active session before filtering; the focused runtime check was prevented by the missing local AI workspace build output.

**Files Needing Attention:** No code changes require author action. `packages/coding-agent/src/modes/interactive/interactive-autocomplete.ts` should be exercised once the local `@bastani/pi-ai` workspace can be built.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted to run the focused autocomplete harness test, but the run exited with status 1 before the test body could execute because the runtime entry for the dependency could not be resolved, and the captured output was written to the associated log.
- Validation was blocked before the test body ran because the harness source remained untracked, and the captured execution output was written to the same log.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(coding-agent): register the thinking..."](https://github.com/bastani-inc/atomic/commit/f413ea49552d338320927fb75f56a664c67a6d5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56843893)</sub>

<!-- /greptile_comment -->