### PR TITLE
test(coding-agent): give RPC bash cancellation tests real-shell headroom

### DIFF
--- a/packages/coding-agent/test/rpc-bash-session-replacement.test.ts
+++ b/packages/coding-agent/test/rpc-bash-session-replacement.test.ts
@@ -19,8 +19,10 @@ const RPC_OUTPUT_WAIT_TIMEOUT_MS = 10_000,
  * this bound is never waited out on the success path; it only has to exceed the
  * scheduling delay between `waitForOutput` returning and the abort landing. At
  * one second a loaded runner could let the tail through and fail spuriously.
- * Kept below the 30 s per-test budget so a genuinely broken abort fails on the
- * output assertion rather than by timing the test out.
+ * Kept below the 30 s per-test budget so a genuinely broken abort fails on an
+ * assertion rather than by timing the test out: the shell runs to completion,
+ * so the awaited result fails `cancelled: true` first, and the no-tail output
+ * assertion would fail after it.
  */
 const RPC_BASH_CANCEL_HEADROOM_SECONDS = 10;
 

--- a/packages/coding-agent/test/rpc-bash-session-replacement.test.ts
+++ b/packages/coding-agent/test/rpc-bash-session-replacement.test.ts
@@ -14,6 +14,22 @@ const RPC_OUTPUT_WAIT_TIMEOUT_MS = 10_000,
 	RPC_OUTPUT_POLL_INTERVAL_MS = 5;
 
 /**
+ * Real-shell headroom between the prefix these cancellation tests wait for and
+ * the tail they assert never arrives. Cancellation terminates the process, so
+ * this bound is never waited out on the success path; it only has to exceed the
+ * scheduling delay between `waitForOutput` returning and the abort landing. At
+ * one second a loaded runner could let the tail through and fail spuriously.
+ * Kept below the 30 s per-test budget so a genuinely broken abort fails on the
+ * output assertion rather than by timing the test out.
+ */
+const RPC_BASH_CANCEL_HEADROOM_SECONDS = 10;
+
+/** `printf <prefix>`, a cancellable gap, then a tail no assertion may observe. */
+function cancellableShellCommand(prefix: string, tail: string): string {
+	return `printf ${prefix}; sleep ${RPC_BASH_CANCEL_HEADROOM_SECONDS}; printf ${tail}`;
+}
+
+/**
  * Holds a bash command in flight until the test releases it.
  *
  * These tests must issue the session replacement *while* the execution is still
@@ -126,7 +142,7 @@ describe("RPC bash ownership across session replacement", () => {
 		const execution = context.handle({
 			id: "old-target",
 			type: "bash",
-			command: "printf old-start; sleep 1; printf old-end",
+			command: cancellableShellCommand("old-start", "old-end"),
 		});
 		await waitForOutput(context.output, "old-target", "old-start");
 		await context.handle({ id: "replace", type: "new_session" });
@@ -163,14 +179,14 @@ describe("RPC bash ownership across session replacement", () => {
 		const oldExecution = context.handle({
 			id: "old-all",
 			type: "bash",
-			command: "printf old-start; sleep 1; printf old-end",
+			command: cancellableShellCommand("old-start", "old-end"),
 		});
 		await waitForOutput(context.output, "old-all", "old-start");
 		await context.handle({ id: "replace", type: "new_session" });
 		const newExecution = context.handle({
 			id: "new-all",
 			type: "bash",
-			command: "printf new-start; sleep 1; printf new-end",
+			command: cancellableShellCommand("new-start", "new-end"),
 		});
 		await waitForOutput(context.output, "new-all", "new-start");
 		await context.handle({ id: "cancel-all", type: "abort_bash" });
@@ -371,7 +387,7 @@ describe("RPC bash ownership across session replacement", () => {
 			rebindSession: async () => {},
 			output: (event) => output.push(event),
 		});
-		const execution = handle({ id: "shutdown-bash", type: "bash", command: "printf start; sleep 1; printf end" });
+		const execution = handle({ id: "shutdown-bash", type: "bash", command: cancellableShellCommand("start", "end") });
 		await waitForOutput(output, "shutdown-bash", "start");
 		await handle.disposeActiveBash();
 		await expect(execution).resolves.toMatchObject({ success: true, data: { cancelled: true } });


### PR DESCRIPTION
## Summary

The RPC bash cancellation tests waited for a `printf` prefix, then asserted that a tail printed one second later never arrives. One second is not real-shell headroom: on a loaded runner the tail can land between `waitForOutput` returning and the abort taking effect, so the test fails for scheduling reasons rather than a cancellation defect.

## Change

Replaces the three inline `printf x; sleep 1; printf y` commands with a single documented constant and helper:

- `RPC_BASH_CANCEL_HEADROOM_SECONDS = 10` — comfortably above the scheduling gap, well below the suite's 30s per-test budget, so a genuinely broken abort still fails on the output assertion rather than by timing the test out.
- `cancellableShellCommand(prefix, tail)` — one shape for all three cancellation cases.

Cancellation terminates the process, so the longer delay is never waited out on the success path; it only widens the window in which a missed abort would be detected.

## Validation

`packages/coding-agent` focused suite:

```
Test Files  1 passed (1)
     Tests  7 passed (7)
```

`git diff --check` passes and exactly one tracked file changes.

## Notes

This follows the repository rule in `AGENTS.md` that a test which only passes on an idle machine is a bug in that test, fixed where it lives with a named constant rather than a bare literal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790295067&installation_model_id=10562&pr_number=2689&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2689&signature=1d84ae3dc80ed17b9a896de9cf35a1f85b830af1448fdda52da14a0c152d82ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The RPC bash session-replacement tests now share a delayed-tail shell command with sufficient cancellation headroom. The updated explanation correctly reflects that a failed cancellation first violates the awaited cancellation-result assertion before the later output assertion is reached.

<h3>Confidence Score: 5/5</h3>

Safe to merge: no blocking failure remains.

No blocking failure remains. The exercised shell behavior confirms that the ten-second delay preserves a cancellation window, and the documented assertion order matches the observed non-cancellation path.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused Node-and-Bash validation using the printf prefix; sleep seconds; printf tail pattern, with the exact script and command capture documented in the artifacts.
- In the one-second headroom test, cancellation arrived 1.2 seconds after the prefix, causing the process to emit prefixtail before exiting.
- In the ten-second headroom test, cancellation timing preserved the prefix and suppressed the tail, with SIGTERM ending the process after only the prefix.
- In the no-cancellation run, the output appeared as prefixtail with cancelled: false, indicating the cancelled: true expectation would fail before the later no-tail assertion.
- An attempt to run the focused Vitest suite was blocked before collection due to the unavailable @bastani/pi-ai/compat package, as shown in the blocker artifacts.

<a href="https://app.greptile.com/trex/runs/20714625/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(coding-agent): correct broken-abort..."](https://github.com/bastani-inc/atomic/commit/64eba6335f0f1ea9b93f70cd7d8f5dc31a5b911d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56894414)</sub>

<!-- /greptile_comment -->