### PR TITLE
chore(deps): take Atomic-only Dependabot bumps, hold pi-tracked pins

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -196,7 +196,7 @@ jobs:
       - name: Install cargo-zigbuild for portable Linux builds
         if: matrix.platform == 'linux'
         timeout-minutes: 3
-        uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
+        uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2.86.7
         with:
           tool: cargo-zigbuild@0.23.0
       - name: Install Windows cross-compile tooling
@@ -208,7 +208,7 @@ jobs:
       - name: Install cargo-xwin
         if: matrix.platform == 'win32'
         timeout-minutes: 3
-        uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
+        uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2.86.7
         with:
           tool: cargo-xwin@0.23.0
       # Pinned so the populate step, the build step, and actions/cache agree

--- a/.github/workflows/warm-toolchain-cache.yml
+++ b/.github/workflows/warm-toolchain-cache.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: Install cargo-xwin
         timeout-minutes: 3
-        uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
+        uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2.86.7
         with:
           tool: cargo-xwin@0.23.0
       - name: Resolve MSVC CRT cache directory

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.12.1"
+version = "3.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459197f1592f4c3dbbf9c1b13f5a4599a343e4ef66b96bc340e2a518b36a6662"
+checksum = "58c5f4d5375213fdb7be2655e152386e82f026f9a5ba36a75556e11359aafe09"
 dependencies = [
  "bitflags 2.13.0",
  "ctor",
@@ -848,9 +848,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.12"
+version = "0.26.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
+checksum = "17ebdd3a5a7e28a1890b876fdbd0c3c0fe0a6336cffaa104f11b9f720c9daa29"
 dependencies = [
  "cc",
  "regex",


### PR DESCRIPTION
Consolidates the Dependabot backlog after checking every open bump against upstream `earendil-works/pi` (`main` HEAD `8fa7eeb`, pi 0.84.3).

The rule applied: a pin that exists upstream tracks upstream, because `packages/ai` and `packages/coding-agent` are forks we resync. A pin that exists only in Atomic is ours to move, so it goes to the latest Dependabot announced.

## Taken here — Atomic-only

| Dependency | Bump | Why it is ours |
| --- | --- | --- |
| `napi` | 3.12.1 → 3.12.2 | upstream pi has no Rust workspace |
| `tree-sitter` | 0.26.12 → 0.26.13 | `crates/atomic-natives` does not exist upstream |
| `taiki-e/install-action` | 2.86.2 → 2.86.7 | installs `cargo-zigbuild`/`cargo-xwin` for a native module upstream does not build |

Supersedes #2642, #2643, #2645.

## Closed — tracks upstream

| PR | Bump | Upstream pi pins |
| --- | --- | --- |
| #2649 | `@aws-sdk/client-bedrock-runtime` 3.1048.0 → 3.1118.0 | **3.1048.0** |
| #2648 | `openai` 6.40.0 → 7.5.0 | **6.40.0** |
| #2647 | `vitest` 4.1.9 → 4.1.11 | **4.1.9** |

All three touch `packages/ai/package.json`, the fork boundary. Moving ahead of pi there buys nothing and costs conflicts on the next port; `openai` 6 → 7 is a provider-SDK major upstream has not taken. These land when pi adopts them.

I also checked the previously closed batch: `typebox` (1.3.7) and `grok-mermaid` (0.2.2) both still match upstream exactly, so nothing was left behind by those closures.

## Verification

- `cargo update --precise` used instead of applying the bot patches; resulting checksums match the Dependabot diffs byte for byte.
- `cargo check --locked --all-targets` — clean, so the lock agrees with the manifests.
- `npm run build` — native module compiles in release on the new crate graph.
- `npm run check` — biome, both typecheck passes, shrinkwrap check.
- `npm run test:ci-contracts` — 72/72, covering the workflow-topology and pinned-action contracts that read the two files edited here.
- `syntax-highlight`, `native-binding-exports`, `bash-pty-native`, `build-native-portability`, `shrinkwrap-atomic-natives` — 24/24.
- Action SHA `b6ff580856c41316412a0b9b60540fbc6f8c82cc` verified against tag `v2.86.7` via the GitHub API; 2.86.7 is the current latest release.

## No changelog entry

Build tooling and the native crate graph with no user-visible package behavior change, per the AGENTS.md infrastructure rule. Matches the precedent in `8aacccca06`, which bumped `napi` and this same action without a changelog entry.

No version was stamped — this is PR-only, per request.

Assistant-model: Claude Opus 5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790306769&installation_model_id=10562&pr_number=2694&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2694&signature=42d8b1da1b649ec421a66b9ca8103865eed59defe55e2edf8a30a67e8c6048b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change updates the SHA-pinned `taiki-e/install-action` used for native release tooling and refreshes the locked `napi` and `tree-sitter` Rust dependencies.

The potential native-build regression was disproved: `cargo check --locked --all-targets` completed successfully, the full workspace build completed successfully, and the compiled `@bastani/atomic-natives` module loaded at runtime with working `glob` and `grep` exports. No defects were found.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the updated Rust lockfile resolves, the native package builds, and the resulting binding loads and performs filesystem search operations correctly.

No final findings remain after exercising the changed native dependency path from locked compilation through runtime module loading.

**Files Needing Attention:** No files need further changes. The updated workflow pins and Cargo.lock entries are covered by the successful native build and runtime checks.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran cargo check --locked --all-targets from the repository root to verify the locked Rust dependency graph resolves.
- Completed the full build with npm run build, including compilation of @bastani/atomic-natives.
- Executed a native binding load-check script that requires the built package and exercises its glob and grep exports.
- Validated the native binding load output showing both exports are functions and return the expected glob paths and grep matches.

<a href="https://app.greptile.com/trex/runs/20735876/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): take Atomic-only Dependabot..."](https://github.com/bastani-inc/atomic/commit/3b53ba736c9845c2f393744df1360c10250686c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56938762)</sub>

<!-- /greptile_comment -->