### PR TITLE
docs(changelog): prepare 0.9.16-alpha.5 release notes

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,8 @@ This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history at t
 
 ## [Unreleased]
 
+## [0.9.16-alpha.5] - 2026-08-26
+
 ### Added
 
 - Added the DeepSeek V4 Flash Vision experimental model to generated catalogs.
@@ -14,6 +16,7 @@ This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history at t
 - Fixed OpenAI-compatible Chat Completions reasoning streams to concatenate incremental reasoning deltas instead of replacing earlier content ([#8605](https://github.com/earendil-works/pi/pull/8605)).
 - Fixed OpenRouter reasoning controls by deriving `off` support and available effort levels from model metadata, preventing reasoning-mandatory models from receiving `effort: "none"` ([#8454](https://github.com/earendil-works/pi/issues/8454)).
 - Fixed OpenAI-compatible Chat Completions requests sending `tool_choice` without tools, which gateways can reject during compaction ([#8607](https://github.com/earendil-works/pi/issues/8607)).
+
 ## [0.9.15] - 2026-08-21
 
 Cumulative release of the `0.9.15-alpha.1` prerelease. The summary below covers the user-visible outcome of that work; the per-change detail remains in the prerelease section below.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.16-alpha.5] - 2026-08-26
+
 ### Added
 
 - Added `/thinking [level]` plus searchable model and per-model thinking selectors. Selectors show saved defaults, search by model/provider/default state, order the current and default models first, and use `Ctrl+S` to persist a startup default while Enter changes only the current session ([#8399](https://github.com/earendil-works/pi/issues/8399)).
@@ -25,7 +27,6 @@
 ### Fixed
 
 - Fixed `/thinking` being absent from slash-command autocomplete and added completions for the active model's available thinking levels.
-
 - Fixed the thinking-level selector so a capability-clamped default still receives the default badge when the saved setting is higher than the active model supports.
 - Failed extension loads now roll back provider registrations applied during that load instead of leaving an earlier provider in the runtime.
 - PowerShell cancellation now terminates the Windows process tree and returns without waiting on descendant-held stdout or stderr.

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.16-alpha.5] - 2026-08-26
+
 ### Added
 
 - Concurrent blocking asks now use a correlation-keyed waiter registry, with configurable `maxPendingAsks` capacity, exact out-of-order reply and selective-disconnect settlement, and a structured refusal when full. Blocking supervisor decisions remain exclusive per child while coexisting with ordinary peer asks ([#2628](https://github.com/bastani-inc/atomic/issues/2628)).

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.16-alpha.5] - 2026-08-26
+
 ### Changed
 
 - Foreground subagent completion, failure, and interruption notifications now render as status-colored tool blocks while preserving their result preview, expansion hint, duration, and session path.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.16-alpha.5] - 2026-08-26
+
 ### Changed
 
 - Raised the public `workflow` tool request deadline from 30 seconds to two minutes. Timed-out requests still return `WORKFLOW_TIMEOUT` with `timeoutMs: 120000`, abort cancellable work, discard late settlement, and never retry. Mutating actions keep the unknown-outcome warning that tells callers to inspect workflow status before retrying ([#2654](https://github.com/bastani-inc/atomic/issues/2654)).


### PR DESCRIPTION
## Summary

Prepares the changelog for the `0.9.16-alpha.5` prerelease by promoting the accumulated `[Unreleased]` entries in each affected package into a dated `[0.9.16-alpha.5]` section. This is the changelog-only PR that must merge before the release tag is cut.

## Changes

- `packages/ai/CHANGELOG.md` — DeepSeek V4 Flash Vision catalog entry; Cloudflare AI Gateway typing, OpenAI-compatible reasoning-delta concatenation, OpenRouter reasoning-control derivation, and `tool_choice`-without-tools fixes.
- `packages/coding-agent/CHANGELOG.md` — `/thinking` and searchable model/thinking selectors, the Windows PowerShell tool, settings diagnostics, and compaction billing notices, plus the associated selector, autocomplete, and PowerShell rendering/cancellation fixes.
- `packages/intercom/CHANGELOG.md` — correlation-keyed waiter registry for concurrent blocking asks.
- `packages/subagents/CHANGELOG.md` — status-colored foreground subagent completion notifications.
- `packages/workflows/CHANGELOG.md` — public `workflow` tool request deadline raised to two minutes.

## Notes

- **Changelog-only diff.** No source, manifest, lockfile, Cargo, or generated version file is touched.
- The release base stays versionless: every `packages/*/package.json`, the workspace Cargo manifest, and the `@bastani/atomic-natives` pin remain at the `0.0.0` placeholder. Verified after committing.
- Already-released version sections are untouched; `test/unit/changelog.test.ts` re-verifies each released section against its tag.
- Validation: `test/unit/changelog.test.ts` and `test/unit/package-metadata.test.ts` (25 tests) ran green, and the pre-commit/pre-push hooks ran `npm run check` plus the full `test:unit`, `test:integration`, and `test:ci-contracts` suites — all passed.
- After this merges, `scripts/cut-release.ts 0.9.16-alpha.5 --base main --push` stamps the real version onto the detached `Release 0.9.16-alpha.5` commit and pushes the tag, which starts `publish.yml`. No tagging or publication happens in this PR.

Assistant-model: Claude Opus 5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790322997&installation_model_id=10562&pr_number=2698&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2698&signature=0be9fd61f162fa5df95301b6dd6a9db6af4ab628db67d9397740b50600475b0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prepares the `0.9.16-alpha.5` prerelease notes across the AI, coding-agent, Intercom, subagents, and workflows packages by moving accumulated entries into dated release sections.

The focused changelog and package-metadata tests passed on both the parent revision and this change. The possibility that the new release headings break release ordering, tag validation, or package metadata was disproved by the passing checks.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the change is limited to release-note organization and the repository's focused release validation passes.

No defects remain in the final review. The focused test command passed all 25 changelog and package-metadata tests against the updated release sections.

**Files Needing Attention:** No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Unit tests for changelog and package-metadata were run on both the parent revision and the PR head, and both runs exited with code 0 with all tests passing.
- The PR-head run parsed the added alpha.5 sections and validated them against locally available release tags.

<a href="https://app.greptile.com/trex/runs/20764754/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.16-alpha.5 ..."](https://github.com/bastani-inc/atomic/commit/45e8dd083ba739c7266e2044cce1f802515e6397) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56991051)</sub>

<!-- /greptile_comment -->