### PR TITLE
sync(pi): port post-8fa7eebd fixes from upstream pi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -303,3 +303,9 @@ evals/jobs/
 
 # subagent test scratch
 .atomic/subagents/
+
+# `bun build --compile` scratch files. Bun writes these beside the output and
+# removes them on success; an interrupted or failed compile leaves them behind.
+# An untracked one failed the 0.9.16-alpha.5 release preflight's clean-checkout
+# check, which is the only thing that ever notices them.
+.*.bun-build

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,11 @@ This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history at t
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI-compatible Chat Completions ignoring an explicitly requested `toolChoice` when no tools are defined ([#8649](https://github.com/earendil-works/pi/issues/8649), [#8638](https://github.com/earendil-works/pi/issues/8638)).
+- Fixed OpenAI-compatible streaming rewriting `thinkingSignature` on every `reasoning_details` delta. Replay metadata is buffered during streaming and serialized once when the thinking block is finalized, including on the error path ([#8671](https://github.com/earendil-works/pi/issues/8671)).
+
 ## [0.9.16-alpha.5] - 2026-08-26
 
 ### Added

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -347,6 +347,15 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 			timestamp: Date.now(),
 		};
 
+		// `reasoning_details` are replay metadata, not user-visible stream deltas.
+		// Keep them in memory during streaming and serialize once when the block is finalized.
+		let streamedReasoningDetails: OpenAIReasoningDetail[] | undefined;
+		const applyStreamedReasoningDetails = (block: ThinkingContent): void => {
+			if (streamedReasoningDetails !== undefined) {
+				block.thinkingSignature = JSON.stringify(streamedReasoningDetails);
+			}
+		};
+
 		const streamDeadline = createStreamDeadline(options?.streamDeadlineMs, options?.signal);
 
 		try {
@@ -448,6 +457,7 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 						partial: output,
 					});
 				} else if (block.type === "thinking") {
+					applyStreamedReasoningDetails(block);
 					stream.push({
 						type: "thinking_end",
 						contentIndex,
@@ -675,13 +685,12 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 					if (Array.isArray(reasoningDetails)) {
 						for (const detail of reasoningDetails) {
 							if (!isOpenAIReasoningDetail(detail)) continue;
-							const block = ensureThinkingBlock("");
-							const preservedDetails = parseOpenAIReasoningDetails(block.thinkingSignature) ?? [];
-							appendOpenAIReasoningDetail(preservedDetails, detail);
+							ensureThinkingBlock("");
+							streamedReasoningDetails ??= [];
 							// Keep provider replay data in the existing signature slot. OpenRouter streams
 							// reasoning_details as deltas: consecutive text/summary deltas are merged into
 							// logical entries, while encrypted entries remain opaque and discrete.
-							block.thinkingSignature = JSON.stringify(preservedDetails);
+							appendOpenAIReasoningDetail(streamedReasoningDetails, detail);
 						}
 					}
 				}
@@ -711,6 +720,9 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 			stream.end();
 		} catch (error) {
 			for (const block of output.content) {
+				if (block.type === "thinking") {
+					applyStreamedReasoningDetails(block);
+				}
 				delete (block as { index?: number }).index;
 				// Streaming scratch buffers are only used during parsing; never persist them.
 				delete (block as { partialArgs?: string }).partialArgs;
@@ -871,7 +883,7 @@ function buildParams(
 		applyAnthropicCacheControl(messages, params.tools, cacheControl);
 	}
 
-	if (options?.toolChoice && params.tools?.length) {
+	if (options?.toolChoice) {
 		params.tool_choice = options.toolChoice;
 	}
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -325,7 +325,7 @@ export interface AnthropicAllowedFallbackModel {
 
 // Unified options with reasoning passed to streamSimple() and completeSimple()
 export interface SimpleStreamOptions extends StreamOptions {
-	/** Provider-neutral tool selection for simple requests. Default: "auto". */
+	/** Provider-neutral tool selection for simple requests. When omitted, adapters use provider-specific behavior. */
 	toolChoice?: ToolChoice;
 	reasoning?: ThinkingLevel;
 	/** Ask a capable provider to return a durable handle and continue the request asynchronously. */

--- a/packages/ai/test/openai-completions-tool-choice.test.ts
+++ b/packages/ai/test/openai-completions-tool-choice.test.ts
@@ -150,7 +150,7 @@ describe("openai-completions tool_choice", () => {
 		expect(params.tools?.length ?? 0).toBeGreaterThan(0);
 	});
 
-	it("omits toolChoice when no tools are provided", async () => {
+	it("includes toolChoice when no tools are provided", async () => {
 		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
 		const model = { ...baseModel, api: "openai-completions" } as const;
 		let payload: unknown;
@@ -170,7 +170,7 @@ describe("openai-completions tool_choice", () => {
 		).result();
 
 		const params = (payload ?? mockState.lastParams) as { tool_choice?: string; tools?: unknown[] };
-		expect(params).not.toHaveProperty("tool_choice");
+		expect(params.tool_choice).toBe("none");
 		expect(params).not.toHaveProperty("tools");
 	});
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed compaction range planning and branch/session summaries forcing `toolChoice: "none"`, which sent `tool_choice` with no tools and could be rejected by gateways ([#8649](https://github.com/earendil-works/pi/issues/8649), [#8638](https://github.com/earendil-works/pi/issues/8638)).
+- Fixed Windows shell aborts crashing Atomic when `taskkill.exe` is not on `PATH`. Both `killProcessTree` and the detached-child guardian worker now spawn the System32 executable and consume the asynchronous spawn error ([#6596](https://github.com/earendil-works/pi/issues/6596)).
+- Fixed Windows `taskkill` spawning without `windowsHide`. Because the spawn is `detached`, Windows allocated and briefly flashed a console window on every process-tree kill.
+- Fixed session files whose final record has no trailing newline not being repaired on load, so a later append no longer concatenates onto that record.
+- Fixed toggling thinking-block visibility discarding partial Bash output. Rendered assistant messages are updated in place instead of rebuilding the chat and its live tool components ([#8611](https://github.com/earendil-works/pi/issues/8611)).
+
+### Changed
+
+- Documented `/thinking`, the Ctrl+S startup-default shortcut in the model and thinking pickers, and the `modelThinkingLevels` setting.
+
 ## [0.9.16-alpha.5] - 2026-08-26
 
 ### Added

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -176,9 +176,10 @@ Type `/` in the editor to trigger commands. [Extensions](#extensions) can regist
 | Command | Description |
 |---------|-------------|
 | `/login`, `/logout` | OAuth authentication |
-| `/model` | Switch models |
+| `/model` | Switch models; Ctrl+S in the picker saves the startup default |
+| `/thinking` | Switch thinking level; Ctrl+S in the picker saves the startup default |
 | `/scoped-models` | Enable/disable models for CTRL+P cycling |
-| `/settings` | Thinking level, theme, message delivery, transport |
+| `/settings` | Theme, message delivery, transport, and other preferences |
 | `/resume` | Pick from previous sessions |
 | `/new` | Start a new session |
 | `/name <name>` | Set session display name |

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -7,7 +7,7 @@ Atomic uses JSON settings files with project settings overriding global settings
 | `~/.atomic/agent/settings.json` | Global (all projects) |
 | `.atomic/settings.json` | Project (current directory) |
 
-Edit directly or use `/settings` for common options. Atomic also reads legacy `~/.pi/agent/settings.json` and `.pi/settings.json` as compatibility fallbacks, with `.atomic` paths taking precedence.
+Edit directly or use `/settings` for common options. To save startup model defaults interactively, use `/model` and press Ctrl+S on the desired model; to save the startup thinking level, use `/thinking` and press Ctrl+S. Atomic also reads legacy `~/.pi/agent/settings.json` and `.pi/settings.json` as compatibility fallbacks, with `.atomic` paths taking precedence.
 
 ## Project Trust
 
@@ -31,9 +31,10 @@ Settings and trust JSON files may start with a UTF-8 BOM, as commonly written by
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `defaultProvider` | string | - | Default provider (e.g., `"anthropic"`, `"openai"`) |
-| `defaultModel` | string | - | Default model ID |
-| `defaultThinkingLevel` | string | - | `"off"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"`; the active model must support the selected level |
+| `defaultProvider` | string | - | Startup provider (e.g., `"anthropic"`, `"openai"`; saved with Ctrl+S in `/model`, or edited manually) |
+| `defaultModel` | string | - | Startup model ID (saved with Ctrl+S in `/model`, or edited manually) |
+| `defaultThinkingLevel` | string | - | Startup thinking level (saved with Ctrl+S in `/thinking`, or edited manually): `"off"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"`; the active model must support the selected level |
+| `modelThinkingLevels` | object | - | Per-model startup thinking levels keyed by `"provider/modelId"`; configure from `/settings` → Default thinking level per model, or edit manually |
 | `hideThinkingBlock` | boolean | `false` | Hide thinking blocks in output |
 | `thinkingBudgets` | object | - | Custom token budgets per thinking level. Anthropic, Google, and Bedrock use these natively. OpenAI-compatible models use them when `compat.thinkingTokenBudgetField` (or `supportsThinkingTokenBudget`) is set. |
 | `showCacheMissNotices` | boolean | `false` | Show transcript notices for significant prompt-cache misses and billed compaction or branch-summary usage |

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -42,11 +42,12 @@ Type `/` in the editor to open command completion. Extensions can register custo
 | Command | Description |
 |---------|-------------|
 | `/login`, `/logout` | Manage OAuth or API-key credentials |
-| `/model` | Switch models |
+| `/model` | Switch models; Ctrl+S in the picker saves the startup default |
+| `/thinking` | Switch thinking level; Ctrl+S in the picker saves the startup default |
 | `/scoped-models` | Enable/disable models for CTRL+P cycling |
 | `/fast` | Toggle Codex fast mode for chat and workflow stages when supported OpenAI or shared ChatGPT Codex transport models are available |
 | `/workflow` | List/run workflows; manage runs (connect/inspect/pause/interrupt/quit/resume); reload workflow resources |
-| `/settings` | Thinking level, theme, message delivery, transport |
+| `/settings` | Theme, message delivery, transport, and other preferences |
 | `/resume` | Pick from previous sessions |
 | `/new` | Start a new session |
 | `/name <name>` | Set session display name |

--- a/packages/coding-agent/src/core/compaction/branch-summarization.ts
+++ b/packages/coding-agent/src/core/compaction/branch-summarization.ts
@@ -375,7 +375,6 @@ export async function generateBranchSummary(
 		signal,
 		cacheRetention: "none",
 		sessionId: uuidv7(),
-		toolChoice: "none",
 		...(budget.reasoning && budget.reasoning !== "off" ? { reasoning: budget.reasoning } : {}),
 	};
 	const response = await (async () => {

--- a/packages/coding-agent/src/core/compaction/range-planner.ts
+++ b/packages/coding-agent/src/core/compaction/range-planner.ts
@@ -279,7 +279,6 @@ export async function planDeletedLineRanges(
 		signal,
 		cacheRetention: "none",
 		sessionId: uuidv7(),
-		toolChoice: "none",
 		...(model.reasoning && reasoning && reasoning !== "off" ? { reasoning } : {}),
 	};
 	const retry = observeRetryActivity(options.callbacks);
@@ -316,8 +315,8 @@ export async function planDeletedLineRanges(
 		return providerFailureOutcome(options, model, response, text, message, false, retry.scheduled());
 	}
 	// Deliberately before truncated-range recovery, unlike upstream 97fa14e39c:
-	// a tool call despite `toolChoice: "none"` means the response derailed, so
-	// none of its partial ranges are salvaged.
+	// the planner request defines no tools, so a tool call is a derailed response
+	// and none of its partial ranges are salvaged.
 	if (response.content.some((block) => block.type === "toolCall")) {
 		return unusableOutcome(
 			options,

--- a/packages/coding-agent/src/core/compaction/session-summarization.ts
+++ b/packages/coding-agent/src/core/compaction/session-summarization.ts
@@ -111,7 +111,6 @@ export async function generateSessionSummary(
 		signal,
 		cacheRetention: "none",
 		sessionId: uuidv7(),
-		toolChoice: "none",
 	};
 	const response = await (async () => {
 		try {

--- a/packages/coding-agent/src/core/session-manager-storage.ts
+++ b/packages/coding-agent/src/core/session-manager-storage.ts
@@ -41,11 +41,11 @@ export function loadEntriesFromFile(filePath: string): FileEntry[] {
 	if (!existsSync(resolvedFilePath)) return [];
 
 	const entries: FileEntry[] = [];
+	let pending = "";
 	const fd = openSync(resolvedFilePath, "r");
 	try {
 		const decoder = new StringDecoder("utf8");
 		const buffer = Buffer.allocUnsafe(SESSION_READ_BUFFER_SIZE);
-		let pending = "";
 
 		while (true) {
 			const bytesRead = readSync(fd, buffer, 0, buffer.length, null);
@@ -70,13 +70,14 @@ export function loadEntriesFromFile(filePath: string): FileEntry[] {
 		closeSync(fd);
 	}
 
-	// Validate session header
+	// Validate session header before repairing the file.
 	if (entries.length === 0) return entries;
 	const header = entries[0];
 	if (header.type !== "session" || !("id" in header) || typeof header.id !== "string") {
 		return [];
 	}
 
+	if (pending) appendFileSync(resolvedFilePath, "\n");
 	return entries;
 }
 

--- a/packages/coding-agent/src/modes/interactive/interactive-editor-actions.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-editor-actions.ts
@@ -2,6 +2,7 @@ import { StartupIdentityComponent } from "./components/startup-identity.ts";
 import { InteractiveModeBase } from "./interactive-mode-base.ts";
 import {
 	APP_NAME,
+	AssistantMessageComponent,
 	CHANGELOG_URL,
 	DynamicBorder,
 	getCapabilities,
@@ -82,21 +83,20 @@ InteractiveModeBase.prototype.setToolsExpanded = function (this: InteractiveMode
 	this.ui.requestRender();
 };
 
+/** Update rendered assistant messages without rebuilding live tool components. */
+InteractiveModeBase.prototype.updateThinkingBlockVisibility = function (this: InteractiveModeBase): void {
+	for (const child of this.chatContainer.children) {
+		if (child instanceof AssistantMessageComponent) {
+			child.setHideThinkingBlock(this.hideThinkingBlock);
+		}
+	}
+	this.ui.requestRender();
+};
+
 InteractiveModeBase.prototype.toggleThinkingBlockVisibility = function (this: InteractiveModeBase): void {
 	this.hideThinkingBlock = !this.hideThinkingBlock;
 	this.settingsManager.setHideThinkingBlock(this.hideThinkingBlock);
-
-	// Rebuild chat from session messages
-	this.chatContainer.clear();
-	this.rebuildChatFromMessages();
-
-	// If streaming, re-add the streaming component with updated visibility and re-render
-	if (this.streamingComponent && this.streamingMessage) {
-		this.streamingComponent.setHideThinkingBlock(this.hideThinkingBlock);
-		this.streamingComponent.updateContent(this.streamingMessage);
-		this.chatContainer.addChild(this.streamingComponent);
-	}
-
+	this.updateThinkingBlockVisibility();
 	this.showStatus(`Thinking blocks: ${this.hideThinkingBlock ? "hidden" : "visible"}`);
 };
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-surface.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-surface.ts
@@ -301,6 +301,7 @@ declare module "./interactive-mode-base.ts" {
 		toggleToolOutputExpansion(): void;
 		setToolsExpanded(expanded: boolean): void;
 		toggleThinkingBlockVisibility(): void;
+		updateThinkingBlockVisibility(): void;
 		openExternalEditor(): Promise<void>;
 		clearEditor(): void;
 		showError(errorMessage: string): void;

--- a/packages/coding-agent/src/modes/interactive/interactive-selectors.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-selectors.ts
@@ -1,6 +1,5 @@
 import { InteractiveModeBase } from "./interactive-mode-base.ts";
 import {
-	AssistantMessageComponent,
 	type Component,
 	configureHttpDispatcher,
 	FastModeSelectorComponent,
@@ -187,13 +186,7 @@ InteractiveModeBase.prototype.showSettingsSelector = function (this: Interactive
 				onHideThinkingBlockChange: (hidden) => {
 					this.hideThinkingBlock = hidden;
 					this.settingsManager.setHideThinkingBlock(hidden);
-					for (const child of this.chatContainer.children) {
-						if (child instanceof AssistantMessageComponent) {
-							child.setHideThinkingBlock(hidden);
-						}
-					}
-					this.chatContainer.clear();
-					this.rebuildChatFromMessages();
+					this.updateThinkingBlockVisibility();
 				},
 				onMermaidRenderingModeChange: (mode) => {
 					this.settingsManager.setMermaidRenderingMode(mode);

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { delimiter } from "node:path";
+import { delimiter, join } from "node:path";
 import { Worker } from "node:worker_threads";
 import { spawn, spawnSync } from "child_process";
 import { getBinDir } from "../config.ts";
@@ -209,6 +209,7 @@ const PARENT_GUARDIAN_SOURCE = `
 const { parentPort, workerData } = require("node:worker_threads");
 const { spawn } = require("node:child_process");
 const { existsSync } = require("node:fs");
+const { join } = require("node:path");
 const tracked = new Set();
 parentPort.on("message", ({ action, pid }) => {
   if (action === "track") tracked.add(pid);
@@ -216,7 +217,13 @@ parentPort.on("message", ({ action, pid }) => {
 });
 function killTree(pid) {
   if (process.platform === "win32") {
-    try { spawn("taskkill", ["/F", "/T", "/PID", String(pid)], { stdio: "ignore", detached: true, env: { ...process.env, AI_AGENT: workerData.aiAgent } }); } catch {}
+    // Same System32 hardening as killProcessTree: PATH is not trusted here, and an
+    // unconsumed async "error" from a failed spawn would take the guardian thread
+    // down and leak every detached child it exists to reap.
+    try {
+      const child = spawn(join(process.env.SystemRoot || "C:\\\\Windows", "System32", "taskkill.exe"), ["/F", "/T", "/PID", String(pid)], { stdio: "ignore", detached: true, windowsHide: true, env: { ...process.env, AI_AGENT: workerData.aiAgent } });
+      child.once("error", () => {});
+    } catch {}
     return;
   }
   try { process.kill(-pid, "SIGKILL"); }
@@ -277,15 +284,25 @@ export function killTrackedDetachedChildren(): void {
  */
 export function killProcessTree(pid: number): void {
 	if (process.platform === "win32") {
-		// Use taskkill on Windows to kill process tree
+		// Use the trusted System32 executable so cleanup does not depend on PATH.
 		try {
-			spawn("taskkill", ["/F", "/T", "/PID", String(pid)], {
-				stdio: "ignore",
-				detached: true,
-				env: createChildProcessEnvironment(),
-			});
+			const child = spawn(
+				join(process.env.SystemRoot ?? "C:\\Windows", "System32", "taskkill.exe"),
+				["/F", "/T", "/PID", String(pid)],
+				{
+					stdio: "ignore",
+					detached: true,
+					// `detached` gives the child its own console on Windows unless this is
+					// set, so omitting it both flashes a window and pays for a console
+					// allocation on every tree kill. Every other spawn in the fork sets it.
+					windowsHide: true,
+					env: createChildProcessEnvironment(),
+				},
+			);
+			// A failed spawn emits "error" asynchronously; consume it to avoid crashing Node.
+			child.once("error", () => {});
 		} catch {
-			// Ignore errors if taskkill fails
+			// Ignore errors if taskkill fails.
 		}
 	} else {
 		// Use SIGKILL on Unix/Linux/Mac

--- a/packages/coding-agent/test/branch-summarization.test.ts
+++ b/packages/coding-agent/test/branch-summarization.test.ts
@@ -134,7 +134,7 @@ describe("safe prose summarization", () => {
 	it.each([
 		["branch", generateBranchSummary],
 		["session", generateSessionSummary],
-	] as const)("disables tools for %s summaries", async (_label, summarize) => {
+	] as const)("does not override tool choice for %s summaries", async (_label, summarize) => {
 		resetIds();
 		let requestOptions: import("@bastani/pi-ai/compat").SimpleStreamOptions | undefined;
 		await summarize([entry(user("summarize safely"))], {
@@ -147,7 +147,7 @@ describe("safe prose summarization", () => {
 				return stream;
 			},
 		});
-		expect(requestOptions?.toolChoice).toBe("none");
+		expect(requestOptions?.toolChoice).toBeUndefined();
 	});
 
 	it.each([

--- a/packages/coding-agent/test/session-manager/file-operations.test.ts
+++ b/packages/coding-agent/test/session-manager/file-operations.test.ts
@@ -66,6 +66,36 @@ describe("loadEntriesFromFile", () => {
 		expect(entries).toHaveLength(2);
 	});
 
+	it("adds a newline after an unterminated valid record", () => {
+		const file = join(tempDir, "unterminated.jsonl");
+		const content =
+			'{"type":"session","id":"abc","timestamp":"2025-01-01T00:00:00Z","cwd":"/tmp"}\n' +
+			'{"type":"message","id":"1","parentId":null,"timestamp":"2025-01-01T00:00:01Z","message":{"role":"user","content":"hi","timestamp":1}}';
+		writeFileSync(file, content);
+
+		expect(loadEntriesFromFile(file)).toHaveLength(2);
+		expect(readFileSync(file, "utf8")).toBe(`${content}\n`);
+	});
+
+	it("adds a newline after an unterminated malformed final fragment", () => {
+		const file = join(tempDir, "malformed-tail.jsonl");
+		const content =
+			'{"type":"session","id":"abc","timestamp":"2025-01-01T00:00:00Z","cwd":"/tmp"}\n' + '{"type":"message"';
+		writeFileSync(file, content);
+
+		expect(loadEntriesFromFile(file)).toHaveLength(1);
+		expect(readFileSync(file, "utf8")).toBe(`${content}\n`);
+	});
+
+	it("does not modify an unterminated non-session file", () => {
+		const file = join(tempDir, "invalid.jsonl");
+		const content = '{"type":"message","id":"1"}';
+		writeFileSync(file, content);
+
+		expect(loadEntriesFromFile(file)).toEqual([]);
+		expect(readFileSync(file, "utf8")).toBe(content);
+	});
+
 	it("opens session files larger than Node's max string length", () => {
 		const file = join(tempDir, "large.jsonl");
 		writeFileSync(

--- a/packages/coding-agent/test/suite/regressions/6596-taskkill-enoent.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6596-taskkill-enoent.test.ts
@@ -1,0 +1,97 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }));
+
+vi.mock("child_process", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("child_process")>();
+	return { ...actual, spawn: spawnMock };
+});
+
+import { killProcessTree } from "../../../src/utils/shell.ts";
+
+function withWindowsPlatform(test: () => void): void {
+	const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+	try {
+		Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+		test();
+	} finally {
+		if (platformDescriptor) Object.defineProperty(process, "platform", platformDescriptor);
+	}
+}
+
+afterEach(() => {
+	spawnMock.mockReset();
+});
+
+describe("issue #6596 taskkill spawn failures", () => {
+	it("uses System32 taskkill and consumes its asynchronous spawn error", () => {
+		const child = new EventEmitter() as ChildProcess;
+		const previousSystemRoot = process.env.SystemRoot;
+		process.env.SystemRoot = "C:\\CustomWindows";
+		spawnMock.mockReturnValue(child);
+
+		try {
+			withWindowsPlatform(() => {
+				killProcessTree(1234);
+			});
+		} finally {
+			if (previousSystemRoot === undefined) delete process.env.SystemRoot;
+			else process.env.SystemRoot = previousSystemRoot;
+		}
+
+		// Atomic also passes a curated child environment, which upstream does not, so
+		// the options are matched on the fields this regression is about rather than
+		// exactly. `windowsHide` is asserted because `detached` otherwise gives the
+		// child its own console window on Windows.
+		expect(spawnMock).toHaveBeenCalledWith(
+			join("C:\\CustomWindows", "System32", "taskkill.exe"),
+			["/F", "/T", "/PID", "1234"],
+			expect.objectContaining({ detached: true, stdio: "ignore", windowsHide: true }),
+		);
+		expect(() => child.emit("error", new Error("spawn taskkill ENOENT"))).not.toThrow();
+	});
+
+	it("falls back to C:\\Windows when SystemRoot is unset", () => {
+		const child = new EventEmitter() as ChildProcess;
+		const previousSystemRoot = process.env.SystemRoot;
+		delete process.env.SystemRoot;
+		spawnMock.mockReturnValue(child);
+
+		try {
+			withWindowsPlatform(() => {
+				killProcessTree(4321);
+			});
+		} finally {
+			if (previousSystemRoot !== undefined) process.env.SystemRoot = previousSystemRoot;
+		}
+
+		expect(spawnMock).toHaveBeenCalledWith(
+			join("C:\\Windows", "System32", "taskkill.exe"),
+			["/F", "/T", "/PID", "4321"],
+			expect.objectContaining({ detached: true, stdio: "ignore", windowsHide: true }),
+		);
+	});
+
+	/**
+	 * Atomic reaps detached children from a worker thread that upstream does not
+	 * have, and it spawned bare `taskkill` with no error listener. A failed spawn
+	 * there takes the guardian thread down and leaks every child it exists to reap,
+	 * so the worker source carries the same hardening as killProcessTree.
+	 */
+	it("hardens taskkill in the detached-child guardian worker source", async () => {
+		const { readFileSync } = await import("node:fs");
+		const shellSource = readFileSync(new URL("../../../src/utils/shell.ts", import.meta.url), "utf8");
+		const guardian = /const PARENT_GUARDIAN_SOURCE = `([\s\S]*?)`;/u.exec(shellSource);
+		expect(guardian).not.toBeNull();
+
+		const workerSource: string = (guardian as RegExpExecArray)[1] as string;
+		expect(workerSource).toContain('require("node:path")');
+		expect(workerSource).toContain('"System32", "taskkill.exe"');
+		expect(workerSource).toMatch(/child\.once\("error"/u);
+		expect(workerSource).toContain("windowsHide: true");
+		expect(workerSource).not.toMatch(/spawn\("taskkill"/u);
+	});
+});


### PR DESCRIPTION
Ports the upstream `earendil-works/pi` commits after `8fa7eebd` that land in packages we actually own.

## Scope

| Commit | Ported | Why |
| --- | --- | --- |
| `7aab6c26e` fix(ai): serialize thinking signature once | ✅ | `packages/ai` is forked as `@bastani/pi-ai` — only arrives by hand |
| `6b36eb592` remove explicit tool choice from compaction | ✅ | spans `packages/ai` + coding-agent, both ours |
| `0b5ee5d8b` repair unterminated session files | ✅ | |
| `b07e17faa` preserve partial Bash output on thinking toggle | ✅ | |
| `7af2d27dc` Windows taskkill spawn crashes | ✅ coding-agent half | `packages/agent` half arrives via `pi-agent-core` bump |
| `42f7f29ad` docs(settings) | ✅ adapted | our docs are Atomic-branded; substance applied, not the diff |
| `b37ebb7f2`, `6c4f36026`, `1ac6128e6` fix(tui) | ⛔ | `packages/tui` only |
| `e86823096` terminal capability overrides | ⛔ | references a pi-tui export absent from 0.84.3 |
| `938109e72` chore: changelog | ⛔ | upstream changelogs; ours written separately |

`@earendil-works/pi-tui` and `pi-agent-core` are dependencies pinned at `^0.84.3` and `0.84.3` is the latest published, so the excluded TUI work reaches us on a version bump rather than a port.

## Divergences worth review

**Compaction split three ways.** Upstream removed `toolChoice: "none"` from a single `completeSummarization` in `compaction.ts`. This fork split that into `range-planner.ts`, `session-summarization.ts` and `branch-summarization.ts`. None of the three passes tools, so once the `packages/ai` half honors an explicit `toolChoice`, all three would have started sending `tool_choice` with no tools — the exact gateway rejection (#8607) that the ai-side guard had been masking. Removing all three is what makes the ai half safe; the halves cannot land separately.

**The range planner's tool-call guard is kept.** Its comment justified it via `toolChoice: "none"`, which goes stale here, so the comment is rewritten rather than the guard removed. Upstream kept its equivalent guard in this same commit. It is not dead code: `openai-completions.ts:654` handles `choice.delta.tool_calls` unconditionally, with no check that tools were sent, so a gateway or proxy can still return one. Without the guard the planner falls through to truncated-range recovery and salvages partial ranges from a derailed response — and the planner's output is a list of transcript lines to *delete*.

**A second taskkill call site.** This fork reaps detached children from a guardian worker thread that upstream does not have, and it spawned bare `taskkill` with no error listener. A failed spawn there takes the guardian down and leaks every child it exists to reap, so it gets the same System32 + consumed-error hardening.

## Beyond the upstream diff

**`windowsHide` on both taskkill spawns.** Upstream's version has it; ours never did — `git log -S windowsHide` finds it has never appeared in `shell.ts`, while every other spawn in the fork sets it (`bash.ts`, `powershell.ts`, `child-process.ts`, `resolve-config-value.ts`, `windows-directory-security.ts`). Since the spawn is `detached`, Windows was allocating and briefly flashing a console window on every process-tree kill. Not a tradeoff against `env` — the two options are orthogonal.

**`.gitignore` for `.*.bun-build`.** An interrupted `bun build --compile` leaves these behind, and one failed the `0.9.16-alpha.5` release preflight's clean-checkout check.

## Verification

- `tsc --noEmit` and the package typecheck clean; `biome check` clean
- ported regression + session-manager + branch-summarization suites: 37/37
- `packages/ai` tool-choice suite: 47/47
- 605 compaction / summarization / thinking / session tests pass
- `test:ci-contracts`: 72/72
- The 3 failures in `generate-models-cloudflare-gateway.test.ts` are **pre-existing on this base**, confirmed by re-running them against a stashed tree.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790354314&installation_model_id=10562&pr_number=2702&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2702&signature=e7b8ffba0b5227e1a3f860981e0835554673cc939520e4d9ca9e8cba7ff13298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change improves OpenAI-compatible tool-choice and reasoning metadata handling, removes forced tool-choice settings from compaction requests, repairs incomplete session JSONL files, preserves live tool output while thinking state updates, and hardens Windows process-tree cleanup.

A read-only session archive can still become unavailable when its final JSONL record lacks a newline: the loader parses the record and then attempts to write the repair newline, so opening or forking the session fails if the archive cannot be modified.

### T-Rex validation blocked
Tool limitation: the authored read-only fixture was rejected by the project's path-normalization layer with `EACCES` before the storage loader could execute its repair append. Writable-path execution confirmed that an unterminated final record is parsed, opened, forked, and repaired successfully; the targeted session-manager test file also passed 24 tests.

<h3>Confidence Score: 4/5</h3>

Not merge-safe until loading and forking valid read-only session archives no longer require modifying the source file.

There is one independent P1 non-security finding. Under the required scoring table, one non-security P1 results in a confidence score of 4.

**Files Needing Attention:** packages/coding-agent/src/core/session-manager-storage.ts needs attention at the newline-repair write, along with its callers in session opening and session forking.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- During general-contract-validation-proof, T-Rex observed that the authored mode-0444 session fixture could be read directly, but the project path-normalization layer returned EACCES before loadEntriesFromFile reached appendFileSync.
- A writable comparison run loaded one entry, opened and forked the session, and added the trailing newline.
- The Vitest run for test/session-manager/file-operations.test.ts completed with all 24 tests passing.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/src/core/session-manager-storage.ts:80
**Repair write breaks loading**

When a readable session has an unterminated final record on read-only storage, `appendFileSync` throws during repair, causing `SessionManager.open` and session forking to fail even though the session was parsed successfully.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["sync(pi): port post-8fa7eebd fixes from ..."](https://github.com/bastani-inc/atomic/commit/231d939380c563d77c9e879e4c2f337ae88a8236) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57147271)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->