### PR TITLE
docs(changelog): fold post-prep fixes into 0.9.16-alpha.5 notes

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,11 +4,6 @@ This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history at t
 
 ## [Unreleased]
 
-### Fixed
-
-- Fixed OpenAI-compatible Chat Completions ignoring an explicitly requested `toolChoice` when no tools are defined ([#8649](https://github.com/earendil-works/pi/issues/8649), [#8638](https://github.com/earendil-works/pi/issues/8638)).
-- Fixed OpenAI-compatible streaming rewriting `thinkingSignature` on every `reasoning_details` delta. Replay metadata is buffered during streaming and serialized once when the thinking block is finalized, including on the error path ([#8671](https://github.com/earendil-works/pi/issues/8671)).
-
 ## [0.9.16-alpha.5] - 2026-08-26
 
 ### Added
@@ -21,6 +16,8 @@ This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history at t
 - Fixed OpenAI-compatible Chat Completions reasoning streams to concatenate incremental reasoning deltas instead of replacing earlier content ([#8605](https://github.com/earendil-works/pi/pull/8605)).
 - Fixed OpenRouter reasoning controls by deriving `off` support and available effort levels from model metadata, preventing reasoning-mandatory models from receiving `effort: "none"` ([#8454](https://github.com/earendil-works/pi/issues/8454)).
 - Fixed OpenAI-compatible Chat Completions requests sending `tool_choice` without tools, which gateways can reject during compaction ([#8607](https://github.com/earendil-works/pi/issues/8607)).
+- Fixed OpenAI-compatible Chat Completions ignoring an explicitly requested `toolChoice` when no tools are defined ([#8649](https://github.com/earendil-works/pi/issues/8649), [#8638](https://github.com/earendil-works/pi/issues/8638)).
+- Fixed OpenAI-compatible streaming rewriting `thinkingSignature` on every `reasoning_details` delta. Replay metadata is buffered during streaming and serialized once when the thinking block is finalized, including on the error path ([#8671](https://github.com/earendil-works/pi/issues/8671)).
 
 ## [0.9.15] - 2026-08-21
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,18 +2,6 @@
 
 ## [Unreleased]
 
-### Fixed
-
-- Fixed compaction range planning and branch/session summaries forcing `toolChoice: "none"`, which sent `tool_choice` with no tools and could be rejected by gateways ([#8649](https://github.com/earendil-works/pi/issues/8649), [#8638](https://github.com/earendil-works/pi/issues/8638)).
-- Fixed Windows shell aborts crashing Atomic when `taskkill.exe` is not on `PATH`. Both `killProcessTree` and the detached-child guardian worker now spawn the System32 executable and consume the asynchronous spawn error ([#6596](https://github.com/earendil-works/pi/issues/6596)).
-- Fixed Windows `taskkill` spawning without `windowsHide`. Because the spawn is `detached`, Windows allocated and briefly flashed a console window on every process-tree kill.
-- Fixed session files whose final record has no trailing newline not being repaired on load, so a later append no longer concatenates onto that record.
-- Fixed toggling thinking-block visibility discarding partial Bash output. Rendered assistant messages are updated in place instead of rebuilding the chat and its live tool components ([#8611](https://github.com/earendil-works/pi/issues/8611)).
-
-### Changed
-
-- Documented `/thinking`, the Ctrl+S startup-default shortcut in the model and thinking pickers, and the `modelThinkingLevels` setting.
-
 ## [0.9.16-alpha.5] - 2026-08-26
 
 ### Added
@@ -35,6 +23,7 @@
 - Deferred uncommon syntax grammars until after first render to reduce interactive startup work while keeping common languages available immediately.
 - Extension examples whose intent is final settlement now listen for `agent_settled`; JSON mode exposes tool-call ID and tool name at stream start; session-share links use canonical terminal hyperlinks and perform GitHub authentication preflight before export ([#8242](https://github.com/earendil-works/pi/issues/8242), [#7953](https://github.com/earendil-works/pi/issues/7953)).
 - Compaction now reports truthful aggregate planner usage notices, including multi-attempt Verbatim planning, when cache-miss notices are enabled.
+- Documented `/thinking`, the Ctrl+S startup-default shortcut in the model and thinking pickers, and the `modelThinkingLevels` setting.
 
 ### Fixed
 
@@ -62,6 +51,11 @@
 - Fixed atomic managed-state rewrites resetting existing file permissions. `auth.json` and `models-store.json` are created owner-only (`0600`) but keep an administrator-managed mode across later rewrites instead of having it reset by the atomic replacement.
 - Fixed explicitly persisted default models disappearing from non-empty model scopes; persisted defaults are now added to both the active and saved scope.
 - Fixed extension messages sent with `triggerTurn: false` while the agent is running being inserted between a tool call and its result; they are now appended after the turn's tool results ([#8537](https://github.com/earendil-works/pi/issues/8537)).
+- Fixed compaction range planning and branch/session summaries forcing `toolChoice: "none"`, which sent `tool_choice` with no tools and could be rejected by gateways ([#8649](https://github.com/earendil-works/pi/issues/8649), [#8638](https://github.com/earendil-works/pi/issues/8638)).
+- Fixed Windows shell aborts crashing Atomic when `taskkill.exe` is not on `PATH`. Both `killProcessTree` and the detached-child guardian worker now spawn the System32 executable and consume the asynchronous spawn error ([#6596](https://github.com/earendil-works/pi/issues/6596)).
+- Fixed Windows `taskkill` spawning without `windowsHide`. Because the spawn is `detached`, Windows allocated and briefly flashed a console window on every process-tree kill.
+- Fixed session files whose final record has no trailing newline not being repaired on load, so a later append no longer concatenates onto that record.
+- Fixed toggling thinking-block visibility discarding partial Bash output. Rendered assistant messages are updated in place instead of rebuilding the chat and its live tool components ([#8611](https://github.com/earendil-works/pi/issues/8611)).
 
 ## [0.9.16-alpha.4] - 2026-08-23
 


### PR DESCRIPTION
## Summary

Follow-up changelog preparation for the `0.9.16-alpha.5` prerelease.

After #2698 prepared the `0.9.16-alpha.5` sections, two more commits landed on `main` and added entries under `## [Unreleased]`:

- cf509d541d — `fix(ci): retry rustup installs, push release tags by explicit refspec, drop pre-push gate` (#2701)
- cf8e453e1e — `sync(pi): port post-8fa7eebd fixes from upstream pi` (#2702)

This moves those user-facing entries into the pending `0.9.16-alpha.5` sections so the prerelease notes describe everything the tag will actually ship.

## Changes

`packages/ai/CHANGELOG.md` — two entries appended to the existing `### Fixed`:

- OpenAI-compatible Chat Completions ignoring an explicitly requested `toolChoice` when no tools are defined.
- OpenAI-compatible streaming rewriting `thinkingSignature` on every `reasoning_details` delta.

`packages/coding-agent/CHANGELOG.md` — one entry appended to the existing `### Changed` and five to the existing `### Fixed`:

- Documented `/thinking`, the Ctrl+S startup-default shortcut, and `modelThinkingLevels`.
- Compaction/summary `toolChoice: "none"` sending `tool_choice` with no tools.
- Windows aborts crashing when `taskkill.exe` is off `PATH`, plus the missing `windowsHide`.
- Session files whose final record lacks a trailing newline not being repaired on load.
- Thinking-block visibility toggling discarding partial Bash output.

Entries were appended to existing subsections rather than creating duplicate `### Fixed` / `### Changed` headings. `[Unreleased]` is now empty in both files.

## Release-section immutability

The `0.9.16-alpha.5` tag does not exist yet — locally or on `origin` — so these sections are still pending and editable. The newest tagged section, `0.9.16-alpha.4`, and everything below it are untouched. This is exactly the boundary `test/unit/changelog.test.ts` enforces: it anchors on the newest section that resolves to a tag and requires the tail to match that tag byte for byte.

## Validation

- Diff is changelog-only: `packages/ai/CHANGELOG.md`, `packages/coding-agent/CHANGELOG.md`. No other tracked or untracked changes.
- The versionless base is intact — all eight `packages/*/package.json`, every `packages/*` entry in `package-lock.json`, the `@bastani/atomic-natives` pin, the Cargo workspace version, `Cargo.lock`, and the `packages/natives/native/index.js` guards all remain at `0.0.0`. No version is stamped here; only `scripts/cut-release.ts` does that, on the detached `Release` commit after this merges.
- `bunx vitest --run --project unit test/unit/changelog.test.ts test/unit/pi-0.84.2-docs-contract.test.ts` — 32 passed.
- Full `npm run check` (biome, typecheck, shrinkwrap) ran green via the pre-commit hooks; no hooks were skipped.

One pre-existing, unrelated note: the test run warns that the compiled native binding is older than the Rust sources. It predates this branch and is untouched by a markdown-only change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790354706&installation_model_id=10562&pr_number=2703&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2703&signature=a7040dc867fafcef57679718ca8a9f1c12932bf4cfb31dc6350f086b50faae93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change creates `0.9.16-alpha.5` release-note sections for the AI and coding-agent packages, moving the intended post-preparation entries out of `Unreleased`. The release-note placement check confirmed that the two AI entries and six coding-agent entries occur once in their intended prerelease sections, with no stale moved entries under `Unreleased`. The focused changelog test suite also passed all 12 checks, and the changelog diff has no whitespace errors.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the release notes are correctly organized and the changelog contracts remain satisfied.

No defects remain in the final review. The focused validation exercised the release-note placement and ordering requirements, including the previously invalid placement condition, and verified the corrected result.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the authored release-note placement contract against the base revision and observed the expected failure for Unreleased entries.
- Ran the same contract from greptile-base to HEAD and confirmed both changelogs passed the placement, unique-heading, ordering, and moved-entry checks.
- Executed the changelog unit tests; all 12 tests passed.

<a href="https://app.greptile.com/trex/runs/20842398/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): fold post-prep fixes in..."](https://github.com/bastani-inc/atomic/commit/f810cec4390c3bfb61a1df2718fd6d3c5e3e94d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57149702)</sub>

<!-- /greptile_comment -->