### PR TITLE
fix(test): repair fallout from the compaction toolChoice removal

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,11 +4,6 @@ This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history at t
 
 ## [Unreleased]
 
-### Fixed
-
-- Fixed OpenAI-compatible Chat Completions ignoring an explicitly requested `toolChoice` when no tools are defined ([#8649](https://github.com/earendil-works/pi/issues/8649), [#8638](https://github.com/earendil-works/pi/issues/8638)).
-- Fixed OpenAI-compatible streaming rewriting `thinkingSignature` on every `reasoning_details` delta. Replay metadata is buffered during streaming and serialized once when the thinking block is finalized, including on the error path ([#8671](https://github.com/earendil-works/pi/issues/8671)).
-
 ## [0.9.16-alpha.5] - 2026-08-26
 
 ### Added
@@ -21,6 +16,8 @@ This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history at t
 - Fixed OpenAI-compatible Chat Completions reasoning streams to concatenate incremental reasoning deltas instead of replacing earlier content ([#8605](https://github.com/earendil-works/pi/pull/8605)).
 - Fixed OpenRouter reasoning controls by deriving `off` support and available effort levels from model metadata, preventing reasoning-mandatory models from receiving `effort: "none"` ([#8454](https://github.com/earendil-works/pi/issues/8454)).
 - Fixed OpenAI-compatible Chat Completions requests sending `tool_choice` without tools, which gateways can reject during compaction ([#8607](https://github.com/earendil-works/pi/issues/8607)).
+- Fixed OpenAI-compatible Chat Completions ignoring an explicitly requested `toolChoice` when no tools are defined ([#8649](https://github.com/earendil-works/pi/issues/8649), [#8638](https://github.com/earendil-works/pi/issues/8638)).
+- Fixed OpenAI-compatible streaming rewriting `thinkingSignature` on every `reasoning_details` delta. Replay metadata is buffered during streaming and serialized once when the thinking block is finalized, including on the error path ([#8671](https://github.com/earendil-works/pi/issues/8671)).
 
 ## [0.9.15] - 2026-08-21
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,18 +2,6 @@
 
 ## [Unreleased]
 
-### Fixed
-
-- Fixed compaction range planning and branch/session summaries forcing `toolChoice: "none"`, which sent `tool_choice` with no tools and could be rejected by gateways ([#8649](https://github.com/earendil-works/pi/issues/8649), [#8638](https://github.com/earendil-works/pi/issues/8638)).
-- Fixed Windows shell aborts crashing Atomic when `taskkill.exe` is not on `PATH`. Both `killProcessTree` and the detached-child guardian worker now spawn the System32 executable and consume the asynchronous spawn error ([#6596](https://github.com/earendil-works/pi/issues/6596)).
-- Fixed Windows `taskkill` spawning without `windowsHide`. Because the spawn is `detached`, Windows allocated and briefly flashed a console window on every process-tree kill.
-- Fixed session files whose final record has no trailing newline not being repaired on load, so a later append no longer concatenates onto that record.
-- Fixed toggling thinking-block visibility discarding partial Bash output. Rendered assistant messages are updated in place instead of rebuilding the chat and its live tool components ([#8611](https://github.com/earendil-works/pi/issues/8611)).
-
-### Changed
-
-- Documented `/thinking`, the Ctrl+S startup-default shortcut in the model and thinking pickers, and the `modelThinkingLevels` setting.
-
 ## [0.9.16-alpha.5] - 2026-08-26
 
 ### Added
@@ -35,6 +23,7 @@
 - Deferred uncommon syntax grammars until after first render to reduce interactive startup work while keeping common languages available immediately.
 - Extension examples whose intent is final settlement now listen for `agent_settled`; JSON mode exposes tool-call ID and tool name at stream start; session-share links use canonical terminal hyperlinks and perform GitHub authentication preflight before export ([#8242](https://github.com/earendil-works/pi/issues/8242), [#7953](https://github.com/earendil-works/pi/issues/7953)).
 - Compaction now reports truthful aggregate planner usage notices, including multi-attempt Verbatim planning, when cache-miss notices are enabled.
+- Documented `/thinking`, the Ctrl+S startup-default shortcut in the model and thinking pickers, and the `modelThinkingLevels` setting.
 
 ### Fixed
 
@@ -62,6 +51,11 @@
 - Fixed atomic managed-state rewrites resetting existing file permissions. `auth.json` and `models-store.json` are created owner-only (`0600`) but keep an administrator-managed mode across later rewrites instead of having it reset by the atomic replacement.
 - Fixed explicitly persisted default models disappearing from non-empty model scopes; persisted defaults are now added to both the active and saved scope.
 - Fixed extension messages sent with `triggerTurn: false` while the agent is running being inserted between a tool call and its result; they are now appended after the turn's tool results ([#8537](https://github.com/earendil-works/pi/issues/8537)).
+- Fixed compaction range planning and branch/session summaries forcing `toolChoice: "none"`, which sent `tool_choice` with no tools and could be rejected by gateways ([#8649](https://github.com/earendil-works/pi/issues/8649), [#8638](https://github.com/earendil-works/pi/issues/8638)).
+- Fixed Windows shell aborts crashing Atomic when `taskkill.exe` is not on `PATH`. Both `killProcessTree` and the detached-child guardian worker now spawn the System32 executable and consume the asynchronous spawn error ([#6596](https://github.com/earendil-works/pi/issues/6596)).
+- Fixed Windows `taskkill` spawning without `windowsHide`. Because the spawn is `detached`, Windows allocated and briefly flashed a console window on every process-tree kill.
+- Fixed session files whose final record has no trailing newline not being repaired on load, so a later append no longer concatenates onto that record.
+- Fixed toggling thinking-block visibility discarding partial Bash output. Rendered assistant messages are updated in place instead of rebuilding the chat and its live tool components ([#8611](https://github.com/earendil-works/pi/issues/8611)).
 
 ## [0.9.16-alpha.4] - 2026-08-23
 

--- a/packages/coding-agent/test/verbatim-compaction-planning.test.ts
+++ b/packages/coding-agent/test/verbatim-compaction-planning.test.ts
@@ -299,7 +299,9 @@ describe("one-pass range planner", () => {
 		expect(calls[0].request.reasoning).toBe("medium");
 		expect("maxTokens" in calls[0].request).toBe(false);
 		expect(calls[0].request.cacheRetention).toBe("none");
-		expect(calls[0].request.toolChoice).toBe("none");
+		// The planner defines no tools, so it no longer forces `toolChoice: "none"`:
+		// sending tool_choice with no tools is what gateways reject (pi #8649/#8638).
+		expect(calls[0].request.toolChoice).toBeUndefined();
 		expect(calls[0].request.sessionId).toEqual(expect.any(String));
 		const firstSessionId = calls[0].request.sessionId;
 		await planDeletedLineRanges(prep.region, prep.parameters, planner(reasoningModel, "off", { apiKey: "key" }), 10, {

--- a/test/unit/interactive-engine-remote-input.test.ts
+++ b/test/unit/interactive-engine-remote-input.test.ts
@@ -190,7 +190,10 @@ function makeProductionThinkingHandler(
 	const editor = new CustomEditor({ requestRender: () => {} } as TUI, getEditorTheme(), keybindings);
 	const mode = Object.assign(Object.create(InteractiveModeBase.prototype), {
 		addTuiInputListener: () => () => {},
-		chatContainer: { clear: () => {} },
+		// `children` matches the real `Container` contract. The thinking toggle now
+		// updates rendered assistant messages in place rather than clearing and
+		// rebuilding the chat, so it reads this instead of only calling clear().
+		chatContainer: { children: [], clear: () => {} },
 		defaultEditor: editor,
 		hideThinkingBlock: false,
 		keybindings,
@@ -205,7 +208,7 @@ function makeProductionThinkingHandler(
 		showStatus: () => {},
 		streamingComponent: undefined,
 		streamingMessage: undefined,
-		ui: {},
+		ui: { requestRender: () => {} },
 	}) as InteractiveModeBase;
 	if (registerThinkingToggle) mode.setupKeyHandlers();
 	return { handler: (data) => mode.handleOverlayUnhandledInput(data), mode, settingWrites };


### PR DESCRIPTION
Repairs three tests that broke on `main` after #2702. CI caught what I did not.

## `verbatim-compaction-planning.test.ts`

Asserted the range planner sends `toolChoice: "none"`. #2702 removed that deliberately — the planner defines no tools, and sending `tool_choice` with no tools is exactly the gateway rejection the upstream fix targets.

When I removed it I grepped `packages/coding-agent/src` for `toolChoice` and **never grepped the test directories**, so I caught `branch-summarization.test.ts` and missed this one.

## `interactive-engine-remote-input.test.ts`

Two unhandled rejections through the thinking toggle:

```
TypeError: this.chatContainer.children is not iterable
TypeError: this.ui.requestRender is not a function
```

The host stub carried `chatContainer: { clear: () => {} }` and `ui: {}`, which sufficed while the toggle cleared and rebuilt the chat. It now updates rendered assistant messages in place, so it reads `chatContainer.children` and calls `ui.requestRender()`. Both are part of the real `Container` and `TUI` contracts — the stub was incomplete and the old path simply never asked.

Worth noting: vitest reported these as **unhandled errors, not failures**, so the file still showed `19 passed`. Only the run-level `Errors 1 error` line exposed it.

## Verification

| Suite | Result |
| --- | --- |
| `test:unit` | 7127 passed, **0 unhandled errors** |
| `test:integration` | 501 passed |
| `test:ci-contracts` | 72 passed |
| coding-agent suite | 3975 passed |

`tsc --noEmit` and `biome check` clean.

Unrelated and not addressed here: `test/unit/mcp-oauth-lifecycle-reset.test.ts` failed on the `main` run at 15032ms but passes locally in 2.98s — load sensitivity on a busy runner, not caused by these changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790357359&installation_model_id=10562&pr_number=2704&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2704&signature=7e00ed3cc0a75ac40c74b5027852eb62e891e7fb6e97a2a760842848603eee83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change updates compaction and thinking-visibility test expectations and moves pending release notes into the alpha.5 section.

One test-coverage issue remains: the Ctrl+T fixture does not verify that already-rendered assistant messages update in place or that a render is requested.

The released-notes concern was disproved. Git checks found no local or origin tag for `0.9.16-alpha.5` at either the base revision or this revision, and the repository’s released-changelog contract passed all 12 checks. The alpha.5 section is therefore still editable.

<h3>Confidence Score: 4/5</h3>

The behavior change is covered by focused tests, but the interactive thinking-toggle regression remains insufficiently protected.

There is one non-security P2 finding. The release-note concern was directly disproved through Git release-status checks and the changelog contract.

**Files Needing Attention:** test/unit/interactive-engine-remote-input.test.ts should assert the visible assistant-message update and render request triggered by Ctrl+T.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P2 finding and linked it to the corresponding review comment for finding details.
- The thinking-toggle production-path coverage harness was prepared and added to the proof artifacts to exercise the production path.
- The existing remote-input test output was captured as an artifact to provide test results with a linked URL for details.
- The production-path harness output was captured as an artifact to provide evidence of harness execution with a linked URL for details.

<a href="https://app.greptile.com/trex/runs/20851792/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
test/unit/interactive-engine-remote-input.test.ts:196
**Thinking-toggle update is untested**

The fixture provides no rendered assistant-message children and a no-op `requestRender`, so the Ctrl+T test can pass even if the in-place thinking visibility update is removed. A production-path harness confirmed that this fixture shape survives that mutation, while a real `AssistantMessageComponent` observes both the rendered text update and render request. Add a rendered assistant child and assert its thinking state changes and `requestRender` is called.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(test): repair fallout from the compa..."](https://github.com/bastani-inc/atomic/commit/b55f85088afd99bcfc2b99d67228650024548bbc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57167842)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->