### PR TITLE
docs(changelog): fold budget and heartbeat guidance into 0.9.16-alpha.5

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,16 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-### Changed
-
-- Agent guidance now treats "no budget" as the default for workflow runs. A `budget` is passed on `run`/`resume` only when the operator asked for a limit, and only the fields they named; otherwise the field is omitted so the workflow declaration and config resolve normally.
-- Agent guidance now assumes the existing 15-minute heartbeat cadence and does not shorten, lengthen, or disable it unless the operator asks. Heartbeats are documented as periodic alignment checks rather than failure signals, so a progressing run is not interrupted, re-capped, or polled in response to one.
-
 ## [0.9.16-alpha.5] - 2026-08-26
 
 ### Changed
 
 - Raised the public `workflow` tool request deadline from 30 seconds to two minutes. Timed-out requests still return `WORKFLOW_TIMEOUT` with `timeoutMs: 120000`, abort cancellable work, discard late settlement, and never retry. Mutating actions keep the unknown-outcome warning that tells callers to inspect workflow status before retrying ([#2654](https://github.com/bastani-inc/atomic/issues/2654)).
+- Agent guidance now treats "no budget" as the default for workflow runs. A `budget` is passed on `run`/`resume` only when the operator asked for a limit, and only the fields they named; otherwise the field is omitted so the workflow declaration and config resolve normally.
+- Agent guidance now assumes the existing 15-minute heartbeat cadence and does not shorten, lengthen, or disable it unless the operator asks. Heartbeats are documented as periodic alignment checks rather than failure signals, so a progressing run is not interrupted, re-capped, or polled in response to one.
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

Prepares the `0.9.16-alpha.5` prerelease notes. The workflow agent-guidance changes from #2705 landed on `main` after the release notes were prepared in #2698, so both entries sat under `[Unreleased]` even though they ship in this prerelease. This moves them into the `0.9.16-alpha.5` `### Changed` section.

## Changes

- `packages/workflows/CHANGELOG.md` — relocate the two agent-guidance entries (default "no budget" for workflow runs; assumed 15-minute heartbeat cadence) from `[Unreleased]` into `[0.9.16-alpha.5]`.

## Validation

- Diff is changelog-only: one file, +2/-5.
- Every release-stamped manifest remains at the versionless `0.0.0` placeholder — `packages/*/package.json`, the `package-lock.json` workspace entries, `Cargo.toml`/`Cargo.lock`, and `packages/natives/native/index.js`.
- `bunx vitest --run --project unit test/unit/changelog.test.ts` — 12 passed.
- `bunx vitest --run --project unit test/unit/package-metadata.test.ts` — 13 passed.
- Pre-commit hooks ran unskipped, including `npm run check`.

## Release

No version stamping happens here. `scripts/cut-release.ts` materializes `0.9.16-alpha.5` on the detached `Release` commit after this PR merges, and pushing that tag starts `publish.yml`.

Assistant-model: Claude Opus 5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790358733&installation_model_id=10562&pr_number=2706&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2706&signature=dc34c47872baa57c76e925737778603625cbd162a135392354519996a0361f75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moves the workflow budget-default and heartbeat-cadence guidance from `Unreleased` into the `0.9.16-alpha.5` release notes, leaving `Unreleased` empty for future changes.

A possible changelog or package-metadata regression was disproved: the exact moved entries were compared before and after the change, and the targeted changelog and package-metadata suites passed all 25 tests.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the release-note relocation preserves the guidance content and passes the relevant changelog and package metadata checks.

No actionable findings remain after the focused validation compared the moved entries across revisions and exercised the targeted test coverage successfully.

**Files Needing Attention:** None. `packages/workflows/CHANGELOG.md` was the only changed tracked file and its release-note structure was validated.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The workflow changelog was compared between the parent and PR and the entries moved intact from Unreleased to 0.9.16-alpha.5 → Changed.
- The targeted changelog and package metadata validation was run; the initial attempt failed because the generated pi-ai entrypoint was missing, and the issue was resolved after the pi-ai prerequisite build completed.
- After the prerequisite build, the targeted validation passed and all 25 tests in the test suite reported success.
- The PR diff and current package identity were reviewed to confirm that the release structure remained consistent after validation.

<a href="https://app.greptile.com/trex/runs/20856588/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): fold budget and heartbe..."](https://github.com/bastani-inc/atomic/commit/fbb2a514a0bd4834eece6effc815a870cac765d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57177954)</sub>

<!-- /greptile_comment -->