### PR TITLE
docs(changelog): fold budget and heartbeat guidance into 0.9.16-alpha.5

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,16 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-### Changed
-
-- Agent guidance now treats "no budget" as the default for workflow runs. A `budget` is passed on `run`/`resume` only when the operator asked for a limit, and only the fields they named; otherwise the field is omitted so the workflow declaration and config resolve normally.
-- Agent guidance now assumes the existing 15-minute heartbeat cadence and does not shorten, lengthen, or disable it unless the operator asks. Heartbeats are documented as periodic alignment checks rather than failure signals, so a progressing run is not interrupted, re-capped, or polled in response to one.
-
 ## [0.9.16-alpha.5] - 2026-08-26
 
 ### Changed
 
 - Raised the public `workflow` tool request deadline from 30 seconds to two minutes. Timed-out requests still return `WORKFLOW_TIMEOUT` with `timeoutMs: 120000`, abort cancellable work, discard late settlement, and never retry. Mutating actions keep the unknown-outcome warning that tells callers to inspect workflow status before retrying ([#2654](https://github.com/bastani-inc/atomic/issues/2654)).
+- Agent guidance now treats "no budget" as the default for workflow runs. A `budget` is passed on `run`/`resume` only when the operator asked for a limit, and only the fields they named; otherwise the field is omitted so the workflow declaration and config resolve normally.
+- Agent guidance now assumes the existing 15-minute heartbeat cadence and does not shorten, lengthen, or disable it unless the operator asks. Heartbeats are documented as periodic alignment checks rather than failure signals, so a progressing run is not interrupted, re-capped, or polled in response to one.
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

Prepares the `0.9.16-alpha.5` prerelease notes. The workflow agent-guidance changes from #2705 landed on `main` after the release notes were prepared in #2698, so both entries sat under `[Unreleased]` even though they ship in this prerelease. This moves them into the `0.9.16-alpha.5` `### Changed` section.

Re-prepared on a `main` that includes the README tool-description resync (#2707). The previous attempt (#2706) branched from `aa5edfd2bc`, which predates that fix, so its integration suite failed and the required `test` context could never report. That PR was closed; this one is branched directly on `29f7450`.

## Changes

- `packages/workflows/CHANGELOG.md` — relocate the two agent-guidance entries (default "no budget" for workflow runs; assumed 15-minute heartbeat cadence) from `[Unreleased]` into `[0.9.16-alpha.5]`.

## Validation

- Diff is changelog-only: one file, +2/-5.
- Every package manifest remains at the `0.0.0` placeholder (`packages/ai`, `coding-agent`, `intercom`, `mcp`, `natives`, `subagents`, `web-access`, `workflows`), as do the Cargo manifests and the `packages/natives/native/index.js` version checks. No lockfile or manifest is touched.
- `bun run test:unit -- test/unit/changelog.test.ts test/unit/package-metadata.test.ts` — 2 files, 25 tests passed.
- Pre-commit hooks ran unskipped, including `npm run check` (biome + typecheck + shrinkwrap check) — passed.

## Notes

The `0.9.16-alpha.5` tag does not exist yet, so its sections are still unreleased and editable. The newest tagged section (`0.9.16-alpha.4`) and everything below it are untouched, and entries were appended to the existing `Changed` subsection rather than creating a duplicate. `[Unreleased]` is now empty.

No version stamping happens here — `scripts/cut-release.ts` materializes the real version on the detached `Release` commit after this merges.

Assistant-model: Claude Opus 5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790360158&installation_model_id=10562&pr_number=2708&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2708&signature=b6bd07733f573a8e36010a61ea283bef302489ae674f54f707763268f3388c11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moves the workflow budget and heartbeat guidance from `[Unreleased]` into the pending `0.9.16-alpha.5` release notes.

The potential release-note placement issue was disproved by an executable changelog check: both entries occur exactly once in `0.9.16-alpha.5` → `Changed`, `[Unreleased]` is empty, and the diff contains one removal and one addition for each relocated entry. The changelog diff has no whitespace errors.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the release notes retain both workflow guidance entries in the intended pending prerelease section without duplication.

The only changed file was checked with an executable parser-based validation against the base revision and current revision. It verified exact entry placement, uniqueness, an empty `[Unreleased]` section, and clean diff whitespace.

**Files Needing Attention:** None. `packages/workflows/CHANGELOG.md` was fully covered by the focused changelog validation.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the changelog placement validation script to verify the relocation between the base and HEAD changelog sections.
- Reviewed the validator output and confirmed all checks for placement, uniqueness, Unreleased-emptiness, and diff-relocation passed.
- Ran the baseline diff whitespace check and confirmed it exited with code 0.

<a href="https://app.greptile.com/trex/runs/20861925/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): fold budget and heartbe..."](https://github.com/bastani-inc/atomic/commit/1482a6abd5fbd96ff988128b49162d47c5689a43) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57187488)</sub>

<!-- /greptile_comment -->