### PR TITLE
docs(changelog): prepare 0.9.16-alpha.6 release notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.16-alpha.6] - 2026-08-26
+
 ### Changed
 
 - The default system prompt now teaches repository-intent inference when a shell tool is available: review recent commits, open and merged PRs, issues and their comments, and project/board status to learn maintainer conventions, and identify the requesting user (`git config user.name`/`user.email`, `gh api user`) to interpret ambiguous requests through their own patterns.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.16-alpha.6] - 2026-08-26
+
 ### Changed
 
 - The `workflow` tool description, agent routing guidance, and workflow docs now treat a blocked run as continuable by default: resume resumable blocks, answer pending prompts, steer past the obstacle, or start a follow-up workflow past a terminal block (inline only when the remaining work is minimal), stopping for user input only when the task is so ambiguous that judgment cannot infer intent from the objective and repository evidence — git history, commits, PRs, issues, and the user's own comments. When `ask_user_question` or human input is unavailable, the agent is instructed to continue fully autonomously on the interpretation best supported by that evidence and to record the assumption.


### PR DESCRIPTION
## Summary

Prepares the changelog for the `0.9.16-alpha.6` prerelease by promoting the accumulated `[Unreleased]` entries in each affected package into a dated `[0.9.16-alpha.6]` section. This is the changelog-only PR that must merge before the release tag is cut.

## Changes

- `packages/coding-agent/CHANGELOG.md` — repository-intent inference in the default system prompt (review commits, PRs, issues, and board status; identify the requesting user via `git config user.name`/`user.email` and `gh api user`), and the `ask_user_question` fallback that continues autonomously on the interpretation best supported by repository evidence instead of stalling.
- `packages/workflows/CHANGELOG.md` — blocked runs treated as continuable by default across the tool description, routing guidance, and docs; the matching `WORKFLOW BLOCKED` lifecycle notice text; and the budget-exceeded blocked-notice variant that asks for approval before resuming with a raised `budget`.

## Notes

- **Changelog-only diff.** No source, manifest, lockfile, Cargo, or generated version file is touched.
- The release base stays versionless: all eight `packages/*/package.json` files and the workspace Cargo manifest remain at the `0.0.0` placeholder. Verified after committing.
- Already-released version sections are untouched; `test/unit/changelog.test.ts` re-verifies each released section against its tag.
- Validation: `test/unit/changelog.test.ts` and `test/unit/package-metadata.test.ts` (25 tests) ran green, and the pre-commit hooks ran `npm run check` — all passed.
- After this merges, `scripts/cut-release.ts 0.9.16-alpha.6 --base main --push` stamps the real version onto the detached `Release 0.9.16-alpha.6` commit and pushes the tag, which starts `publish.yml`. No tagging or publication happens in this PR.

Assistant-model: Claude Opus 5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790369058&installation_model_id=10562&pr_number=2710&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2710&signature=2362654aee1e4a2ad587753c2059ecd9de1822eb40c6c39ada602cab9d8b3fdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Promotes the accumulated coding-agent and workflows release notes into dated `0.9.16-alpha.6` sections.

The focused changelog and package-metadata checks passed both before and after the release-heading update, confirming that the new sections retain valid release structure and package-version metadata.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the change is limited to release-note headings and the affected validation checks pass.

No actionable defects were found. The focused tests passed with the release-note promotion in place and confirmed the expected changelog and package metadata structure.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before promotion, T-Rex ran the unit tests for changelog and package-metadata and confirmed the command exited with status 0, reporting 2 passed files and 25 passed tests.
- After promotion, T-Rex re-ran the same unit tests and confirmed the command still exited with status 0, reporting 2 passed files and 25 passed tests.
- T-Rex performed a focused diff check with git diff --check HEAD^ HEAD and confirmed it exited without errors, indicating no issues surfaced in the focused inspection.

<a href="https://app.greptile.com/trex/runs/20893750/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.16-alpha.6 ..."](https://github.com/bastani-inc/atomic/commit/02c52ef8d7ab42c73adfbb66e95abee317f596e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57248002)</sub>

<!-- /greptile_comment -->