### PR TITLE
docs(changelog): prepare 0.9.16-alpha.7 release notes

### DIFF
--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.16-alpha.7] - 2026-08-26
+
 ### Added
 
 - New bundled `qlty` skill for code-quality verification through the [qlty](https://qlty.sh) CLI: linting (`qlty check`), auto-formatting (`qlty fmt`), maintainability metrics (`qlty metrics`), and code smells such as duplication and deep nesting (`qlty smells`). The skill triggers on requests for verifiers or high code quality, directs the agent to `https://docs.qlty.sh/llms.txt` as the authoritative documentation index, instructs it to enable the qlty plugins and linter extensions that fit the codebase rather than invoking per-tool linters ad hoc, and ships source-attributed reference excerpts under `skills/qlty/references/`.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.16-alpha.7] - 2026-08-26
+
 ### Changed
 
 - Builtin `goal` and `ralph` stage prompts now carry a shared `code_quality_verification` section pointing stages at the `qlty` skill (or `skill: "qlty"` delegation) for linting, auto-formatting, complexity and duplication metrics, and code smells — weighted higher when the objective asks for verifiers or high code quality. It reaches the goal controller, goal orchestrator, goal reviewer, ralph orchestrator, and both ralph reviewers, alongside the existing end-to-end verification guidance. Repository-defined checks in AGENTS.md/CLAUDE.md, package scripts, and CI remain authoritative.


### PR DESCRIPTION
Opens a `0.9.16-alpha.7` section in the `subagents` and `workflows` changelogs and moves the entries that ship in this prerelease out of `[Unreleased]` into it.

## What moved

- **`packages/subagents`** — the bundled `qlty` skill for code-quality verification (`qlty check`/`fmt`/`metrics`/`smells`).
- **`packages/workflows`** — the shared `code_quality_verification` and `repository_intent` stage-prompt sections across the goal controller, goal orchestrator, goal reviewer, ralph orchestrator, and both ralph reviewers, plus the `workflow` tool's repository-intent clause in the pre-launch architecture pass.

All of it lands from #2711.

## Scope

Changelog-only. No manifest, lockfile, Cargo file, or generated version file is touched — verified that every workspace package, the `package-lock.json` workspace entries, `[workspace.package]` in `Cargo.toml`, `Cargo.lock`, and the `packages/natives/native/index.js` checks all remain at the `0.0.0` placeholder, and that `0.9.16` appears nowhere outside the changelogs.

`main` stays versionless. `scripts/cut-release.ts` stamps the real version onto the detached `Release 0.9.16-alpha.7` commit after this merges; that tag push is what starts `publish.yml`. Nothing here tags or publishes.

`0.9.16-alpha.6` and every released section below it are untouched.

## Validation

- `npm run check` — biome, both typecheck passes, shrinkwrap check: pass
- `test/unit/changelog.test.ts` + `test/unit/package-metadata.test.ts` — 25 tests: pass
- `npm run test:ci-contracts` — 12 files, 72 tests: pass

Assistant-model: Claude Opus 5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790378363&installation_model_id=10562&pr_number=2712&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2712&signature=051362bdd3e28e5ce01366ca3c57aaab6adcca3df7f3d792fecd3d5dd74c35be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `0.9.16-alpha.7` release-note sections for the bundled qlty skill and the workflow code-quality and repository-intent guidance.

The potential release-note structure issue was disproved: the production changelog parser recognizes `0.9.16-alpha.7` as the newest entry in both files, and the focused changelog, package-metadata, and release-publisher checks pass.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the parsed release-note structure and passing focused release documentation checks.

No defects remain: the relevant release-note failure path was exercised directly and contradicted by successful parsing and focused test results.

**Files Needing Attention:** None. `packages/subagents/CHANGELOG.md` and `packages/workflows/CHANGELOG.md` were validated as correctly structured release notes.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the production parseChangelog path before and after the update, and verified both changelogs moved their latest prerelease sections to 0.9.16-alpha.7 while preserving the older release sections.
- Ran the unit test suite for changelog metadata and related areas; the Vitest run completed with 25 passing tests.
- Ran the release publisher contract tests; the contract suite completed with 2 passing tests.
- Noted that base-state tests were blocked by missing local cargo and napi tooling, but the direct parseChangelog before/after comparison still completed successfully.

<a href="https://app.greptile.com/trex/runs/20923360/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.16-alpha.7 ..."](https://github.com/bastani-inc/atomic/commit/d84aa46f1191832472c5f2c00990235567428c94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57304010)</sub>

<!-- /greptile_comment -->