### PR TITLE
fix(publish): merge every package changelog into GitHub Release notes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -508,8 +508,7 @@ jobs:
           rm -rf release-assets npm-packages
           mkdir release-assets npm-packages
           cp packages/coding-agent/binaries/atomic-*.tar.gz packages/coding-agent/binaries/atomic-*.zip release-assets/
-          awk -v ver="$VERSION" 'BEGIN { found=0 } /^## \[/ { if (found) exit; if ($0 ~ "^## \\[" ver "\\]") { found=1; next } } found { print }' packages/coding-agent/CHANGELOG.md > release-assets/RELEASE_NOTES.md
-          test -s release-assets/RELEASE_NOTES.md || echo "Release $VERSION" > release-assets/RELEASE_NOTES.md
+          bun run scripts/build-release-notes.ts "$VERSION" --out release-assets/RELEASE_NOTES.md
           (cd release-assets && sha256sum atomic-*.tar.gz atomic-*.zip > SHA256SUMS)
           bun run --cwd packages/ai build
           for dir in packages/natives/npm/* packages/natives packages/ai packages/coding-agent; do npm pack "./$dir" --pack-destination npm-packages; done

--- a/scripts/build-release-notes.ts
+++ b/scripts/build-release-notes.ts
@@ -1,0 +1,204 @@
+#!/usr/bin/env bun
+/**
+ * Builds the GitHub Release notes body for a version by merging every
+ * `packages/*\/CHANGELOG.md` section for that version into one flat set of
+ * `###` sections.
+ *
+ * Five packages (workflows, subagents, mcp, web-access, intercom) ship bundled
+ * inside `@bastani/atomic` rather than being published independently, so their
+ * entries are user-facing for anyone installing it. Reading only
+ * `packages/coding-agent/CHANGELOG.md` silently drops them: Atomic
+ * 0.9.16-alpha.7 changed only subagents and workflows and published a release
+ * page whose entire body was the commit subject.
+ *
+ * There is deliberately no empty-notes fallback. A version that no changelog
+ * describes is a preparation mistake, and failing here costs a re-cut, whereas
+ * a contentless page is only fixable after users have already seen it.
+ */
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** Subsection headings in the order AGENTS.md documents them. */
+const CANONICAL_SECTIONS: readonly string[] = ["Breaking Changes", "Added", "Changed", "Fixed", "Removed"];
+
+/**
+ * Packages whose entries lead each merged section. `coding-agent` is the
+ * package users install, so its notes read first; every other package follows
+ * in a stable alphabetical order.
+ */
+const LEAD_PACKAGES: readonly string[] = ["coding-agent"];
+
+export interface ChangelogSource {
+	/** Directory name under `packages/`, used only for ordering. */
+	readonly name: string;
+	readonly content: string;
+}
+
+export interface VersionSection {
+	/** Prose appearing under the version heading before the first `###`. */
+	readonly preamble: string;
+	/** Section title to its entry lines, in first-appearance order. */
+	readonly sections: ReadonlyMap<string, string>;
+}
+
+function trimBlankEdges(lines: readonly string[]): string[] {
+	let start = 0;
+	let end = lines.length;
+	while (start < end && lines[start].trim() === "") start += 1;
+	while (end > start && lines[end - 1].trim() === "") end -= 1;
+	return lines.slice(start, end);
+}
+
+/**
+ * Extracts one version's body, or null when the file has no such section. The
+ * closing bracket in the heading keeps `0.9.1` from matching `0.9.15`.
+ */
+export function extractVersionSection(content: string, version: string): VersionSection | null {
+	const lines = content.split("\n");
+	const heading = `## [${version}]`;
+	const start = lines.findIndex((line) => line.startsWith(heading));
+	if (start < 0) return null;
+
+	const body: string[] = [];
+	for (let index = start + 1; index < lines.length; index += 1) {
+		const line = lines[index];
+		if (line.startsWith("## ")) break;
+		body.push(line);
+	}
+
+	const preamble: string[] = [];
+	const collected = new Map<string, string[]>();
+	let current: string[] | null = null;
+	for (const line of body) {
+		if (line.startsWith("### ")) {
+			const title = line.slice(4).trim();
+			let bucket = collected.get(title);
+			if (!bucket) {
+				bucket = [];
+				collected.set(title, bucket);
+			}
+			current = bucket;
+			continue;
+		}
+		(current ?? preamble).push(line);
+	}
+
+	const sections = new Map<string, string>();
+	for (const [title, entryLines] of collected) {
+		const text = trimBlankEdges(entryLines).join("\n");
+		if (text.length > 0) sections.set(title, text);
+	}
+	return { preamble: trimBlankEdges(preamble).join("\n"), sections };
+}
+
+function orderSources(sources: readonly ChangelogSource[]): ChangelogSource[] {
+	return [...sources].sort((left, right) => {
+		const leftLead = LEAD_PACKAGES.indexOf(left.name);
+		const rightLead = LEAD_PACKAGES.indexOf(right.name);
+		if (leftLead !== rightLead) {
+			if (leftLead < 0) return 1;
+			if (rightLead < 0) return -1;
+			return leftLead - rightLead;
+		}
+		return left.name.localeCompare(right.name);
+	});
+}
+
+/** Canonical sections first, then any others in first-appearance order. */
+function orderSectionTitles(titles: readonly string[]): string[] {
+	const known = CANONICAL_SECTIONS.filter((title) => titles.includes(title));
+	return [...known, ...titles.filter((title) => !CANONICAL_SECTIONS.includes(title))];
+}
+
+/**
+ * Merges every source's section for `version` into one flat notes body.
+ *
+ * @throws when no source documents the version, so a contentless release page
+ * can never be staged.
+ */
+export function buildReleaseNotes(sources: readonly ChangelogSource[], version: string): string {
+	const preambles: string[] = [];
+	const merged = new Map<string, string[]>();
+
+	for (const source of orderSources(sources)) {
+		const section = extractVersionSection(source.content, version);
+		if (!section) continue;
+		// Packages that share a release often repeat one identical summary
+		// paragraph; a merged body states it once.
+		if (section.preamble.length > 0 && !preambles.includes(section.preamble)) preambles.push(section.preamble);
+		for (const [title, entries] of section.sections) {
+			const bucket = merged.get(title);
+			if (bucket) bucket.push(entries);
+			else merged.set(title, [entries]);
+		}
+	}
+
+	const blocks: string[] = [...preambles];
+	for (const title of orderSectionTitles([...merged.keys()])) {
+		blocks.push(`### ${title}\n\n${(merged.get(title) ?? []).join("\n")}`);
+	}
+
+	if (blocks.length === 0) {
+		throw new Error(
+			`No packages/*/CHANGELOG.md documents version ${version}. ` +
+				`Add the release notes under a "## [${version}]" heading and re-cut the release.`,
+		);
+	}
+	return `${blocks.join("\n\n")}\n`;
+}
+
+/** Reads every `packages/*\/CHANGELOG.md` that exists. */
+export function readChangelogSources(packagesDir: string): ChangelogSource[] {
+	const sources: ChangelogSource[] = [];
+	for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
+		if (!entry.isDirectory()) continue;
+		const path = join(packagesDir, entry.name, "CHANGELOG.md");
+		if (!existsSync(path)) continue;
+		sources.push({ name: entry.name, content: readFileSync(path, "utf-8") });
+	}
+	return sources;
+}
+
+function usage(): never {
+	process.stderr.write("usage: build-release-notes.ts <version> [--out <path>] [--packages-dir <path>]\n");
+	process.exit(2);
+}
+
+function main(argv: readonly string[]): void {
+	let version = "";
+	let out = "";
+	let packagesDir = "";
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (arg === "--out" || arg === "--packages-dir") {
+			const value = argv[index + 1];
+			if (value === undefined) usage();
+			if (arg === "--out") out = value;
+			else packagesDir = value;
+			index += 1;
+			continue;
+		}
+		if (arg.startsWith("-") || version !== "") usage();
+		version = arg;
+	}
+	if (version === "") usage();
+
+	if (packagesDir === "") {
+		packagesDir = join(dirname(dirname(fileURLToPath(import.meta.url))), "packages");
+	}
+
+	const notes = buildReleaseNotes(readChangelogSources(packagesDir), version);
+	if (out === "") process.stdout.write(notes);
+	else writeFileSync(out, notes);
+}
+
+if (import.meta.main) {
+	try {
+		main(process.argv.slice(2));
+	} catch (error) {
+		process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+		process.exit(1);
+	}
+}

--- a/test/ci/release-publisher-contracts.test.ts
+++ b/test/ci/release-publisher-contracts.test.ts
@@ -139,3 +139,25 @@ test("publish pipeline prepares exact native package set and publishes in depend
 		/npm view "\$name@\$VERSION" version[\s\S]*already exists; skipping[\s\S]*npm publish "\$\{tarballs\[\$name\]\}" --provenance/u,
 	);
 });
+
+test("release notes merge every package changelog and never fall back to a contentless body", async () => {
+	const workflow = await readText(`${root}/.github/workflows/publish.yml`);
+	assert.match(
+		workflow,
+		/bun run scripts\/build-release-notes\.ts "\$VERSION" --out release-assets\/RELEASE_NOTES\.md/u,
+		"release notes must come from the merging builder, not a single package changelog",
+	);
+	// Reading one changelog silently dropped the five packages bundled into
+	// @bastani/atomic; the fallback then published the commit subject as the
+	// entire body (0.9.16-alpha.7).
+	assert.doesNotMatch(
+		workflow,
+		/RELEASE_NOTES\.md[\s\S]{0,80}\|\|[\s\S]{0,40}echo "Release \$VERSION"/u,
+		"an empty-notes fallback must not mask a missing changelog entry",
+	);
+	assert.doesNotMatch(
+		workflow,
+		/awk[^\n]*packages\/coding-agent\/CHANGELOG\.md/u,
+		"notes must not be extracted from packages/coding-agent/CHANGELOG.md alone",
+	);
+});

--- a/test/unit/build-release-notes.test.ts
+++ b/test/unit/build-release-notes.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, test } from "vitest";
+import { bunExecutable, spawnSyncCollect } from "../helpers/runtime.js";
+
+interface NotesResult {
+	readonly exitCode: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+function createPackagesDir(changelogs: Readonly<Record<string, string>>): string {
+	const root = mkdtempSync(join(tmpdir(), "atomic-release-notes-"));
+	const packagesDir = join(root, "packages");
+	for (const [name, content] of Object.entries(changelogs)) {
+		mkdirSync(join(packagesDir, name), { recursive: true });
+		writeFileSync(join(packagesDir, name, "CHANGELOG.md"), content);
+	}
+	mkdirSync(join(packagesDir, "no-changelog"), { recursive: true });
+	return packagesDir;
+}
+
+function runNotes(packagesDir: string, version: string): NotesResult {
+	const result = spawnSyncCollect({
+		cmd: [
+			bunExecutable(),
+			"run",
+			join(process.cwd(), "scripts", "build-release-notes.ts"),
+			version,
+			"--packages-dir",
+			packagesDir,
+		],
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	return { exitCode: result.exitCode, stdout: result.stdout.toString(), stderr: result.stderr.toString() };
+}
+
+describe("scripts/build-release-notes.ts", () => {
+	test("merges sections from every package into one flat body without per-package headings", () => {
+		const packagesDir = createPackagesDir({
+			"coding-agent": "# Changelog\n\n## [1.0.0]\n\n### Fixed\n\n- agent fix\n",
+			subagents: "# Changelog\n\n## [1.0.0]\n\n### Added\n\n- subagent feature\n",
+			workflows: "# Changelog\n\n## [1.0.0]\n\n### Fixed\n\n- workflow fix\n\n### Added\n\n- workflow feature\n",
+		});
+		try {
+			const result = runNotes(packagesDir, "1.0.0");
+			assert.equal(result.exitCode, 0, result.stderr);
+			// Canonical AGENTS.md order, not the order the sections were encountered.
+			assert.equal(
+				result.stdout,
+				"### Added\n\n- subagent feature\n- workflow feature\n\n### Fixed\n\n- agent fix\n- workflow fix\n",
+			);
+			assert.ok(!result.stdout.includes("## subagents"), "must not attribute entries to packages");
+		} finally {
+			rmSync(join(packagesDir, ".."), { recursive: true, force: true });
+		}
+	});
+
+	test("fails closed when no package documents the version", () => {
+		const packagesDir = createPackagesDir({
+			"coding-agent": "# Changelog\n\n## [Unreleased]\n\n## [0.9.0]\n\n### Fixed\n\n- old fix\n",
+		});
+		try {
+			const result = runNotes(packagesDir, "1.0.0");
+			assert.equal(result.exitCode, 1);
+			assert.match(result.stderr, /No packages\/\*\/CHANGELOG\.md documents version 1\.0\.0/);
+			assert.equal(result.stdout, "", "a failed build must not emit partial notes");
+		} finally {
+			rmSync(join(packagesDir, ".."), { recursive: true, force: true });
+		}
+	});
+
+	test("fails closed when the version heading exists but carries no entries", () => {
+		const packagesDir = createPackagesDir({
+			"coding-agent": "# Changelog\n\n## [1.0.0]\n\n## [0.9.0]\n\n### Fixed\n\n- old fix\n",
+		});
+		try {
+			const result = runNotes(packagesDir, "1.0.0");
+			assert.equal(result.exitCode, 1);
+			assert.doesNotMatch(result.stdout, /old fix/, "must not bleed into the next version section");
+		} finally {
+			rmSync(join(packagesDir, ".."), { recursive: true, force: true });
+		}
+	});
+
+	test("orders coding-agent entries first and preserves unknown section headings", () => {
+		const packagesDir = createPackagesDir({
+			workflows: "# Changelog\n\n## [1.0.0]\n\n### Changed\n\n- workflow change\n\n### Security\n\n- hardening\n",
+			"coding-agent": "# Changelog\n\n## [1.0.0]\n\n### Changed\n\n- agent change\n",
+			intercom: "# Changelog\n\n## [1.0.0]\n\n### Changed\n\n- intercom change\n",
+		});
+		try {
+			const result = runNotes(packagesDir, "1.0.0");
+			assert.equal(result.exitCode, 0, result.stderr);
+			assert.equal(
+				result.stdout,
+				"### Changed\n\n- agent change\n- intercom change\n- workflow change\n\n### Security\n\n- hardening\n",
+			);
+		} finally {
+			rmSync(join(packagesDir, ".."), { recursive: true, force: true });
+		}
+	});
+
+	test("states a shared preamble once and keeps distinct ones", () => {
+		const shared = "Cumulative release summary.";
+		const packagesDir = createPackagesDir({
+			"coding-agent": `# Changelog\n\n## [1.0.0]\n\n${shared}\n\n### Added\n\n- a\n`,
+			subagents: `# Changelog\n\n## [1.0.0]\n\n${shared}\n\n### Added\n\n- b\n`,
+			workflows: `# Changelog\n\n## [1.0.0]\n\nWorkflow-specific note.\n\n### Added\n\n- c\n`,
+		});
+		try {
+			const result = runNotes(packagesDir, "1.0.0");
+			assert.equal(result.exitCode, 0, result.stderr);
+			assert.equal(result.stdout.split(shared).length - 1, 1, "identical preambles must collapse to one");
+			assert.equal(result.stdout, `${shared}\n\nWorkflow-specific note.\n\n### Added\n\n- a\n- b\n- c\n`);
+		} finally {
+			rmSync(join(packagesDir, ".."), { recursive: true, force: true });
+		}
+	});
+
+	test("does not confuse a version with a longer version sharing its prefix", () => {
+		const packagesDir = createPackagesDir({
+			"coding-agent": "# Changelog\n\n## [0.9.15]\n\n### Fixed\n\n- fifteen\n\n## [0.9.1]\n\n### Fixed\n\n- one\n",
+		});
+		try {
+			const result = runNotes(packagesDir, "0.9.1");
+			assert.equal(result.exitCode, 0, result.stderr);
+			assert.equal(result.stdout, "### Fixed\n\n- one\n");
+		} finally {
+			rmSync(join(packagesDir, ".."), { recursive: true, force: true });
+		}
+	});
+
+	test("preserves multi-line entries verbatim", () => {
+		const packagesDir = createPackagesDir({
+			"coding-agent": "# Changelog\n\n## [1.0.0]\n\n### Fixed\n\n- first line\n  continued line\n- second entry\n",
+		});
+		try {
+			const result = runNotes(packagesDir, "1.0.0");
+			assert.equal(result.exitCode, 0, result.stderr);
+			assert.equal(result.stdout, "### Fixed\n\n- first line\n  continued line\n- second entry\n");
+		} finally {
+			rmSync(join(packagesDir, ".."), { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Problem

The 0.9.16-alpha.7 release page body is, in its entirety:

```
Release 0.9.16-alpha.7
```

`publish.yml` extracted release notes from `packages/coding-agent/CHANGELOG.md` alone, then fell back to the commit subject when that file had no section for the version:

```
awk -v ver="$VERSION" ... packages/coding-agent/CHANGELOG.md > release-assets/RELEASE_NOTES.md
test -s release-assets/RELEASE_NOTES.md || echo "Release $VERSION" > release-assets/RELEASE_NOTES.md
```

Five packages (`workflows`, `subagents`, `mcp`, `web-access`, `intercom`) ship bundled *inside* `@bastani/atomic` rather than being published independently, so their entries are user-facing for anyone installing it — but they could never reach a release page.

alpha.7 changed only `subagents` (the qlty skill) and `workflows` (the `code_quality_verification` and `repository_intent` prompt sections), so `awk` matched nothing and the fallback fired. Every earlier release happened to touch `coding-agent`, which is why this is the first one to surface it.

## Change

`scripts/build-release-notes.ts` merges the version section from **every** `packages/*/CHANGELOG.md` into one flat set of sections:

- Canonical AGENTS.md order — Breaking Changes, Added, Changed, Fixed, Removed — with unknown headings (`Security`, `Performance`, … 26 exist historically) preserved after them rather than dropped.
- No per-package headings or attribution; `coding-agent` entries lead each section, then the rest alphabetically.
- Identical preambles collapse to one. 0.9.15 repeats the same "Cumulative release…" paragraph in five changelogs.
- Multi-line entries preserved verbatim; the closing bracket in `## [x]` keeps `0.9.1` from matching `0.9.15`.

**The fallback is removed.** A version that no changelog documents now fails the build. That costs a re-cut, whereas a contentless page is only fixable after users have seen it.

## Verification

- `npm run check` clean
- `npm run test:unit` — 7143 passed / 24 skipped across 711 files
- `npm run test:ci-contracts` — 73 passed, including a new contract test pinning the builder and rejecting both the fallback and the single-changelog `awk`
- Replayed against real data: alpha.7 now renders its 4 real entries under Added/Changed; 0.9.15 renders one preamble and all 5 sections; a nonexistent version exits 1

No changelog entry — AGENTS.md classifies release/publish pipeline changes as infrastructure.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790380945&installation_model_id=10562&pr_number=2713&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2713&signature=dd3990658d1a225242dbc1219a3b034ef68108310520408b4910701f77e7701f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces single-package release-note extraction with a fail-closed builder that merges the target version from every package changelog.
- Orders canonical sections consistently while preserving unknown headings and multiline content.
- Deduplicates identical release preambles and prioritizes coding-agent entries.
- Integrates the builder into the publishing workflow and adds unit and CI contract coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable issue identified.

The builder matches existing changelog conventions, preserves the intended release-note content, and is correctly provisioned and sequenced in the publishing workflow.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/build-release-notes.ts | Adds deterministic extraction and merging of release notes across package changelogs, with explicit failure when no content exists. |
| .github/workflows/publish.yml | Replaces the coding-agent-only awk extraction and fallback body with the new Bun builder. |
| test/unit/build-release-notes.test.ts | Covers merging, ordering, preamble deduplication, missing content, prefix-safe version matching, and multiline entries. |
| test/ci/release-publisher-contracts.test.ts | Enforces use of the merging builder and prevents restoration of the single-changelog extractor or contentless fallback. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Package changelogs] --> B[Extract matching version sections]
  B --> C[Order package contributions]
  C --> D[Deduplicate preambles]
  D --> E[Merge and order subsections]
  E --> F[RELEASE_NOTES.md]
  F --> G[GitHub Release]
  B -->|No documented content| H[Fail publish build]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(publish): merge every package change..."](https://github.com/bastani-inc/atomic/commit/5cf1ebce2ec57d4473d699316ea0e9d9de8b58d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57315325)</sub>

<!-- /greptile_comment -->