### PR TITLE
feat(workflows): add Coder workspace client

### DIFF
--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -3702,6 +3702,10 @@ Runtime config defaults:
 | `environment.idleMinutes` | `240` when configured | Idle-stop duration copied into a resolved environment binding. |
 | `environment.retentionHours` | `12` when configured | Retention duration copied into a resolved environment binding. |
 
+Coder workspace acquisition resolves the configured organization name to its deployment ID, or uses the current user's first organization when `organization` is omitted. Atomic then resolves the template's active version, expands every rich parameter explicitly from template defaults, preset values, and configured overrides, and resolves the preset ID by its deployment-owned name. Workspace creation therefore never enters Coder's interactive parameter picker. Start, stop, and delete are workspace-build transitions, and startup is complete only after the authenticated `agent-connection-watch` stream reports the agent lifecycle as `ready`; the wait has a bounded timeout.
+
+Atomic does not assume that `coder` is installed on `PATH`. It reads the deployment's build information, downloads that deployment's own CLI binary for the control machine's operating system and architecture, validates the binary's reported version, and caches it by deployment ID, exact deployment version, OS, and architecture. A different deployment or deployment upgrade gets a different pinned binary.
+
 Invalid JSON or invalid shapes produce `CONFIG_INVALID` diagnostics. Missing config files are ignored.
 
 ## Settings

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - Added the optional workflow `environment` config block for Coder deployment and template bindings, including the single-template shorthand, per-template preset and string parameters, idle and retention settings, and project-level replacement semantics. Authored workflows can map a template-name input through `environmentFromInputs`; Atomic freezes that declaration and resolves it to a typed run binding while leaving unconfigured workflows local and unchanged.
+- Added the Coder workspace API client for organization, active-template-version, rich-parameter, and named-preset resolution; explicit non-interactive workspace creation; lifecycle builds; bounded agent-ready watching; and stop/delete transitions. Atomic can also acquire and validate the deployment's own matching Coder CLI into a deployment/version/platform-specific cache instead of relying on `coder` from `PATH`.
 
 ### Fixed
 

--- a/packages/workflows/src/runs/shared/run-environment-coder.ts
+++ b/packages/workflows/src/runs/shared/run-environment-coder.ts
@@ -1,0 +1,480 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { chmod, mkdir, rename, rm, writeFile } from "node:fs/promises";
+import { arch as hostArchitecture, platform as hostPlatform } from "node:os";
+import { dirname, join } from "node:path";
+import type { EnvironmentBinding } from "../../shared/types.js";
+
+const SESSION_TOKEN_HEADER = "Coder-Session-Token";
+const JSON_HEADERS = { Accept: "application/json", "Content-Type": "application/json" } as const;
+
+export interface CoderWorkspace {
+	readonly id: string;
+	readonly latestBuildId: string;
+}
+
+export interface CoderBuild {
+	readonly id: string;
+}
+
+export interface CoderBuildRequest {
+	readonly transition: "start" | "stop" | "delete";
+	readonly templateVersionId?: string;
+	readonly templateVersionPresetId?: string;
+	readonly richParameterValues?: readonly CoderParameterValue[];
+}
+
+export interface CoderParameterValue {
+	readonly name: string;
+	readonly value: string;
+}
+
+export interface WaitForAgentReadyOptions {
+	readonly timeoutMs: number;
+	readonly agentName?: string;
+}
+
+export interface CoderWebSocket {
+	readonly OPEN: number;
+	readonly readyState: number;
+	addEventListener(type: string, listener: (event: Event | MessageEvent) => void): void;
+	removeEventListener(type: string, listener: (event: Event | MessageEvent) => void): void;
+	close(): void;
+}
+
+export type CoderFetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+export interface CreateCoderClientOptions {
+	readonly deployment: string;
+	readonly sessionToken: string;
+	readonly fetch?: CoderFetch;
+	readonly webSocket?: (url: string, headers: Readonly<Record<string, string>>) => CoderWebSocket;
+}
+
+export class CoderApiError extends Error {
+	constructor(
+		message: string,
+		readonly status?: number,
+		readonly detail?: string,
+	) {
+		super(message);
+		this.name = "CoderApiError";
+	}
+}
+
+export class CoderAgentStartTimeoutError extends Error {
+	constructor(readonly timeoutMs: number) {
+		super(`Coder workspace agent did not become ready within ${timeoutMs}ms`);
+		this.name = "CoderAgentStartTimeoutError";
+	}
+}
+
+export class CoderAgentStartError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "CoderAgentStartError";
+	}
+}
+
+export interface CoderClient {
+	createWorkspace(name: string, binding: EnvironmentBinding, signal: AbortSignal): Promise<CoderWorkspace>;
+	createBuild(workspaceId: string, request: CoderBuildRequest, signal: AbortSignal): Promise<CoderBuild>;
+	waitForAgentReady(workspaceId: string, options: WaitForAgentReadyOptions, signal: AbortSignal): Promise<void>;
+	stopWorkspace(workspaceId: string, signal: AbortSignal): Promise<CoderBuild>;
+	deleteWorkspace(workspaceId: string, signal: AbortSignal): Promise<CoderBuild>;
+}
+
+interface JsonObject {
+	readonly [key: string]: JsonValue;
+}
+type JsonValue = null | boolean | number | string | readonly JsonValue[] | JsonObject;
+
+function isObject(value: JsonValue): value is JsonObject {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(value: JsonValue, field: string, context: string): string {
+	if (!isObject(value) || typeof value[field] !== "string" || value[field].length === 0) {
+		throw new CoderApiError(`Coder returned an invalid ${context}: missing ${field}`);
+	}
+	return value[field];
+}
+
+function arrayField(value: JsonValue, field: string, context: string): readonly JsonValue[] {
+	if (!isObject(value) || !Array.isArray(value[field])) {
+		throw new CoderApiError(`Coder returned an invalid ${context}: missing ${field}`);
+	}
+	return value[field];
+}
+
+function deploymentUrl(deployment: string, path: string): URL {
+	const base = new URL(deployment);
+	base.pathname = `${base.pathname.replace(/\/$/u, "")}/${path.replace(/^\//u, "")}`;
+	base.search = "";
+	base.hash = "";
+	return base;
+}
+
+function segment(value: string): string {
+	return encodeURIComponent(value);
+}
+
+function defaultWebSocket(url: string, headers: Readonly<Record<string, string>>): CoderWebSocket {
+	interface WebSocketWithHeadersConstructor {
+		new (url: string, options: { readonly headers: Readonly<Record<string, string>> }): CoderWebSocket;
+	}
+	const Constructor = globalThis.WebSocket as unknown as WebSocketWithHeadersConstructor;
+	if (Constructor === undefined) throw new CoderApiError("This runtime cannot open the Coder agent readiness watch");
+	return new Constructor(url, { headers });
+}
+
+async function responseJson(response: Response, context: string): Promise<JsonValue> {
+	if (!response.ok) {
+		const detail = await response.text();
+		throw new CoderApiError(`Coder ${context} failed with HTTP ${response.status}`, response.status, detail);
+	}
+	try {
+		return (await response.json()) as JsonValue;
+	} catch (error) {
+		throw new CoderApiError(
+			`Coder returned invalid JSON for ${context}`,
+			response.status,
+			error instanceof Error ? error.message : String(error),
+		);
+	}
+}
+
+function requestBody(request: CoderBuildRequest): JsonObject {
+	return {
+		transition: request.transition,
+		...(request.templateVersionId === undefined ? {} : { template_version_id: request.templateVersionId }),
+		...(request.templateVersionPresetId === undefined
+			? {}
+			: { template_version_preset_id: request.templateVersionPresetId }),
+		...(request.richParameterValues === undefined
+			? {}
+			: {
+					rich_parameter_values: request.richParameterValues.map(({ name, value }) => ({ name, value })),
+				}),
+	};
+}
+
+export function createCoderClient(options: CreateCoderClientOptions): CoderClient {
+	const requestFetch = options.fetch ?? globalThis.fetch;
+	const openWebSocket = options.webSocket ?? defaultWebSocket;
+	const headers = { ...JSON_HEADERS, [SESSION_TOKEN_HEADER]: options.sessionToken };
+
+	const request = async (path: string, init: RequestInit, context: string): Promise<JsonValue> => {
+		const response = await requestFetch(deploymentUrl(options.deployment, path), {
+			...init,
+			headers: { ...headers, ...init.headers },
+		});
+		return responseJson(response, context);
+	};
+
+	const get = (path: string, signal: AbortSignal, context: string): Promise<JsonValue> =>
+		request(path, { method: "GET", signal }, context);
+
+	const post = (path: string, body: JsonObject, signal: AbortSignal, context: string): Promise<JsonValue> =>
+		request(path, { method: "POST", body: JSON.stringify(body), signal }, context);
+
+	const resolveOrganizationId = async (binding: EnvironmentBinding, signal: AbortSignal): Promise<string> => {
+		if (binding.organization !== undefined) {
+			const organization = await get(
+				`api/v2/organizations/${segment(binding.organization)}`,
+				signal,
+				`resolve organization ${binding.organization}`,
+			);
+			return stringField(organization, "id", "organization");
+		}
+
+		const user = await get("api/v2/users/me", signal, "resolve current user");
+		const firstOrganizationId = arrayField(user, "organization_ids", "current user")[0];
+		if (typeof firstOrganizationId !== "string" || firstOrganizationId.length === 0) {
+			throw new CoderApiError("The current Coder user belongs to no organization");
+		}
+		return firstOrganizationId;
+	};
+
+	const createBuild = async (
+		workspaceId: string,
+		buildRequest: CoderBuildRequest,
+		signal: AbortSignal,
+	): Promise<CoderBuild> => {
+		const value = await post(
+			`api/v2/workspaces/${segment(workspaceId)}/builds`,
+			requestBody(buildRequest),
+			signal,
+			`create ${buildRequest.transition} build`,
+		);
+		return { id: stringField(value, "id", "workspace build") };
+	};
+
+	return {
+		async createWorkspace(name, binding, signal) {
+			const organizationId = await resolveOrganizationId(binding, signal);
+			const template = await get(
+				`api/v2/organizations/${segment(organizationId)}/templates/${segment(binding.template)}`,
+				signal,
+				`resolve template ${binding.template}`,
+			);
+			const versionId = stringField(template, "active_version_id", "template");
+			const richParameters = await get(
+				`api/v2/templateversions/${segment(versionId)}/rich-parameters`,
+				signal,
+				"resolve template parameters",
+			);
+			if (!Array.isArray(richParameters)) throw new CoderApiError("Coder returned invalid template parameters");
+
+			let presetId: string | undefined;
+			const presetValues = new Map<string, string>();
+			if (binding.preset !== undefined) {
+				const presets = await get(
+					`api/v2/templateversions/${segment(versionId)}/presets`,
+					signal,
+					"resolve template presets",
+				);
+				if (!Array.isArray(presets)) throw new CoderApiError("Coder returned invalid template presets");
+				const preset = presets.find((candidate) => isObject(candidate) && candidate.name === binding.preset);
+				if (preset === undefined) {
+					throw new CoderApiError(`Coder template ${binding.template} has no preset named ${binding.preset}`);
+				}
+				presetId = stringField(preset, "id", "template preset");
+				for (const parameter of arrayField(preset, "parameters", "template preset")) {
+					presetValues.set(
+						stringField(parameter, "name", "preset parameter"),
+						stringField(parameter, "value", "preset parameter"),
+					);
+				}
+			}
+
+			const richParameterValues = richParameters.map((parameter): CoderParameterValue => {
+				const parameterName = stringField(parameter, "name", "template parameter");
+				const configured = binding.parameters[parameterName];
+				return {
+					name: parameterName,
+					value:
+						configured ??
+						presetValues.get(parameterName) ??
+						stringField(parameter, "default_value", "template parameter"),
+				};
+			});
+			for (const configuredName of Object.keys(binding.parameters)) {
+				if (!richParameterValues.some(({ name: parameterName }) => parameterName === configuredName)) {
+					throw new CoderApiError(
+						`Coder template ${binding.template} has no rich parameter named ${configuredName}`,
+					);
+				}
+			}
+
+			const value = await post(
+				"api/v2/users/me/workspaces",
+				{
+					name,
+					rich_parameter_values: richParameterValues.map(({ name: parameterName, value: parameterValue }) => ({
+						name: parameterName,
+						value: parameterValue,
+					})),
+					template_version_id: versionId,
+					...(presetId === undefined ? {} : { template_version_preset_id: presetId }),
+					ttl_ms: binding.idleMinutes * 60_000,
+				},
+				signal,
+				"create workspace",
+			);
+			const latestBuild = isObject(value) ? value.latest_build : undefined;
+			return {
+				id: stringField(value, "id", "workspace"),
+				latestBuildId: stringField(latestBuild ?? null, "id", "workspace latest build"),
+			};
+		},
+		createBuild,
+		async waitForAgentReady(workspaceId, waitOptions, signal) {
+			if (!Number.isFinite(waitOptions.timeoutMs) || waitOptions.timeoutMs <= 0) {
+				throw new TypeError("Coder agent readiness timeout must be positive");
+			}
+			if (signal.aborted) throw signal.reason instanceof Error ? signal.reason : new Error("aborted");
+			const watch = deploymentUrl(
+				options.deployment,
+				`api/v2/workspaces/${segment(workspaceId)}/agent-connection-watch`,
+			);
+			watch.protocol = watch.protocol === "https:" ? "wss:" : "ws:";
+			if (waitOptions.agentName !== undefined) watch.searchParams.set("agent_name", waitOptions.agentName);
+			const socket = openWebSocket(watch.toString(), { [SESSION_TOKEN_HEADER]: options.sessionToken });
+
+			await new Promise<void>((resolve, reject) => {
+				let settled = false;
+				const finish = (error?: Error): void => {
+					if (settled) return;
+					settled = true;
+					clearTimeout(timeout);
+					signal.removeEventListener("abort", onAbort);
+					socket.removeEventListener("message", onMessage);
+					socket.removeEventListener("error", onError);
+					socket.removeEventListener("close", onClose);
+					socket.close();
+					if (error) reject(error);
+					else resolve();
+				};
+				const onAbort = (): void => finish(signal.reason instanceof Error ? signal.reason : new Error("aborted"));
+				const onError = (): void => finish(new CoderAgentStartError("Coder agent readiness watch failed"));
+				const onClose = (): void =>
+					finish(new CoderAgentStartError("Coder agent readiness watch closed before ready"));
+				const onMessage = (event: Event | MessageEvent): void => {
+					if (!(event instanceof MessageEvent) || typeof event.data !== "string") return;
+					let value: JsonValue;
+					try {
+						value = JSON.parse(event.data) as JsonValue;
+					} catch {
+						finish(new CoderAgentStartError("Coder agent readiness watch returned invalid JSON"));
+						return;
+					}
+					if (!isObject(value)) return;
+					if (isObject(value.error)) {
+						const message = typeof value.error.message === "string" ? value.error.message : "unknown watch error";
+						finish(new CoderAgentStartError(message));
+						return;
+					}
+					if (
+						isObject(value.build_update) &&
+						["failed", "canceled"].includes(String(value.build_update.job_status))
+					) {
+						finish(new CoderAgentStartError(`Coder workspace build ${String(value.build_update.job_status)}`));
+						return;
+					}
+					if (isObject(value.agent_update) && value.agent_update.lifecycle === "ready") finish();
+				};
+				const timeout = setTimeout(
+					() => finish(new CoderAgentStartTimeoutError(waitOptions.timeoutMs)),
+					waitOptions.timeoutMs,
+				);
+				signal.addEventListener("abort", onAbort, { once: true });
+				socket.addEventListener("message", onMessage);
+				socket.addEventListener("error", onError);
+				socket.addEventListener("close", onClose);
+				if (signal.aborted) onAbort();
+			});
+		},
+		stopWorkspace: (workspaceId, signal) => createBuild(workspaceId, { transition: "stop" }, signal),
+		deleteWorkspace: (workspaceId, signal) => createBuild(workspaceId, { transition: "delete" }, signal),
+	};
+}
+
+export interface AcquireCoderCliOptions {
+	readonly deployment: string;
+	readonly cacheDirectory: string;
+	readonly fetch?: CoderFetch;
+	readonly platform?: NodeJS.Platform;
+	readonly architecture?: string;
+	readonly verifyBinary?: (path: string, deploymentVersion: string) => Promise<void>;
+	readonly signal: AbortSignal;
+}
+
+function cliTarget(platform: NodeJS.Platform, architecture: string): { os: string; arch: string; extension: string } {
+	const os = platform === "win32" ? "windows" : platform === "darwin" || platform === "linux" ? platform : undefined;
+	const resolvedArchitecture = architecture === "x64" ? "amd64" : architecture === "arm" ? "armv7" : architecture;
+	if (os === undefined || !["amd64", "arm64", "armv7"].includes(resolvedArchitecture)) {
+		throw new CoderApiError(`Coder CLI does not support ${platform}/${architecture}`);
+	}
+	return { os, arch: resolvedArchitecture, extension: os === "windows" ? ".exe" : "" };
+}
+
+function safeCachePart(value: string, label: string): string {
+	const normalized = value.replace(/^v/u, "");
+	if (!/^[A-Za-z0-9._+-]+$/u.test(normalized)) throw new CoderApiError(`Coder returned an invalid ${label}`);
+	return normalized;
+}
+
+function versionIdentity(value: string): string {
+	const match = /v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)/u.exec(value);
+	if (match?.[1] === undefined) throw new CoderApiError(`Cannot read Coder version from ${JSON.stringify(value)}`);
+	return match[1];
+}
+
+async function verifyCoderBinary(path: string, deploymentVersion: string): Promise<void> {
+	const output = await new Promise<string>((resolve, reject) => {
+		execFile(path, ["version"], { timeout: 30_000 }, (error, stdout, stderr) => {
+			if (error) {
+				reject(new CoderApiError(`Downloaded Coder CLI could not run: ${stderr.trim() || error.message}`));
+				return;
+			}
+			resolve(`${stdout}\n${stderr}`);
+		});
+	});
+	if (versionIdentity(output) !== versionIdentity(deploymentVersion)) {
+		throw new CoderApiError(`Downloaded Coder CLI does not match deployment version ${deploymentVersion}`);
+	}
+}
+
+export async function acquireCoderCli(options: AcquireCoderCliOptions): Promise<string> {
+	const requestFetch = options.fetch ?? globalThis.fetch;
+	const target = cliTarget(options.platform ?? hostPlatform(), options.architecture ?? hostArchitecture());
+	const buildInfoResponse = await requestFetch(deploymentUrl(options.deployment, "api/v2/buildinfo"), {
+		headers: { Accept: "application/json" },
+		signal: options.signal,
+	});
+	const buildInfo = await responseJson(buildInfoResponse, "resolve deployment version");
+	const deploymentId = safeCachePart(stringField(buildInfo, "deployment_id", "build info"), "deployment id");
+	const deploymentVersion = stringField(buildInfo, "version", "build info");
+	const versionDirectory = safeCachePart(deploymentVersion, "deployment version");
+	const binaryName = `coder${target.extension}`;
+	const destination = join(
+		options.cacheDirectory,
+		"coder",
+		deploymentId,
+		versionDirectory,
+		`${target.os}-${target.arch}`,
+		binaryName,
+	);
+	const verify = options.verifyBinary ?? verifyCoderBinary;
+	if (existsSync(destination)) {
+		try {
+			await verify(destination, deploymentVersion);
+			return destination;
+		} catch {
+			await rm(destination, { force: true });
+		}
+	}
+
+	const response = await requestFetch(deploymentUrl(options.deployment, `bin/coder-${target.os}-${target.arch}`), {
+		headers: { Accept: "application/octet-stream" },
+		signal: options.signal,
+	});
+	if (!response.ok) {
+		throw new CoderApiError(
+			`Coder CLI download failed with HTTP ${response.status}`,
+			response.status,
+			await response.text(),
+		);
+	}
+	const bytes = new Uint8Array(await response.arrayBuffer());
+	if (bytes.byteLength === 0) throw new CoderApiError("Coder CLI download was empty");
+
+	await mkdir(dirname(destination), { recursive: true });
+	const temporary = `${destination}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+	try {
+		await writeFile(temporary, bytes, { mode: 0o755 });
+		if (target.os !== "windows") await chmod(temporary, 0o755);
+		try {
+			await rename(temporary, destination);
+		} catch (error) {
+			if (!existsSync(destination)) throw error;
+			try {
+				await verify(destination, deploymentVersion);
+				return destination;
+			} catch {
+				await rm(destination, { force: true });
+				await rename(temporary, destination);
+			}
+		}
+		try {
+			await verify(destination, deploymentVersion);
+		} catch (error) {
+			await rm(destination, { force: true });
+			throw error;
+		}
+		return destination;
+	} finally {
+		await rm(temporary, { force: true });
+	}
+}

--- a/test/unit/run-environment-coder.test.ts
+++ b/test/unit/run-environment-coder.test.ts
@@ -1,0 +1,264 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, test } from "vitest";
+import {
+	acquireCoderCli,
+	CoderAgentStartTimeoutError,
+	type CoderWebSocket,
+	createCoderClient,
+} from "../../packages/workflows/src/runs/shared/run-environment-coder.js";
+
+interface RecordedRequest {
+	readonly url: string;
+	readonly init: RequestInit;
+}
+
+function json(value: object, status = 200): Response {
+	return new Response(JSON.stringify(value), { status, headers: { "content-type": "application/json" } });
+}
+
+function createFetch(responses: readonly Response[], requests: RecordedRequest[]) {
+	let index = 0;
+	return async (input: string | URL | Request, init: RequestInit = {}): Promise<Response> => {
+		requests.push({ url: String(input), init });
+		const response = responses[index++];
+		if (response === undefined) throw new Error(`unexpected request ${String(input)}`);
+		return response;
+	};
+}
+
+class ScriptedSocket implements CoderWebSocket {
+	readonly OPEN = 1;
+	readyState = 0;
+	private readonly listeners = new Map<string, Set<(event: Event | MessageEvent) => void>>();
+
+	constructor(private readonly messages: readonly object[]) {
+		queueMicrotask(() => {
+			this.readyState = this.OPEN;
+			this.emit("open", new Event("open"));
+			for (const message of this.messages) {
+				this.emit("message", new MessageEvent("message", { data: JSON.stringify(message) }));
+			}
+		});
+	}
+
+	addEventListener(type: string, listener: (event: Event | MessageEvent) => void): void {
+		const listeners = this.listeners.get(type) ?? new Set();
+		listeners.add(listener);
+		this.listeners.set(type, listeners);
+	}
+
+	removeEventListener(type: string, listener: (event: Event | MessageEvent) => void): void {
+		this.listeners.get(type)?.delete(listener);
+	}
+
+	close(): void {
+		this.readyState = 3;
+	}
+
+	private emit(type: string, event: Event | MessageEvent): void {
+		for (const listener of this.listeners.get(type) ?? []) listener(event);
+	}
+}
+
+describe("Coder run-environment client", () => {
+	test("resolves deployment-owned template inputs and creates a workspace with every parameter explicit", async () => {
+		const requests: RecordedRequest[] = [];
+		const client = createCoderClient({
+			deployment: "https://coder.test/root/",
+			sessionToken: "secret-token",
+			fetch: createFetch(
+				[
+					json({ id: "org-named" }),
+					json({ id: "template-1", active_version_id: "version-7" }),
+					json([
+						{ name: "cpu", default_value: "2" },
+						{ name: "region", default_value: "default-region" },
+						{ name: "feature", default_value: "off" },
+					]),
+					json([{ id: "preset-standard", name: "standard", parameters: [{ name: "cpu", value: "4" }] }]),
+					json({ id: "workspace-9", latest_build: { id: "build-1" } }),
+				],
+				requests,
+			),
+		});
+
+		const workspace = await client.createWorkspace(
+			"atomic-run-123",
+			{
+				deployment: "https://coder.test/root/",
+				organization: "engineering",
+				template: "dev-large",
+				preset: "standard",
+				parameters: { region: "configured-region" },
+				idleMinutes: 240,
+				retentionHours: 12,
+			},
+			new AbortController().signal,
+		);
+
+		assert.equal(workspace.id, "workspace-9");
+		assert.deepEqual(
+			requests.map((request) => new URL(request.url).pathname),
+			[
+				"/root/api/v2/organizations/engineering",
+				"/root/api/v2/organizations/org-named/templates/dev-large",
+				"/root/api/v2/templateversions/version-7/rich-parameters",
+				"/root/api/v2/templateversions/version-7/presets",
+				"/root/api/v2/users/me/workspaces",
+			],
+		);
+		assert.equal(new Headers(requests[4]?.init.headers).get("Coder-Session-Token"), "secret-token");
+		assert.deepEqual(JSON.parse(String(requests[4]?.init.body)), {
+			name: "atomic-run-123",
+			rich_parameter_values: [
+				{ name: "cpu", value: "4" },
+				{ name: "region", value: "configured-region" },
+				{ name: "feature", value: "off" },
+			],
+			template_version_id: "version-7",
+			template_version_preset_id: "preset-standard",
+			ttl_ms: 14_400_000,
+		});
+	});
+
+	test("creates lifecycle builds and waits for the workspace agent lifecycle to become ready", async () => {
+		const requests: RecordedRequest[] = [];
+		const socketUrls: string[] = [];
+		const client = createCoderClient({
+			deployment: "https://coder.test",
+			sessionToken: "token",
+			fetch: createFetch(
+				[json({ id: "build-start" }), json({ id: "build-stop" }), json({ id: "build-delete" })],
+				requests,
+			),
+			webSocket: (url) => {
+				socketUrls.push(url);
+				return new ScriptedSocket([
+					{ build_update: { transition: "start", job_status: "running" } },
+					{ agent_update: { id: "agent-1", lifecycle: "ready" } },
+				]);
+			},
+		});
+
+		await client.createBuild("workspace-1", { transition: "start" }, new AbortController().signal);
+		await client.waitForAgentReady("workspace-1", { timeoutMs: 1_000 }, new AbortController().signal);
+		await client.stopWorkspace("workspace-1", new AbortController().signal);
+		await client.deleteWorkspace("workspace-1", new AbortController().signal);
+
+		assert.deepEqual(
+			requests.map((request) => JSON.parse(String(request.init.body))),
+			[{ transition: "start" }, { transition: "stop" }, { transition: "delete" }],
+		);
+		assert.deepEqual(socketUrls, ["wss://coder.test/api/v2/workspaces/workspace-1/agent-connection-watch"]);
+	});
+
+	test("bounds a workspace whose agent never reports ready", async () => {
+		const client = createCoderClient({
+			deployment: "https://coder.test",
+			sessionToken: "token",
+			fetch,
+			webSocket: () => new ScriptedSocket([{ agent_update: { id: "agent-1", lifecycle: "starting" } }]),
+		});
+
+		await assert.rejects(
+			client.waitForAgentReady("workspace-1", { timeoutMs: 10 }, new AbortController().signal),
+			CoderAgentStartTimeoutError,
+		);
+	});
+	test("uses the current user's first organization when the binding does not name one", async () => {
+		const requests: RecordedRequest[] = [];
+		const client = createCoderClient({
+			deployment: "https://coder.test",
+			sessionToken: "token",
+			fetch: createFetch(
+				[
+					json({ organization_ids: ["org-first", "org-second"] }),
+					json({ active_version_id: "version-1" }),
+					json([]),
+					json({ id: "workspace-1", latest_build: { id: "build-1" } }),
+				],
+				requests,
+			),
+		});
+
+		await client.createWorkspace(
+			"atomic-run-default-org",
+			{
+				deployment: "https://coder.test",
+				template: "dev",
+				parameters: {},
+				idleMinutes: 240,
+				retentionHours: 12,
+			},
+			new AbortController().signal,
+		);
+
+		assert.deepEqual(
+			requests.map((request) => new URL(request.url).pathname),
+			[
+				"/api/v2/users/me",
+				"/api/v2/organizations/org-first/templates/dev",
+				"/api/v2/templateversions/version-1/rich-parameters",
+				"/api/v2/users/me/workspaces",
+			],
+		);
+	});
+});
+
+describe("Coder CLI acquisition", () => {
+	test("downloads the deployment version into a deployment-specific cache without consulting PATH", async () => {
+		const root = await mkdtemp(join(tmpdir(), "atomic-coder-cli-"));
+		const requests: string[] = [];
+		const verified: Array<{ path: string; version: string }> = [];
+		try {
+			const path = await acquireCoderCli({
+				deployment: "https://coder.test/base",
+				cacheDirectory: root,
+				fetch: async (input) => {
+					const url = String(input);
+					requests.push(url);
+					return url.endsWith("/api/v2/buildinfo")
+						? json({ deployment_id: "deployment-a", version: "v2.36.3+build" })
+						: new Response("deployment-cli-binary");
+				},
+				platform: "linux",
+				architecture: "x64",
+				verifyBinary: async (candidate, version) => {
+					verified.push({ path: candidate, version });
+				},
+				signal: new AbortController().signal,
+			});
+
+			assert.equal(path, join(root, "coder", "deployment-a", "2.36.3+build", "linux-amd64", "coder"));
+			assert.deepEqual(requests, [
+				"https://coder.test/base/api/v2/buildinfo",
+				"https://coder.test/base/bin/coder-linux-amd64",
+			]);
+			assert.equal(await readFile(path, "utf8"), "deployment-cli-binary");
+			assert.deepEqual(verified, [{ path, version: "v2.36.3+build" }]);
+
+			const cached = await acquireCoderCli({
+				deployment: "https://coder.test/base",
+				cacheDirectory: root,
+				fetch: async (input) => {
+					requests.push(String(input));
+					return json({ deployment_id: "deployment-a", version: "v2.36.3+build" });
+				},
+				platform: "linux",
+				architecture: "x64",
+				verifyBinary: async (candidate, version) => {
+					verified.push({ path: candidate, version });
+				},
+				signal: new AbortController().signal,
+			});
+			assert.equal(cached, path);
+			assert.equal(requests.filter((url) => url.endsWith("/bin/coder-linux-amd64")).length, 1);
+			assert.equal(verified.length, 2);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
Assistant-model: GPT-5.6 Sol

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790382634&installation_model_id=10562&pr_number=2714&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2714&signature=de79f31ff6f617d266d787b68e922fa6f048f5b2f8a99fb61f8570d338dcb585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds Coder workspace creation, lifecycle controls, agent-readiness monitoring, and deployment-specific CLI acquisition. One blocking security issue remains: a CLI downloaded from a cleartext HTTP deployment is executed before its authenticity is established.

<h3>Confidence Score: 3/5</h3>

Not merge-safe until downloaded Coder CLI artifacts are authenticated before execution.

One actionable P1 security finding remains: an unauthenticated HTTP CLI download can execute arbitrary code on the workflow host. The scoring policy assigns a score of 3 to one security P1.

**Files Needing Attention:** packages/workflows/src/runs/shared/run-environment-coder.ts

<details open><summary><h3>Security Review</h3></summary>

An on-path attacker able to modify traffic to a configured HTTP Coder deployment can provide a CLI that executes on the workflow host. The implementation relies on the downloaded program's self-reported version only after running it, which neither prevents that first execution nor authenticates a version-matching payload.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex retrieved the HTTP-downloaded Coder CLI reproduction source and captured the reproduction script.
- T-Rex observed a mismatched HTTP payload before rejection during the reproduction.
- T-Rex confirmed the HTTP payload was accepted after the default verifier execution.
- T-Rex ran a focused Coder acquisition unit-test as part of the reproduction validation.
- T-Rex generated hashes for core reproduction artifacts to verify integrity.

<a href="https://app.greptile.com/trex/runs/21352739/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/workflows/src/runs/shared/run-environment-coder.ts:439
**Unauthenticated HTTP CLI executes during verification**

`acquireCoderCli` accepts an `http:` deployment URL, saves its `/bin/coder-*` response with execute permission, then invokes it as `coder version` before establishing that the bytes are authentic. A network attacker able to alter traffic to a cleartext Coder deployment can therefore execute arbitrary code on the workflow host. The version check is not an integrity check: a payload that prints the expected version is accepted and cached, while even a mismatched payload runs once before rejection. Require HTTPS for CLI acquisition and verify a checksum or signature from an independently trusted source before making or invoking the downloaded file.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["feat(workflows): add Coder workspace cli..."](https://github.com/bastani-inc/atomic/commit/99b6edf12bb30ff1559103e36b10695ce62e2176) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57961172)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->