### PR TITLE
fix(build): ship the intercom broker's import closure so intercom and subagent work in installed packages

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed installed packages where the intercom broker crashed at startup, leaving both the `intercom` and `subagent` tools entirely non-functional, and fixed the workflows SDK `types` condition pointing to a source file that is not shipped.
+
 ## [0.9.16-alpha.6] - 2026-08-26
 
 ### Changed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed installed packages where the intercom broker crashed at startup, leaving both the `intercom` and `subagent` tools entirely non-functional, and fixed the workflows SDK `types` condition pointing to a source file that is not shipped.
+- Fixed installed packages where the intercom broker failed to start on every launch, leaving both the `intercom` and `subagent` tools entirely non-functional.
 
 ## [0.9.16-alpha.6] - 2026-08-26
 

--- a/packages/coding-agent/scripts/copy-builtin-packages.ts
+++ b/packages/coding-agent/scripts/copy-builtin-packages.ts
@@ -47,7 +47,6 @@ const packagesRoot = resolve(packageRoot, "..");
 const workflowsDistDir = join(distBuiltinDir, "workflows");
 const workflowsAuthoringTsconfig = join(packageRoot, "tsconfig.workflows-types.json");
 const workflowsAmbientDts = join(workflowsDistDir, "ambient.d.ts");
-const workflowsAuthoringDeclaration = "src/authoring.d.ts";
 const workflowsAmbientReference = '/// <reference path="./builtin/workflows/ambient.d.ts" />';
 // Raw authoring-surface sources that are type-only at runtime (all importers use
 // `import type`), so deleting their `.ts` copies is behaviorally inert; only the
@@ -96,7 +95,7 @@ const INSTALLED_KEEP_PREFIXES: Record<BuiltinPackageDirName, readonly string[]> 
 		"ambient.d.ts",
 		INSTALLED_EXTENSION_ENTRIES.workflows,
 		WORKFLOWS_SDK_BUNDLE_ENTRY,
-		workflowsAuthoringDeclaration,
+		"src/authoring.d.ts",
 		"src/shared/authoring-contract.d.ts",
 		"builtin/",
 		"skills/",
@@ -310,7 +309,6 @@ function pointWorkflowsSdkAtBundle(pkg: Record<string, unknown>): void {
 		| undefined;
 	if (exportsField?.["."]) {
 		exportsField["."].default = `./${WORKFLOWS_SDK_BUNDLE_ENTRY}`;
-		exportsField["."].types = `./${workflowsAuthoringDeclaration}`;
 	}
 }
 

--- a/packages/coding-agent/scripts/copy-builtin-packages.ts
+++ b/packages/coding-agent/scripts/copy-builtin-packages.ts
@@ -15,6 +15,11 @@ import {
 	WORKFLOWS_SDK_BUNDLE_ENTRY,
 	type BuiltinPackageDirName,
 } from "../src/core/builtin-install-layout.ts";
+import {
+	deriveImportClosure,
+	INSTALLED_IMPORT_CLOSURE_ROOTS,
+	shouldSkipBuiltinCopyEntry,
+} from "./derive-import-closure.js";
 
 interface BuiltinCopy {
 	label: string;
@@ -42,6 +47,7 @@ const packagesRoot = resolve(packageRoot, "..");
 const workflowsDistDir = join(distBuiltinDir, "workflows");
 const workflowsAuthoringTsconfig = join(packageRoot, "tsconfig.workflows-types.json");
 const workflowsAmbientDts = join(workflowsDistDir, "ambient.d.ts");
+const workflowsAuthoringDeclaration = "src/authoring.d.ts";
 const workflowsAmbientReference = '/// <reference path="./builtin/workflows/ambient.d.ts" />';
 // Raw authoring-surface sources that are type-only at runtime (all importers use
 // `import type`), so deleting their `.ts` copies is behaviorally inert; only the
@@ -90,7 +96,7 @@ const INSTALLED_KEEP_PREFIXES: Record<BuiltinPackageDirName, readonly string[]> 
 		"ambient.d.ts",
 		INSTALLED_EXTENSION_ENTRIES.workflows,
 		WORKFLOWS_SDK_BUNDLE_ENTRY,
-		"src/authoring.d.ts",
+		workflowsAuthoringDeclaration,
 		"src/shared/authoring-contract.d.ts",
 		"builtin/",
 		"skills/",
@@ -148,23 +154,7 @@ function assertPackageDir(packageDir: string, expectedName: string): void {
 }
 
 function shouldSkipEntry(name: string): boolean {
-	return (
-		name === "node_modules" ||
-		name === ".git" ||
-		name === ".github" ||
-		name === "coverage" ||
-		name === ".nyc_output" ||
-		name === ".DS_Store" ||
-		name === ".turbo" ||
-		name === ".vite" ||
-		name === ".vitest" ||
-		name === "test" ||
-		name === "tests" ||
-		name.endsWith(".test.ts") ||
-		name.endsWith(".test.mjs") ||
-		name.endsWith(".spec.ts") ||
-		name.endsWith(".map")
-	);
+	return shouldSkipBuiltinCopyEntry(name);
 }
 
 function copyFilteredDirectory(sourceDir: string, destinationDir: string): void {
@@ -320,20 +310,32 @@ function pointWorkflowsSdkAtBundle(pkg: Record<string, unknown>): void {
 		| undefined;
 	if (exportsField?.["."]) {
 		exportsField["."].default = `./${WORKFLOWS_SDK_BUNDLE_ENTRY}`;
+		exportsField["."].types = `./${workflowsAuthoringDeclaration}`;
 	}
 }
 
-function shouldKeepInstalledPath(dirName: BuiltinPackageDirName, relativePath: string): boolean {
+function shouldKeepInstalledPath(
+	dirName: BuiltinPackageDirName,
+	relativePath: string,
+	importClosure: ReadonlySet<string>,
+): boolean {
 	const normalized = relativePath.split("\\").join("/");
-	return INSTALLED_KEEP_PREFIXES[dirName].some((keep) => {
-		if (keep.endsWith("/")) {
-			return normalized === keep.slice(0, -1) || normalized.startsWith(keep);
-		}
-		return normalized === keep;
-	});
+	return (
+		importClosure.has(normalized) ||
+		INSTALLED_KEEP_PREFIXES[dirName].some((keep) => {
+			if (keep.endsWith("/")) {
+				return normalized === keep.slice(0, -1) || normalized.startsWith(keep);
+			}
+			return normalized === keep;
+		})
+	);
 }
 
-function pruneInstalledPackage(packageDir: string, dirName: BuiltinPackageDirName): void {
+function pruneInstalledPackage(
+	packageDir: string,
+	dirName: BuiltinPackageDirName,
+	importClosure: ReadonlySet<string>,
+): void {
 	const visit = (dir: string): void => {
 		for (const entry of readdirSync(dir)) {
 			const fullPath = join(dir, entry);
@@ -346,7 +348,7 @@ function pruneInstalledPackage(packageDir: string, dirName: BuiltinPackageDirNam
 				}
 				continue;
 			}
-			if (!shouldKeepInstalledPath(dirName, relativePath)) {
+			if (!shouldKeepInstalledPath(dirName, relativePath, importClosure)) {
 				rmSync(fullPath);
 			}
 		}
@@ -354,12 +356,16 @@ function pruneInstalledPackage(packageDir: string, dirName: BuiltinPackageDirNam
 	visit(packageDir);
 }
 
+const installedImportClosures = new Map<BuiltinPackageDirName, ReadonlySet<string>>();
+
 rmSync(distBuiltinDir, { recursive: true, force: true });
 mkdirSync(distBuiltinDir, { recursive: true });
 
 for (const copy of getCopyPlan()) {
 	const destinationDir = join(distBuiltinDir, copy.destinationName);
 	copyFilteredDirectory(copy.sourceDir, destinationDir);
+	const closureRoots = INSTALLED_IMPORT_CLOSURE_ROOTS[copy.destinationName] ?? [];
+	installedImportClosures.set(copy.destinationName, deriveImportClosure(copy.sourceDir, closureRoots));
 	console.log(`Copied builtin ${copy.label} -> ${join("dist", "builtin", basename(destinationDir))}`);
 }
 
@@ -414,6 +420,6 @@ for (const dirName of ["subagents", "mcp", "web-access", "intercom"] as const) {
 }
 
 for (const dirName of WORKSPACE_BUILTINS.map((entry) => entry.workspaceDirName)) {
-	pruneInstalledPackage(join(distBuiltinDir, dirName), dirName);
+	pruneInstalledPackage(join(distBuiltinDir, dirName), dirName, installedImportClosures.get(dirName) ?? new Set());
 	console.log(`Pruned installed sources for ${dirName}`);
 }

--- a/packages/coding-agent/scripts/derive-import-closure.ts
+++ b/packages/coding-agent/scripts/derive-import-closure.ts
@@ -1,0 +1,151 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import type { BuiltinPackageDirName } from "../src/core/builtin-install-layout.js";
+
+// Only packages whose kept raw TypeScript runs directly from the filesystem participate. The intercom broker is
+// spawned as its own jiti process, so it has no host aliases or virtualModules fallback. Workflows is deliberately
+// excluded: its installed authoring surface prunes raw sources for issue #1208, and tracing it would resurrect them.
+export const INSTALLED_IMPORT_CLOSURE_ROOTS: Partial<Record<BuiltinPackageDirName, readonly string[]>> = {
+	intercom: ["broker/"],
+};
+import { parse } from "@babel/parser";
+
+const SKIPPED_ENTRY_NAMES = new Set([
+	"node_modules",
+	".git",
+	".github",
+	"coverage",
+	".nyc_output",
+	".DS_Store",
+	".turbo",
+	".vite",
+	".vitest",
+	"test",
+	"tests",
+]);
+
+interface SyntaxNode {
+	[key: string]: SyntaxValue | undefined;
+	type?: string;
+	value?: string;
+}
+
+type SyntaxValue = string | number | boolean | null | SyntaxNode | SyntaxValue[];
+
+export function shouldSkipBuiltinCopyEntry(name: string): boolean {
+	return (
+		SKIPPED_ENTRY_NAMES.has(name) ||
+		name.endsWith(".test.ts") ||
+		name.endsWith(".test.mjs") ||
+		name.endsWith(".spec.ts") ||
+		name.endsWith(".map")
+	);
+}
+
+function inside(parent: string, path: string): boolean {
+	const fromParent = relative(parent, path);
+	return fromParent !== ".." && !fromParent.startsWith(`..${sep}`) && !isAbsolute(fromParent);
+}
+
+function relativeImports(path: string): string[] {
+	const imports = new Set<string>();
+	const visit = (value: SyntaxValue | undefined): void => {
+		if (Array.isArray(value)) {
+			for (const item of value) visit(item);
+			return;
+		}
+		if (value === null || typeof value !== "object") return;
+		if (
+			value.type === "ImportDeclaration" ||
+			value.type === "ExportNamedDeclaration" ||
+			value.type === "ExportAllDeclaration"
+		) {
+			const specifier = value.source;
+			if (typeof specifier === "object" && !Array.isArray(specifier) && specifier?.value?.startsWith(".")) {
+				imports.add(specifier.value);
+			}
+		} else if (value.type === "TSImportType") {
+			const specifier = value.argument;
+			if (typeof specifier === "object" && !Array.isArray(specifier) && specifier?.value?.startsWith(".")) {
+				imports.add(specifier.value);
+			}
+		} else if (value.type === "ImportExpression") {
+			const specifier = value.source;
+			if (typeof specifier === "object" && !Array.isArray(specifier) && specifier?.value?.startsWith(".")) {
+				imports.add(specifier.value);
+			}
+		}
+		for (const [key, child] of Object.entries(value)) {
+			if (key !== "loc" && key !== "extra") visit(child);
+		}
+	};
+	visit(parse(readFileSync(path, "utf8"), { sourceType: "module", plugins: ["typescript"] }) as object as SyntaxNode);
+	return [...imports];
+}
+
+function resolveRelativeImport(importer: string, specifier: string): string | undefined {
+	const emittedPath = resolve(dirname(importer), specifier);
+	const sourcePath = emittedPath
+		.replace(/\.mjs$/u, ".mts")
+		.replace(/\.cjs$/u, ".cts")
+		.replace(/\.jsx$/u, ".tsx")
+		.replace(/\.js$/u, ".ts");
+	return [sourcePath, emittedPath, `${emittedPath}.ts`, join(emittedPath, "index.ts")].find(
+		(path) => existsSync(path) && statSync(path).isFile(),
+	);
+}
+
+function normalizedRelativePath(parent: string, path: string): string {
+	return relative(parent, path).split("\\").join("/");
+}
+
+function pathIsSkipped(packageRoot: string, path: string): boolean {
+	return normalizedRelativePath(packageRoot, path).split("/").some(shouldSkipBuiltinCopyEntry);
+}
+
+/**
+ * Derive every source file transitively reached by relative imports from raw TypeScript files beneath the roots.
+ * Imports that leave the package or resolve into excluded test/build directories are deliberately not copied.
+ */
+export function deriveImportClosure(packageRoot: string, roots: readonly string[]): ReadonlySet<string> {
+	const resolvedPackageRoot = resolve(packageRoot);
+	const pending: string[] = [];
+	const visited = new Set<string>();
+	const closure = new Set<string>();
+
+	const addRootFiles = (path: string): void => {
+		if (!inside(resolvedPackageRoot, path) || !existsSync(path) || pathIsSkipped(resolvedPackageRoot, path)) return;
+		const stats = statSync(path);
+		if (stats.isDirectory()) {
+			for (const entry of readdirSync(path)) addRootFiles(join(path, entry));
+		} else if (stats.isFile() && path.endsWith(".ts")) {
+			pending.push(path);
+		}
+	};
+	for (const root of roots) addRootFiles(resolve(resolvedPackageRoot, root));
+
+	while (pending.length > 0) {
+		const path = pending.pop();
+		if (path === undefined) break;
+		const relativePath = normalizedRelativePath(resolvedPackageRoot, path);
+		if (visited.has(relativePath)) continue;
+		visited.add(relativePath);
+		closure.add(relativePath);
+		for (const specifier of relativeImports(path)) {
+			const unresolvedPath = resolve(dirname(path), specifier);
+			if (!inside(resolvedPackageRoot, unresolvedPath)) {
+				throw new Error(`Relative import ${specifier} from ${relativePath} escapes the package root`);
+			}
+			const dependency = resolveRelativeImport(path, specifier);
+			if (dependency === undefined) {
+				throw new Error(`Unresolved relative import ${specifier} from ${relativePath}`);
+			}
+			if (!pathIsSkipped(resolvedPackageRoot, dependency)) {
+				const dependencyRelativePath = normalizedRelativePath(resolvedPackageRoot, dependency);
+				closure.add(dependencyRelativePath);
+				if (dependency.endsWith(".ts") && !visited.has(dependencyRelativePath)) pending.push(dependency);
+			}
+		}
+	}
+	return closure;
+}

--- a/packages/coding-agent/scripts/derive-import-closure.ts
+++ b/packages/coding-agent/scripts/derive-import-closure.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { parse } from "@babel/parser";
 import type { BuiltinPackageDirName } from "../src/core/builtin-install-layout.js";
 
 // Only packages whose kept raw TypeScript runs directly from the filesystem participate. The intercom broker is
@@ -8,7 +9,6 @@ import type { BuiltinPackageDirName } from "../src/core/builtin-install-layout.j
 export const INSTALLED_IMPORT_CLOSURE_ROOTS: Partial<Record<BuiltinPackageDirName, readonly string[]>> = {
 	intercom: ["broker/"],
 };
-import { parse } from "@babel/parser";
 
 const SKIPPED_ENTRY_NAMES = new Set([
 	"node_modules",
@@ -105,7 +105,7 @@ function pathIsSkipped(packageRoot: string, path: string): boolean {
 
 /**
  * Derive every source file transitively reached by relative imports from raw TypeScript files beneath the roots.
- * Imports that leave the package or resolve into excluded test/build directories are deliberately not copied.
+ * Imports cannot escape the package, and excluded test/build paths are never copied.
  */
 export function deriveImportClosure(packageRoot: string, roots: readonly string[]): ReadonlySet<string> {
 	const resolvedPackageRoot = resolve(packageRoot);

--- a/packages/coding-agent/scripts/derive-import-closure.ts
+++ b/packages/coding-agent/scripts/derive-import-closure.ts
@@ -3,6 +3,11 @@ import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { parse } from "@babel/parser";
 import type { BuiltinPackageDirName } from "../src/core/builtin-install-layout.js";
 
+// This build-time walker intentionally remains separate from test/unit/module-graph-walker.ts. The latter models
+// the complete runtime loader graph for tests, while production packaging code must not import from the test tree.
+// This narrower walker follows relative filesystem edges only, but matches the test walker by failing closed when a
+// direct import or require specifier cannot be determined statically.
+
 // Only packages whose kept raw TypeScript runs directly from the filesystem participate. The intercom broker is
 // spawned as its own jiti process, so it has no host aliases or virtualModules fallback. Workflows is deliberately
 // excluded: its installed authoring surface prunes raw sources for issue #1208, and tracing it would resurrect them.
@@ -47,6 +52,32 @@ function inside(parent: string, path: string): boolean {
 	return fromParent !== ".." && !fromParent.startsWith(`..${sep}`) && !isAbsolute(fromParent);
 }
 
+function stringLiteralValue(value: SyntaxValue | undefined): string | undefined {
+	return typeof value === "object" && value !== null && !Array.isArray(value) && typeof value.value === "string"
+		? value.value
+		: undefined;
+}
+
+function isIdentifier(value: SyntaxValue | undefined, name: string): boolean {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		!Array.isArray(value) &&
+		value.type === "Identifier" &&
+		value.name === name
+	);
+}
+
+function requireSpecifier(value: SyntaxNode, path: string): string | undefined {
+	if (value.type !== "CallExpression" || !isIdentifier(value.callee, "require")) return undefined;
+	const argument = Array.isArray(value.arguments) ? value.arguments[0] : undefined;
+	const specifier = stringLiteralValue(argument);
+	if (specifier === undefined) {
+		throw new Error(`Non-literal require() specifier in ${path}`);
+	}
+	return specifier;
+}
+
 export function relativeImportSpecifiers(path: string): string[] {
 	const imports = new Set<string>();
 	const visit = (value: SyntaxValue | undefined): void => {
@@ -55,26 +86,30 @@ export function relativeImportSpecifiers(path: string): string[] {
 			return;
 		}
 		if (value === null || typeof value !== "object") return;
+		let specifier: string | undefined;
 		if (
 			value.type === "ImportDeclaration" ||
 			value.type === "ExportNamedDeclaration" ||
 			value.type === "ExportAllDeclaration"
 		) {
-			const specifier = value.source;
-			if (typeof specifier === "object" && !Array.isArray(specifier) && specifier?.value?.startsWith(".")) {
-				imports.add(specifier.value);
-			}
+			specifier = stringLiteralValue(value.source);
 		} else if (value.type === "TSImportType") {
-			const specifier = value.argument;
-			if (typeof specifier === "object" && !Array.isArray(specifier) && specifier?.value?.startsWith(".")) {
-				imports.add(specifier.value);
-			}
+			// Babel 8 stores this on `source`; `argument` is the explicit fallback for older parser majors.
+			specifier = stringLiteralValue(value.source) ?? stringLiteralValue(value.argument);
 		} else if (value.type === "ImportExpression") {
-			const specifier = value.source;
-			if (typeof specifier === "object" && !Array.isArray(specifier) && specifier?.value?.startsWith(".")) {
-				imports.add(specifier.value);
+			specifier = stringLiteralValue(value.source);
+			if (specifier === undefined) {
+				// Packaging cannot prove a computed edge is safe. Fail closed instead of silently pruning its target.
+				throw new Error(`Non-literal import() specifier in ${path}`);
 			}
+		} else if (value.type === "CallExpression" && isIdentifier(value.callee, "Import")) {
+			const argument = Array.isArray(value.arguments) ? value.arguments[0] : undefined;
+			specifier = stringLiteralValue(argument);
+			if (specifier === undefined) throw new Error(`Non-literal import() specifier in ${path}`);
+		} else {
+			specifier = requireSpecifier(value, path);
 		}
+		if (specifier?.startsWith(".")) imports.add(specifier);
 		for (const [key, child] of Object.entries(value)) {
 			if (key !== "loc" && key !== "extra") visit(child);
 		}
@@ -140,11 +175,14 @@ export function deriveImportClosure(packageRoot: string, roots: readonly string[
 			if (dependency === undefined) {
 				throw new Error(`Unresolved relative import ${specifier} from ${relativePath}`);
 			}
-			if (!pathIsSkipped(resolvedPackageRoot, dependency)) {
-				const dependencyRelativePath = normalizedRelativePath(resolvedPackageRoot, dependency);
-				closure.add(dependencyRelativePath);
-				if (dependency.endsWith(".ts") && !visited.has(dependencyRelativePath)) pending.push(dependency);
+			const dependencyRelativePath = normalizedRelativePath(resolvedPackageRoot, dependency);
+			if (pathIsSkipped(resolvedPackageRoot, dependency)) {
+				throw new Error(
+					`Relative import ${specifier} from ${relativePath} resolves to excluded path ${dependencyRelativePath}`,
+				);
 			}
+			closure.add(dependencyRelativePath);
+			if (dependency.endsWith(".ts") && !visited.has(dependencyRelativePath)) pending.push(dependency);
 		}
 	}
 	return closure;

--- a/packages/coding-agent/scripts/derive-import-closure.ts
+++ b/packages/coding-agent/scripts/derive-import-closure.ts
@@ -47,7 +47,7 @@ function inside(parent: string, path: string): boolean {
 	return fromParent !== ".." && !fromParent.startsWith(`..${sep}`) && !isAbsolute(fromParent);
 }
 
-function relativeImports(path: string): string[] {
+export function relativeImportSpecifiers(path: string): string[] {
 	const imports = new Set<string>();
 	const visit = (value: SyntaxValue | undefined): void => {
 		if (Array.isArray(value)) {
@@ -83,7 +83,7 @@ function relativeImports(path: string): string[] {
 	return [...imports];
 }
 
-function resolveRelativeImport(importer: string, specifier: string): string | undefined {
+export function resolveRelativeImport(importer: string, specifier: string): string | undefined {
 	const emittedPath = resolve(dirname(importer), specifier);
 	const sourcePath = emittedPath
 		.replace(/\.mjs$/u, ".mts")
@@ -131,7 +131,7 @@ export function deriveImportClosure(packageRoot: string, roots: readonly string[
 		if (visited.has(relativePath)) continue;
 		visited.add(relativePath);
 		closure.add(relativePath);
-		for (const specifier of relativeImports(path)) {
+		for (const specifier of relativeImportSpecifiers(path)) {
 			const unresolvedPath = resolve(dirname(path), specifier);
 			if (!inside(resolvedPackageRoot, unresolvedPath)) {
 				throw new Error(`Relative import ${specifier} from ${relativePath} escapes the package root`);

--- a/test/unit/builtin-copy-import-closure.test.ts
+++ b/test/unit/builtin-copy-import-closure.test.ts
@@ -40,9 +40,19 @@ test("builtin copy derives transitive relative imports without copying excluded 
 	try {
 		makeDirectorySync(join(fixture, "broker"), { recursive: true });
 		makeDirectorySync(join(fixture, "node_modules", "ignored"), { recursive: true });
-		writeTextSync(join(fixture, "broker", "entry.ts"), 'export { value } from "../new-dependency.js";\n');
+		writeTextSync(
+			join(fixture, "broker", "entry.ts"),
+			[
+				'export { value } from "../new-dependency.js";',
+				'type Imported = import("../type-target.js").Foo;',
+				'const required = require("../require-target.js");',
+				"export const loaded: Imported | typeof required = required;",
+			].join("\n"),
+		);
 		writeTextSync(join(fixture, "new-dependency.ts"), 'export { value } from "./nested.js";\n');
 		writeTextSync(join(fixture, "nested.ts"), "export const value = 1;\n");
+		writeTextSync(join(fixture, "type-target.ts"), "export interface Foo { value: number }\n");
+		writeTextSync(join(fixture, "require-target.ts"), "export const required = true;\n");
 		writeTextSync(join(fixture, "unrelated.ts"), "export const unrelated = true;\n");
 		writeTextSync(join(fixture, "unrelated.test.ts"), "throw new Error();\n");
 		writeTextSync(join(fixture, "unrelated.spec.ts"), "throw new Error();\n");
@@ -52,10 +62,43 @@ test("builtin copy derives transitive relative imports without copying excluded 
 			"broker/entry.ts",
 			"nested.ts",
 			"new-dependency.ts",
+			"require-target.ts",
+			"type-target.ts",
 		]);
 
 		writeTextSync(join(fixture, "broker", "entry.ts"), 'export { value } from "../../outside.js";\n');
 		assert.throws(() => deriveImportClosure(fixture, ["broker/"]), /escapes the package root/u);
+	} finally {
+		removeTempDirectory(fixture);
+	}
+});
+
+test("builtin copy fails closed on non-literal dynamic specifiers", () => {
+	const fixture = makeTempDirectory("atomic-builtin-dynamic-import-");
+	try {
+		makeDirectorySync(join(fixture, "broker"), { recursive: true });
+		const entry = join(fixture, "broker", "entry.ts");
+		writeTextSync(entry, "const target = './dynamic.js';\nvoid import(target);\n");
+		assert.throws(() => deriveImportClosure(fixture, ["broker/"]), /Non-literal import\(\) specifier/u);
+
+		writeTextSync(entry, "const target = './dynamic.js';\nrequire(target);\n");
+		assert.throws(() => deriveImportClosure(fixture, ["broker/"]), /Non-literal require\(\) specifier/u);
+	} finally {
+		removeTempDirectory(fixture);
+	}
+});
+
+test("builtin copy rejects a relative import that resolves beneath an excluded path", () => {
+	const fixture = makeTempDirectory("atomic-builtin-excluded-import-");
+	try {
+		makeDirectorySync(join(fixture, "broker"), { recursive: true });
+		makeDirectorySync(join(fixture, "test"), { recursive: true });
+		writeTextSync(join(fixture, "broker", "entry.ts"), 'export { helper } from "../test/helper.js";\n');
+		writeTextSync(join(fixture, "test", "helper.ts"), "export const helper = true;\n");
+		assert.throws(
+			() => deriveImportClosure(fixture, ["broker/"]),
+			/Relative import \.\.\/test\/helper\.js from broker\/entry\.ts resolves to excluded path test\/helper\.ts/u,
+		);
 	} finally {
 		removeTempDirectory(fixture);
 	}

--- a/test/unit/builtin-copy-import-closure.test.ts
+++ b/test/unit/builtin-copy-import-closure.test.ts
@@ -4,6 +4,8 @@ import { test } from "vitest";
 import {
 	deriveImportClosure,
 	INSTALLED_IMPORT_CLOSURE_ROOTS,
+	relativeImportSpecifiers,
+	resolveRelativeImport,
 } from "../../packages/coding-agent/scripts/derive-import-closure.js";
 import {
 	fileExistsSync,
@@ -11,18 +13,9 @@ import {
 	makeTempDirectory,
 	moduleDir,
 	readDirectorySync,
-	readTextSync,
 	removeTempDirectory,
 	writeTextSync,
 } from "../helpers/runtime.js";
-
-interface WorkflowsManifest {
-	exports?: {
-		"."?: {
-			types?: string;
-		};
-	};
-}
 
 const root = join(moduleDir(import.meta.url), "../..");
 const distBuiltinRoot = join(root, "packages", "coding-agent", "dist", "builtin");
@@ -68,11 +61,22 @@ test("builtin copy derives transitive relative imports without copying excluded 
 	}
 });
 
-test("shipped raw TypeScript closure roots have no unresolved relative imports", () => {
-	for (const [packageName, roots] of Object.entries(INSTALLED_IMPORT_CLOSURE_ROOTS)) {
+test("every shipped raw TypeScript file has resolvable relative imports", () => {
+	for (const packageName of Object.keys(INSTALLED_IMPORT_CLOSURE_ROOTS)) {
 		const packageRoot = join(distBuiltinRoot, packageName);
 		requireBuiltPath(packageRoot);
-		assert.doesNotThrow(() => deriveImportClosure(packageRoot, roots));
+		const rawTypeScriptFiles = listFiles(packageRoot).filter(
+			(path) => path.endsWith(".ts") && !path.endsWith(".d.ts"),
+		);
+		for (const relativePath of rawTypeScriptFiles) {
+			const importer = join(packageRoot, relativePath);
+			for (const specifier of relativeImportSpecifiers(importer)) {
+				assert.ok(
+					resolveRelativeImport(importer, specifier),
+					`Unresolved relative import ${specifier} from ${packageName}/${relativePath}`,
+				);
+			}
+		}
 	}
 });
 
@@ -95,14 +99,4 @@ test("shipped intercom includes broker dependencies without excluded files", () 
 		files.some((path) => path.split("/").includes("node_modules")),
 		false,
 	);
-});
-
-test("shipped workflows manifest points its types condition at the emitted declaration", () => {
-	const workflowsRoot = join(distBuiltinRoot, "workflows");
-	const manifestPath = join(workflowsRoot, "package.json");
-	const declarationPath = join(workflowsRoot, "src", "authoring.d.ts");
-	requireBuiltPath(manifestPath);
-	const manifest = JSON.parse(readTextSync(manifestPath, "utf8")) as WorkflowsManifest;
-	assert.equal(manifest.exports?.["."]?.types, "./src/authoring.d.ts");
-	assert.ok(fileExistsSync(declarationPath), "The workflows authoring declaration must be shipped");
 });

--- a/test/unit/builtin-copy-import-closure.test.ts
+++ b/test/unit/builtin-copy-import-closure.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { test } from "vitest";
+import {
+	deriveImportClosure,
+	INSTALLED_IMPORT_CLOSURE_ROOTS,
+} from "../../packages/coding-agent/scripts/derive-import-closure.js";
+import {
+	fileExistsSync,
+	makeDirectorySync,
+	makeTempDirectory,
+	moduleDir,
+	readDirectorySync,
+	readTextSync,
+	removeTempDirectory,
+	writeTextSync,
+} from "../helpers/runtime.js";
+
+interface WorkflowsManifest {
+	exports?: {
+		"."?: {
+			types?: string;
+		};
+	};
+}
+
+const root = join(moduleDir(import.meta.url), "../..");
+const distBuiltinRoot = join(root, "packages", "coding-agent", "dist", "builtin");
+const buildCommand = "npm --workspace=@bastani/atomic run build";
+
+function requireBuiltPath(path: string): void {
+	assert.ok(fileExistsSync(path), `Missing built artifact ${path}. Run \`${buildCommand}\` before this test.`);
+}
+
+function listFiles(path: string, prefix = ""): string[] {
+	const files: string[] = [];
+	for (const entry of readDirectorySync(path, { withFileTypes: true })) {
+		const relativePath = prefix === "" ? entry.name : `${prefix}/${entry.name}`;
+		if (entry.isDirectory()) files.push(...listFiles(join(path, entry.name), relativePath));
+		else if (entry.isFile()) files.push(relativePath);
+	}
+	return files;
+}
+
+test("builtin copy derives transitive relative imports without copying excluded files", () => {
+	const fixture = makeTempDirectory("atomic-builtin-import-closure-");
+	try {
+		makeDirectorySync(join(fixture, "broker"), { recursive: true });
+		makeDirectorySync(join(fixture, "node_modules", "ignored"), { recursive: true });
+		writeTextSync(join(fixture, "broker", "entry.ts"), 'export { value } from "../new-dependency.js";\n');
+		writeTextSync(join(fixture, "new-dependency.ts"), 'export { value } from "./nested.js";\n');
+		writeTextSync(join(fixture, "nested.ts"), "export const value = 1;\n");
+		writeTextSync(join(fixture, "unrelated.ts"), "export const unrelated = true;\n");
+		writeTextSync(join(fixture, "unrelated.test.ts"), "throw new Error();\n");
+		writeTextSync(join(fixture, "unrelated.spec.ts"), "throw new Error();\n");
+		writeTextSync(join(fixture, "node_modules", "ignored", "index.ts"), "throw new Error();\n");
+
+		assert.deepEqual([...deriveImportClosure(fixture, ["broker/"])].sort(), [
+			"broker/entry.ts",
+			"nested.ts",
+			"new-dependency.ts",
+		]);
+
+		writeTextSync(join(fixture, "broker", "entry.ts"), 'export { value } from "../../outside.js";\n');
+		assert.throws(() => deriveImportClosure(fixture, ["broker/"]), /escapes the package root/u);
+	} finally {
+		removeTempDirectory(fixture);
+	}
+});
+
+test("shipped raw TypeScript closure roots have no unresolved relative imports", () => {
+	for (const [packageName, roots] of Object.entries(INSTALLED_IMPORT_CLOSURE_ROOTS)) {
+		const packageRoot = join(distBuiltinRoot, packageName);
+		requireBuiltPath(packageRoot);
+		assert.doesNotThrow(() => deriveImportClosure(packageRoot, roots));
+	}
+});
+
+test("shipped intercom includes broker dependencies without excluded files", () => {
+	const intercomRoot = join(distBuiltinRoot, "intercom");
+	requireBuiltPath(intercomRoot);
+	for (const path of ["group.ts", "session-target.ts", "source-ownership.ts", "types.ts"]) {
+		assert.ok(fileExistsSync(join(intercomRoot, path)), `Missing shipped intercom dependency ${path}`);
+	}
+	const files = listFiles(intercomRoot);
+	assert.equal(
+		files.some((path) => path.endsWith(".test.ts")),
+		false,
+	);
+	assert.equal(
+		files.some((path) => path.endsWith(".spec.ts")),
+		false,
+	);
+	assert.equal(
+		files.some((path) => path.split("/").includes("node_modules")),
+		false,
+	);
+});
+
+test("shipped workflows manifest points its types condition at the emitted declaration", () => {
+	const workflowsRoot = join(distBuiltinRoot, "workflows");
+	const manifestPath = join(workflowsRoot, "package.json");
+	const declarationPath = join(workflowsRoot, "src", "authoring.d.ts");
+	requireBuiltPath(manifestPath);
+	const manifest = JSON.parse(readTextSync(manifestPath, "utf8")) as WorkflowsManifest;
+	assert.equal(manifest.exports?.["."]?.types, "./src/authoring.d.ts");
+	assert.ok(fileExistsSync(declarationPath), "The workflows authoring declaration must be shipped");
+});


### PR DESCRIPTION
## Problem

In the published `0.9.16-alpha.7` package, `dist/builtin/intercom/` was missing `group.ts`, `session-target.ts`, `source-ownership.ts`, and `types.ts`.

`INSTALLED_KEEP_PREFIXES.intercom` kept `broker/` but none of the sibling modules the broker imports. The broker is spawned as its own jiti process with plain filesystem resolution — no host alias, no `virtualModules` fallback — so it crashed at `require.resolve` on **every** startup:

```
Cannot find module '../session-target.js' imported from
  .../dist/builtin/intercom/broker/send-handler.ts
  code: 'MODULE_NOT_FOUND'
```

That made the `intercom` tool completely unusable, and because subagent results are delivered over intercom, it made the `subagent` tool completely unusable too — for every agent, in an installed package.

It shipped because intercom is lazy and tool-driven: the broker only spawns on first intercom use, so CLI-boot smoke tests never touch it. `send-handler.ts` gained the `../session-target.js` import in 518a952071 and nothing caught the missing sibling.

## Change

The copy step now **derives** the closure instead of listing filenames. `packages/coding-agent/scripts/derive-import-closure.ts` parses each kept raw `.ts` file with `@babel/parser` and walks its relative import edges transitively; `pruneInstalledPackage` keeps anything in that closure in addition to the existing keep-list. A new cross-directory import inside `broker/` is pulled into the shipped tree with no keep-list edit.

Edges followed: `import`/`export … from`, `export *`, dynamic `import()`, type-position `import("…")`, and relative `require()`.

**The walker fails closed everywhere it cannot prove an edge is safe.** It throws — rather than silently pruning a target — when a specifier is unresolved, escapes the package root, resolves beneath an excluded path, or is a non-literal `import()`/`require()` argument. Packaging cannot prove a computed edge is safe, so it refuses to guess.

Scope is deliberately narrow. Only `intercom: ["broker/"]` participates, because it is the one kept raw tree that runs directly off the filesystem in its own process. **Workflows is excluded on purpose**: its installed authoring surface prunes raw sources for #1208, and tracing it would resurrect them. Its shipped tree is path-identical at 278 files after this change.

Exclusions are unchanged and shared with the copy step: `node_modules`, `test`/`tests`, `*.test.ts`, `*.spec.ts`, `*.map`, and the usual dot-directories.

## Verification

Captured on the implementation run at `1c79fe535f`:

- `bun run copy-builtin-packages` → intercom **26** files (the four missing modules present); workflows **278**, `diff` against baseline empty
- Scan over the built tree: `total unresolved: 0` relative specifiers under `dist/builtin/intercom`
- Negative case, at the compiled-binary level: deleting `session-target.ts` from the built tree reproduces the literal `Cannot find module '../session-target.js'` through `Module._resolveFilename`; restoring via the copy step passes again
- End-to-end through a binary built with `npm run build:binary --workspace=@bastani/atomic`: a real prompt drove the `intercom` tool to `Connected: Yes`, and a subagent completed with `Delivered single subagent result via intercom` and zero `intercom_result_error`. Credential-free legs ran on a crabbox linux runner; the model-driven legs ran locally on darwin-arm64, because `.crabbox.yaml` `env.allow` is `[CI, NODE_OPTIONS]` and no credential may reach the runner. Full transcripts are posted as a comment below.
- `npm run test:unit -- test/unit/builtin-copy-import-closure.test.ts` — 5 passed
- `npm run test:unit -- test/unit/intercom-broker-runtime-graph.test.ts` — 24 passed
- `npm run check` — passes

`test/unit/builtin-copy-import-closure.test.ts` covers the derivation against fixtures (transitive closure, exclusions, escape, excluded-path, non-literal specifiers) and asserts against the real built tree that every relative import in every shipped raw `.ts` file resolves, and that the four intercom modules are present. The tree assertion fails when any of the four is removed.

Only scoped suites plus `npm run check` were run, per the run's standing instruction; full CI has not run on both platforms.

## Known, non-blocking

Review flagged two P3s that are latent today and left for follow-up rather than widened into this fix:

- `deriveImportClosure` recurses only into `.ts`. A `.mts`/`.cts`/`.tsx` dependency is copied but not re-entered, so its own imports could be pruned. No such file exists in any participating package today.
- The `CallExpression`/`Import`-callee fallback for dynamic `import()` is unreachable on current Babel majors.

Separately, `dist/builtin/workflows/builtin/*.ts` still has 33 pre-existing unresolved relative imports of the same class. #2716 replaces that surface in a separate stacked change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790388723&installation_model_id=10562&pr_number=2718&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2718&signature=58f75532530a1d5699462c59bada1f6a44e9dc6a3210ca4c39fdb4726fe56d41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change ensures installed Intercom packages retain the complete set of statically referenced runtime TypeScript files, including dependencies reached through `require()` and TypeScript import types. The potential failure where installed Intercom omits broker dependencies was disproved by running the import-closure harness against the real package: it found and retained the 20-file closure, and it rejected computed and excluded-path imports as intended. No defects were found; the change is safe to merge.

<h3>Confidence Score: 5/5</h3>

The installed Intercom import closure retains the tested runtime dependencies and safely rejects unsupported dynamic or excluded import edges.

No review findings remain after an executable check exercised the real Intercom dependency closure, installed-file projection, and failure paths for computed and excluded imports.

**Files Needing Attention:** No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the end-to-end Intercom packaging walker harness before installing the projection against the real packages tree and observed a 20-file runtime closure with all relative edges resolving.
- Reran the harness after the projection installation and observed that the installed projection retained those 20 files, while computed import() and require() paths and imports into excluded paths were rejected.
- Validated the derive-import-closure.ts region (lines 145-188) against the harness to confirm expected behavior.

<a href="https://app.greptile.com/trex/runs/20946248/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(build): fail closed on builtin impor..."](https://github.com/bastani-inc/atomic/commit/1c79fe535f06aee23c112bad8587566f589a1f1a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57349344)</sub>

<!-- /greptile_comment -->