### PR TITLE
feat(workflows): finalize pending stage delivery lifecycle (#2717)

### DIFF
--- a/packages/intercom/inbound-message-admission.ts
+++ b/packages/intercom/inbound-message-admission.ts
@@ -1,4 +1,5 @@
 import { DeliveredMessageCache } from "./broker/delivered-message-cache.js";
+import { isMessage, isSessionInfo } from "./broker/client-message-validation.js";
 import type { Message, SessionInfo } from "./types.js";
 
 export interface InboundMessageReservation {
@@ -20,12 +21,34 @@ interface PendingInboundMessage {
   delivering: boolean;
 }
 
+export interface PersistedInboundMessageEntry {
+  readonly customType?: unknown;
+  readonly details?: unknown;
+  readonly stageAdmissionKey?: unknown;
+}
+
 /** Deduplicates broker deliveries before reply-tracker or turn-context side effects. */
 export class InboundMessageAdmission {
   private readonly delivered = new DeliveredMessageCache();
   private readonly pending = new Map<string, PendingInboundMessage>();
+  private readonly persistentlyDelivered = new Set<string>();
+
+  restore(entries: Iterable<unknown>): void {
+    this.persistentlyDelivered.clear();
+    for (const value of entries) {
+      if (typeof value !== "object" || value === null) continue;
+      const entry = value as PersistedInboundMessageEntry;
+      if (entry.customType !== "intercom_message" || typeof entry.stageAdmissionKey !== "string") continue;
+      if (typeof entry.details !== "object" || entry.details === null) continue;
+      const details = entry.details as { readonly from?: unknown; readonly message?: unknown };
+      if (!isSessionInfo(details.from) || !isMessage(details.message)) continue;
+      if (entry.stageAdmissionKey !== `intercom:${details.message.id}`) continue;
+      this.persistentlyDelivered.add(details.message.id);
+    }
+  }
 
   admit(from: SessionInfo, message: Message): InboundMessageAdmissionResult {
+    if (this.persistentlyDelivered.has(message.id)) return { kind: "duplicate" };
     const signature = JSON.stringify({ from: from.id, message });
     if (this.delivered.lookup(message.id, signature) !== "miss") return { kind: "duplicate" };
     const pending = this.pending.get(message.id);
@@ -60,6 +83,7 @@ export class InboundMessageAdmission {
     if (pending?.reservation !== reservation) return;
     this.pending.delete(reservation.messageId);
     this.delivered.record(reservation.messageId, reservation.signature);
+    this.persistentlyDelivered.add(reservation.messageId);
     pending.resolve();
   }
 

--- a/packages/intercom/index-heavy.ts
+++ b/packages/intercom/index-heavy.ts
@@ -70,6 +70,7 @@ interface PendingStageMessageEvent extends PendingStageMessageRequest {
 interface PendingStageUndeliverableEvent {
   handled: boolean;
   completion?: Promise<boolean>;
+  readonly runId: string;
   readonly senderId: string;
   readonly messageId: string;
   readonly notificationId: string;
@@ -80,6 +81,7 @@ function isPendingStageUndeliverableEvent(value: unknown): value is PendingStage
   if (typeof value !== "object" || value === null) return false;
   const event = value as Partial<PendingStageUndeliverableEvent>;
   return (
+    typeof event.runId === "string" &&
     typeof event.handled === "boolean" &&
     typeof event.senderId === "string" &&
     typeof event.messageId === "string" &&
@@ -725,11 +727,20 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
     payload.completion = completion;
     void completion.catch(() => {});
   });
+  async function pendingStageNotificationClient(runId: string): Promise<IntercomClient> {
+    const route = pendingStageRoutes.get(runId);
+    if (route === undefined) throw new Error("Pending workflow route is unavailable");
+    if (client?.isConnected() && clientRegistrationGroup === normalizeGroup(route.group)) return client;
+    await ensurePendingStageRouteClient(runId, route);
+    const routeClient = pendingStageRouteClients.get(runId)?.client;
+    if (!routeClient?.isConnected()) throw new Error("Pending workflow route is disconnected");
+    return routeClient;
+  }
   pi.events.on(PENDING_STAGE_UNDELIVERABLE_EVENT, (payload) => {
     if (!isPendingStageUndeliverableEvent(payload) || payload.handled) return;
     payload.handled = true;
     const actionable = `Pending workflow stage could not receive intercom message: ${payload.reason}`;
-    payload.completion = ensureConnected("background")
+    payload.completion = pendingStageNotificationClient(payload.runId)
       .then((activeClient) =>
         activeClient.send(payload.senderId, {
           text: actionable,

--- a/packages/intercom/index-heavy.ts
+++ b/packages/intercom/index-heavy.ts
@@ -775,6 +775,7 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
         sessionHomeGroup = null;
       } else {
         sessionHomeGroup = resolveHomeGroup(config, value);
+        inboundDeliveries.restore(value.sessionManager.getBranch());
       }
       runtimeContext = value;
     },

--- a/packages/intercom/index-heavy.ts
+++ b/packages/intercom/index-heavy.ts
@@ -43,6 +43,7 @@ if (process.env.ATOMIC_TEST_LAZY_IMPORT_SENTINEL_FILE) {
 const INTERCOM_SESSION_ID_ENV = `${APP_NAME.toUpperCase()}_INTERCOM_SESSION_ID`;
 const PENDING_STAGE_ROUTE_EVENT = "atomic:workflow-pending-stage-route";
 const PENDING_STAGE_MESSAGE_EVENT = "atomic:workflow-pending-stage-message";
+const PENDING_STAGE_UNDELIVERABLE_EVENT = "atomic:workflow-pending-stage-undeliverable";
 
 interface PendingStageRouteRegistrationEvent {
   readonly runId: string;
@@ -64,6 +65,25 @@ interface PendingStageRouteClientState {
 interface PendingStageMessageEvent extends PendingStageMessageRequest {
   handled: boolean;
   completion?: Promise<PendingStageMessageResult>;
+}
+
+interface PendingStageUndeliverableEvent {
+  handled: boolean;
+  completion?: Promise<boolean>;
+  readonly senderId: string;
+  readonly messageId: string;
+  readonly reason: string;
+}
+
+function isPendingStageUndeliverableEvent(value: unknown): value is PendingStageUndeliverableEvent {
+  if (typeof value !== "object" || value === null) return false;
+  const event = value as Partial<PendingStageUndeliverableEvent>;
+  return (
+    typeof event.handled === "boolean" &&
+    typeof event.senderId === "string" &&
+    typeof event.messageId === "string" &&
+    typeof event.reason === "string"
+  );
 }
 
 function isPendingStageRouteRegistrationEvent(value: unknown): value is PendingStageRouteRegistrationEvent {
@@ -702,6 +722,21 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
     );
     payload.completion = completion;
     void completion.catch(() => {});
+  });
+  pi.events.on(PENDING_STAGE_UNDELIVERABLE_EVENT, (payload) => {
+    if (!isPendingStageUndeliverableEvent(payload) || payload.handled) return;
+    payload.handled = true;
+    const actionable = `Pending workflow stage could not receive intercom message: ${payload.reason}`;
+    payload.completion = ensureConnected("background")
+      .then((activeClient) =>
+        activeClient.send(payload.senderId, {
+          text: actionable,
+          replyTo: payload.messageId,
+          replyError: actionable,
+        }),
+      )
+      .then((result) => result.delivered)
+      .catch(() => false);
   });
 
   registerSubagentRelay(pi, {

--- a/packages/intercom/index-heavy.ts
+++ b/packages/intercom/index-heavy.ts
@@ -1,6 +1,11 @@
 import { APP_NAME, type ExtensionAPI, type ExtensionContext } from "@bastani/atomic";
 import { appendFileSync } from "node:fs";
-import { IntercomClient, type PendingStageMessageRequest, type PendingStageMessageResult } from "./broker/client.js";
+import {
+	IntercomClient,
+	type PendingStageMessageRequest,
+	type PendingStageMessageResult,
+	type PendingStageNotificationRequest,
+} from "./broker/client.js";
 import { spawnBrokerIfNeeded } from "./broker/spawn.js";
 import { InlineMessageComponent } from "./ui/inline-message.js";
 import { loadConfig, type IntercomConfig } from "./config.ts";
@@ -72,6 +77,8 @@ interface PendingStageUndeliverableEvent {
   completion?: Promise<boolean>;
   readonly runId: string;
   readonly senderId: string;
+	readonly senderRegistrationName?: string;
+	readonly senderReturnAddress?: string;
   readonly messageId: string;
   readonly notificationId: string;
   readonly reason: string;
@@ -84,6 +91,8 @@ function isPendingStageUndeliverableEvent(value: unknown): value is PendingStage
     typeof event.runId === "string" &&
     typeof event.handled === "boolean" &&
     typeof event.senderId === "string" &&
+		(event.senderRegistrationName === undefined || typeof event.senderRegistrationName === "string") &&
+		(event.senderReturnAddress === undefined || typeof event.senderReturnAddress === "string") &&
     typeof event.messageId === "string" &&
     typeof event.notificationId === "string" &&
     typeof event.reason === "string"
@@ -452,6 +461,104 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
         }),
     );
   }
+	async function admitPendingStageNotification(
+		nextClient: IntercomClient,
+		request: PendingStageNotificationRequest,
+	): Promise<boolean> {
+		const messageGeneration = runtimeGeneration;
+		const liveContext = client === nextClient ? getLiveContext() : null;
+		if (liveContext === null) return false;
+		const attachmentText = request.message.content.attachments?.length
+			? formatAttachments(request.message.content.attachments)
+			: "";
+		const bodyText = `${request.message.content.text}${attachmentText}`;
+		const replyCommand = config.replyHint && request.message.expectsReply
+			? `intercom({ action: "reply", message: "..." })`
+			: undefined;
+		const entry = { from: request.from, message: request.message, replyCommand, bodyText };
+		const admission = inboundDeliveries.admit(request.from, request.message);
+		if (admission.kind === "duplicate") return true;
+		if (admission.kind === "pending") {
+			return admission.completion.then(() => true, () => false);
+		}
+		const reservation = admission.reservation;
+		const commit = (): void => { inboundDeliveries.commit(reservation); };
+		replyTracker = bindWorkflowReplyTracker(liveContext, replyTracker);
+		if (routeIncomingReply(replyWaiters.pending(), request.from, request.message)) {
+			commit();
+			return true;
+		}
+		const replyContext = replyTracker.recordIncomingMessage(request.from, request.message);
+		const release = createWorkflowStageDeliveryFailureHandler({
+			entry,
+			admission: inboundDeliveries,
+			reservation,
+			tracker: replyTracker,
+			replyContext,
+			currentClient: () => client,
+			commit,
+		});
+		const reject = async (error: unknown): Promise<false> => {
+			await release(error);
+			return false;
+		};
+		const stageClosed = liveContext.orchestrationContext?.kind === "workflow-stage"
+			&& liveContext.orchestrationContext.messageAdmission?.isOpen() === false;
+		if (stageClosed) return reject(new Error("Workflow stage is closed before notification admission"));
+		const stageDelivery = admitWorkflowStageInbound(
+			liveContext,
+			(admissionBarrier) => {
+				replyTracker.queueTurnContext(replyContext);
+				return retryStableDelivery({
+					deliver: () => sendIncomingMessage(entry, "trigger", messageGeneration, false, undefined, admissionBarrier),
+					isCurrent: () => Boolean(getLiveContext(liveContext, messageGeneration)),
+				});
+			},
+			() => foregroundDetachHandoff.claim(
+				request.from,
+				request.message,
+				messageGeneration,
+				() => Boolean(getLiveContext(liveContext, messageGeneration)),
+			),
+			release,
+		);
+		if (stageDelivery !== false) {
+			try {
+				await stageDelivery;
+				commit();
+				return true;
+			} catch (error) {
+				return reject(error);
+			}
+		}
+		try {
+			const activeContext = getLiveContext(liveContext, messageGeneration);
+			if (activeContext === null || !activeContext.isIdle()) {
+				return reject(new Error("Intercom session is not ready for acknowledged notification delivery"));
+			}
+			replyTracker.queueTurnContext(replyContext);
+			await retryStableDelivery({
+				deliver: () => sendIncomingMessage(entry, "trigger", messageGeneration, false),
+				isCurrent: () => Boolean(getLiveContext(liveContext, messageGeneration)),
+			});
+			commit();
+			return true;
+		} catch (error) {
+			return reject(error);
+		}
+	}
+	function handlePendingStageNotification(nextClient: IntercomClient, request: PendingStageNotificationRequest): void {
+		void admitPendingStageNotification(nextClient, request)
+			.catch(() => false)
+			.then((delivered) => {
+				if (client !== nextClient || !nextClient.isConnected()) return;
+				try {
+					nextClient.respondPendingStageNotification(request.requestId, delivered);
+				} catch {
+					// Broker disconnect keeps the durable sender outbox pending for retry.
+				}
+			});
+	}
   function attachClientHandlers(nextClient: IntercomClient): void {
     nextClient.on("message", (from: SessionInfo, message: Message, channel?: "supervisor") => {
       const liveContext = getLiveContext();
@@ -463,6 +570,9 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
     nextClient.on("pending_stage_message", (request: PendingStageMessageRequest) => {
       handlePendingStageMessage(nextClient, request, () => client === nextClient);
     });
+		nextClient.on("pending_stage_notification", (request: PendingStageNotificationRequest) => {
+			handlePendingStageNotification(nextClient, request);
+		});
     nextClient.on("peer_disconnected", (notice: PeerDisconnectNotice) => {
       if (client !== nextClient) {
         return;
@@ -582,7 +692,7 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
 
     const promise = (async () => {
       await spawnBrokerIfNeeded(config.brokerCommand, config.brokerArgs);
-      const nextClient = new IntercomClient();
+		const nextClient = new IntercomClient(`${currentSessionId}:pending-stage-route:${runId}`);
       state.client = nextClient;
       attachPendingStageRouteClientHandlers(runId, state, nextClient);
       await nextClient.connect(
@@ -662,7 +772,7 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
       return reconnectPromise;
     }
     const nextReconnectPromise = (async () => {
-      const nextClient = new IntercomClient();
+		const nextClient = new IntercomClient(currentSessionId);
       const registration = buildRegistration();
       client = nextClient;
       attachClientHandlers(nextClient);
@@ -740,17 +850,26 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
     if (!isPendingStageUndeliverableEvent(payload) || payload.handled) return;
     payload.handled = true;
     const actionable = `Pending workflow stage could not receive intercom message: ${payload.reason}`;
-    payload.completion = pendingStageNotificationClient(payload.runId)
-      .then((activeClient) =>
-        activeClient.send(payload.senderId, {
-          text: actionable,
-          replyTo: payload.messageId,
-          replyError: actionable,
-          messageId: payload.notificationId,
-        }),
-      )
-      .then((result) => result.delivered)
-      .catch(() => false);
+		payload.completion = pendingStageNotificationClient(payload.runId)
+			.then((activeClient) => {
+				const route = pendingStageRoutes.get(payload.runId);
+				if (route === undefined) throw new Error("Pending workflow route is unavailable");
+				return activeClient.sendPendingStageNotification(
+					payload.runId,
+					route.capability,
+					payload.senderId,
+					payload.senderRegistrationName,
+					{
+						text: actionable,
+						replyTo: payload.messageId,
+						replyError: actionable,
+						messageId: payload.notificationId,
+					},
+					payload.senderReturnAddress,
+				);
+			})
+			.then((result) => result.delivered)
+			.catch(() => false);
   });
 
   registerSubagentRelay(pi, {

--- a/packages/intercom/index-heavy.ts
+++ b/packages/intercom/index-heavy.ts
@@ -72,6 +72,7 @@ interface PendingStageUndeliverableEvent {
   completion?: Promise<boolean>;
   readonly senderId: string;
   readonly messageId: string;
+  readonly notificationId: string;
   readonly reason: string;
 }
 
@@ -82,6 +83,7 @@ function isPendingStageUndeliverableEvent(value: unknown): value is PendingStage
     typeof event.handled === "boolean" &&
     typeof event.senderId === "string" &&
     typeof event.messageId === "string" &&
+    typeof event.notificationId === "string" &&
     typeof event.reason === "string"
   );
 }
@@ -733,6 +735,7 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
           text: actionable,
           replyTo: payload.messageId,
           replyError: actionable,
+          messageId: payload.notificationId,
         }),
       )
       .then((result) => result.delivered)

--- a/packages/intercom/index.ts
+++ b/packages/intercom/index.ts
@@ -44,6 +44,30 @@ interface SupervisorAuthorizationRequest {
 
 const WORKFLOW_STAGE_LATE_MESSAGE_EVENT = "atomic:workflow-stage-late-message";
 const PENDING_STAGE_ROUTE_EVENT = "atomic:workflow-pending-stage-route";
+const PENDING_STAGE_UNDELIVERABLE_EVENT = "atomic:workflow-pending-stage-undeliverable";
+
+interface PendingStageUndeliverableRelay {
+	handled?: boolean;
+	completion?: Promise<boolean>;
+	runId?: string;
+	senderId?: string;
+	messageId?: string;
+	notificationId?: string;
+	reason?: string;
+}
+
+function isPendingStageUndeliverableRelay(value: unknown): value is PendingStageUndeliverableRelay &
+	Required<Pick<PendingStageUndeliverableRelay, "runId" | "senderId" | "messageId" | "notificationId" | "reason">> {
+	if (typeof value !== "object" || value === null) return false;
+	const event = value as PendingStageUndeliverableRelay;
+	return (
+		typeof event.runId === "string" &&
+		typeof event.senderId === "string" &&
+		typeof event.messageId === "string" &&
+		typeof event.notificationId === "string" &&
+		typeof event.reason === "string"
+	);
+}
 
 interface WorkflowStageLateMessageEvent {
 	handled?: boolean;
@@ -385,6 +409,24 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 			if (!forwarded.completion) throw new Error("Intercom supervisor authorization provider is unavailable");
 			return await forwarded.completion;
 		});
+	});
+	pi.events.on(PENDING_STAGE_UNDELIVERABLE_EVENT, (payload) => {
+		if (!isPendingStageUndeliverableRelay(payload) || payload.handled === true) return;
+		payload.handled = true;
+		const forwarded = { ...payload, handled: false, completion: undefined };
+		payload.completion = loadHeavy(latestLifecycleContext())
+			.then(async (handle) => {
+				handle.assertCurrent();
+				await dispatchEventHandlers(handle.heavy, PENDING_STAGE_UNDELIVERABLE_EVENT, forwarded);
+				handle.assertCurrent();
+				return forwarded.handled === true && forwarded.completion !== undefined
+					? await forwarded.completion
+					: false;
+			})
+			.catch((error) => {
+				console.error(`Intercom event relay failed (${PENDING_STAGE_UNDELIVERABLE_EVENT}):`, error);
+				return false;
+			});
 	});
 	for (const eventName of [
 		SUBAGENT_CONTROL_INTERCOM_EVENT,

--- a/packages/intercom/index.ts
+++ b/packages/intercom/index.ts
@@ -51,6 +51,8 @@ interface PendingStageUndeliverableRelay {
 	completion?: Promise<boolean>;
 	runId?: string;
 	senderId?: string;
+	senderRegistrationName?: string;
+	senderReturnAddress?: string;
 	messageId?: string;
 	notificationId?: string;
 	reason?: string;
@@ -63,6 +65,8 @@ function isPendingStageUndeliverableRelay(value: unknown): value is PendingStage
 	return (
 		typeof event.runId === "string" &&
 		typeof event.senderId === "string" &&
+		(event.senderRegistrationName === undefined || typeof event.senderRegistrationName === "string") &&
+		(event.senderReturnAddress === undefined || typeof event.senderReturnAddress === "string") &&
 		typeof event.messageId === "string" &&
 		typeof event.notificationId === "string" &&
 		typeof event.reason === "string"

--- a/packages/workflows/src/durable/dbos-metadata.ts
+++ b/packages/workflows/src/durable/dbos-metadata.ts
@@ -226,6 +226,12 @@ function serializePendingStageMessages(messages: readonly PendingStageMessage[])
 		status: entry.status,
 		...(entry.deliveredAt !== undefined ? { deliveredAt: entry.deliveredAt } : {}),
 		...(entry.undeliverableReason !== undefined ? { undeliverableReason: entry.undeliverableReason } : {}),
+		...(entry.undeliverableNotificationId !== undefined
+			? { undeliverableNotificationId: entry.undeliverableNotificationId }
+			: {}),
+		...(entry.undeliverableNotifiedAt !== undefined
+			? { undeliverableNotifiedAt: entry.undeliverableNotifiedAt }
+			: {}),
 	}));
 }
 
@@ -255,6 +261,8 @@ function isPendingStageMessage(value: WorkflowSerializableValue): boolean {
 		(value.status === "queued" || value.status === "delivered" || value.status === "undeliverable") &&
 		(value.deliveredAt === undefined || typeof value.deliveredAt === "string") &&
 		(value.undeliverableReason === undefined || typeof value.undeliverableReason === "string") &&
+		(value.undeliverableNotificationId === undefined || typeof value.undeliverableNotificationId === "string") &&
+		(value.undeliverableNotifiedAt === undefined || typeof value.undeliverableNotifiedAt === "string") &&
 		isPendingStageSender(value.from) &&
 		isPendingStageIntercomMessage(value.message)
 	);

--- a/packages/workflows/src/extension/pending-stage-intercom.ts
+++ b/packages/workflows/src/extension/pending-stage-intercom.ts
@@ -255,28 +255,49 @@ function knownUninitializedStage(
 		: undefined;
 }
 
+function pendingStageUndeliverableReason(
+	run: ReturnType<Store["runs"]>[number],
+	entry: PendingStageMessage,
+): string | undefined {
+	const stage = run.stages.find((candidate) => candidate.id === entry.stageKey || candidate.name === entry.stageKey);
+	if (run.status === "cancelled") {
+		return `Workflow run ${run.id} terminated with status cancelled before stage ${entry.stageKey} started`;
+	}
+	if (stage?.status === "skipped") {
+		return `Workflow stage ${entry.stageKey} was skipped${stage.skippedReason ? ` (${stage.skippedReason})` : ""}`;
+	}
+	if (isTerminalRunStatus(run.status)) {
+		return `Workflow run ${run.id} terminated with status ${run.status} before stage ${entry.stageKey} started`;
+	}
+	return undefined;
+}
+
+function needsUndeliverableSettlement(run: ReturnType<Store["runs"]>[number], entry: PendingStageMessage): boolean {
+	if (entry.status === "queued") return pendingStageUndeliverableReason(run, entry) !== undefined;
+	return (
+		entry.status === "undeliverable" &&
+		entry.undeliverableNotificationId !== undefined &&
+		entry.undeliverableNotifiedAt === undefined &&
+		entry.undeliverableReason !== undefined
+	);
+}
+
 /** Settle queued messages whose destination can no longer enter the pre-start lifecycle window. */
 export async function settleUndeliverablePendingStageMessages(
 	activeStore: Store,
 	notify: (entry: PendingStageMessage, reason: string, notificationId: string) => Promise<boolean>,
 ): Promise<number> {
+	const runs = activeStore.runs();
+	if (!runs.some((run) => run.pendingStageMessages?.some((entry) => needsUndeliverableSettlement(run, entry)))) {
+		return 0;
+	}
 	let settled = 0;
 	const backend = getDurableBackend();
-	for (const run of activeStore.runs()) {
+	for (const run of runs) {
 		for (const snapshotEntry of run.pendingStageMessages ?? []) {
 			let entry = snapshotEntry;
 			if (entry.status === "queued") {
-				const stage = run.stages.find(
-					(candidate) => candidate.id === entry.stageKey || candidate.name === entry.stageKey,
-				);
-				let reason: string | undefined;
-				if (run.status === "cancelled") {
-					reason = `Workflow run ${run.id} terminated with status cancelled before stage ${entry.stageKey} started`;
-				} else if (stage?.status === "skipped") {
-					reason = `Workflow stage ${entry.stageKey} was skipped${stage.skippedReason ? ` (${stage.skippedReason})` : ""}`;
-				} else if (isTerminalRunStatus(run.status)) {
-					reason = `Workflow run ${run.id} terminated with status ${run.status} before stage ${entry.stageKey} started`;
-				}
+				const reason = pendingStageUndeliverableReason(run, entry);
 				if (reason === undefined) continue;
 				if (
 					await activeStore.markPendingStageMessageUndeliverable(run.id, entry.stageKey, entry.id, reason, backend)

--- a/packages/workflows/src/extension/pending-stage-intercom.ts
+++ b/packages/workflows/src/extension/pending-stage-intercom.ts
@@ -255,11 +255,28 @@ function knownUninitializedStage(
 		: undefined;
 }
 
+function pendingStageDestination(
+	run: ReturnType<Store["runs"]>[number],
+	entry: PendingStageMessage,
+): ReturnType<Store["runs"]>[number]["stages"][number] | undefined {
+	if (entry.stageId !== undefined) {
+		const candidates = run.stages.filter((stage) => stage.id === entry.stageId);
+		return candidates.length === 1 ? candidates[0] : undefined;
+	}
+	if (entry.stageReplayKey !== undefined) {
+		const candidates = run.stages.filter((stage) => stage.replayKey === entry.stageReplayKey);
+		return candidates.length === 1 ? candidates[0] : undefined;
+	}
+	const exactIds = run.stages.filter((stage) => stage.id === entry.stageKey);
+	const candidates = exactIds.length > 0 ? exactIds : run.stages.filter((stage) => stage.name === entry.stageKey);
+	return candidates.length === 1 ? candidates[0] : undefined;
+}
+
 function pendingStageUndeliverableReason(
 	run: ReturnType<Store["runs"]>[number],
 	entry: PendingStageMessage,
 ): string | undefined {
-	const stage = run.stages.find((candidate) => candidate.id === entry.stageKey || candidate.name === entry.stageKey);
+	const stage = pendingStageDestination(run, entry);
 	if (run.status === "cancelled") {
 		return `Workflow run ${run.id} terminated with status cancelled before stage ${entry.stageKey} started`;
 	}

--- a/packages/workflows/src/extension/pending-stage-intercom.ts
+++ b/packages/workflows/src/extension/pending-stage-intercom.ts
@@ -45,18 +45,24 @@ interface PendingStageUndeliverableEvent extends Record<string, unknown> {
 	completion?: Promise<boolean>;
 	readonly senderId: string;
 	readonly messageId: string;
+	readonly notificationId: string;
 	readonly reason: string;
 }
 
 export function registerPendingStageIntercomBridge(pi: WorkflowEventSurface, activeStore: Store): () => void {
 	let disposed = false;
 	let sweepPromise: Promise<void> = Promise.resolve();
-	const notifyUndeliverable = async (entry: PendingStageMessage, reason: string): Promise<boolean> => {
+	const notifyUndeliverable = async (
+		entry: PendingStageMessage,
+		reason: string,
+		notificationId: string,
+	): Promise<boolean> => {
 		if (entry.message.expectsReply !== true) return true;
 		const payload: PendingStageUndeliverableEvent = {
 			handled: false,
 			senderId: entry.from.id,
 			messageId: entry.message.id,
+			notificationId,
 			reason,
 		};
 		pi.events?.emit?.(PENDING_STAGE_UNDELIVERABLE_EVENT, payload);
@@ -251,40 +257,55 @@ function knownUninitializedStage(
 /** Settle queued messages whose destination can no longer enter the pre-start lifecycle window. */
 export async function settleUndeliverablePendingStageMessages(
 	activeStore: Store,
-	notify: (entry: PendingStageMessage, reason: string) => Promise<boolean>,
+	notify: (entry: PendingStageMessage, reason: string, notificationId: string) => Promise<boolean>,
 ): Promise<number> {
 	let settled = 0;
-	const touchedRunIds = new Set<string>();
+	const backend = getDurableBackend();
 	for (const run of activeStore.runs()) {
-		for (const entry of run.pendingStageMessages ?? []) {
-			if (entry.status !== "queued") continue;
-			const stage = run.stages.find(
-				(candidate) => candidate.id === entry.stageKey || candidate.name === entry.stageKey,
+		for (const snapshotEntry of run.pendingStageMessages ?? []) {
+			let entry = snapshotEntry;
+			if (entry.status === "queued") {
+				const stage = run.stages.find(
+					(candidate) => candidate.id === entry.stageKey || candidate.name === entry.stageKey,
+				);
+				let reason: string | undefined;
+				if (run.status === "cancelled") {
+					reason = `Workflow run ${run.id} terminated with status cancelled before stage ${entry.stageKey} started`;
+				} else if (stage?.status === "skipped") {
+					reason = `Workflow stage ${entry.stageKey} was skipped${stage.skippedReason ? ` (${stage.skippedReason})` : ""}`;
+				} else if (isTerminalRunStatus(run.status)) {
+					reason = `Workflow run ${run.id} terminated with status ${run.status} before stage ${entry.stageKey} started`;
+				}
+				if (reason === undefined) continue;
+				if (
+					await activeStore.markPendingStageMessageUndeliverable(run.id, entry.stageKey, entry.id, reason, backend)
+				) {
+					settled += 1;
+				}
+				const currentRun = activeStore.runs().find((candidate) => candidate.id === run.id);
+				const currentEntry = currentRun?.pendingStageMessages?.find(
+					(candidate) => candidate.stageKey === entry.stageKey && candidate.id === entry.id,
+				);
+				if (currentEntry === undefined) continue;
+				entry = currentEntry;
+			}
+			if (
+				entry.status !== "undeliverable" ||
+				entry.undeliverableNotificationId === undefined ||
+				entry.undeliverableNotifiedAt !== undefined ||
+				entry.undeliverableReason === undefined
+			)
+				continue;
+			if (!(await notify(entry, entry.undeliverableReason, entry.undeliverableNotificationId))) continue;
+			await activeStore.markPendingStageMessageUndeliverableNotified(
+				run.id,
+				entry.stageKey,
+				entry.id,
+				entry.undeliverableNotificationId,
+				new Date().toISOString(),
+				backend,
 			);
-			let reason: string | undefined;
-			if (run.status === "cancelled") {
-				reason = `Workflow run ${run.id} terminated with status cancelled before stage ${entry.stageKey} started`;
-			} else if (stage?.status === "skipped") {
-				reason = `Workflow stage ${entry.stageKey} was skipped${stage.skippedReason ? ` (${stage.skippedReason})` : ""}`;
-			} else if (isTerminalRunStatus(run.status)) {
-				reason = `Workflow run ${run.id} terminated with status ${run.status} before stage ${entry.stageKey} started`;
-			}
-			if (reason === undefined || !(await notify(entry, reason))) continue;
-			if (activeStore.markPendingStageMessageUndeliverable(run.id, entry.stageKey, entry.id, reason)) {
-				settled += 1;
-				touchedRunIds.add(run.id);
-			}
 		}
 	}
-	for (const runId of touchedRunIds) await persistPendingStageMessages(activeStore, runId);
 	return settled;
-}
-
-async function persistPendingStageMessages(activeStore: Store, runId: string): Promise<void> {
-	const backend = getDurableBackend();
-	const handle = backend.getWorkflow(runId);
-	const run = activeStore.runs().find((candidate) => candidate.id === runId);
-	if (handle === undefined || run === undefined) return;
-	backend.registerWorkflow({ ...handle, pendingStageMessages: run.pendingStageMessages ?? [] });
-	await backend.flush();
 }

--- a/packages/workflows/src/extension/pending-stage-intercom.ts
+++ b/packages/workflows/src/extension/pending-stage-intercom.ts
@@ -43,6 +43,7 @@ interface PendingStageMessageEvent {
 interface PendingStageUndeliverableEvent extends Record<string, unknown> {
 	handled: boolean;
 	completion?: Promise<boolean>;
+	readonly runId: string;
 	readonly senderId: string;
 	readonly messageId: string;
 	readonly notificationId: string;
@@ -57,9 +58,9 @@ export function registerPendingStageIntercomBridge(pi: WorkflowEventSurface, act
 		reason: string,
 		notificationId: string,
 	): Promise<boolean> => {
-		if (entry.message.expectsReply !== true) return true;
 		const payload: PendingStageUndeliverableEvent = {
 			handled: false,
+			runId: entry.runId,
 			senderId: entry.from.id,
 			messageId: entry.message.id,
 			notificationId,

--- a/packages/workflows/src/extension/pending-stage-intercom.ts
+++ b/packages/workflows/src/extension/pending-stage-intercom.ts
@@ -34,6 +34,8 @@ interface PendingStageMessageEvent {
 		| { readonly outcome: "refused"; readonly reason: string; readonly reasonCode?: "message_id_conflict" }
 	>;
 	readonly requestId?: string;
+	readonly senderRegistrationName?: string;
+	readonly senderReturnAddress?: string;
 	readonly from?: PendingStageSender;
 	readonly runId?: string;
 	readonly stageKey?: string;
@@ -45,6 +47,8 @@ interface PendingStageUndeliverableEvent extends Record<string, unknown> {
 	completion?: Promise<boolean>;
 	readonly runId: string;
 	readonly senderId: string;
+	readonly senderRegistrationName?: string;
+	readonly senderReturnAddress?: string;
 	readonly messageId: string;
 	readonly notificationId: string;
 	readonly reason: string;
@@ -62,6 +66,10 @@ export function registerPendingStageIntercomBridge(pi: WorkflowEventSurface, act
 			handled: false,
 			runId: entry.runId,
 			senderId: entry.from.id,
+			...(entry.senderRegistrationName === undefined
+				? {}
+				: { senderRegistrationName: entry.senderRegistrationName }),
+			...(entry.senderReturnAddress === undefined ? {} : { senderReturnAddress: entry.senderReturnAddress }),
 			messageId: entry.message.id,
 			notificationId,
 			reason,
@@ -133,6 +141,8 @@ function isPendingStageMessageEvent(value: unknown): value is PendingStageMessag
 		typeof event.stageKey === "string" &&
 		typeof event.from?.id === "string" &&
 		(event.from.name === undefined || typeof event.from.name === "string") &&
+		(event.senderRegistrationName === undefined || typeof event.senderRegistrationName === "string") &&
+		(event.senderReturnAddress === undefined || typeof event.senderReturnAddress === "string") &&
 		typeof event.message?.id === "string" &&
 		typeof event.message.timestamp === "number" &&
 		typeof event.message.content?.text === "string"
@@ -201,6 +211,8 @@ async function queueAndPersist(
 		runId: event.runId,
 		stageKey: event.stageKey,
 		from: event.from,
+		...(event.senderRegistrationName === undefined ? {} : { senderRegistrationName: event.senderRegistrationName }),
+		...(event.senderReturnAddress === undefined ? {} : { senderReturnAddress: event.senderReturnAddress }),
 		message: event.message,
 		queuedAt: new Date().toISOString(),
 	};
@@ -309,8 +321,12 @@ export async function settleUndeliverablePendingStageMessages(
 		return 0;
 	}
 	let settled = 0;
-	const backend = getDurableBackend();
+	const rootBackend = getDurableBackend();
 	for (const run of runs) {
+		const backend = durableBackendForRun(rootBackend, runs, run.id);
+		if (backend === undefined) {
+			throw new Error(`atomic-workflows: workflow run ${run.id} has no durable owner for pending-stage settlement`);
+		}
 		for (const snapshotEntry of run.pendingStageMessages ?? []) {
 			let entry = snapshotEntry;
 			if (entry.status === "queued") {

--- a/packages/workflows/src/extension/pending-stage-intercom.ts
+++ b/packages/workflows/src/extension/pending-stage-intercom.ts
@@ -3,10 +3,17 @@ import { durableBackendForRun, durableRootRunIdForRun } from "../durable/run-own
 import { workflowInvocationIntercomGroup } from "../shared/intercom-group.js";
 import { workflowPendingStageRouteCapability } from "../shared/pending-stage-route-capability.js";
 import type { Store } from "../shared/store.js";
-import type { PendingStageMessageInput, PendingStageQueueResult, PendingStageSender } from "../shared/store-types.js";
+import { isTerminalRunStatus } from "../shared/store-internal.js";
+import type {
+	PendingStageMessage,
+	PendingStageMessageInput,
+	PendingStageQueueResult,
+	PendingStageSender,
+} from "../shared/store-types.js";
 
 const PENDING_STAGE_ROUTE_EVENT = "atomic:workflow-pending-stage-route";
 const PENDING_STAGE_MESSAGE_EVENT = "atomic:workflow-pending-stage-message";
+const PENDING_STAGE_UNDELIVERABLE_EVENT = "atomic:workflow-pending-stage-undeliverable";
 const PENDING_STAGE_ASK_REFUSAL =
 	"Cannot ask a workflow stage whose session has not initialized. Use send; Atomic will queue the message until the stage session initializes.";
 
@@ -33,9 +40,29 @@ interface PendingStageMessageEvent {
 	readonly message?: PendingStageMessageInput["message"];
 }
 
+interface PendingStageUndeliverableEvent extends Record<string, unknown> {
+	handled: boolean;
+	completion?: Promise<boolean>;
+	readonly senderId: string;
+	readonly messageId: string;
+	readonly reason: string;
+}
+
 export function registerPendingStageIntercomBridge(pi: WorkflowEventSurface, activeStore: Store): () => void {
 	let disposed = false;
-	const announceOwners = (): void => {
+	let sweepPromise: Promise<void> = Promise.resolve();
+	const notifyUndeliverable = async (entry: PendingStageMessage, reason: string): Promise<boolean> => {
+		if (entry.message.expectsReply !== true) return true;
+		const payload: PendingStageUndeliverableEvent = {
+			handled: false,
+			senderId: entry.from.id,
+			messageId: entry.message.id,
+			reason,
+		};
+		pi.events?.emit?.(PENDING_STAGE_UNDELIVERABLE_EVENT, payload);
+		return payload.handled && (await payload.completion) === true;
+	};
+	const announceRoutes = (): void => {
 		if (disposed) return;
 		const runs = activeStore.runs();
 		for (const run of runs) {
@@ -47,9 +74,13 @@ export function registerPendingStageIntercomBridge(pi: WorkflowEventSurface, act
 				capability: workflowPendingStageRouteCapability(activeStore, run.id),
 			});
 		}
+		sweepPromise = sweepPromise
+			.then(() => settleUndeliverablePendingStageMessages(activeStore, notifyUndeliverable))
+			.then(() => undefined)
+			.catch((error: Error) => console.warn("atomic-workflows: pending stage delivery sweep failed", error));
 	};
-	const unsubscribeStore = activeStore.subscribeInvalidation(announceOwners);
-	announceOwners();
+	const unsubscribeStore = activeStore.subscribeInvalidation(announceRoutes);
+	announceRoutes();
 	const subscription = pi.events?.on?.(PENDING_STAGE_MESSAGE_EVENT, (payload) => {
 		if (disposed || !isPendingStageMessageEvent(payload) || payload.handled) return;
 		const runs = activeStore.runs();
@@ -215,4 +246,45 @@ function knownUninitializedStage(
 		stage.sessionFile === undefined
 		? stage
 		: undefined;
+}
+
+/** Settle queued messages whose destination can no longer enter the pre-start lifecycle window. */
+export async function settleUndeliverablePendingStageMessages(
+	activeStore: Store,
+	notify: (entry: PendingStageMessage, reason: string) => Promise<boolean>,
+): Promise<number> {
+	let settled = 0;
+	const touchedRunIds = new Set<string>();
+	for (const run of activeStore.runs()) {
+		for (const entry of run.pendingStageMessages ?? []) {
+			if (entry.status !== "queued") continue;
+			const stage = run.stages.find(
+				(candidate) => candidate.id === entry.stageKey || candidate.name === entry.stageKey,
+			);
+			let reason: string | undefined;
+			if (run.status === "cancelled") {
+				reason = `Workflow run ${run.id} terminated with status cancelled before stage ${entry.stageKey} started`;
+			} else if (stage?.status === "skipped") {
+				reason = `Workflow stage ${entry.stageKey} was skipped${stage.skippedReason ? ` (${stage.skippedReason})` : ""}`;
+			} else if (isTerminalRunStatus(run.status)) {
+				reason = `Workflow run ${run.id} terminated with status ${run.status} before stage ${entry.stageKey} started`;
+			}
+			if (reason === undefined || !(await notify(entry, reason))) continue;
+			if (activeStore.markPendingStageMessageUndeliverable(run.id, entry.stageKey, entry.id, reason)) {
+				settled += 1;
+				touchedRunIds.add(run.id);
+			}
+		}
+	}
+	for (const runId of touchedRunIds) await persistPendingStageMessages(activeStore, runId);
+	return settled;
+}
+
+async function persistPendingStageMessages(activeStore: Store, runId: string): Promise<void> {
+	const backend = getDurableBackend();
+	const handle = backend.getWorkflow(runId);
+	const run = activeStore.runs().find((candidate) => candidate.id === runId);
+	if (handle === undefined || run === undefined) return;
+	backend.registerWorkflow({ ...handle, pendingStageMessages: run.pendingStageMessages ?? [] });
+	await backend.flush();
 }

--- a/packages/workflows/src/extension/wiring.ts
+++ b/packages/workflows/src/extension/wiring.ts
@@ -370,7 +370,12 @@ function withWorkflowStageSessionOptions(
 		...options,
 		excludedTools,
 		...(meta
-			? { orchestrationContext: meta.orchestrationContext ?? makeWorkflowStageOrchestrationContext(meta, pi) }
+			? {
+					orchestrationContext:
+						meta.orchestrationContext ??
+						options.orchestrationContext ??
+						makeWorkflowStageOrchestrationContext(meta, pi),
+				}
 			: {}),
 	};
 }
@@ -476,10 +481,12 @@ export function buildRuntimeAdapters(
 				);
 				const result = await createSession(sessionOptions);
 				const bindable = result.session as BindableStageSession;
-				if (shouldBindStageUiContext(pi, meta) && typeof bindable.bindExtensions === "function") {
-					await bindable.bindExtensions({
-						uiContext: makeStageExtensionUiContext(pi.ui ?? {}, meta, broker),
-					});
+				if (typeof bindable.bindExtensions === "function") {
+					await bindable.bindExtensions(
+						shouldBindStageUiContext(pi, meta)
+							? { uiContext: makeStageExtensionUiContext(pi.ui ?? {}, meta, broker) }
+							: {},
+					);
 				}
 				return result;
 			},

--- a/packages/workflows/src/shared/pending-stage-delivery.ts
+++ b/packages/workflows/src/shared/pending-stage-delivery.ts
@@ -142,9 +142,7 @@ export function markPendingStageMessageUndeliverable(
 		...entry,
 		status: "undeliverable",
 		undeliverableReason: reason,
-		...(entry.message.expectsReply === true
-			? { undeliverableNotificationId: pendingStageUndeliverableNotificationId(entry) }
-			: {}),
+		undeliverableNotificationId: pendingStageUndeliverableNotificationId(entry),
 	}));
 }
 

--- a/packages/workflows/src/shared/pending-stage-delivery.ts
+++ b/packages/workflows/src/shared/pending-stage-delivery.ts
@@ -9,6 +9,7 @@ export type {
 
 /** Maximum queued messages retained for one canonical workflow stage. */
 export const PENDING_STAGE_MESSAGE_LIMIT = 50;
+const PENDING_STAGE_UNDELIVERABLE_NOTIFICATION_PREFIX = "atomic-pending-stage-undeliverable";
 
 export interface PendingStageIdentity {
 	readonly id: string;
@@ -141,7 +142,44 @@ export function markPendingStageMessageUndeliverable(
 		...entry,
 		status: "undeliverable",
 		undeliverableReason: reason,
+		...(entry.message.expectsReply === true
+			? { undeliverableNotificationId: pendingStageUndeliverableNotificationId(entry) }
+			: {}),
 	}));
+}
+
+export function markPendingStageMessageUndeliverableNotified(
+	messages: readonly PendingStageMessage[],
+	runId: string,
+	stageKey: string,
+	messageId: string,
+	notificationId: string,
+	notifiedAt: string,
+): readonly PendingStageMessage[] {
+	const index = messages.findIndex(
+		(entry) =>
+			matchesPendingStage(entry, runId, stageKey) &&
+			entry.id === messageId &&
+			entry.status === "undeliverable" &&
+			entry.undeliverableNotificationId === notificationId &&
+			entry.undeliverableNotifiedAt === undefined,
+	);
+	if (index < 0) return messages;
+	const next = [...messages];
+	next[index] = { ...next[index]!, undeliverableNotifiedAt: notifiedAt };
+	return next;
+}
+
+/** Stable broker identity lets DeliveredMessageCache consume workflow-process crash retries. */
+export function pendingStageUndeliverableNotificationId(
+	entry: Pick<PendingStageMessage, "runId" | "stageKey" | "id">,
+): string {
+	return [
+		PENDING_STAGE_UNDELIVERABLE_NOTIFICATION_PREFIX,
+		encodeURIComponent(entry.runId),
+		encodeURIComponent(entry.stageKey),
+		encodeURIComponent(entry.id),
+	].join(":");
 }
 
 function updateQueuedPendingStageMessage(

--- a/packages/workflows/src/shared/store-pending-stage-delivery-methods.ts
+++ b/packages/workflows/src/shared/store-pending-stage-delivery-methods.ts
@@ -2,6 +2,7 @@ import type { DurableWorkflowBackend } from "../durable/backend.js";
 import {
 	markPendingStageMessageDelivered,
 	markPendingStageMessageUndeliverable,
+	markPendingStageMessageUndeliverableNotified,
 	type PendingStageIdentity,
 	type PendingStageMessage,
 	type PendingStageMessageInput,
@@ -20,6 +21,7 @@ type PendingStageDeliveryStoreMethods = Pick<
 	| "pendingStageMessagesFor"
 	| "markPendingStageMessageDelivered"
 	| "markPendingStageMessageUndeliverable"
+	| "markPendingStageMessageUndeliverableNotified"
 >;
 
 export function createPendingStageDeliveryStoreMethods(context: StoreContext): PendingStageDeliveryStoreMethods {
@@ -150,6 +152,34 @@ export function createPendingStageDeliveryStoreMethods(context: StoreContext): P
 					messageId,
 					reason,
 					resolvePendingStageIdentity(run, stageKey),
+				);
+				if (next === current) return false;
+				await persistTransition(backend, runId, next);
+				run.pendingStageMessages = [...next];
+				context.bumpAndNotify();
+				return true;
+			});
+		},
+
+		async markPendingStageMessageUndeliverableNotified(
+			runId: string,
+			stageKey: string,
+			messageId: string,
+			notificationId: string,
+			notifiedAt: string,
+			backend: DurableWorkflowBackend,
+		): Promise<boolean> {
+			return await serialize(runId, async () => {
+				const run = context.findRun(runId);
+				if (run === undefined) return false;
+				const current = run.pendingStageMessages ?? [];
+				const next = markPendingStageMessageUndeliverableNotified(
+					current,
+					runId,
+					stageKey,
+					messageId,
+					notificationId,
+					notifiedAt,
 				);
 				if (next === current) return false;
 				await persistTransition(backend, runId, next);

--- a/packages/workflows/src/shared/store-public-types.ts
+++ b/packages/workflows/src/shared/store-public-types.ts
@@ -133,6 +133,14 @@ export interface Store {
 		reason: string,
 		backend: DurableWorkflowBackend,
 	): Promise<boolean>;
+	markPendingStageMessageUndeliverableNotified(
+		runId: string,
+		stageKey: string,
+		messageId: string,
+		notificationId: string,
+		notifiedAt: string,
+		backend: DurableWorkflowBackend,
+	): Promise<boolean>;
 	/** Compare-and-swap a cached child run's owning boundary during durable replay. */
 	reconcileRunParentStage(runId: string, expectedParentStageId: string, parentStageId: string): boolean;
 	recordStageStart(runId: string, stage: StageSnapshot): void;

--- a/packages/workflows/src/shared/store-types.ts
+++ b/packages/workflows/src/shared/store-types.ts
@@ -254,11 +254,22 @@ export interface PendingStageMessage {
 	readonly status: "queued" | "delivered" | "undeliverable";
 	readonly deliveredAt?: string;
 	readonly undeliverableReason?: string;
+	/** Deterministic outbox identity retained until the correlated sender notification is acknowledged. */
+	readonly undeliverableNotificationId?: string;
+	readonly undeliverableNotifiedAt?: string;
 }
 
 export type PendingStageMessageInput = Omit<
 	PendingStageMessage,
-	"id" | "stageId" | "stageReplayKey" | "admissionOrder" | "status" | "deliveredAt" | "undeliverableReason"
+	| "id"
+	| "stageId"
+	| "stageReplayKey"
+	| "admissionOrder"
+	| "status"
+	| "deliveredAt"
+	| "undeliverableReason"
+	| "undeliverableNotificationId"
+	| "undeliverableNotifiedAt"
 >;
 
 export type PendingStageQueueResult =

--- a/test/integration/workflow-pending-stage-delivery.test.ts
+++ b/test/integration/workflow-pending-stage-delivery.test.ts
@@ -18,6 +18,7 @@ const TARGET = `${RUN_ID}:reviewer`;
 const BROKER_FRAME_TIMEOUT_MS = 5_000;
 const BROKER_STARTUP_TIMEOUT_MS = 10_000;
 const BROKER_SHUTDOWN_TIMEOUT_MS = 5_000;
+const STORE_EVENT_TIMEOUT_MS = 5_000;
 const repoRoot = resolve(import.meta.dirname, "../..");
 const extensionDir = join(repoRoot, "packages/intercom");
 const agentDir = mkdtempSync(join(tmpdir(), "pending-stage-"));
@@ -289,6 +290,23 @@ async function executeIntercom(
 	const execute = fixture.tools.get("intercom")?.execute;
 	assert.ok(execute);
 	return execute("test-call", params, undefined, undefined, fixture.context);
+}
+
+function waitForStoreState(activeStore: ReturnType<typeof createStore>, predicate: () => boolean): Promise<void> {
+	if (predicate()) return Promise.resolve();
+	return new Promise((resolve, reject) => {
+		let unsubscribe = (): void => {};
+		const timer = setTimeout(() => {
+			unsubscribe();
+			reject(new Error("Timed out waiting for store state"));
+		}, STORE_EVENT_TIMEOUT_MS);
+		unsubscribe = activeStore.subscribeInvalidation(() => {
+			if (!predicate()) return;
+			clearTimeout(timer);
+			unsubscribe();
+			resolve();
+		});
+	});
 }
 
 interface BrokerFrameWaiter {
@@ -1771,13 +1789,8 @@ test("an ordinary queued send receives one correlated failure when its stage bec
 			status: "running",
 			createdAt: 1,
 		});
+		await owner.waitForEventCompletion("atomic:workflow-pending-stage-route");
 		await sender.start();
-		const discoveryDeadline = Date.now() + OWNER_DISCOVERY_BUDGET_MS;
-		while (Date.now() < discoveryDeadline) {
-			const listed = await executeIntercom(sender, { action: "list" });
-			if (listed.content.some(({ text }) => text.includes("undeliverable-owner"))) break;
-			await new Promise((resolveDelay) => setTimeout(resolveDelay, 20));
-		}
 		const queued = await executeIntercom(sender, {
 			action: "send",
 			to: `${runId}:reviewer`,
@@ -1787,6 +1800,11 @@ test("an ordinary queued send receives one correlated failure when its stage bec
 		assert.ok(queued.details.messageId);
 		assert.equal(store.pendingStageMessagesFor(runId, "reviewer")[0]?.message.expectsReply, undefined);
 
+		const failureVisible = sender.waitForInjectedCount(1);
+		const notified = waitForStoreState(
+			store,
+			() => store.runs()[0]?.pendingStageMessages?.[0]?.undeliverableNotifiedAt !== undefined,
+		);
 		store.recordStageEnd(runId, {
 			id: "reviewer-id",
 			name: "reviewer",
@@ -1795,21 +1813,12 @@ test("an ordinary queued send receives one correlated failure when its stage bec
 			toolEvents: [],
 			skippedReason: "fail-fast",
 		});
-		const deliveryDeadline = Date.now() + 2_000;
-		while (Date.now() < deliveryDeadline && sender.injectedMessages.length === 0) {
-			await new Promise((resolveDelay) => setTimeout(resolveDelay, 10));
-		}
+		await failureVisible;
+		await notified;
 		const failure = sender.injectedMessages[0];
 		assert.match(failure?.content ?? "", /could not receive intercom message:.*skipped.*fail-fast/i);
 		assert.equal(failure?.details?.message?.replyTo, queued.details.messageId);
 		assert.match(failure?.details?.message?.replyError ?? "", /could not receive intercom message/i);
-		const notifiedDeadline = Date.now() + 2_000;
-		while (
-			Date.now() < notifiedDeadline &&
-			store.runs()[0]?.pendingStageMessages?.[0]?.undeliverableNotifiedAt === undefined
-		) {
-			await new Promise((resolveDelay) => setTimeout(resolveDelay, 10));
-		}
 		assert.equal(typeof store.runs()[0]?.pendingStageMessages?.[0]?.undeliverableNotifiedAt, "string");
 		assert.equal(sender.injectedMessages.length, 1);
 	} finally {

--- a/test/integration/workflow-pending-stage-delivery.test.ts
+++ b/test/integration/workflow-pending-stage-delivery.test.ts
@@ -68,7 +68,7 @@ interface TestContext {
 			isOpen(): boolean;
 		};
 	};
-	sessionManager: { getSessionId(): string };
+	sessionManager: { getSessionId(): string; getBranch(): [] };
 	ui: {
 		confirm(): Promise<boolean>;
 		notify(): void;
@@ -160,7 +160,7 @@ function extensionFixture(
 						pendingStageDelivery,
 					}
 				: { intercomGroup }),
-		sessionManager: { getSessionId: () => sessionId },
+		sessionManager: { getSessionId: () => sessionId, getBranch: () => [] },
 		ui: {
 			confirm: async () => true,
 			notify() {},

--- a/test/integration/workflow-pending-stage-delivery.test.ts
+++ b/test/integration/workflow-pending-stage-delivery.test.ts
@@ -95,7 +95,7 @@ interface InjectedMessage {
 	content?: string;
 	details?: {
 		from?: { id?: string; name?: string };
-		message?: { id?: string; timestamp?: number };
+		message?: { id?: string; timestamp?: number; replyTo?: string; replyError?: string };
 	};
 }
 
@@ -1730,6 +1730,91 @@ test("raw malformed messages are rejected before durable mutation and valid opti
 		await raw.close();
 		rawClients.delete(raw);
 		disposeBridge();
+		await owner.shutdown();
+	}
+});
+
+test("an ordinary queued send receives one correlated failure when its stage becomes undeliverable", async () => {
+	const runId = "71805cb7-169f-4531-ad39-bbcab6b01087";
+	const group = `workflow:${runId}`;
+	const store = createStore();
+	const backend = new InMemoryDurableBackend();
+	setDurableBackend(backend);
+	const owner = extensionFixture("undeliverable-owner", "undeliverable-owner", undefined, "default");
+	const sender = extensionFixture("undeliverable-sender", "undeliverable-sender", undefined, group);
+	intercom(owner.pi as never);
+	const disposeBridge = registerPendingStageIntercomBridge(owner.pi as never, store);
+	intercom(sender.pi as never);
+	try {
+		await owner.start();
+		store.recordRunStart({
+			id: runId,
+			name: "undeliverable",
+			inputs: {},
+			status: "running",
+			stages: [
+				{
+					id: "reviewer-id",
+					name: "reviewer",
+					status: "pending",
+					parentIds: [],
+					toolEvents: [],
+					pendingStageDeliveryAvailable: true,
+				},
+			],
+			startedAt: 1,
+		});
+		backend.registerWorkflow({
+			workflowId: runId,
+			name: "undeliverable",
+			inputs: {},
+			status: "running",
+			createdAt: 1,
+		});
+		await sender.start();
+		const discoveryDeadline = Date.now() + OWNER_DISCOVERY_BUDGET_MS;
+		while (Date.now() < discoveryDeadline) {
+			const listed = await executeIntercom(sender, { action: "list" });
+			if (listed.content.some(({ text }) => text.includes("undeliverable-owner"))) break;
+			await new Promise((resolveDelay) => setTimeout(resolveDelay, 20));
+		}
+		const queued = await executeIntercom(sender, {
+			action: "send",
+			to: `${runId}:reviewer`,
+			message: "ordinary handoff",
+		});
+		assert.equal(queued.details.queued, true);
+		assert.ok(queued.details.messageId);
+		assert.equal(store.pendingStageMessagesFor(runId, "reviewer")[0]?.message.expectsReply, undefined);
+
+		store.recordStageEnd(runId, {
+			id: "reviewer-id",
+			name: "reviewer",
+			status: "skipped",
+			parentIds: [],
+			toolEvents: [],
+			skippedReason: "fail-fast",
+		});
+		const deliveryDeadline = Date.now() + 2_000;
+		while (Date.now() < deliveryDeadline && sender.injectedMessages.length === 0) {
+			await new Promise((resolveDelay) => setTimeout(resolveDelay, 10));
+		}
+		const failure = sender.injectedMessages[0];
+		assert.match(failure?.content ?? "", /could not receive intercom message:.*skipped.*fail-fast/i);
+		assert.equal(failure?.details?.message?.replyTo, queued.details.messageId);
+		assert.match(failure?.details?.message?.replyError ?? "", /could not receive intercom message/i);
+		const notifiedDeadline = Date.now() + 2_000;
+		while (
+			Date.now() < notifiedDeadline &&
+			store.runs()[0]?.pendingStageMessages?.[0]?.undeliverableNotifiedAt === undefined
+		) {
+			await new Promise((resolveDelay) => setTimeout(resolveDelay, 10));
+		}
+		assert.equal(typeof store.runs()[0]?.pendingStageMessages?.[0]?.undeliverableNotifiedAt, "string");
+		assert.equal(sender.injectedMessages.length, 1);
+	} finally {
+		disposeBridge();
+		await sender.shutdown();
 		await owner.shutdown();
 	}
 });

--- a/test/integration/workflow-pending-stage-delivery.test.ts
+++ b/test/integration/workflow-pending-stage-delivery.test.ts
@@ -43,6 +43,7 @@ const { registerPendingStageIntercomBridge } = await import(
 	"../../packages/workflows/src/extension/pending-stage-intercom.js"
 );
 const { workflow } = await import("../../packages/workflows/src/authoring/workflow.js");
+const { buildRuntimeAdapters } = await import("../../packages/workflows/src/extension/wiring.js");
 const { run } = await import("../../packages/workflows/src/runs/foreground/executor.js");
 const { createWorkflowPendingStageDelivery } = await import(
 	"../../packages/workflows/src/runs/foreground/pending-stage-delivery.js"
@@ -877,9 +878,42 @@ test("one composite workflow-stage target transitions atomically from durable qu
 			},
 			ready: () => pendingStageDelivery.ready(),
 		};
-		reviewer = extensionFixture("reviewer-runtime-session", "reviewer", heldPendingStageDelivery);
-		intercom(reviewer.pi as never);
-		const reviewerStart = reviewer.start();
+		let forwardedPendingStageDelivery: ReturnType<typeof createWorkflowPendingStageDelivery> | undefined;
+		const stageAdapters = buildRuntimeAdapters(
+			{},
+			{
+				createAgentSession: async (options) => {
+					forwardedPendingStageDelivery = options?.orchestrationContext?.pendingStageDelivery;
+					reviewer = extensionFixture("reviewer-runtime-session", "reviewer", heldPendingStageDelivery);
+					intercom(reviewer.pi as never);
+					return {
+						session: {
+							bindExtensions: () => reviewer?.start(),
+						} as never,
+					};
+				},
+			},
+		);
+		const reviewerStart = stageAdapters.agentSession?.create(
+			{
+				orchestrationContext: {
+					kind: "workflow-stage",
+					workflowRunId: RUN_ID,
+					workflowStageId: "reviewer-id",
+					workflowStageName: "reviewer",
+					constraints: { disableWorkflowTool: true },
+					intercomGroup: GROUP,
+					pendingStageDelivery,
+				},
+			} as never,
+			{
+				runId: RUN_ID,
+				stageId: "reviewer-id",
+				stageName: "reviewer",
+				executionMode: "non_interactive",
+			},
+		);
+		assert.ok(reviewerStart);
 		await drainEntered;
 
 		const transition = await executeIntercom(sender, {
@@ -889,6 +923,8 @@ test("one composite workflow-stage target transitions atomically from durable qu
 		});
 		releaseDrain();
 		await reviewerStart;
+		assert.equal(forwardedPendingStageDelivery, pendingStageDelivery);
+		assert.ok(reviewer);
 		assert.equal(transition.isError, false);
 		assert.equal(transition.details.delivered, true);
 		assert.equal(transition.details.queued, undefined);
@@ -900,6 +936,8 @@ test("one composite workflow-stage target transitions atomically from durable qu
 		assert.notEqual(pendingMessageIndex, -1);
 		assert.equal(reviewer.injectedOptions[pendingMessageIndex]?.triggerTurn, undefined);
 		assert.equal(reviewer.injectedOptions[pendingMessageIndex]?.deliverAs, undefined);
+		assert.equal(reviewer.injectedMessages[pendingMessageIndex]?.customType, "intercom_message");
+		assert.match(reviewer.injectedMessages[pendingMessageIndex]?.content ?? "", /^\*\*📨 From stage-a\*\*/);
 		assert.equal(
 			reviewer.injectedMessages.filter(({ content }) => content?.includes("Scope changed: preserve raw amendments."))
 				.length,
@@ -912,6 +950,7 @@ test("one composite workflow-stage target transitions atomically from durable qu
 			1,
 		);
 		assert.equal(reviewer.injectedMessages[pendingMessageIndex]?.details?.from?.name, "stage-a");
+		assert.equal(Boolean(reviewer.injectedMessages[pendingMessageIndex]?.details?.from?.id), true);
 		assert.equal(typeof reviewer.injectedMessages[pendingMessageIndex]?.details?.message?.timestamp, "number");
 		assert.equal(store.runs()[0]?.pendingStageMessages?.length, 1);
 		assert.equal(store.runs()[0]?.pendingStageMessages?.[0]?.status, "delivered");

--- a/test/integration/workflow-pending-stage-delivery.test.ts
+++ b/test/integration/workflow-pending-stage-delivery.test.ts
@@ -40,7 +40,7 @@ const { setDurableBackend } = await import("../../packages/workflows/src/durable
 const { WorkflowStageAdmissionBoundary: StageAdmissionBoundary } = await import(
 	"../../packages/coding-agent/src/core/workflow-stage-admission.ts"
 );
-const { registerPendingStageIntercomBridge } = await import(
+const { registerPendingStageIntercomBridge, settleUndeliverablePendingStageMessages } = await import(
 	"../../packages/workflows/src/extension/pending-stage-intercom.js"
 );
 const { workflow } = await import("../../packages/workflows/src/authoring/workflow.js");
@@ -130,6 +130,10 @@ function extensionFixture(
 	const lifecycleHandlers = new Map<string, LifecycleHandler[]>();
 	const eventHandlers = new Map<string, EventHandler[]>();
 	const eventCompletions = new Map<string, Promise<void>>();
+	const eventCompletionWaiters = new Map<
+		string,
+		Array<{ resolve(completion: Promise<void>): void; reject(error: Error): void }>
+	>();
 	const tools = new Map<string, CapturedTool>();
 	const injectedMessages: InjectedMessage[] = [];
 	const injectedOptions: Array<InjectedMessageOptions | undefined> = [];
@@ -230,7 +234,10 @@ function extensionFixture(
 			emit(name: string, payload: object) {
 				for (const handler of eventHandlers.get(name) ?? []) void handler(payload);
 				const completion = (payload as { completion?: Promise<void> }).completion;
-				if (completion !== undefined) eventCompletions.set(name, completion);
+				if (completion === undefined) return;
+				eventCompletions.set(name, completion);
+				for (const waiter of eventCompletionWaiters.get(name) ?? []) waiter.resolve(completion);
+				eventCompletionWaiters.delete(name);
 			},
 		},
 	};
@@ -247,10 +254,25 @@ function extensionFixture(
 			if (injectedMessages.length >= count) return Promise.resolve();
 			return new Promise((resolveWaiter) => injectedWaiters.push({ count, resolve: resolveWaiter }));
 		},
-		waitForEventCompletion(name: string): Promise<void> {
-			const completion = eventCompletions.get(name);
-			assert.ok(completion, `Expected ${name} to expose a completion promise`);
-			return completion;
+		async waitForEventCompletion(name: string): Promise<void> {
+			const existing = eventCompletions.get(name);
+			if (existing !== undefined) return await existing;
+			const completion = await new Promise<Promise<void>>((resolveCompletion, reject) => {
+				const waiters = eventCompletionWaiters.get(name) ?? [];
+				const waiter = { resolve: resolveCompletion, reject };
+				waiters.push(waiter);
+				eventCompletionWaiters.set(name, waiters);
+				setTimeout(() => {
+					const active = eventCompletionWaiters.get(name) ?? [];
+					if (!active.includes(waiter)) return;
+					eventCompletionWaiters.set(
+						name,
+						active.filter((candidate) => candidate !== waiter),
+					);
+					reject(new Error(`Timed out waiting for event completion ${name}`));
+				}, STORE_EVENT_TIMEOUT_MS);
+			});
+			await completion;
 		},
 		start: () => fire("session_start", { type: "session_start", reason: "startup" }),
 		shutdown: () => fire("session_shutdown", { type: "session_shutdown", reason: "quit" }),
@@ -1825,5 +1847,220 @@ test("an ordinary queued send receives one correlated failure when its stage bec
 		disposeBridge();
 		await sender.shutdown();
 		await owner.shutdown();
+	}
+});
+
+test("a reconnected logical sender receives its durable undeliverable notice after a broker restart", async () => {
+	const runId = "33333333-3333-4333-8333-333333333333";
+	const group = `workflow:${runId}`;
+	const nestedSenderRunId = "44444444-4444-4444-8444-444444444444";
+	const nestedSenderContext: TestContext["orchestrationContext"] = {
+		intercomGroup: group,
+		kind: "workflow-stage",
+		workflowRunId: nestedSenderRunId,
+		workflowStageId: "nested-planner-id",
+		workflowStageName: "nested-planner",
+	};
+	const sdk = createMockSdk();
+	const writer = new DbosDurableBackend(sdk, { executorId: "sender-reconnect-writer" });
+	writer.registerWorkflow({
+		workflowId: runId,
+		name: "sender-reconnect",
+		inputs: {},
+		status: "running",
+		createdAt: 1,
+	});
+	await writer.flush();
+	setDurableBackend(writer);
+	const writerStore = createStore();
+	writerStore.recordRunStart({
+		id: runId,
+		name: "sender-reconnect",
+		inputs: {},
+		status: "running",
+		stages: [
+			{
+				id: "reviewer-id",
+				name: "reviewer",
+				status: "pending",
+				parentIds: [],
+				toolEvents: [],
+				pendingStageDeliveryAvailable: true,
+			},
+		],
+		startedAt: 1,
+	});
+	const ownerBefore = extensionFixture(
+		"sender-reconnect-owner-before",
+		"sender-reconnect-owner",
+		undefined,
+		"default",
+	);
+	const senderBefore = extensionFixture(
+		"sender-reconnect-session-before",
+		"planner",
+		undefined,
+		group,
+		nestedSenderContext,
+	);
+	intercomHeavy(ownerBefore.pi as never);
+	let disposeBefore = (): void => {};
+	intercomHeavy(senderBefore.pi as never);
+	let ownerAfter: ReturnType<typeof extensionFixture> | undefined;
+	let senderAfter: ReturnType<typeof extensionFixture> | undefined;
+	let disposeAfter = (): void => {};
+	try {
+		await ownerBefore.start();
+		await senderBefore.start();
+		disposeBefore = registerPendingStageIntercomBridge(ownerBefore.pi as never, writerStore);
+		await ownerBefore.waitForEventCompletion("atomic:workflow-pending-stage-route");
+		const queued = await executeIntercom(senderBefore, {
+			action: "send",
+			to: `${runId}:reviewer`,
+			message: "scope changed before the broker restart",
+		});
+		assert.equal(queued.details.queued, true);
+		assert.ok(queued.details.messageId);
+		const storedBeforeRestart = writerStore.pendingStageMessagesFor(runId, "reviewer")[0];
+		assert.ok(storedBeforeRestart);
+		assert.equal(storedBeforeRestart.from.name, "planner");
+		assert.equal(storedBeforeRestart.from.group, group);
+		assert.equal(storedBeforeRestart.senderRegistrationName, "planner");
+		assert.equal(storedBeforeRestart.senderReturnAddress, "sender-reconnect-session-before");
+		await writer.flush();
+
+		disposeBefore();
+		await senderBefore.shutdown();
+		await ownerBefore.shutdown();
+		await stopBroker();
+		await startBroker();
+
+		const reader = new DbosDurableBackend(sdk, { executorId: "sender-reconnect-reader" });
+		await reader.hydrateWorkflow(runId);
+		const reloadedStore = createStore();
+		reloadedStore.recordRunStart({
+			id: runId,
+			name: "sender-reconnect",
+			inputs: {},
+			status: "running",
+			stages: [
+				{
+					id: "reviewer-id",
+					name: "reviewer",
+					status: "pending",
+					parentIds: [],
+					toolEvents: [],
+					pendingStageDeliveryAvailable: true,
+				},
+			],
+			startedAt: 1,
+			pendingStageMessages: [...(reader.getWorkflow(runId)?.pendingStageMessages ?? [])],
+		});
+		setDurableBackend(reader);
+		ownerAfter = extensionFixture("sender-reconnect-owner-after", "sender-reconnect-owner", undefined, "default");
+		senderAfter = extensionFixture(
+			"sender-reconnect-session-before",
+			"planner",
+			undefined,
+			group,
+			nestedSenderContext,
+		);
+		intercomHeavy(ownerAfter.pi as never);
+		intercomHeavy(senderAfter.pi as never);
+		await ownerAfter.start();
+		await senderAfter.start();
+		disposeAfter = registerPendingStageIntercomBridge(ownerAfter.pi as never, reloadedStore);
+		await ownerAfter.waitForEventCompletion("atomic:workflow-pending-stage-route");
+
+		const senderAfterStatus = await executeIntercom(senderAfter, { action: "status" });
+		const senderAfterId = /Session ID: ([0-9a-f-]+)/i.exec(senderAfterStatus.content[0]?.text ?? "")?.[1];
+		assert.ok(senderAfterId);
+		assert.notEqual(senderAfterId, storedBeforeRestart.from.id);
+
+		reloadedStore.recordStageEnd(runId, {
+			id: "reviewer-id",
+			name: "reviewer",
+			status: "skipped",
+			parentIds: [],
+			toolEvents: [],
+			skippedReason: "branch not taken",
+		});
+		await ownerAfter.waitForEventCompletion("atomic:workflow-pending-stage-undeliverable");
+		await waitForStoreState(
+			reloadedStore,
+			() => reloadedStore.runs()[0]?.pendingStageMessages?.[0]?.undeliverableNotifiedAt !== undefined,
+		);
+
+		const storedAfterRestart = reloadedStore.runs()[0]?.pendingStageMessages?.[0];
+		assert.ok(storedAfterRestart);
+		assert.equal(storedAfterRestart.from.id, storedBeforeRestart.from.id);
+		assert.equal(storedAfterRestart.from.name, storedBeforeRestart.from.name);
+		assert.equal(storedAfterRestart.from.group, storedBeforeRestart.from.group);
+		assert.equal(storedAfterRestart.senderRegistrationName, storedBeforeRestart.senderRegistrationName);
+		assert.equal(storedAfterRestart.senderReturnAddress, storedBeforeRestart.senderReturnAddress);
+		assert.equal(senderAfter.injectedMessages.length, 1);
+		assert.equal(typeof storedAfterRestart.undeliverableNotifiedAt, "string");
+		const notice = senderAfter.injectedMessages[0];
+		assert.equal(notice?.details?.message?.replyTo, queued.details.messageId);
+		assert.match(notice?.details?.message?.replyError ?? "", /branch not taken/);
+
+		const notificationId = storedAfterRestart.undeliverableNotificationId;
+		const notifiedAt = storedAfterRestart.undeliverableNotifiedAt;
+		assert.ok(notificationId);
+		assert.equal(notice?.details?.message?.id, notificationId);
+		assert.equal(storedAfterRestart.message.id, queued.details.messageId);
+		assert.equal(storedAfterRestart.message.content.text, "scope changed before the broker restart");
+		assert.ok(notifiedAt);
+		disposeAfter();
+		disposeAfter = (): void => {};
+		await senderAfter.shutdown();
+		await ownerAfter.shutdown();
+		await stopBroker();
+		await startBroker();
+
+		const receiptReader = new DbosDurableBackend(sdk, { executorId: "sender-reconnect-receipt-reader" });
+		await receiptReader.hydrateWorkflow(runId);
+		const restartedStore = createStore();
+		restartedStore.recordRunStart({
+			id: runId,
+			name: "sender-reconnect",
+			inputs: {},
+			status: "running",
+			stages: [
+				{
+					id: "reviewer-id",
+					name: "reviewer",
+					status: "skipped",
+					parentIds: [],
+					toolEvents: [],
+					skippedReason: "branch not taken",
+					pendingStageDeliveryAvailable: true,
+				},
+			],
+			startedAt: 1,
+			pendingStageMessages: [...(receiptReader.getWorkflow(runId)?.pendingStageMessages ?? [])],
+		});
+		setDurableBackend(receiptReader);
+		let retryNotifications = 0;
+		assert.equal(
+			await settleUndeliverablePendingStageMessages(restartedStore, async () => {
+				retryNotifications += 1;
+				return true;
+			}),
+			0,
+		);
+		const receiptAfterRestart = restartedStore.runs()[0]?.pendingStageMessages?.[0];
+		assert.equal(retryNotifications, 0);
+		assert.equal(receiptAfterRestart?.undeliverableNotificationId, notificationId);
+		assert.equal(receiptAfterRestart?.undeliverableNotifiedAt, notifiedAt);
+		assert.equal(senderAfter.injectedMessages.length, 1);
+	} finally {
+		disposeAfter();
+		if (senderAfter !== undefined) await senderAfter.shutdown();
+		if (ownerAfter !== undefined) await ownerAfter.shutdown();
+		disposeBefore();
+		await senderBefore.shutdown();
+		await ownerBefore.shutdown();
+		if (broker === undefined) await startBroker();
 	}
 });

--- a/test/manual/render-preview.ts
+++ b/test/manual/render-preview.ts
@@ -195,6 +195,7 @@ const store: Store = {
 	pendingStageMessagesFor: () => [],
 	markPendingStageMessageDelivered: async () => false,
 	markPendingStageMessageUndeliverable: async () => false,
+	markPendingStageMessageUndeliverableNotified: async () => false,
 	reconcileRunParentStage: () => false,
 	recordStageStart: () => {},
 	recordStageWorkflowChildRun: () => false,

--- a/test/unit/intercom-inbound-message-admission.test.ts
+++ b/test/unit/intercom-inbound-message-admission.test.ts
@@ -35,6 +35,18 @@ test("duplicate broker delivery cannot enqueue a second reply turn context", () 
 	assert.throws(() => tracker.resolveReplyTarget({}), /No active intercom context/);
 });
 
+test("durable custom-message receipt suppresses delivery after process restart", () => {
+	const restored = new InboundMessageAdmission();
+	restored.restore([
+		{
+			customType: "intercom_message",
+			stageAdmissionKey: `intercom:${message.id}`,
+			details: { from: sender, message },
+		},
+	]);
+	assert.equal(restored.admit(sender, { ...message }).kind, "duplicate");
+	assert.equal(restored.admit(sender, { ...message, id: "new-message" }).kind, "reserved");
+});
 test("released reservation permits a stable broker delivery retry", () => {
 	const admission = new InboundMessageAdmission();
 	const first = admission.reserve(sender, message);

--- a/test/unit/intercom-lazy-relay-context.test.ts
+++ b/test/unit/intercom-lazy-relay-context.test.ts
@@ -43,7 +43,7 @@ function fixture(options: { rejectLateRoutes?: number } = {}) {
 	const ctx = {
 		hasUI: false,
 		cwd: process.cwd(),
-		sessionManager: { getSessionId: () => SESSION_ID },
+		sessionManager: { getSessionId: () => SESSION_ID, getBranch: () => [] },
 		model: { id: "test-model" },
 		isIdle: () => true,
 		ui: { notify() {} },
@@ -270,7 +270,7 @@ describe("lazy relay lifecycle-context fallback", () => {
 			model: { id: "test-model" },
 			isIdle: () => true,
 			ui: { notify() {} },
-			sessionManager: { getSessionId: () => "closed-stage-source" },
+			sessionManager: { getSessionId: () => "closed-stage-source", getBranch: () => [] },
 			orchestrationContext: {
 				kind: "workflow-stage" as const,
 				messageAdmission: { boundary, extensionState: new Map(), isOpen: () => boundary.isOpen() },

--- a/test/unit/intercom-workflow-foreground-first-refusal.test.ts
+++ b/test/unit/intercom-workflow-foreground-first-refusal.test.ts
@@ -10,7 +10,7 @@ interface HandlerContext {
 	readonly model: { readonly id: string };
 	readonly isIdle: () => boolean;
 	readonly ui: { readonly notify: () => void };
-	readonly sessionManager: { readonly getSessionId: () => string };
+	readonly sessionManager: { readonly getSessionId: () => string; readonly getBranch: () => [] };
 	readonly orchestrationContext: {
 		readonly kind: "workflow-stage";
 		readonly messageAdmission: { readonly isOpen: () => boolean };
@@ -97,7 +97,7 @@ function fixture(acknowledgement: AcknowledgementMode) {
 		model: { id: "test-model" },
 		isIdle: () => false,
 		ui: { notify() {} },
-		sessionManager: { getSessionId: () => "workflow-stage-session" },
+		sessionManager: { getSessionId: () => "workflow-stage-session", getBranch: () => [] },
 		orchestrationContext: {
 			kind: "workflow-stage",
 			messageAdmission: { isOpen: () => true },

--- a/test/unit/overlay-graph-helpers.ts
+++ b/test/unit/overlay-graph-helpers.ts
@@ -103,6 +103,7 @@ export function makeStore(snap: StoreSnapshot): Store {
 		pendingStageMessagesFor: () => [],
 		markPendingStageMessageDelivered: async () => false,
 		markPendingStageMessageUndeliverable: async () => false,
+		markPendingStageMessageUndeliverableNotified: async () => false,
 		reconcileRunParentStage: () => false,
 		recordStageStart: () => {},
 		recordStageWorkflowChildRun: () => false,

--- a/test/unit/wiring-adapters-02-01.test.ts
+++ b/test/unit/wiring-adapters-02-01.test.ts
@@ -500,15 +500,17 @@ describe("buildRuntimeAdapters — SDK AgentSession adapter", () => {
 		assert.equal(calls[0]?.excludedTools?.includes("structured_output"), false);
 	});
 
-	test("non-interactive stage sessions exclude ask_user_question without blocking opt-in structured_output", async () => {
+	test("non-interactive stage sessions bind extension lifecycle without exposing UI-only tools", async () => {
 		const calls: Array<CreateAgentSessionOptions | undefined> = [];
 		let bindCalls = 0;
+		let boundWithUiContext = false;
 		const session = {
 			...fakeSession(),
-			async bindExtensions(): Promise<void> {
+			async bindExtensions(bindings: { uiContext?: object }): Promise<void> {
 				bindCalls += 1;
+				boundWithUiContext = bindings.uiContext !== undefined;
 			},
-		} satisfies StageSessionRuntime & { bindExtensions(): Promise<void> };
+		} satisfies StageSessionRuntime & { bindExtensions(bindings: { uiContext?: object }): Promise<void> };
 		const adapters = buildRuntimeAdapters(
 			{},
 			{
@@ -531,6 +533,7 @@ describe("buildRuntimeAdapters — SDK AgentSession adapter", () => {
 
 		assert.deepEqual(calls[0]?.excludedTools, ["workflow", "ask_user_question"]);
 		assert.equal(calls[0]?.excludedTools?.includes("structured_output"), false);
-		assert.equal(bindCalls, 0);
+		assert.equal(bindCalls, 1);
+		assert.equal(boundWithUiContext, false);
 	});
 });

--- a/test/unit/workflow-pending-stage-delivery-lifecycle.test.ts
+++ b/test/unit/workflow-pending-stage-delivery-lifecycle.test.ts
@@ -1,5 +1,12 @@
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import type net from "node:net";
+import { afterEach, describe, test } from "vitest";
+import { DeliveredMessageCache } from "../../packages/intercom/broker/delivered-message-cache.js";
+import { type BrokerConnectedSession, handleBrokerSend } from "../../packages/intercom/broker/send-handler.js";
+import type { BrokerMessage, Message, SessionInfo } from "../../packages/intercom/types.js";
+import { InMemoryDurableBackend } from "../../packages/workflows/src/durable/backend.js";
+import { DbosDurableBackend } from "../../packages/workflows/src/durable/dbos-backend.js";
+import { setDurableBackend } from "../../packages/workflows/src/durable/factory.js";
 import { settleUndeliverablePendingStageMessages } from "../../packages/workflows/src/extension/pending-stage-intercom.js";
 import { createStore } from "../../packages/workflows/src/shared/store.js";
 import type {
@@ -8,6 +15,7 @@ import type {
 	StageStatus,
 } from "../../packages/workflows/src/shared/store-types.js";
 import { testRunId } from "../helpers/run-id.js";
+import { createMockSdk } from "./durable-dbos-backend-helpers.js";
 
 function pendingMessage(runId: string, stageKey: string, expectsReply = true): PendingStageMessageInput {
 	return {
@@ -24,8 +32,9 @@ function pendingMessage(runId: string, stageKey: string, expectsReply = true): P
 	};
 }
 
-function lifecycleFixture(runStatus: RunStatus, stageStatus: StageStatus = "pending") {
+async function lifecycleFixture(runStatus: RunStatus, stageStatus: StageStatus = "pending") {
 	const activeStore = createStore();
+	const backend = new InMemoryDurableBackend();
 	const runId = testRunId(`pending-delivery-${runStatus}-${stageStatus}`);
 	activeStore.recordRunStart({ id: runId, name: "flow", inputs: {}, status: runStatus, stages: [], startedAt: 1 });
 	activeStore.recordStageStart(runId, {
@@ -36,18 +45,23 @@ function lifecycleFixture(runStatus: RunStatus, stageStatus: StageStatus = "pend
 		toolEvents: [],
 		...(stageStatus === "skipped" ? { skippedReason: "fail-fast" } : {}),
 	});
-	const accepted = activeStore.queueStageMessage(
+	backend.registerWorkflow({ workflowId: runId, name: "flow", inputs: {}, status: "running", createdAt: 1 });
+	setDurableBackend(backend);
+	const accepted = await activeStore.queueStageMessage(
 		pendingMessage(runId, "review-stage"),
 		`workflow:${runId}`,
 		`workflow:${runId}`,
+		backend,
 	);
 	assert.equal(accepted?.ok, true);
-	return { activeStore, runId };
+	return { activeStore, backend, runId };
 }
+
+afterEach(() => setDurableBackend(undefined));
 
 describe("pending workflow stage delivery lifecycle", () => {
 	test("marks a skipped stage message undeliverable and notifies its sender", async () => {
-		const { activeStore } = lifecycleFixture("running", "skipped");
+		const { activeStore } = await lifecycleFixture("running", "skipped");
 		const notifications: string[] = [];
 		assert.equal(
 			await settleUndeliverablePendingStageMessages(activeStore, async (entry, reason) => {
@@ -61,7 +75,7 @@ describe("pending workflow stage delivery lifecycle", () => {
 	});
 
 	test("settles a cancelled run separately", async () => {
-		const { activeStore } = lifecycleFixture("cancelled", "skipped");
+		const { activeStore } = await lifecycleFixture("cancelled", "skipped");
 		const reasons: string[] = [];
 		await settleUndeliverablePendingStageMessages(activeStore, async (_entry, reason) => {
 			reasons.push(reason);
@@ -72,7 +86,7 @@ describe("pending workflow stage delivery lifecycle", () => {
 	});
 
 	test("settles a known pending stage when its run completes before initialization", async () => {
-		const { activeStore } = lifecycleFixture("completed");
+		const { activeStore } = await lifecycleFixture("completed");
 		const reasons: string[] = [];
 		await settleUndeliverablePendingStageMessages(activeStore, async (_entry, reason) => {
 			reasons.push(reason);
@@ -84,9 +98,140 @@ describe("pending workflow stage delivery lifecycle", () => {
 
 	test("leaves blocked and nonterminal stage routing untouched", async () => {
 		for (const status of ["blocked", "running", "completed"] as const) {
-			const { activeStore } = lifecycleFixture("running", status);
+			const { activeStore } = await lifecycleFixture("running", status);
 			assert.equal(await settleUndeliverablePendingStageMessages(activeStore, async () => true), 0);
 			assert.equal(activeStore.runs()[0]?.pendingStageMessages?.[0]?.status, "queued");
 		}
 	});
+});
+
+test("a crash after sender-visible failure notification reloads to exactly one notification and terminal state", async () => {
+	const runId = testRunId("pending-delivery-notification-crash");
+	const group = `workflow:${runId}`;
+	const persistedSdk = createMockSdk();
+	let failNextMetadataWrite = false;
+	const sdk = {
+		...persistedSdk,
+		async recordStepOutput(...args: Parameters<typeof persistedSdk.recordStepOutput>) {
+			if (failNextMetadataWrite) {
+				failNextMetadataWrite = false;
+				throw new Error("simulated process exit after notification");
+			}
+			await persistedSdk.recordStepOutput(...args);
+		},
+	};
+	const writer = new DbosDurableBackend(sdk, { executorId: "notification-writer" });
+	writer.registerWorkflow({ workflowId: runId, name: "flow", inputs: {}, status: "running", createdAt: 1 });
+	await writer.flush();
+	setDurableBackend(writer);
+	const activeStore = createStore();
+	activeStore.recordRunStart({ id: runId, name: "flow", inputs: {}, status: "running", stages: [], startedAt: 1 });
+	activeStore.recordStageStart(runId, {
+		id: "review-stage",
+		name: "reviewer",
+		status: "skipped",
+		parentIds: [],
+		toolEvents: [],
+		skippedReason: "fail-fast",
+	});
+	await activeStore.queueStageMessage(pendingMessage(runId, "review-stage"), group, group, writer);
+
+	const workflowSocket = {} as net.Socket;
+	const senderSocket = {} as net.Socket;
+	const sessionInfo = (id: string, name: string): SessionInfo => ({
+		id,
+		name,
+		group,
+		cwd: "/repo",
+		model: "test",
+		pid: 1,
+		startedAt: 1,
+		lastActivity: 1,
+	});
+	const sessions = new Map<string, BrokerConnectedSession>([
+		["workflow-owner", { socket: workflowSocket, info: sessionInfo("workflow-owner", "workflow-owner") }],
+		["planner-session", { socket: senderSocket, info: sessionInfo("planner-session", "planner") }],
+	]);
+	const deliveredMessages = new DeliveredMessageCache();
+	const writes: Array<{ socket: net.Socket; message: BrokerMessage }> = [];
+	const notifyThroughBroker = async (
+		entry: Parameters<typeof settleUndeliverablePendingStageMessages>[1] extends (
+			entry: infer Entry,
+			...args: never[]
+		) => unknown
+			? Entry
+			: never,
+		reason: string,
+		notificationId: string,
+	): Promise<boolean> => {
+		const actionable = `Pending workflow stage could not receive intercom message: ${reason}`;
+		const message: Message = {
+			id: notificationId,
+			timestamp: Date.now(),
+			replyTo: entry.message.id,
+			replyError: actionable,
+			content: { text: actionable },
+		};
+		handleBrokerSend(
+			workflowSocket,
+			{ type: "send", to: entry.from.id, message },
+			"workflow-owner",
+			sessions,
+			deliveredMessages,
+			(socket, brokerMessage) => writes.push({ socket, message: brokerMessage }),
+		);
+		return writes.some(
+			(write) =>
+				write.socket === workflowSocket &&
+				write.message.type === "delivered" &&
+				write.message.messageId === notificationId,
+		);
+	};
+
+	await assert.rejects(
+		settleUndeliverablePendingStageMessages(activeStore, async (entry, reason, notificationId) => {
+			const delivered = await notifyThroughBroker(entry, reason, notificationId);
+			failNextMetadataWrite = true;
+			return delivered;
+		}),
+		/simulated process exit after notification/,
+	);
+	assert.equal(writes.filter((write) => write.socket === senderSocket && write.message.type === "message").length, 1);
+
+	const reader = new DbosDurableBackend(sdk, { executorId: "notification-reader" });
+	await reader.hydrateWorkflow(runId);
+	const pendingNotification = reader.getWorkflow(runId)?.pendingStageMessages?.[0];
+	assert.equal(pendingNotification?.status, "undeliverable");
+	assert.equal(
+		typeof (pendingNotification as { undeliverableNotificationId?: string })?.undeliverableNotificationId,
+		"string",
+	);
+	assert.equal((pendingNotification as { undeliverableNotifiedAt?: string })?.undeliverableNotifiedAt, undefined);
+	const reloadedStore = createStore();
+	reloadedStore.recordRunStart({
+		id: runId,
+		name: "flow",
+		inputs: {},
+		status: "running",
+		stages: [
+			{
+				id: "review-stage",
+				name: "reviewer",
+				status: "skipped",
+				parentIds: [],
+				toolEvents: [],
+				skippedReason: "fail-fast",
+			},
+		],
+		startedAt: 1,
+		pendingStageMessages: [...(reader.getWorkflow(runId)?.pendingStageMessages ?? [])],
+	});
+	setDurableBackend(reader);
+	assert.equal(await settleUndeliverablePendingStageMessages(reloadedStore, notifyThroughBroker), 0);
+	assert.equal(writes.filter((write) => write.socket === senderSocket && write.message.type === "message").length, 1);
+	const terminal = new DbosDurableBackend(sdk, { executorId: "notification-terminal-reader" });
+	await terminal.hydrateWorkflow(runId);
+	const terminalEntry = terminal.getWorkflow(runId)?.pendingStageMessages?.[0];
+	assert.equal(terminalEntry?.status, "undeliverable");
+	assert.equal(typeof (terminalEntry as { undeliverableNotifiedAt?: string })?.undeliverableNotifiedAt, "string");
 });

--- a/test/unit/workflow-pending-stage-delivery-lifecycle.test.ts
+++ b/test/unit/workflow-pending-stage-delivery-lifecycle.test.ts
@@ -11,8 +11,12 @@ import { InboundMessageAdmission } from "../../packages/intercom/inbound-message
 import type { BrokerMessage, Message, SessionInfo } from "../../packages/intercom/types.js";
 import { InMemoryDurableBackend } from "../../packages/workflows/src/durable/backend.js";
 import { DbosDurableBackend } from "../../packages/workflows/src/durable/dbos-backend.js";
+import { resetDbosLifecycleForTests } from "../../packages/workflows/src/durable/dbos-lifecycle.js";
 import { setDurableBackend } from "../../packages/workflows/src/durable/factory.js";
-import { settleUndeliverablePendingStageMessages } from "../../packages/workflows/src/extension/pending-stage-intercom.js";
+import {
+	registerPendingStageIntercomBridge,
+	settleUndeliverablePendingStageMessages,
+} from "../../packages/workflows/src/extension/pending-stage-intercom.js";
 import { createStore } from "../../packages/workflows/src/shared/store.js";
 import type {
 	PendingStageMessage,
@@ -67,10 +71,104 @@ async function lifecycleFixture(runStatus: RunStatus, stageStatus: StageStatus =
 
 afterEach(() => {
 	setDurableBackend(undefined);
+	resetDbosLifecycleForTests();
 	for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 
 describe("pending workflow stage delivery lifecycle", () => {
+	test("registers against an empty store without touching an uninitialized durable backend", async () => {
+		const activeStore = createStore();
+		setDurableBackend(undefined);
+		resetDbosLifecycleForTests();
+		const warnings: unknown[][] = [];
+		const originalWarn = console.warn;
+		console.warn = (...args: unknown[]) => warnings.push(args);
+		try {
+			const dispose = registerPendingStageIntercomBridge({}, activeStore);
+			await new Promise((resolve) => setImmediate(resolve));
+			dispose();
+			assert.deepEqual(warnings, []);
+		} finally {
+			console.warn = originalWarn;
+		}
+	});
+
+	test("sweeps eligible durable state added after empty startup exactly once", async () => {
+		const activeStore = createStore();
+		setDurableBackend(undefined);
+		resetDbosLifecycleForTests();
+		let notifications = 0;
+		const dispose = registerPendingStageIntercomBridge(
+			{
+				events: {
+					emit(event, payload) {
+						if (event !== "atomic:workflow-pending-stage-undeliverable") return;
+						notifications += 1;
+						payload.handled = true;
+						payload.completion = Promise.resolve(true);
+					},
+				},
+			},
+			activeStore,
+		);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		const backend = new InMemoryDurableBackend();
+		const runId = testRunId("pending-delivery-after-empty-startup");
+		backend.registerWorkflow({ workflowId: runId, name: "flow", inputs: {}, status: "running", createdAt: 1 });
+		setDurableBackend(backend);
+		activeStore.recordRunStart({ id: runId, name: "flow", inputs: {}, status: "running", stages: [], startedAt: 1 });
+		activeStore.recordStageStart(runId, {
+			id: "review-stage",
+			name: "reviewer",
+			status: "pending",
+			parentIds: [],
+			toolEvents: [],
+		});
+		await activeStore.queueStageMessage(
+			pendingMessage(runId, "review-stage"),
+			`workflow:${runId}`,
+			`workflow:${runId}`,
+			backend,
+		);
+		const notified = Promise.withResolvers<void>();
+		const unsubscribe = activeStore.subscribeInvalidation(() => {
+			if (activeStore.runs()[0]?.pendingStageMessages?.[0]?.undeliverableNotifiedAt !== undefined) {
+				notified.resolve();
+			}
+		});
+		activeStore.recordRunEnd(runId, "completed");
+		await notified.promise;
+		unsubscribe();
+		await new Promise((resolve) => setImmediate(resolve));
+
+		assert.equal(notifications, 1);
+		assert.equal(activeStore.runs()[0]?.pendingStageMessages?.[0]?.status, "undeliverable");
+		assert.equal(typeof activeStore.runs()[0]?.pendingStageMessages?.[0]?.undeliverableNotifiedAt, "string");
+		dispose();
+	});
+
+	test("reports a durable backend error when eligible settlement work exists", async () => {
+		const { activeStore } = await lifecycleFixture("completed");
+		setDurableBackend(undefined);
+		resetDbosLifecycleForTests();
+		const warnings: unknown[][] = [];
+		const originalWarn = console.warn;
+		console.warn = (...args: unknown[]) => warnings.push(args);
+		let dispose = (): void => {};
+		try {
+			dispose = registerPendingStageIntercomBridge({}, activeStore);
+			await new Promise((resolve) => setImmediate(resolve));
+			assert.equal(warnings.length, 1);
+			assert.equal(warnings[0]?.[0], "atomic-workflows: pending stage delivery sweep failed");
+			assert.equal((warnings[0]?.[1] as Error | undefined)?.name, "DbosNotReadyError");
+			assert.equal(activeStore.runs()[0]?.pendingStageMessages?.[0]?.status, "queued");
+		} finally {
+			dispose();
+			console.warn = originalWarn;
+		}
+	});
+
 	test("marks a skipped stage message undeliverable and notifies its sender", async () => {
 		const { activeStore } = await lifecycleFixture("running", "skipped");
 		const notifications: string[] = [];

--- a/test/unit/workflow-pending-stage-delivery-lifecycle.test.ts
+++ b/test/unit/workflow-pending-stage-delivery-lifecycle.test.ts
@@ -25,7 +25,7 @@ import { createMockSdk } from "./durable-dbos-backend-helpers.js";
 
 const tempDirs: string[] = [];
 
-function pendingMessage(runId: string, stageKey: string, expectsReply = true): PendingStageMessageInput {
+function pendingMessage(runId: string, stageKey: string, expectsReply = false): PendingStageMessageInput {
 	return {
 		runId,
 		stageKey,
@@ -33,7 +33,7 @@ function pendingMessage(runId: string, stageKey: string, expectsReply = true): P
 		message: {
 			id: `message-${stageKey}`,
 			timestamp: 1_725_000_000_000,
-			expectsReply,
+			...(expectsReply ? { expectsReply: true } : {}),
 			content: { text: "scope changed" },
 		},
 		queuedAt: "2026-08-26T00:00:00.000Z",

--- a/test/unit/workflow-pending-stage-delivery-lifecycle.test.ts
+++ b/test/unit/workflow-pending-stage-delivery-lifecycle.test.ts
@@ -13,6 +13,7 @@ import { InMemoryDurableBackend } from "../../packages/workflows/src/durable/bac
 import { DbosDurableBackend } from "../../packages/workflows/src/durable/dbos-backend.js";
 import { resetDbosLifecycleForTests } from "../../packages/workflows/src/durable/dbos-lifecycle.js";
 import { setDurableBackend } from "../../packages/workflows/src/durable/factory.js";
+import { ScopedDurableBackend } from "../../packages/workflows/src/durable/scoped-backend.js";
 import {
 	registerPendingStageIntercomBridge,
 	settleUndeliverablePendingStageMessages,
@@ -229,6 +230,111 @@ describe("pending workflow stage delivery lifecycle", () => {
 		assert.equal(activeStore.runs()[0]?.pendingStageMessages?.[0]?.status, "undeliverable");
 	});
 
+	test("keeps the stable notification outbox pending until recipient acknowledgement", async () => {
+		const { activeStore, backend } = await lifecycleFixture("running", "skipped");
+		const attempts: string[] = [];
+		const reject = async (_entry: PendingStageMessage, _reason: string, notificationId: string) => {
+			attempts.push(notificationId);
+			return false;
+		};
+		assert.equal(await settleUndeliverablePendingStageMessages(activeStore, reject), 1);
+		assert.equal(await settleUndeliverablePendingStageMessages(activeStore, reject), 0);
+		const pendingReceipt = activeStore.runs()[0]?.pendingStageMessages?.[0];
+		assert.equal(pendingReceipt?.status, "undeliverable");
+		assert.equal(pendingReceipt?.undeliverableNotifiedAt, undefined);
+		assert.equal(
+			backend.getWorkflow(activeStore.runs()[0]!.id)?.pendingStageMessages?.[0]?.undeliverableNotifiedAt,
+			undefined,
+		);
+		assert.equal(attempts.length, 2);
+		assert.equal(attempts[0], attempts[1]);
+
+		assert.equal(
+			await settleUndeliverablePendingStageMessages(activeStore, async (_entry, _reason, notificationId) => {
+				attempts.push(notificationId);
+				return true;
+			}),
+			0,
+		);
+		const acknowledgedReceipt = activeStore.runs()[0]?.pendingStageMessages?.[0];
+		assert.equal(typeof acknowledgedReceipt?.undeliverableNotifiedAt, "string");
+		assert.equal(attempts[2], attempts[0]);
+		assert.equal(
+			backend.getWorkflow(activeStore.runs()[0]!.id)?.pendingStageMessages?.[0]?.undeliverableNotifiedAt,
+			acknowledgedReceipt?.undeliverableNotifiedAt,
+		);
+	});
+
+	test("settles and notifies a terminal nested child through the root durable owner exactly once", async () => {
+		const rootRunId = testRunId("pending-delivery-nested-root");
+		const childRunId = testRunId("pending-delivery-nested-child");
+		const group = `workflow:${rootRunId}`;
+		const activeStore = createStore();
+		activeStore.recordRunStart({
+			id: rootRunId,
+			name: "root",
+			inputs: {},
+			status: "running",
+			stages: [
+				{
+					id: "child-boundary",
+					name: "workflow:child",
+					status: "running",
+					parentIds: [],
+					toolEvents: [],
+					replayKey: "workflow:child:1",
+					workflowChildRun: { alias: "child", workflow: "child", runId: childRunId },
+				},
+			],
+			startedAt: 1,
+		});
+		activeStore.recordRunStart({
+			id: childRunId,
+			name: "child",
+			inputs: {},
+			status: "completed",
+			parentRunId: rootRunId,
+			parentStageId: "child-boundary",
+			rootRunId,
+			stages: [
+				{
+					id: "child-review-stage",
+					name: "reviewer",
+					status: "pending",
+					parentIds: [],
+					toolEvents: [],
+					replayKey: "stage:reviewer:1",
+				},
+			],
+			startedAt: 2,
+		});
+		const backend = new InMemoryDurableBackend();
+		backend.registerWorkflow({ workflowId: rootRunId, name: "root", inputs: {}, status: "running", createdAt: 1 });
+		setDurableBackend(backend);
+		const childBackend = new ScopedDurableBackend(backend, {
+			rootWorkflowId: rootRunId,
+			scopePrefix: "workflow:child:1",
+		});
+		const input = pendingMessage(childRunId, "child-review-stage");
+		assert.equal(
+			(await activeStore.queueStageMessage({ ...input, from: { ...input.from, group } }, group, group, childBackend))
+				?.ok,
+			true,
+		);
+		const notifications: string[] = [];
+		const notify = async (entry: PendingStageMessage, reason: string, notificationId: string) => {
+			notifications.push(`${entry.runId}:${notificationId}:${reason}`);
+			return true;
+		};
+
+		assert.equal(await settleUndeliverablePendingStageMessages(activeStore, notify), 1);
+		assert.equal(await settleUndeliverablePendingStageMessages(activeStore, notify), 0);
+		assert.equal(notifications.length, 1);
+		assert.match(notifications[0] ?? "", new RegExp(`^${childRunId}:.*completed`));
+		assert.equal(backend.getWorkflow(childRunId), undefined);
+		assert.equal(backend.getWorkflow(rootRunId)?.pendingStageMessages?.[0]?.status, "undeliverable");
+		assert.equal(typeof backend.getWorkflow(rootRunId)?.pendingStageMessages?.[0]?.undeliverableNotifiedAt, "string");
+	});
 	test("settles a name-addressed skipped destination by canonical identity after durable reload and rename", async () => {
 		const runId = testRunId("pending-delivery-canonical-rename");
 		const group = `workflow:${runId}`;

--- a/test/unit/workflow-pending-stage-delivery-lifecycle.test.ts
+++ b/test/unit/workflow-pending-stage-delivery-lifecycle.test.ts
@@ -69,6 +69,52 @@ async function lifecycleFixture(runStatus: RunStatus, stageStatus: StageStatus =
 	return { activeStore, backend, runId };
 }
 
+async function renamedLifecycleFixture(runStatus: RunStatus, restoredStageStatus: StageStatus) {
+	const runId = testRunId(`pending-delivery-renamed-${runStatus}-${restoredStageStatus}`);
+	const group = `workflow:${runId}`;
+	const backend = new InMemoryDurableBackend();
+	backend.registerWorkflow({ workflowId: runId, name: "flow", inputs: {}, status: "running", createdAt: 1 });
+	setDurableBackend(backend);
+	const writerStore = createStore();
+	writerStore.recordRunStart({ id: runId, name: "flow", inputs: {}, status: "running", stages: [], startedAt: 1 });
+	writerStore.recordStageStart(runId, {
+		id: "stable-stage-id",
+		name: "old-reviewer-name",
+		replayKey: "stage:reviewer:1",
+		status: "pending",
+		parentIds: [],
+		toolEvents: [],
+	});
+	const queued = await writerStore.queueStageMessage(
+		pendingMessage(runId, "old-reviewer-name"),
+		group,
+		group,
+		backend,
+	);
+	assert.equal(queued?.ok, true);
+	const activeStore = createStore();
+	activeStore.recordRunStart({
+		id: runId,
+		name: "flow",
+		inputs: {},
+		status: runStatus,
+		stages: [
+			{
+				id: "stable-stage-id",
+				name: "renamed-reviewer",
+				replayKey: "stage:reviewer:1",
+				status: restoredStageStatus,
+				parentIds: [],
+				toolEvents: [],
+				...(restoredStageStatus === "skipped" ? { skippedReason: "replayed fail-fast" } : {}),
+			},
+		],
+		startedAt: 1,
+		pendingStageMessages: [...(backend.getWorkflow(runId)?.pendingStageMessages ?? [])],
+	});
+	return { activeStore, backend, runId };
+}
+
 afterEach(() => {
 	setDurableBackend(undefined);
 	resetDbosLifecycleForTests();
@@ -183,26 +229,238 @@ describe("pending workflow stage delivery lifecycle", () => {
 		assert.equal(activeStore.runs()[0]?.pendingStageMessages?.[0]?.status, "undeliverable");
 	});
 
-	test("settles a cancelled run separately", async () => {
-		const { activeStore } = await lifecycleFixture("cancelled", "skipped");
-		const reasons: string[] = [];
-		await settleUndeliverablePendingStageMessages(activeStore, async (_entry, reason) => {
-			reasons.push(reason);
-			return true;
+	test("settles a name-addressed skipped destination by canonical identity after durable reload and rename", async () => {
+		const runId = testRunId("pending-delivery-canonical-rename");
+		const group = `workflow:${runId}`;
+		const backend = new InMemoryDurableBackend();
+		backend.registerWorkflow({ workflowId: runId, name: "flow", inputs: {}, status: "running", createdAt: 1 });
+		setDurableBackend(backend);
+		const writerStore = createStore();
+		writerStore.recordRunStart({ id: runId, name: "flow", inputs: {}, status: "running", stages: [], startedAt: 1 });
+		writerStore.recordStageStart(runId, {
+			id: "stable-stage-id",
+			name: "old-reviewer-name",
+			replayKey: "stage:reviewer:1",
+			status: "pending",
+			parentIds: [],
+			toolEvents: [],
 		});
-		assert.equal(activeStore.runs()[0]?.pendingStageMessages?.[0]?.status, "undeliverable");
-		assert.match(reasons[0] ?? "", /terminated with status cancelled/);
+		writerStore.recordStageStart(runId, {
+			id: "unrelated-stage-id",
+			name: "other-reviewer-name",
+			replayKey: "stage:other:1",
+			status: "pending",
+			parentIds: [],
+			toolEvents: [],
+		});
+		const queued = await writerStore.queueStageMessage(
+			pendingMessage(runId, "old-reviewer-name"),
+			group,
+			group,
+			backend,
+		);
+		const unrelated = await writerStore.queueStageMessage(
+			pendingMessage(runId, "other-reviewer-name"),
+			group,
+			group,
+			backend,
+		);
+		assert.equal(queued?.ok, true);
+		assert.equal(queued?.ok ? queued.entry.stageId : undefined, "stable-stage-id");
+		assert.equal(queued?.ok ? queued.entry.stageReplayKey : undefined, "stage:reviewer:1");
+		assert.equal(unrelated?.ok, true);
+
+		const reloadedStore = createStore();
+		reloadedStore.recordRunStart({
+			id: runId,
+			name: "flow",
+			inputs: {},
+			status: "running",
+			stages: [
+				{
+					id: "stable-stage-id",
+					name: "renamed-reviewer",
+					replayKey: "stage:reviewer:1",
+					status: "skipped",
+					parentIds: [],
+					toolEvents: [],
+					skippedReason: "replayed fail-fast",
+				},
+				{
+					id: "unrelated-stage-id",
+					name: "renamed-other-reviewer",
+					replayKey: "stage:other:1",
+					status: "running",
+					parentIds: [],
+					toolEvents: [],
+				},
+			],
+			startedAt: 1,
+			pendingStageMessages: [...(backend.getWorkflow(runId)?.pendingStageMessages ?? [])],
+		});
+		const notifications: string[] = [];
+		const notify = async (_entry: PendingStageMessage, reason: string): Promise<boolean> => {
+			notifications.push(reason);
+			return true;
+		};
+		assert.equal(await settleUndeliverablePendingStageMessages(reloadedStore, notify), 1);
+		assert.equal(await settleUndeliverablePendingStageMessages(reloadedStore, notify), 0);
+		assert.deepEqual(notifications, ["Workflow stage old-reviewer-name was skipped (replayed fail-fast)"]);
+		const entries = reloadedStore.runs()[0]?.pendingStageMessages ?? [];
+		assert.equal(entries.find((entry) => entry.stageId === "stable-stage-id")?.status, "undeliverable");
+		assert.equal(entries.find((entry) => entry.stageId === "unrelated-stage-id")?.status, "queued");
 	});
 
-	test("settles a known pending stage when its run completes before initialization", async () => {
-		const { activeStore } = await lifecycleFixture("completed");
+	test("uses stable replay identity when a durable entry has no canonical stage id", async () => {
+		const { backend, runId } = await renamedLifecycleFixture("running", "skipped");
+		const durableEntry = backend.getWorkflow(runId)?.pendingStageMessages?.[0];
+		assert.ok(durableEntry !== undefined);
+		const { stageId: discardedStageId, ...replayEntry } = durableEntry;
+		assert.equal(discardedStageId, "stable-stage-id");
+		assert.equal(replayEntry.stageReplayKey, "stage:reviewer:1");
+		const replayedStore = createStore();
+		replayedStore.recordRunStart({
+			id: runId,
+			name: "flow",
+			inputs: {},
+			status: "running",
+			stages: [
+				{
+					id: "recreated-stage-id",
+					name: "renamed-reviewer",
+					replayKey: "stage:reviewer:1",
+					status: "skipped",
+					parentIds: [],
+					toolEvents: [],
+					skippedReason: "replayed by stable key",
+				},
+			],
+			startedAt: 1,
+			pendingStageMessages: [replayEntry],
+		});
+		const notifications: string[] = [];
+		assert.equal(
+			await settleUndeliverablePendingStageMessages(replayedStore, async (_entry, reason) => {
+				notifications.push(reason);
+				return true;
+			}),
+			1,
+		);
+		assert.deepEqual(notifications, ["Workflow stage old-reviewer-name was skipped (replayed by stable key)"]);
+		assert.equal(replayedStore.runs()[0]?.pendingStageMessages?.[0]?.status, "undeliverable");
+	});
+
+	test("retains exact legacy id and unique-name fallback without collapsing duplicate names", async () => {
+		const { backend, runId } = await renamedLifecycleFixture("running", "skipped");
+		const durableEntry = backend.getWorkflow(runId)?.pendingStageMessages?.[0];
+		assert.ok(durableEntry !== undefined);
+		const { stageId: discardedStageId, stageReplayKey: discardedReplayKey, ...legacyBase } = durableEntry;
+		assert.equal(discardedStageId, "stable-stage-id");
+		assert.equal(discardedReplayKey, "stage:reviewer:1");
+		const legacyEntry = (stageKey: string, id: string): PendingStageMessage => ({
+			...legacyBase,
+			id,
+			stageKey,
+			message: { ...legacyBase.message, id },
+		});
+		const legacyById = legacyEntry("legacy-stage-id", "legacy-id-message");
+		const legacyByName = legacyEntry("legacy-reviewer", "legacy-name-message");
+		const ambiguousLegacy = legacyEntry("duplicate-reviewer", "ambiguous-name-message");
+		const unknownCanonical: PendingStageMessage = {
+			...legacyEntry("legacy-reviewer", "unknown-canonical-message"),
+			stageId: "missing-canonical-stage",
+		};
+		const activeStore = createStore();
+		activeStore.recordRunStart({
+			id: runId,
+			name: "flow",
+			inputs: {},
+			status: "running",
+			stages: [
+				{
+					id: "legacy-stage-id",
+					name: "renamed-legacy-id",
+					status: "skipped",
+					parentIds: [],
+					toolEvents: [],
+					skippedReason: "legacy id",
+				},
+				{
+					id: "legacy-name-stage-id",
+					name: "legacy-reviewer",
+					status: "skipped",
+					parentIds: [],
+					toolEvents: [],
+					skippedReason: "legacy name",
+				},
+				{
+					id: "duplicate-a",
+					name: "duplicate-reviewer",
+					status: "skipped",
+					parentIds: [],
+					toolEvents: [],
+				},
+				{
+					id: "duplicate-b",
+					name: "duplicate-reviewer",
+					status: "running",
+					parentIds: [],
+					toolEvents: [],
+				},
+			],
+			startedAt: 1,
+			pendingStageMessages: [legacyById, legacyByName, ambiguousLegacy, unknownCanonical],
+		});
+		const notifications: string[] = [];
+		const notify = async (entry: PendingStageMessage, reason: string): Promise<boolean> => {
+			notifications.push(`${entry.id}:${reason}`);
+			return true;
+		};
+		assert.equal(await settleUndeliverablePendingStageMessages(activeStore, notify), 2);
+		assert.equal(await settleUndeliverablePendingStageMessages(activeStore, notify), 0);
+		assert.deepEqual(notifications, [
+			"legacy-id-message:Workflow stage legacy-stage-id was skipped (legacy id)",
+			"legacy-name-message:Workflow stage legacy-reviewer was skipped (legacy name)",
+		]);
+		const statuses = Object.fromEntries(
+			(activeStore.runs()[0]?.pendingStageMessages ?? []).map((entry) => [entry.id, entry.status]),
+		);
+		assert.deepEqual(statuses, {
+			"legacy-id-message": "undeliverable",
+			"legacy-name-message": "undeliverable",
+			"ambiguous-name-message": "queued",
+			"unknown-canonical-message": "queued",
+		});
+	});
+
+	test("settles a name-addressed cancelled destination after durable reload and rename", async () => {
+		const { activeStore } = await renamedLifecycleFixture("cancelled", "skipped");
 		const reasons: string[] = [];
-		await settleUndeliverablePendingStageMessages(activeStore, async (_entry, reason) => {
+		const notify = async (_entry: PendingStageMessage, reason: string): Promise<boolean> => {
 			reasons.push(reason);
 			return true;
-		});
+		};
+		assert.equal(await settleUndeliverablePendingStageMessages(activeStore, notify), 1);
+		assert.equal(await settleUndeliverablePendingStageMessages(activeStore, notify), 0);
+		assert.deepEqual(reasons, [
+			`Workflow run ${activeStore.runs()[0]?.id} terminated with status cancelled before stage old-reviewer-name started`,
+		]);
 		assert.equal(activeStore.runs()[0]?.pendingStageMessages?.[0]?.status, "undeliverable");
-		assert.match(reasons[0] ?? "", /completed before stage review-stage started/);
+	});
+
+	test("settles a name-addressed terminal-before-init destination after durable reload and rename", async () => {
+		const { activeStore } = await renamedLifecycleFixture("completed", "pending");
+		const reasons: string[] = [];
+		const notify = async (_entry: PendingStageMessage, reason: string): Promise<boolean> => {
+			reasons.push(reason);
+			return true;
+		};
+		assert.equal(await settleUndeliverablePendingStageMessages(activeStore, notify), 1);
+		assert.equal(await settleUndeliverablePendingStageMessages(activeStore, notify), 0);
+		assert.deepEqual(reasons, [
+			`Workflow run ${activeStore.runs()[0]?.id} terminated with status completed before stage old-reviewer-name started`,
+		]);
+		assert.equal(activeStore.runs()[0]?.pendingStageMessages?.[0]?.status, "undeliverable");
 	});
 
 	test("leaves blocked and nonterminal stage routing untouched", async () => {

--- a/test/unit/workflow-pending-stage-delivery-lifecycle.test.ts
+++ b/test/unit/workflow-pending-stage-delivery-lifecycle.test.ts
@@ -1,8 +1,13 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
 import type net from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, test } from "vitest";
+import { SessionManager } from "../../packages/coding-agent/src/core/session-manager-core.ts";
 import { DeliveredMessageCache } from "../../packages/intercom/broker/delivered-message-cache.js";
 import { type BrokerConnectedSession, handleBrokerSend } from "../../packages/intercom/broker/send-handler.js";
+import { InboundMessageAdmission } from "../../packages/intercom/inbound-message-admission.js";
 import type { BrokerMessage, Message, SessionInfo } from "../../packages/intercom/types.js";
 import { InMemoryDurableBackend } from "../../packages/workflows/src/durable/backend.js";
 import { DbosDurableBackend } from "../../packages/workflows/src/durable/dbos-backend.js";
@@ -10,12 +15,15 @@ import { setDurableBackend } from "../../packages/workflows/src/durable/factory.
 import { settleUndeliverablePendingStageMessages } from "../../packages/workflows/src/extension/pending-stage-intercom.js";
 import { createStore } from "../../packages/workflows/src/shared/store.js";
 import type {
+	PendingStageMessage,
 	PendingStageMessageInput,
 	RunStatus,
 	StageStatus,
 } from "../../packages/workflows/src/shared/store-types.js";
 import { testRunId } from "../helpers/run-id.js";
 import { createMockSdk } from "./durable-dbos-backend-helpers.js";
+
+const tempDirs: string[] = [];
 
 function pendingMessage(runId: string, stageKey: string, expectsReply = true): PendingStageMessageInput {
 	return {
@@ -57,7 +65,10 @@ async function lifecycleFixture(runStatus: RunStatus, stageStatus: StageStatus =
 	return { activeStore, backend, runId };
 }
 
-afterEach(() => setDurableBackend(undefined));
+afterEach(() => {
+	setDurableBackend(undefined);
+	for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
 
 describe("pending workflow stage delivery lifecycle", () => {
 	test("marks a skipped stage message undeliverable and notifies its sender", async () => {
@@ -152,15 +163,15 @@ test("a crash after sender-visible failure notification reloads to exactly one n
 		["workflow-owner", { socket: workflowSocket, info: sessionInfo("workflow-owner", "workflow-owner") }],
 		["planner-session", { socket: senderSocket, info: sessionInfo("planner-session", "planner") }],
 	]);
-	const deliveredMessages = new DeliveredMessageCache();
-	const writes: Array<{ socket: net.Socket; message: BrokerMessage }> = [];
+	const recipientSessionDir = mkdtempSync(join(tmpdir(), "pending-failure-recipient-"));
+	tempDirs.push(recipientSessionDir);
+	let recipientSession = SessionManager.create("/repo", recipientSessionDir);
+	let recipientAdmission = new InboundMessageAdmission();
+	let deliveredMessages = new DeliveredMessageCache();
+	let senderVisibleNotifications = 0;
+	let wireNotifications = 0;
 	const notifyThroughBroker = async (
-		entry: Parameters<typeof settleUndeliverablePendingStageMessages>[1] extends (
-			entry: infer Entry,
-			...args: never[]
-		) => unknown
-			? Entry
-			: never,
+		entry: PendingStageMessage,
 		reason: string,
 		notificationId: string,
 	): Promise<boolean> => {
@@ -172,14 +183,43 @@ test("a crash after sender-visible failure notification reloads to exactly one n
 			replyError: actionable,
 			content: { text: actionable },
 		};
+		const writes: Array<{ socket: net.Socket; message: BrokerMessage }> = [];
+		const recipientCompletions: Promise<void>[] = [];
 		handleBrokerSend(
 			workflowSocket,
 			{ type: "send", to: entry.from.id, message },
 			"workflow-owner",
 			sessions,
 			deliveredMessages,
-			(socket, brokerMessage) => writes.push({ socket, message: brokerMessage }),
+			(socket, brokerMessage) => {
+				writes.push({ socket, message: brokerMessage });
+				if (socket !== senderSocket || brokerMessage.type !== "message") return;
+				wireNotifications++;
+				const admission = recipientAdmission.admit(brokerMessage.from, brokerMessage.message);
+				if (admission.kind === "pending") {
+					recipientCompletions.push(admission.completion);
+					return;
+				}
+				if (admission.kind === "duplicate") return;
+				recipientCompletions.push(
+					Promise.resolve().then(() => {
+						senderVisibleNotifications++;
+						recipientSession.appendCustomMessageEntry(
+							"intercom_message",
+							brokerMessage.message.content.text,
+							true,
+							{ from: brokerMessage.from, message: brokerMessage.message },
+							undefined,
+							undefined,
+							`intercom:${brokerMessage.message.id}`,
+						);
+						recipientSession.flush();
+						recipientAdmission.commit(admission.reservation);
+					}),
+				);
+			},
 		);
+		await Promise.all(recipientCompletions);
 		return writes.some(
 			(write) =>
 				write.socket === workflowSocket &&
@@ -196,7 +236,8 @@ test("a crash after sender-visible failure notification reloads to exactly one n
 		}),
 		/simulated process exit after notification/,
 	);
-	assert.equal(writes.filter((write) => write.socket === senderSocket && write.message.type === "message").length, 1);
+	assert.equal(senderVisibleNotifications, 1);
+	assert.equal(wireNotifications, 1);
 
 	const reader = new DbosDurableBackend(sdk, { executorId: "notification-reader" });
 	await reader.hydrateWorkflow(runId);
@@ -227,8 +268,16 @@ test("a crash after sender-visible failure notification reloads to exactly one n
 		pendingStageMessages: [...(reader.getWorkflow(runId)?.pendingStageMessages ?? [])],
 	});
 	setDurableBackend(reader);
+	// Simulate broker and sender-stage process restarts from their durable records.
+	deliveredMessages = new DeliveredMessageCache();
+	const recipientSessionFile = recipientSession.getSessionFile();
+	assert.ok(recipientSessionFile !== undefined);
+	recipientSession = SessionManager.open(recipientSessionFile, recipientSessionDir, "/repo");
+	recipientAdmission = new InboundMessageAdmission();
+	recipientAdmission.restore(recipientSession.getBranch());
 	assert.equal(await settleUndeliverablePendingStageMessages(reloadedStore, notifyThroughBroker), 0);
-	assert.equal(writes.filter((write) => write.socket === senderSocket && write.message.type === "message").length, 1);
+	assert.equal(wireNotifications, 2);
+	assert.equal(senderVisibleNotifications, 1);
 	const terminal = new DbosDurableBackend(sdk, { executorId: "notification-terminal-reader" });
 	await terminal.hydrateWorkflow(runId);
 	const terminalEntry = terminal.getWorkflow(runId)?.pendingStageMessages?.[0];

--- a/test/unit/workflow-pending-stage-delivery-lifecycle.test.ts
+++ b/test/unit/workflow-pending-stage-delivery-lifecycle.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { settleUndeliverablePendingStageMessages } from "../../packages/workflows/src/extension/pending-stage-intercom.js";
+import { createStore } from "../../packages/workflows/src/shared/store.js";
+import type {
+	PendingStageMessageInput,
+	RunStatus,
+	StageStatus,
+} from "../../packages/workflows/src/shared/store-types.js";
+import { testRunId } from "../helpers/run-id.js";
+
+function pendingMessage(runId: string, stageKey: string, expectsReply = true): PendingStageMessageInput {
+	return {
+		runId,
+		stageKey,
+		from: { id: "planner-session", name: "planner", group: `workflow:${runId}` },
+		message: {
+			id: `message-${stageKey}`,
+			timestamp: 1_725_000_000_000,
+			expectsReply,
+			content: { text: "scope changed" },
+		},
+		queuedAt: "2026-08-26T00:00:00.000Z",
+	};
+}
+
+function lifecycleFixture(runStatus: RunStatus, stageStatus: StageStatus = "pending") {
+	const activeStore = createStore();
+	const runId = testRunId(`pending-delivery-${runStatus}-${stageStatus}`);
+	activeStore.recordRunStart({ id: runId, name: "flow", inputs: {}, status: runStatus, stages: [], startedAt: 1 });
+	activeStore.recordStageStart(runId, {
+		id: "review-stage",
+		name: "reviewer",
+		status: stageStatus,
+		parentIds: [],
+		toolEvents: [],
+		...(stageStatus === "skipped" ? { skippedReason: "fail-fast" } : {}),
+	});
+	const accepted = activeStore.queueStageMessage(
+		pendingMessage(runId, "review-stage"),
+		`workflow:${runId}`,
+		`workflow:${runId}`,
+	);
+	assert.equal(accepted?.ok, true);
+	return { activeStore, runId };
+}
+
+describe("pending workflow stage delivery lifecycle", () => {
+	test("marks a skipped stage message undeliverable and notifies its sender", async () => {
+		const { activeStore } = lifecycleFixture("running", "skipped");
+		const notifications: string[] = [];
+		assert.equal(
+			await settleUndeliverablePendingStageMessages(activeStore, async (entry, reason) => {
+				notifications.push(`${entry.from.id}:${entry.message.id}:${reason}`);
+				return true;
+			}),
+			1,
+		);
+		assert.match(notifications[0] ?? "", /planner-session:message-review-stage:.*skipped.*fail-fast/);
+		assert.equal(activeStore.runs()[0]?.pendingStageMessages?.[0]?.status, "undeliverable");
+	});
+
+	test("settles a cancelled run separately", async () => {
+		const { activeStore } = lifecycleFixture("cancelled", "skipped");
+		const reasons: string[] = [];
+		await settleUndeliverablePendingStageMessages(activeStore, async (_entry, reason) => {
+			reasons.push(reason);
+			return true;
+		});
+		assert.equal(activeStore.runs()[0]?.pendingStageMessages?.[0]?.status, "undeliverable");
+		assert.match(reasons[0] ?? "", /terminated with status cancelled/);
+	});
+
+	test("settles a known pending stage when its run completes before initialization", async () => {
+		const { activeStore } = lifecycleFixture("completed");
+		const reasons: string[] = [];
+		await settleUndeliverablePendingStageMessages(activeStore, async (_entry, reason) => {
+			reasons.push(reason);
+			return true;
+		});
+		assert.equal(activeStore.runs()[0]?.pendingStageMessages?.[0]?.status, "undeliverable");
+		assert.match(reasons[0] ?? "", /completed before stage review-stage started/);
+	});
+
+	test("leaves blocked and nonterminal stage routing untouched", async () => {
+		for (const status of ["blocked", "running", "completed"] as const) {
+			const { activeStore } = lifecycleFixture("running", status);
+			assert.equal(await settleUndeliverablePendingStageMessages(activeStore, async () => true), 0);
+			assert.equal(activeStore.runs()[0]?.pendingStageMessages?.[0]?.status, "queued");
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Finalizes pending Intercom delivery when a known workflow stage never initializes.

- marks messages undeliverable when a stage is skipped, cancelled, or terminal before initialization
- notifies ordinary `send` callers through a correlated delivery-failure message
- persists deterministic notification identity and recipient-side durable admission for exactly-once visibility across restarts
- binds delivery state into headless stage startup without changing live, late, or completed-stage routing
- uses deterministic lifecycle/store events in tests rather than sleep polling

This layer does not change the existing workflow tool `send` action or its delivery modes.

## Stack

Layer 3 of stack #2724; base: #2721. #2723 supplies user-facing guidance and release notes.

## Validation

- skipped, cancelled, terminal-before-initialization, notification crash/reload, and headless-stage regressions
- live/late/closed Intercom coverage
- workflow-tool source/schema diff against `main` is empty
- `npm run check`, unit, integration, and coding-agent suites

Draft until exact-head CI/CodeQL, complete local compiled-binary FINAL6, and final review gates pass.

Related: #2717


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Finalizes pending workflow-stage delivery when a stage becomes terminal before initialization.
- Persists undeliverable state and deterministic notification identity before notifying the original sender.
- Adds acknowledged broker routing and durable recipient-side admission so crash retries remain idempotent.
- Propagates pending-stage delivery into headless stage startup and adds lifecycle, restart, and routing coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/workflows/src/extension/pending-stage-intercom.ts | Settles terminal pending-stage messages through persisted undeliverable state followed by acknowledged sender notification. |
| packages/workflows/src/shared/store-pending-stage-delivery-methods.ts | Adds serialized, persist-first transitions for undeliverable notification receipts. |
| packages/workflows/src/shared/pending-stage-delivery.ts | Introduces deterministic notification IDs and immutable terminal-notification state. |
| packages/intercom/inbound-message-admission.ts | Restores delivered message identities from durable session entries before admitting retries. |
| packages/intercom/index-heavy.ts | Adds acknowledged pending-stage notification delivery and stable sender return-address routing. |
| packages/intercom/index.ts | Relays undeliverable events through lazy heavy-runtime initialization. |
| packages/workflows/src/durable/dbos-metadata.ts | Serializes and validates the added durable notification identity and receipt fields. |
| test/integration/workflow-pending-stage-delivery.test.ts | Covers correlated failure delivery, broker restart, durable identity restoration, and headless stage startup. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(workflows): settle nested pending st..."](https://github.com/bastani-inc/atomic/commit/d0b415b80f2179417b857fb69c3c035debf41bc3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57473529)</sub>

<!-- /greptile_comment -->