### PR TITLE
fix(coding-agent): preserve mutable modules in compiled loader

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fixed installed packages where the intercom broker failed to start on every launch, leaving both the `intercom` and `subagent` tools entirely non-functional.
+- Fixed Bun-compiled binaries crashing when a transformed extension performed a second `proper-lockfile` operation. Compiled extension imports now reuse the host's lockfile module instead of transforming and proxy-wrapping its mutable internals.
 
 - Fixed the published workflow SDK so importing `@bastani/atomic` no longer injects the workflows graph into every consumer's TypeScript program, consumers can typecheck against the package again, and workflow authoring types no longer silently collapse to `any`. ([#2716](https://github.com/bastani-inc/atomic/issues/2716))
 

--- a/packages/coding-agent/src/core/extensions/loader-virtual-modules.ts
+++ b/packages/coding-agent/src/core/extensions/loader-virtual-modules.ts
@@ -25,6 +25,7 @@ async function loadVirtualModules(): Promise<Record<string, object>> {
 		piAi,
 		piAiOauth,
 		piAiCloudflareGatewayBinding,
+		properLockfile,
 		piCodingAgent,
 	] = await Promise.all([
 		import("typebox"),
@@ -43,6 +44,10 @@ async function loadVirtualModules(): Promise<Record<string, object>> {
 		// packages import the host entry) reach this specifier, so it needs a key
 		// of its own instead of falling through to the compat/root prefix alias.
 		import("@bastani/pi-ai/api/cloudflare-gateway-binding"),
+		// proper-lockfile mutates graceful-fs with a non-configurable cache
+		// symbol. Keep that dependency graph in the compiled host: evaluating it
+		// through Jiti would put its stale-value caching proxy in the middle.
+		import("proper-lockfile"),
 		// NOTE: This import works because loader.ts exports are NOT re-exported from index.ts,
 		// avoiding a circular dependency while preserving the package-name extension import path.
 		import("../../index.ts"),
@@ -66,6 +71,7 @@ async function loadVirtualModules(): Promise<Record<string, object>> {
 		"@earendil-works/pi-ai/compat": piAi,
 		"@earendil-works/pi-ai/oauth": piAiOauth,
 		"@earendil-works/pi-ai/api/cloudflare-gateway-binding": piAiCloudflareGatewayBinding,
+		"proper-lockfile": properLockfile,
 		"@bastani/atomic": piCodingAgent,
 		"@mariozechner/pi-agent-core": piAgentCore,
 		"@mariozechner/pi-tui": piTui,

--- a/test/ci/extension-loader-binary-boundary.test.ts
+++ b/test/ci/extension-loader-binary-boundary.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, realpathSync } from "node:fs";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "vitest";
+import {
+	bunExecutable,
+	copyFileSync,
+	makeDirectorySync,
+	removeTempDirectory,
+	spawnSyncCollect,
+	writeTextSync,
+} from "../helpers/runtime.js";
+
+const root = fileURLToPath(new URL("../..", import.meta.url));
+/** Two real Bun builds plus execution of the compiled extension-loader boundary. */
+const COMPILED_EXTENSION_LOADER_TIMEOUT_MS = 120_000;
+
+function sha256(path: string): string {
+	return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function formatCommand(command: readonly string[]): string {
+	return command.map((part) => JSON.stringify(part)).join(" ");
+}
+
+test(
+	"compiled extension loading preserves mutable CommonJS module semantics",
+	() => {
+		// Keep the fixture below the repository root so the extension's bare
+		// import resolves the repository-installed proper-lockfile package, exactly
+		// as it does for a project extension loaded by the production binary.
+		const fixture = mkdtempSync(join(root, ".tmp-extension-loader-boundary."));
+		const runtimeDir = join(fixture, "runtime");
+		const executablePath = join(runtimeDir, process.platform === "win32" ? "atomic.exe" : "atomic");
+		const appPath = join(runtimeDir, "app.js");
+		const extensionPath = join(fixture, "extension.ts");
+		makeDirectorySync(runtimeDir, { recursive: true });
+
+		try {
+			writeTextSync(
+				join(fixture, "app-entry.ts"),
+				`import { extensionLoaderTestHooks } from ${JSON.stringify(join(root, "packages/coding-agent/src/core/extensions/loader-virtual-modules.ts"))};\n` +
+					"void (async () => {\n" +
+					'  const entry = process.argv[2];\n  if (!entry) throw new Error("missing extension path");\n' +
+					"  const factory = await extensionLoaderTestHooks.loadExtensionModuleTransformed(entry);\n" +
+					'  if (typeof factory !== "function") throw new Error("extension did not load");\n' +
+					"  await factory({} as never);\n" +
+					'  console.log("extension lock probe: OK");\n' +
+					"})();\n",
+			);
+			writeTextSync(
+				extensionPath,
+				'import lockfile from "proper-lockfile";\n' +
+					'import { join } from "node:path";\n' +
+					"export default async function extension(): Promise<void> {\n" +
+					'  if (typeof lockfile.lock !== "function") throw new Error("proper-lockfile default import is invalid");\n' +
+					'  const target = join(import.meta.dirname, "target.json");\n' +
+					'  await Bun.write(target, "{}");\n' +
+					"  for (let index = 0; index < 2; index++) {\n" +
+					"    const release = await lockfile.lock(target, { realpath: false });\n" +
+					"    await release();\n" +
+					"  }\n" +
+					"}\n",
+			);
+			writeTextSync(
+				join(fixture, "split-loader.ts"),
+				'import { dirname, join } from "node:path";\n' +
+					'import { pathToFileURL } from "node:url";\n' +
+					'void import(pathToFileURL(join(dirname(process.execPath), "app.js")).href);\n',
+			);
+
+			const extensionRequire = createRequire(extensionPath);
+			const resolvedLockfile = extensionRequire.resolve("proper-lockfile");
+			const repositoryLockfileRoot = realpathSync(join(root, "node_modules", "proper-lockfile"));
+			assert.ok(
+				realpathSync(resolvedLockfile).startsWith(`${repositoryLockfileRoot}/`),
+				`fixture resolved an external proper-lockfile: ${resolvedLockfile}`,
+			);
+
+			const appBuildCommand = [
+				bunExecutable(),
+				"build",
+				"--target=bun",
+				"--format=cjs",
+				"--external=mupdf",
+				"--external=*native-modifiers.js",
+				join(fixture, "app-entry.ts"),
+				"--outfile",
+				appPath,
+			] as const;
+			const appBuild = spawnSyncCollect(appBuildCommand, { cwd: root });
+			assert.equal(appBuild.exitCode, 0, appBuild.stderr.toString());
+			copyFileSync(
+				join(root, "node_modules/@earendil-works/pi-tui/dist/native-modifiers.js"),
+				join(runtimeDir, "native-modifiers.js"),
+			);
+			copyFileSync(
+				join(root, "node_modules/@earendil-works/pi-tui/dist/native-module-path.js"),
+				join(runtimeDir, "native-module-path.js"),
+			);
+
+			const launcherBuildCommand = [
+				bunExecutable(),
+				"build",
+				"--compile",
+				"--bytecode",
+				"--format=cjs",
+				"--external=mupdf",
+				"--no-compile-autoload-dotenv",
+				"--no-compile-autoload-bunfig",
+				join(fixture, "split-loader.ts"),
+				"--outfile",
+				executablePath,
+			] as const;
+			const launcherBuild = spawnSyncCollect(launcherBuildCommand, { cwd: root });
+			assert.equal(launcherBuild.exitCode, 0, launcherBuild.stderr.toString());
+
+			const head = spawnSyncCollect(["git", "rev-parse", "HEAD"], { cwd: root });
+			assert.equal(head.exitCode, 0, head.stderr.toString());
+			console.log(`fixture proper-lockfile: ${resolvedLockfile}`);
+			console.log(`repository HEAD: ${head.stdout.toString().trim()}`);
+			console.log(`app build: ${formatCommand(appBuildCommand)}`);
+			console.log(`launcher build: ${formatCommand(launcherBuildCommand)}`);
+			console.log(`app.js sha256: ${sha256(appPath)}`);
+			console.log(`atomic sha256: ${sha256(executablePath)}`);
+
+			const startupCommand = [executablePath, extensionPath] as const;
+			console.log(`startup: ${formatCommand(startupCommand)}`);
+			const startup = spawnSyncCollect(startupCommand, { cwd: fixture });
+			assert.equal(startup.exitCode, 0, startup.stderr.toString());
+			assert.equal(startup.stdout.toString().trim(), "extension lock probe: OK");
+		} finally {
+			removeTempDirectory(fixture);
+		}
+	},
+	COMPILED_EXTENSION_LOADER_TIMEOUT_MS,
+);

--- a/test/ci/extension-loader-binary-boundary.test.ts
+++ b/test/ci/extension-loader-binary-boundary.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { mkdtempSync, readFileSync, realpathSync } from "node:fs";
 import { createRequire } from "node:module";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { test } from "vitest";
 import {
@@ -76,7 +76,7 @@ test(
 			const resolvedLockfile = extensionRequire.resolve("proper-lockfile");
 			const repositoryLockfileRoot = realpathSync(join(root, "node_modules", "proper-lockfile"));
 			assert.ok(
-				realpathSync(resolvedLockfile).startsWith(`${repositoryLockfileRoot}/`),
+				realpathSync(resolvedLockfile).startsWith(`${repositoryLockfileRoot}${sep}`),
 				`fixture resolved an external proper-lockfile: ${resolvedLockfile}`,
 			);
 


### PR DESCRIPTION
## Summary

- keep `proper-lockfile` in the compiled host module graph and expose that live module to Jiti-loaded extensions
- add a compiled-loader regression that resolves the repository-installed package, performs two real lock/release cycles through an authored default import, and uses the production split-launcher boundary
- document the installed-binary fix

This is an independent loader prerequisite. #2717 exposed the defect when workflow stage startup performed the second lock operation, but #2717 did not introduce it.

## Current-main ownership proof

A detached clean worktree at exact `origin/main` `49e02619031621dc1024c251199678b119bae66c` built the production binary with:

```text
npm --workspace=@bastani/atomic run build:binary
app.js sha256 ae33c02db56efdca8f8dbec98a98cda0da1eea0400b878a704f3c88f10d1c402
atomic sha256 cadd85d9d198ffc43176082a0854ce72be21264a36b83b4dc262a48c27ca6c63
```

The fixture was inside that repository worktree, resolved `proper-lockfile` to that worktree's `node_modules/proper-lockfile/index.js`, and had SHA-256 `d72cf57df16a9b178261400b0b535f70f8fe7e378fdc1b98310eeb3a56359858`. Running it through the built binary failed with exit 1:

```text
TypeError: Proxy handler's 'get' result of a non-configurable and non-writable property should be the same value as the target's property
      at probe (.../node_modules/proper-lockfile/lib/mtime-precision.js:6:29)
      at guarded (internal:shared:114:26)
```

This is not the invalid temp-project module-resolution failure: both the test and full production-binary run prove the exact repository `proper-lockfile` resolution before execution.

## Root cause

Jiti's CommonJS interop proxy memoizes each `get` result. `proper-lockfile` first reads its private precision symbol from the Jiti-proxied `graceful-fs` export, memoizing `undefined`, then installs `{ value: "ms" }` with the default non-writable/non-configurable descriptor. Its next read receives Jiti's stale cached `undefined`; the runtime rejects that result because a proxy must return the target's exact value for a non-configurable, non-writable data property.

The narrow fix mirrors the existing compiled-host virtual-module strategy: native-import `proper-lockfile` once and provide that module for the exact specifier. It does not patch dependencies, disable locking, or change source/development alias behavior.

## Validation

- same focused compiled boundary: RED on main, GREEN on this commit
- full repository production binary: same fixture SHA and command GREEN on this commit (`app.js` `4c26ceb7...`, launcher `cadd85d9...`)
- `npm run check`
- CI contract project: 74 passed
- focused loader agent tests: 20 passed
- relevant workflow loader unit tests: 40 passed
- packed #2719 workflow SDK integration: passed
- explicit current and legacy workflow-specifier assertion: both authored default exports retained the host workflow brand

The PR is ready for review. Final-head Linux/Windows CI, CodeQL, and Greptile are green; the merge-ref has zero open CodeQL alerts. It remains unmerged and is not gh-stack-linked to #2724.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790416245&installation_model_id=10562&pr_number=2726&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2726&signature=f13cc215c9aa5f2712ebe56d3f085c97a9d4b4869246be2b796a85f4062431d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The compiled extension loader now preserves `proper-lockfile`'s mutable CommonJS behavior for installed binary builds. The binary-boundary test also uses the native path separator, so its repository containment check works with Windows paths.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The compiled split-launcher flow successfully loaded a TypeScript extension using a default `proper-lockfile` import and completed two lock/release cycles. The Windows containment expression correctly accepts a child path while rejecting a similarly named sibling.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated Windows containment logic by reproducing containment checks with Windows-native canonical paths and confirming that using root + win32.sep correctly identifies legitimate child paths while root + '/' does not.
- Completed the extension loader boundary tests at PR head, demonstrating that the pre-fix state failed with a Proxy invariant error and the post-fix state passes after applying the virtual module fix.

<a href="https://app.greptile.com/trex/runs/20999028/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(ci): make loader resolution asserti..."](https://github.com/bastani-inc/atomic/commit/7cfeb2f2a2189816d1043321eda3ce9273471c1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57449830)</sub>

<!-- /greptile_comment -->
