### PR TITLE
fix(workflows): guide heartbeat Intercom routing

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Added a dedicated `workflow answer` action for responding to pending primitive and structured human-in-the-loop prompts without exposing stage-message delivery semantics.
 - Added durable pending-stage message state for ordinary Intercom delivery, including FIFO delivery before the first model turn, resume/replay persistence, exactly-once stage-attempt handling, lifecycle failure notifications, and guidance for propagating material updates to known workflow stages that have not started. ([#2717](https://github.com/bastani-inc/atomic/issues/2717))
 
+### Changed
+
+- Periodic workflow heartbeat prompts now guide supervising agents to use ordinary Intercom when steering or communication is useful, match an update's reach to the expanded workflow topology, send shared scope or acceptance changes consistently across every relevant live and known unstarted worker/reviewer stage, account for immediate and queued pre-first-turn delivery, and use workflow pause, resume, interrupt, or quit for run control.
+
 ### Removed
 
 - Removed the public `workflow send` action and its stage-chat delivery modes. Use `workflow answer` for pending human-input prompts, `workflow resume` for paused control, and ordinary Intercom for live or deferred workflow-stage communication.

--- a/packages/workflows/src/extension/workflow-heartbeat-notice.ts
+++ b/packages/workflows/src/extension/workflow-heartbeat-notice.ts
@@ -25,8 +25,16 @@ export function formatWorkflowHeartbeatNoticeText(details: WorkflowHeartbeatEven
 	return (
 		`${WORKFLOW_HEARTBEAT_GLYPH} Workflow "${workflowName}" heartbeat (run ${details.runId}) — still running` +
 		`${elapsed === undefined ? "" : ` after ${elapsed}`}, on a ${cadence} cadence. ` +
-		"This is a periodic alignment check, not a failure. Review whether the run is still on goal, then " +
-		"continue, steer it, stop and replace it, or ask the user. " +
+		"This is a periodic alignment check. Review whether the run is still on goal. " +
+		"When steering or communication is useful, use Intercom. Consider the expanded workflow topology and match " +
+		"each update's reach to its impact: send a local update to its affected stage; when shared scope or acceptance " +
+		"criteria change, send the same authoritative Intercom update to every relevant live and known unstarted " +
+		"`<runId>:<stageKey>`, including each worker-to-reviewer loop. Intercom delivers immediately to live stages and " +
+		"queues updates for known stages that have not started, delivering them before their first model turn, so workers " +
+		"and reviewers begin with one consistent contract. " +
+		"Use `ask` once the target has a live session that can reply. " +
+		"Use workflow pause, resume, interrupt, or quit for run control. " +
+		"Continue the progressing run when no intervention is needed, or ask the user when a decision is needed. " +
 		`Inspect: /workflow status ${details.runId}`
 	);
 }

--- a/test/unit/workflow-heartbeat-scheduler.test.ts
+++ b/test/unit/workflow-heartbeat-scheduler.test.ts
@@ -735,6 +735,25 @@ describe("workflow heartbeat delivery", () => {
 		assert.equal(send.details.workflowName, "audit-auth");
 		assert.match(send.content, /audit-auth/);
 		assert.ok(send.content.includes(`/workflow status ${runId}`), "the parent is told how to inspect the run");
+		assert.match(send.content, /This is a periodic alignment check\. Review whether the run is still on goal\./);
+		assert.ok(
+			send.content.includes("When steering or communication is useful, use Intercom."),
+			"the parent uses Intercom when the alignment review calls for communication",
+		);
+		assert.match(send.content, /Consider the expanded workflow topology/);
+		assert.match(send.content, /match each update's reach to its impact/);
+		assert.match(send.content, /send a local update to its affected stage/);
+		assert.match(send.content, /shared scope or acceptance criteria change/);
+		assert.match(send.content, /same authoritative Intercom update/);
+		assert.match(send.content, /every relevant live and known unstarted `<runId>:<stageKey>`/);
+		assert.match(send.content, /worker-to-reviewer loop/);
+		assert.match(send.content, /Intercom delivers immediately to live stages/);
+		assert.match(send.content, /queues updates for known stages that have not started/);
+		assert.match(send.content, /delivering them before their first model turn/);
+		assert.match(send.content, /workers and reviewers begin with one consistent contract/);
+		assert.match(send.content, /Use `ask` once the target has a live session that can reply/);
+		assert.match(send.content, /Use workflow pause, resume, interrupt, or quit for run control/);
+		assert.match(send.content, /Continue the progressing run when no intervention is needed/);
 		harness.scheduler.dispose();
 	});
 


### PR DESCRIPTION
## Summary

- present each heartbeat as a periodic alignment check and keep communication conditional on its usefulness
- consider the expanded workflow topology and match each update's reach to its impact
- send a local update to its affected stage; send one authoritative shared-scope or acceptance-criteria update to every relevant live and known unstarted `<runId>:<stageKey>`, including worker-to-reviewer loops
- explain immediate live delivery and queued pre-first-turn delivery so workers and reviewers begin with one consistent contract
- preserve live-session `ask`, affirmative workflow pause/resume/interrupt/quit controls, status inspection, and the continue path

## Stack dependency

Depends on #2730. This is the third dependent slice above the four #2717 delivery PRs and the workflow answer/removal slices in stack #2724.

## Validation

- RED: `/tmp/2717-heartbeat-topology-red.log` (1 expected failure; 79 passed)
- Focused scheduler: 80/80 passed (`/tmp/2717-heartbeat-topology-green.log`)
- `npm run check`: passed (`/tmp/2717-heartbeat-topology-check.log`)

Draft pending exact-head CI/CodeQL, final evidence, and Greptile review across the complete seven-PR stack.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The heartbeat notice adds guidance for alignment checks, Intercom communication, and workflow controls. A reproduced routing failure remains: a nested worker or reviewer cannot be reached using the top-level run ID shown by the heartbeat, so the guidance must explain that its owning child-run ID is required.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until the heartbeat guidance identifies the owning child-run ID required to contact nested workers and reviewers.

The failure was reproduced through both live Intercom delivery and queued pre-start delivery, then contrasted with successful delivery using the child-run ID. Existing focused coverage independently confirms child-run-scoped queue delivery.

**Files Needing Attention:** packages/workflows/src/extension/workflow-heartbeat-notice.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran a focused nested-run routing reproduction to validate the posted P1 finding.
- The reproduction produced three outputs: a root-run target failure, a child-run target successful delivery, and an existing pending-stage routing test result.
- A second finding-comment-proof for P1 was produced to corroborate the initial finding.
- General contract validation confirms exact runId resolution for nested stages, broker-managed pending-stage routes by runId, and a guideline to reference the stage's own runId in heartbeat messages for expanded nested stages.

<a href="https://app.greptile.com/trex/runs/21168086/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Heartbeat notice omits child-run identity required for nested-stage Intercom targets**

   - **Bug**
     - For a nested `reviewer` registered under child run `22222222-2222-4222-8222-222222222222`, targeting the heartbeat root `11111111-1111-4111-8111-111111111111:reviewer` failed immediate delivery with `Session not found`; its queued route was unhandled and did not queue any message. The equivalent child-run target delivered immediately and queued/drained successfully before the stage's first turn.
   - **Cause**
     - `formatWorkflowHeartbeatNoticeText` at `packages/workflows/src/extension/workflow-heartbeat-notice.ts:29-33` describes all expanded topology targets generically as `<runId>:<stageKey>` while the heartbeat identifies the root run, but routing and queue lookup are scoped to the exact target run ID. The notice never directs callers to select the child run ID for a nested stage.
   - **Fix**
     - Amend the heartbeat text to explicitly say that an expanded nested stage uses its own/owning child-run ID in `<runId>:<stageKey>` (for example, obtain it from expanded workflow status), not necessarily the top-level heartbeat run ID.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/workflows/src/extension/workflow-heartbeat-notice.ts:29-33
**Nested routing loses identity**

A nested worker or reviewer is registered under its owning child-run ID, but this notice only describes targets generically as `<runId>:<stageKey>` while identifying the heartbeat’s top-level run. Using that root ID for a nested reviewer fails immediate Intercom delivery (`Session not found`), and queued delivery is unhandled rather than stored for the child worker. Explicitly state that expanded nested workers and reviewers must use their owning child-run ID in `<runId>:<stageKey>`—for example, the ID shown for that worker in workflow status—not the heartbeat’s top-level run ID.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(workflows): guide heartbeat Intercom..."](https://github.com/bastani-inc/atomic/commit/bdb48dcf4fe3e7d5e8bcf4d8899fcd009d093fce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57774597)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->