### PR TITLE
docs(changelog): prepare 0.9.16-alpha.8 release notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.16-alpha.8] - 2026-08-27
+
 ### Breaking Changes
 
 - Removed the public `workflow send` action. Use `workflow answer` for pending workflow prompts and ordinary Intercom for workflow-stage communication.

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.16-alpha.8] - 2026-08-27
+
 ### Added
 
 - Extended ordinary `send` delivery to known workflow stages whose sessions have not initialized, with durable FIFO queueing, a distinct `queued` acknowledgment, same-group enforcement, bounded per-stage capacity, structured pre-start `ask` refusal, and delivery through the existing Intercom path before the stage's first model turn. ([#2717](https://github.com/bastani-inc/atomic/issues/2717))

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.16-alpha.8] - 2026-08-27
+
 ### Added
 
 - Added a dedicated `workflow answer` action for responding to pending primitive and structured human-in-the-loop prompts without exposing stage-message delivery semantics.


### PR DESCRIPTION
## Summary

Prepares the changelogs for the `0.9.16-alpha.8` prerelease by moving the accumulated `[Unreleased]` entries in each affected package into a dated release section. This changelog-only PR must merge before the release tag is cut.

## Changes

- `packages/coding-agent/CHANGELOG.md` records the workflow API migration, GitHub Copilot fast mode, isolated model/thinking persistence fixes, installed Intercom broker repair, compiled lockfile-module reuse, and the published workflow SDK type-resolution fix.
- `packages/intercom/CHANGELOG.md` records deferred FIFO delivery to known workflow stages before their sessions initialize.
- `packages/workflows/CHANGELOG.md` records `workflow answer`, pending-stage message persistence and delivery, heartbeat routing guidance, and removal of `workflow send`.

## Scope

The diff contains only the three prepared changelogs. All eight package manifests, workspace lock entries, Cargo manifests and lock data, and the native generated version checks remain at `0.0.0`. The target version appears nowhere outside package changelogs.

`main` stays versionless. After this PR merges, `scripts/cut-release.ts` will stamp `0.9.16-alpha.8` only on the detached release commit. Pushing that tag starts `publish.yml`; this PR does not tag or publish.

## Validation

- `bun run check`
- `bun run vitest --run test/unit/changelog.test.ts test/unit/package-metadata.test.ts` (25 tests passed)
- `bun run scripts/build-release-notes.ts 0.9.16-alpha.8`
- Bun-based versionless invariant check across package manifests, `package-lock.json`, Cargo files, and `packages/natives/native/index.js`

Assistant-model: GPT-5.6 Sol

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790477305&installation_model_id=10562&pr_number=2733&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2733&signature=f4ee98cf9a3bdec49ab60cc4fd0d45bfbce115093d59d73720ebc83fbbc3d601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prepares the `0.9.16-alpha.8` prerelease changelogs by moving accumulated entries from the Unreleased sections into dated release sections.

- Adds the release heading to the coding-agent changelog.
- Adds the release heading to the Intercom changelog.
- Adds the release heading to the workflows changelog.

<h3>Confidence Score: 5/5</h3>

The changelog-only PR appears safe to merge.

The new headings follow the repository’s release-section format, remain compatible with release-note extraction, and implement the documented pre-tag changelog preparation flow.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/coding-agent/CHANGELOG.md | Adds a correctly formatted `0.9.16-alpha.8` release heading above the accumulated coding-agent entries. |
| packages/intercom/CHANGELOG.md | Adds a correctly formatted `0.9.16-alpha.8` release heading above the accumulated Intercom entry. |
| packages/workflows/CHANGELOG.md | Adds a correctly formatted `0.9.16-alpha.8` release heading above the accumulated workflow entries. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.16-alpha.8 ..."](https://github.com/bastani-inc/atomic/commit/aa36b57c4b3180ec733679abd167467349c95fb0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57776163)</sub>

<!-- /greptile_comment -->