### PR TITLE
feat(extensions): emit UI prompt lifecycle events

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `ui_prompt_start` and `ui_prompt_end` extension events around blocking `ctx.ui` prompts so integrations can distinguish active agent work from waiting for user input. Nested and overlapping prompts form one balanced outer span, and prompt failures or UI-context replacement still emit the matching end notification without delaying the prompt UI. ([#5329](https://github.com/earendil-works/pi/issues/5329))
+
 ## [0.9.16-alpha.8] - 2026-08-27
 
 ### Breaking Changes

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -637,6 +637,25 @@ pi.on("agent_settled", async (_event, ctx) => {
 });
 ```
 
+#### ui_prompt_start / ui_prompt_end
+
+These notification-only events wrap blocking user-facing extension prompts opened through `ctx.ui.select()`, `ctx.ui.confirm()`, `ctx.ui.input()`, `ctx.ui.editor()`, and `ctx.ui.custom()`. Each event has `reason: "ui_prompt"`, the prompt `kind`, and the prompt `title` when that method accepts one. Host and status integrations can use the pair to report that Atomic is waiting for the user instead of still working.
+
+Atomic coalesces nested or overlapping prompts into one outer span. The end event keeps the outer prompt's kind and title and fires after every prompt in that span settles, including rejected promises and synchronous failures. Rebinding the host UI context closes an active span before a prompt from the new context can begin.
+
+Handlers run best-effort from the microtask queue. Atomic does not await them before opening or closing the prompt, so a slow handler cannot delay the UI.
+
+```typescript
+pi.on("ui_prompt_start", (event) => {
+  // event.kind - "select" | "confirm" | "input" | "editor" | "custom"
+  // event.title - prompt title when available
+});
+
+pi.on("ui_prompt_end", (event) => {
+  // Atomic is no longer waiting on this outer prompt span.
+});
+```
+
 #### turn_start / turn_end
 
 Fired for each turn (one LLM response + tool calls).

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -88,6 +88,7 @@ import type {
 	ToolCallEventResult,
 	ToolResultEvent,
 	ToolResultEventResult,
+	UIPromptKind,
 	UserBashEvent,
 	UserBashEventResult,
 } from "./types.ts";
@@ -151,6 +152,8 @@ export class ExtensionRunner {
 	private shortcutDiagnostics: ResourceDiagnostic[] = [];
 	private commandDiagnostics: ResourceDiagnostic[] = [];
 	private staleMessage: string | undefined;
+	private uiPromptBinding = 0;
+	private activeUIPrompt: { depth: number; kind: UIPromptKind; title: string | undefined } | undefined;
 
 	constructor(
 		extensions: Extension[],
@@ -275,8 +278,83 @@ export class ExtensionRunner {
 	}
 
 	setUIContext(uiContext?: ExtensionUIContext, mode: ExtensionMode = "print"): void {
-		this.uiContext = uiContext ?? noOpUIContext;
+		this.endActiveUIPrompt();
+		const binding = ++this.uiPromptBinding;
+		this.uiContext = uiContext ? this.wrapUIPromptContext(uiContext, binding) : noOpUIContext;
 		this.mode = mode;
+	}
+
+	private wrapUIPromptContext(ui: ExtensionUIContext, binding: number): ExtensionUIContext {
+		return {
+			...ui,
+			select: (title, options, opts) =>
+				this.withUIPrompt(binding, "select", title, () => ui.select(title, options, opts)),
+			confirm: (title, message, opts) =>
+				this.withUIPrompt(binding, "confirm", title, () => ui.confirm(title, message, opts)),
+			input: (title, placeholder, opts) =>
+				this.withUIPrompt(binding, "input", title, () => ui.input(title, placeholder, opts)),
+			editor: (title, prefill, opts) =>
+				this.withUIPrompt(binding, "editor", title, () => ui.editor(title, prefill, opts)),
+			custom: (factory, options) =>
+				this.withUIPrompt(binding, "custom", undefined, () => ui.custom(factory, options)),
+		};
+	}
+
+	private withUIPrompt<T>(
+		binding: number,
+		kind: UIPromptKind,
+		title: string | undefined,
+		run: () => Promise<T>,
+	): Promise<T> {
+		if (binding !== this.uiPromptBinding) return run();
+
+		let prompt = this.activeUIPrompt;
+		if (!prompt) {
+			prompt = { depth: 0, kind, title };
+			this.activeUIPrompt = prompt;
+			this.emitUIPromptEvent({
+				type: "ui_prompt_start",
+				reason: "ui_prompt",
+				kind,
+				...(title === undefined ? {} : { title }),
+			});
+		}
+		prompt.depth += 1;
+
+		let finished = false;
+		const finish = () => {
+			if (finished) return;
+			finished = true;
+			if (this.activeUIPrompt !== prompt) return;
+
+			prompt.depth -= 1;
+			if (prompt.depth === 0) this.endActiveUIPrompt(prompt);
+		};
+
+		try {
+			return run().finally(finish);
+		} catch (error) {
+			finish();
+			throw error;
+		}
+	}
+
+	private endActiveUIPrompt(prompt = this.activeUIPrompt): void {
+		if (!prompt || this.activeUIPrompt !== prompt) return;
+		this.activeUIPrompt = undefined;
+		prompt.depth = 0;
+		this.emitUIPromptEvent({
+			type: "ui_prompt_end",
+			reason: "ui_prompt",
+			kind: prompt.kind,
+			...(prompt.title === undefined ? {} : { title: prompt.title }),
+		});
+	}
+
+	private emitUIPromptEvent(event: Extract<RunnerEmitEvent, { type: "ui_prompt_start" | "ui_prompt_end" }>): void {
+		queueMicrotask(() => {
+			void this.emit(event);
+		});
 	}
 
 	getUIContext(): ExtensionUIContext {

--- a/packages/coding-agent/src/modes/interactive/interactive-extension-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-extension-runtime.ts
@@ -29,7 +29,7 @@ InteractiveModeBase.prototype.setupExtensionShortcuts = function (
 
 	// Create a context for shortcut handlers
 	const createContext = (): ExtensionContext => ({
-		ui: this.createExtensionUIContext(),
+		ui: extensionRunner.getUIContext(),
 		mode: "tui",
 		hasUI: true,
 		cwd: this.sessionManager.getCwd(),

--- a/packages/coding-agent/test/extensions-ui-prompt-events.test.ts
+++ b/packages/coding-agent/test/extensions-ui-prompt-events.test.ts
@@ -1,0 +1,378 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { createEventBus } from "../src/core/event-bus.ts";
+import { createExtensionRuntime, loadExtensionFromFactory } from "../src/core/extensions/loader.ts";
+import { ExtensionRunner } from "../src/core/extensions/runner.ts";
+import { noOpUIContext } from "../src/core/extensions/runner-ui.ts";
+import type {
+	ExtensionFactory,
+	ExtensionUIContext,
+	UIPromptEndEvent,
+	UIPromptKind,
+	UIPromptStartEvent,
+} from "../src/core/extensions/types.ts";
+import { InteractiveModeBase } from "../src/modes/interactive/interactive-mode-base.ts";
+import "../src/modes/interactive/interactive-extension-runtime.ts";
+
+type UIPromptEvent = UIPromptStartEvent | UIPromptEndEvent;
+
+interface Deferred<T> {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+	reject: (reason: Error) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	let reject!: (reason: Error) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
+}
+
+function createUI(overrides: Partial<ExtensionUIContext> = {}): ExtensionUIContext {
+	return { ...noOpUIContext, ...overrides };
+}
+
+async function flushNotifications(): Promise<void> {
+	await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+async function createRunner(
+	options: {
+		onStart?: (event: UIPromptStartEvent) => void | Promise<void>;
+		onEnd?: (event: UIPromptEndEvent) => void | Promise<void>;
+		configure?: ExtensionFactory;
+	} = {},
+): Promise<{ runner: ExtensionRunner; events: UIPromptEvent[] }> {
+	const events: UIPromptEvent[] = [];
+	const runtime = createExtensionRuntime();
+	const extension = await loadExtensionFromFactory(
+		async (pi) => {
+			pi.on("ui_prompt_start", async (event) => {
+				events.push(event);
+				await options.onStart?.(event);
+			});
+			pi.on("ui_prompt_end", async (event) => {
+				events.push(event);
+				await options.onEnd?.(event);
+			});
+			await options.configure?.(pi);
+		},
+		process.cwd(),
+		createEventBus(),
+		runtime,
+		"<ui-prompt-events>",
+	);
+	return {
+		runner: new ExtensionRunner([extension], runtime, process.cwd(), {} as never, {} as never),
+		events,
+	};
+}
+
+test("in-process extension shortcuts emit prompt lifecycle events", async () => {
+	const shortcutFinished = deferred<void>();
+	const { runner, events } = await createRunner({
+		configure: (pi) => {
+			pi.registerShortcut("ctrl+g", {
+				description: "Open a prompt",
+				handler: async (ctx) => {
+					assert.equal(await ctx.ui.select("Shortcut prompt", ["one"]), "one");
+					shortcutFinished.resolve();
+				},
+			});
+		},
+	});
+	const rawUI = createUI({ select: async () => "one" });
+	runner.setUIContext(rawUI, "tui");
+
+	let onExtensionShortcut: ((data: string) => boolean) | undefined;
+	const context = {
+		keybindings: { getEffectiveConfig: () => ({}) },
+		sessionManager: { getCwd: () => process.cwd() },
+		session: {
+			scopedModels: [],
+			model: undefined,
+			modelRuntime: {},
+			isStreaming: false,
+			settingsManager: { isProjectTrusted: () => true },
+			agent: { signal: new AbortController().signal },
+			pendingMessageCount: 0,
+			systemPrompt: "",
+			abort: () => {},
+			getContextUsage: () => undefined,
+			compact: async () => undefined,
+		},
+		createExtensionUIContext: () => rawUI,
+		get defaultEditor() {
+			return {
+				set onExtensionShortcut(handler: (data: string) => boolean) {
+					onExtensionShortcut = handler;
+				},
+			};
+		},
+		showError: (message: string) => assert.fail(message),
+	};
+	const setup = Reflect.get(InteractiveModeBase.prototype, "setupExtensionShortcuts") as (
+		this: typeof context,
+		extensionRunner: ExtensionRunner,
+	) => void;
+
+	setup.call(context, runner);
+	assert.equal(onExtensionShortcut?.("\x07"), true);
+	await shortcutFinished.promise;
+	await flushNotifications();
+
+	assert.deepEqual(events, [
+		{ type: "ui_prompt_start", reason: "ui_prompt", kind: "select", title: "Shortcut prompt" },
+		{ type: "ui_prompt_end", reason: "ui_prompt", kind: "select", title: "Shortcut prompt" },
+	]);
+});
+
+test("all blocking extension UI prompts emit lifecycle events and preserve their arguments", async () => {
+	const { runner, events } = await createRunner();
+	const signal = new AbortController().signal;
+	const dialogOptions = { signal };
+	const customOptions = { overlay: true } as const;
+	const customFactory: Parameters<ExtensionUIContext["custom"]>[0] = () => ({
+		render: () => [],
+		invalidate: () => {},
+	});
+	const calls: UIPromptKind[] = [];
+
+	runner.setUIContext(
+		createUI({
+			select: async (title, options, opts) => {
+				assert.equal(title, "Select title");
+				assert.deepEqual(options, ["one", "two"]);
+				assert.equal(opts, dialogOptions);
+				calls.push("select");
+				return "one";
+			},
+			confirm: async (title, message, opts) => {
+				assert.equal(title, "Confirm title");
+				assert.equal(message, "Continue?");
+				assert.equal(opts, dialogOptions);
+				calls.push("confirm");
+				return true;
+			},
+			input: async (title, placeholder, opts) => {
+				assert.equal(title, "Input title");
+				assert.equal(placeholder, "Type here");
+				assert.equal(opts, dialogOptions);
+				calls.push("input");
+				return "typed";
+			},
+			editor: async (title, prefill, opts) => {
+				assert.equal(title, "Editor title");
+				assert.equal(prefill, "draft");
+				assert.equal(opts, dialogOptions);
+				calls.push("editor");
+				return "edited";
+			},
+			custom: (async (factory, options) => {
+				assert.equal(factory, customFactory);
+				assert.equal(options, customOptions);
+				calls.push("custom");
+				return "custom result";
+			}) as ExtensionUIContext["custom"],
+		}),
+	);
+
+	const ui = runner.getUIContext();
+	assert.equal(await ui.select("Select title", ["one", "two"], dialogOptions), "one");
+	assert.equal(await ui.confirm("Confirm title", "Continue?", dialogOptions), true);
+	assert.equal(await ui.input("Input title", "Type here", dialogOptions), "typed");
+	assert.equal(await ui.editor("Editor title", "draft", dialogOptions), "edited");
+	assert.equal(await ui.custom(customFactory, customOptions), "custom result");
+	await flushNotifications();
+
+	assert.deepEqual(calls, ["select", "confirm", "input", "editor", "custom"]);
+	assert.deepEqual(events, [
+		{ type: "ui_prompt_start", reason: "ui_prompt", kind: "select", title: "Select title" },
+		{ type: "ui_prompt_end", reason: "ui_prompt", kind: "select", title: "Select title" },
+		{ type: "ui_prompt_start", reason: "ui_prompt", kind: "confirm", title: "Confirm title" },
+		{ type: "ui_prompt_end", reason: "ui_prompt", kind: "confirm", title: "Confirm title" },
+		{ type: "ui_prompt_start", reason: "ui_prompt", kind: "input", title: "Input title" },
+		{ type: "ui_prompt_end", reason: "ui_prompt", kind: "input", title: "Input title" },
+		{ type: "ui_prompt_start", reason: "ui_prompt", kind: "editor", title: "Editor title" },
+		{ type: "ui_prompt_end", reason: "ui_prompt", kind: "editor", title: "Editor title" },
+		{ type: "ui_prompt_start", reason: "ui_prompt", kind: "custom" },
+		{ type: "ui_prompt_end", reason: "ui_prompt", kind: "custom" },
+	]);
+});
+
+test("Atomic-only host UI methods pass through without prompt lifecycle events", async () => {
+	const { runner, events } = await createRunner();
+	const hostInputForm: NonNullable<ExtensionUIContext["hostInputForm"]> = async () => undefined;
+	const hostSessionPicker: NonNullable<ExtensionUIContext["hostSessionPicker"]> = () => ({
+		result: Promise.resolve(undefined),
+		update: () => {},
+		error: () => {},
+		close: () => {},
+	});
+	runner.setUIContext(createUI({ hostInputForm, hostSessionPicker }));
+
+	const ui = runner.getUIContext();
+	assert.equal(ui.hostInputForm, hostInputForm);
+	assert.equal(ui.hostSessionPicker, hostSessionPicker);
+	await flushNotifications();
+	assert.deepEqual(events, []);
+});
+
+test("nested prompts coalesce into the outer prompt span", async () => {
+	const { runner, events } = await createRunner();
+	const outer = deferred<string | undefined>();
+	const inner = deferred<string | undefined>();
+	let ui!: ExtensionUIContext;
+
+	runner.setUIContext(
+		createUI({
+			select: async () => {
+				const nested = ui.input("Nested input");
+				inner.resolve("nested value");
+				await nested;
+				return outer.promise;
+			},
+			input: () => inner.promise,
+		}),
+	);
+	ui = runner.getUIContext();
+
+	const outerPrompt = ui.select("Outer select", ["one"]);
+	await flushNotifications();
+	assert.deepEqual(events, [{ type: "ui_prompt_start", reason: "ui_prompt", kind: "select", title: "Outer select" }]);
+
+	outer.resolve("one");
+	assert.equal(await outerPrompt, "one");
+	await flushNotifications();
+
+	assert.deepEqual(events, [
+		{ type: "ui_prompt_start", reason: "ui_prompt", kind: "select", title: "Outer select" },
+		{ type: "ui_prompt_end", reason: "ui_prompt", kind: "select", title: "Outer select" },
+	]);
+});
+
+test("overlapping prompts retain outer metadata until every prompt settles", async () => {
+	const { runner, events } = await createRunner();
+	const first = deferred<string | undefined>();
+	const second = deferred<boolean>();
+	runner.setUIContext(
+		createUI({
+			select: () => first.promise,
+			confirm: () => second.promise,
+		}),
+	);
+	const ui = runner.getUIContext();
+
+	const firstPrompt = ui.select("Outer title", ["one"]);
+	const secondPrompt = ui.confirm("Inner title", "Continue?");
+	await flushNotifications();
+	assert.equal(events.length, 1);
+
+	first.resolve("one");
+	assert.equal(await firstPrompt, "one");
+	await flushNotifications();
+	assert.equal(events.length, 1);
+
+	second.resolve(true);
+	assert.equal(await secondPrompt, true);
+	await flushNotifications();
+	assert.deepEqual(events, [
+		{ type: "ui_prompt_start", reason: "ui_prompt", kind: "select", title: "Outer title" },
+		{ type: "ui_prompt_end", reason: "ui_prompt", kind: "select", title: "Outer title" },
+	]);
+});
+
+test("synchronous throws and asynchronous rejections each end their prompt span once", async () => {
+	const { runner, events } = await createRunner();
+	const syncError = new Error("sync failure");
+	const asyncError = new Error("async failure");
+	runner.setUIContext(
+		createUI({
+			select: () => {
+				throw syncError;
+			},
+			input: async () => {
+				throw asyncError;
+			},
+		}),
+	);
+	const ui = runner.getUIContext();
+
+	assert.throws(() => ui.select("Sync prompt", ["one"]), syncError);
+	await assert.rejects(ui.input("Async prompt"), asyncError);
+	await flushNotifications();
+
+	assert.deepEqual(events, [
+		{ type: "ui_prompt_start", reason: "ui_prompt", kind: "select", title: "Sync prompt" },
+		{ type: "ui_prompt_end", reason: "ui_prompt", kind: "select", title: "Sync prompt" },
+		{ type: "ui_prompt_start", reason: "ui_prompt", kind: "input", title: "Async prompt" },
+		{ type: "ui_prompt_end", reason: "ui_prompt", kind: "input", title: "Async prompt" },
+	]);
+});
+
+test("pending lifecycle handlers do not delay prompt display or settlement", async () => {
+	const startHandler = deferred<void>();
+	const endHandler = deferred<void>();
+	const { runner, events } = await createRunner({
+		onStart: () => startHandler.promise,
+		onEnd: () => endHandler.promise,
+	});
+	const prompt = deferred<string | undefined>();
+	let opened = false;
+	runner.setUIContext(
+		createUI({
+			select: () => {
+				opened = true;
+				return prompt.promise;
+			},
+		}),
+	);
+
+	const result = runner.getUIContext().select("Queued notifications", ["one"]);
+	assert.equal(opened, true);
+	await flushNotifications();
+	assert.equal(events[0]?.type, "ui_prompt_start");
+
+	prompt.resolve("one");
+	assert.equal(await result, "one");
+	await flushNotifications();
+	assert.deepEqual(
+		events.map((event) => event.type),
+		["ui_prompt_start", "ui_prompt_end"],
+	);
+
+	startHandler.resolve();
+	endHandler.resolve();
+});
+
+test("rebinding the UI context closes the old span without corrupting the new span", async () => {
+	const { runner, events } = await createRunner();
+	const oldPrompt = deferred<string | undefined>();
+	const newPrompt = deferred<boolean>();
+	runner.setUIContext(createUI({ select: () => oldPrompt.promise }));
+	const oldResult = runner.getUIContext().select("Old prompt", ["one"]);
+	await flushNotifications();
+
+	runner.setUIContext(createUI({ confirm: () => newPrompt.promise }));
+	const newResult = runner.getUIContext().confirm("New prompt", "Continue?");
+	await flushNotifications();
+
+	oldPrompt.resolve("one");
+	assert.equal(await oldResult, "one");
+	await flushNotifications();
+	assert.equal(events.length, 3);
+
+	newPrompt.resolve(true);
+	assert.equal(await newResult, true);
+	await flushNotifications();
+	assert.deepEqual(events, [
+		{ type: "ui_prompt_start", reason: "ui_prompt", kind: "select", title: "Old prompt" },
+		{ type: "ui_prompt_end", reason: "ui_prompt", kind: "select", title: "Old prompt" },
+		{ type: "ui_prompt_start", reason: "ui_prompt", kind: "confirm", title: "New prompt" },
+		{ type: "ui_prompt_end", reason: "ui_prompt", kind: "confirm", title: "New prompt" },
+	]);
+});

--- a/packages/coding-agent/test/pi-0.83.0-direct-fixes.test.ts
+++ b/packages/coding-agent/test/pi-0.83.0-direct-fixes.test.ts
@@ -340,10 +340,14 @@ describe("Pi 0.83.0 direct coding-agent parity", () => {
 
 		const setup = Reflect.get(InteractiveModeBase.prototype, "setupExtensionShortcuts") as (
 			this: typeof context,
-			runner: { getShortcuts: () => Map<string, { handler: (ctx: unknown) => void }> },
+			runner: {
+				getShortcuts: () => Map<string, { handler: (ctx: unknown) => void }>;
+				getUIContext: () => object;
+			},
 		) => void;
 
 		setup.call(context, {
+			getUIContext: () => context.createExtensionUIContext(),
 			getShortcuts: () =>
 				new Map([
 					[


### PR DESCRIPTION
## Summary

Completes the `earendil-works/pi@ccfe79ed23` port by emitting balanced extension UI prompt lifecycle events. This PR is stacked on the public event-contract layer in #2734.

## Changes

- Emit best-effort `ui_prompt_start` and `ui_prompt_end` notifications around select, confirm, input, editor, and custom prompts.
- Coalesce nested and overlapping prompts into one balanced outer waiting span.
- Handle synchronous throws, promise rejections, context rebinding, and in-process shortcut prompts without leaking lifecycle depth.
- Preserve Atomic-only host UI methods and outer prompt metadata.
- Add focused lifecycle and shortcut-path regression tests.
- Document the events in Atomic's extension guide and Unreleased changelog.

## Verification

- `npm run check`
- `npm run docs:check --workspace=@bastani/atomic`
- Full coding-agent suite: 4,017 tests passed, 40 skipped
- Focused contract, lifecycle, and shortcut tests
- Fresh max-effort review plus one bounded repair/re-review cycle
- `git diff --check`

## Stack

1. #2734 — public UI prompt event contract
2. **This PR:** runtime lifecycle behavior, tests, docs, and changelog

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790485098&installation_model_id=10562&pr_number=2735&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2735&signature=918a114cf1afeaddea931c5abbbb65bfcfc06e8b9a688a5cb73beda9fd6115fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds balanced lifecycle notifications around extension UI prompts, coalesces nested and overlapping prompts into a single outer span, and applies the wrapped UI context to interactive extension shortcuts. The focused regression test needs to follow the coding-agent package’s Vitest assertion convention.

<h3>Confidence Score: 4/5</h3>

The implementation is safe to merge after aligning the new test with the repository’s required assertion style.

There is one non-security P2 finding. Under the scoring policy, a review containing only P2 findings receives a score of 4.

**Files Needing Attention:** packages/coding-agent/test/extensions-ui-prompt-events.test.ts

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/test/extensions-ui-prompt-events.test.ts:1
**Vitest assertion convention bypassed**

This new package-level test imports `node:assert/strict` and uses `assert.*` throughout, contrary to the coding-agent test convention requiring Vitest `expect` assertions. This makes assertion style and failure diagnostics inconsistent with neighboring package tests.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(extensions): emit UI prompt lifecyc..."](https://github.com/bastani-inc/atomic/commit/7f8c2b21a54ca0da88ddaf3fbee1ad53f9f3abe8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57801156)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - For tests under packages/coding-agent/test/, follo... ([source](https://app.greptile.com/bastani-inc/github/bastani-inc/atomic/-/custom-context?memory=be6d0f11-42ea-4577-b84f-332cded4f9a9))

<!-- /greptile_comment -->