### PR TITLE
docs(changelog): prepare 0.9.16-alpha.9 release notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.16-alpha.9] - 2026-08-27
+
 ### Added
 
 - Added `ui_prompt_start` and `ui_prompt_end` extension events around blocking `ctx.ui` prompts so integrations can distinguish active agent work from waiting for user input. Nested and overlapping prompts form one balanced outer span, and prompt failures or UI-context replacement still emit the matching end notification without delaying the prompt UI. ([#5329](https://github.com/earendil-works/pi/issues/5329))


### PR DESCRIPTION
## Summary

Prepares the `@bastani/atomic` changelog for the `0.9.16-alpha.9` prerelease by moving the accumulated `[Unreleased]` entry into a dated release section. This changelog-only PR must merge before the release tag is cut.

## Changes

- Records the new `ui_prompt_start` and `ui_prompt_end` extension events around blocking `ctx.ui` prompts, including balanced handling for nested, overlapping, failed, and replaced UI contexts.

## Scope

The diff contains only `packages/coding-agent/CHANGELOG.md`. All eight package manifests, workspace lock entries, Cargo manifests and lock data, and generated native version checks remain at `0.0.0`. The target version appears nowhere outside package changelogs.

`main` stays versionless. After this PR merges, `scripts/cut-release.ts` will stamp `0.9.16-alpha.9` only on the detached release commit. Pushing that tag starts `publish.yml`; this PR does not tag or publish.

## Validation

- `bun run check`
- `bun run vitest --run test/unit/changelog.test.ts test/unit/package-metadata.test.ts` (25 tests passed)
- `bun run scripts/build-release-notes.ts 0.9.16-alpha.9`
- Bun-based versionless invariant check across package manifests, `package-lock.json`, Cargo files, and `packages/natives/native/index.js`

Assistant-model: GPT-5.6 Sol

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790488815&installation_model_id=10562&pr_number=2738&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2738&signature=de4d42677288d29a42bd1676f47efed60c4c58cd361bae499775757f8d93491f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates `packages/coding-agent/CHANGELOG.md` for `0.9.16-alpha.9`, placing the UI prompt lifecycle-event entry in the dated release section and leaving `Unreleased` ready for future work.

The release-notes generator accepts the new version, emits the lifecycle-event entry once, and preserves an empty Unreleased section. The focused release-note test suite passed.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the changelog entry produces the intended alpha.9 release notes without repeating the entry or populating Unreleased.

No defects were found. The real release-note generator was exercised against the previous and current changelog states, and focused release-note tests passed.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the real Bun release-notes validation script against the parent snapshot and confirmed it exited with status 1 because 0.9.16-alpha.9 was not documented.
- Ran the generator against the current changelog and confirmed it exited with status 0, emitting only the expected '### Added' lifecycle-event note.
- Validated that the alpha.9 entry occurs once and that Unreleased has no body, while the targeted release-notes unit tests completed successfully with 7 of 7 tests passing.
- Compared before/after states using the second proof and confirmed the current checkout exited 0, produced only the expected '### Added' note, and that the script assertions verified the entry occurs once with Unreleased remaining empty.

<a href="https://app.greptile.com/trex/runs/21188337/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.16-alpha.9 ..."](https://github.com/bastani-inc/atomic/commit/ac6bcdda26345edc09d66d94bdb4feab077ad6e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57812124)</sub>

<!-- /greptile_comment -->