### PR TITLE
feat(intercom): model session group memberships

### DIFF
--- a/packages/intercom/group.ts
+++ b/packages/intercom/group.ts
@@ -20,6 +20,11 @@ export const DEFAULT_GROUP = "default";
 
 const RESERVED_RUNTIME_GROUPS = new Set(["true", "auto"]);
 
+/** Runtime representation of a session's normalized group memberships. */
+export type GroupMemberships = ReadonlySet<string>;
+
+type GroupMembershipInput = readonly (string | null | undefined)[] | ReadonlySet<string | null | undefined>;
+
 /**
  * Normalize an intercom group id. Undefined, empty, or whitespace-only values
  * collapse to the shared {@link DEFAULT_GROUP} so ungrouped sessions all compare
@@ -29,6 +34,22 @@ export function normalizeGroup(value?: string | null): string {
 	if (typeof value !== "string") return DEFAULT_GROUP;
 	const trimmed = value.trim();
 	return trimmed.length > 0 ? trimmed : DEFAULT_GROUP;
+}
+
+/**
+ * Normalize serialized group memberships into a non-empty set. Duplicate names
+ * collapse, and an absent or empty collection retains legacy default membership.
+ * A legacy `group` value is merged so single-group clients remain authoritative.
+ */
+export function normalizeGroups(
+	values?: GroupMembershipInput | null,
+	legacyGroup?: string | null,
+): Set<string> {
+	const groups = new Set<string>();
+	for (const value of values ?? []) groups.add(normalizeGroup(value));
+	if (legacyGroup !== undefined) groups.add(normalizeGroup(legacyGroup));
+	if (groups.size === 0) groups.add(DEFAULT_GROUP);
+	return groups;
 }
 
 /**
@@ -44,6 +65,25 @@ export function validateRuntimeGroup(value: unknown): string {
 		throw new Error(`Intercom group name "${group}" is reserved; choose another name`);
 	}
 	return group;
+}
+
+/** Add one validated runtime group to a normalized membership set. */
+export function addGroup(groups: GroupMemberships, value: unknown): Set<string> {
+	const next = normalizeGroups(groups);
+	next.add(validateRuntimeGroup(value));
+	return next;
+}
+
+/** Remove one normalized group while retaining default membership when none remain. */
+export function removeGroup(groups: GroupMemberships, value?: string | null): Set<string> {
+	const next = normalizeGroups(groups);
+	next.delete(normalizeGroup(value));
+	return normalizeGroups(next);
+}
+
+/** Test a normalized group membership. */
+export function hasGroup(groups: GroupMemberships, value?: string | null): boolean {
+	return normalizeGroups(groups).has(normalizeGroup(value));
 }
 
 interface HomeGroupContext {

--- a/packages/intercom/types.ts
+++ b/packages/intercom/types.ts
@@ -7,7 +7,9 @@ export interface SessionInfo {
   startedAt: number;
   lastActivity: number;
   status?: string;
-  /** Session's intercom group; undefined is treated as the shared "default" group. */
+  /** Session's normalized intercom group memberships. */
+  groups?: string[];
+  /** Legacy single-group membership; accepted alongside `groups` for compatibility. */
   group?: string;
 }
 
@@ -82,7 +84,16 @@ export type ClientMessage =
 		reason?: string;
 		reasonCode?: "message_id_conflict";
 	  }
-  | { type: "presence"; name?: string; status?: string; model?: string; group?: string; requestId?: string };
+  | {
+      type: "presence";
+      name?: string;
+      status?: string;
+      model?: string;
+      groups?: string[];
+      /** Legacy single-group membership; accepted alongside `groups` for compatibility. */
+      group?: string;
+      requestId?: string;
+    };
 
 export type BrokerMessage =
   | { type: "registered"; sessionId: string; supervisorSessionId?: string }

--- a/test/unit/intercom-group.test.ts
+++ b/test/unit/intercom-group.test.ts
@@ -2,8 +2,12 @@ import assert from "node:assert/strict";
 import { runtimeIntercomGroupEnvKey } from "@bastani/atomic";
 import { afterEach, test } from "vitest";
 import {
+	addGroup,
 	DEFAULT_GROUP,
+	hasGroup,
 	normalizeGroup,
+	normalizeGroups,
+	removeGroup,
 	resolveHomeGroup,
 	validateRuntimeGroup,
 } from "../../packages/intercom/group.js";
@@ -35,6 +39,43 @@ test("normalizeGroup collapses empty/whitespace/undefined to default and trims n
 	assert.equal(normalizeGroup("   "), DEFAULT_GROUP);
 	assert.equal(normalizeGroup("default"), DEFAULT_GROUP);
 	assert.equal(normalizeGroup("  teamA  "), "teamA");
+});
+
+test("normalizeGroups turns protocol memberships into a normalized set", () => {
+	assert.deepEqual(normalizeGroups(), new Set([DEFAULT_GROUP]));
+	assert.deepEqual(normalizeGroups([]), new Set([DEFAULT_GROUP]));
+	assert.deepEqual(normalizeGroups(["  teamA  ", "teamA", "", "   "]), new Set(["teamA", DEFAULT_GROUP]));
+});
+
+test("normalizeGroups honours the legacy single group alongside set memberships", () => {
+	assert.deepEqual(normalizeGroups(undefined, " legacy "), new Set(["legacy"]));
+	assert.deepEqual(normalizeGroups(["teamA"], "legacy"), new Set(["teamA", "legacy"]));
+	assert.deepEqual(normalizeGroups(["teamA"], "   "), new Set(["teamA", DEFAULT_GROUP]));
+});
+
+test("normalization preserves reserved sentinels while runtime addition rejects them", () => {
+	assert.deepEqual(normalizeGroups([" true ", "AUTO"]), new Set(["true", "AUTO"]));
+	assert.throws(() => addGroup(new Set([DEFAULT_GROUP]), "true"), /reserved/);
+	assert.throws(() => addGroup(new Set([DEFAULT_GROUP]), " AUTO "), /reserved/);
+});
+
+test("group membership helpers add, remove, and test normalized memberships without mutating their input", () => {
+	const original = new Set([DEFAULT_GROUP]);
+	const joined = addGroup(original, "  teamA  ");
+
+	assert.deepEqual(original, new Set([DEFAULT_GROUP]));
+	assert.deepEqual(joined, new Set([DEFAULT_GROUP, "teamA"]));
+	assert.equal(hasGroup(joined, " teamA "), true);
+	assert.equal(hasGroup(joined, "teamB"), false);
+
+	const left = removeGroup(joined, DEFAULT_GROUP);
+	assert.deepEqual(joined, new Set([DEFAULT_GROUP, "teamA"]));
+	assert.deepEqual(left, new Set(["teamA"]));
+	assert.deepEqual(removeGroup(left, "teamA"), new Set([DEFAULT_GROUP]));
+});
+
+test("adding a membership rejects empty values", () => {
+	assert.throws(() => addGroup(new Set([DEFAULT_GROUP]), ""), /non-empty/);
 });
 
 test("validateRuntimeGroup trims named groups and permits explicit default", () => {

--- a/test/unit/intercom-protocol-groups.test.ts
+++ b/test/unit/intercom-protocol-groups.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import type { ClientMessage, SessionInfo } from "../../packages/intercom/types.js";
+
+const BASE_SESSION = {
+	id: "session-1",
+	cwd: "/repo",
+	model: "test",
+	pid: 1,
+	startedAt: 1,
+	lastActivity: 1,
+} as const;
+
+test("the session protocol carries a set of group memberships", () => {
+	const session: SessionInfo = { ...BASE_SESSION, groups: ["default", "reviewers"] };
+	const presence: ClientMessage = { type: "presence", groups: ["default", "reviewers"] };
+	const registration: ClientMessage = {
+		type: "register",
+		session: {
+			cwd: BASE_SESSION.cwd,
+			model: BASE_SESSION.model,
+			pid: BASE_SESSION.pid,
+			startedAt: BASE_SESSION.startedAt,
+			lastActivity: BASE_SESSION.lastActivity,
+			groups: ["default", "reviewers"],
+		},
+	};
+
+	assert.deepEqual(session.groups, ["default", "reviewers"]);
+	assert.deepEqual(presence.groups, ["default", "reviewers"]);
+	assert.deepEqual(registration.session.groups, ["default", "reviewers"]);
+});
+
+test("legacy single-group clients remain valid protocol clients", () => {
+	const session: SessionInfo = { ...BASE_SESSION, group: "reviewers" };
+	const registration: ClientMessage = {
+		type: "register",
+		session: {
+			cwd: session.cwd,
+			model: session.model,
+			pid: session.pid,
+			startedAt: session.startedAt,
+			lastActivity: session.lastActivity,
+			group: session.group,
+		},
+	};
+	const presence: ClientMessage = { type: "presence", group: "reviewers" };
+
+	assert.equal(session.group, "reviewers");
+	assert.equal(registration.session.group, "reviewers");
+	assert.equal(presence.group, "reviewers");
+});


### PR DESCRIPTION
Assistant-model: GPT-5.6 Sol

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790497329&installation_model_id=10562&pr_number=2740&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2740&signature=2fa9d1dbedb6ab6406cd399f09edb089a90812aa15e8ec86cd709f6d337f39ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change introduces multi-group membership fields and helper functions for Intercom sessions. The broker still treats groups-only clients as members of `default`, preventing them from being discovered or messaged by peers in their requested group.

<h3>Confidence Score: 4/5</h3>

Not merge-safe for clients using the new groups-only protocol: registration, presence, discovery, and direct routing do not honor their requested memberships.

The score is 4 under the required table because one non-security P1 remains. The prior membership finding is OUTSTANDING: flora131 stated that groups-only registration, presence, discovery, and direct delivery were fixed, but the current broker stores a groups-only `reviewers` session as `default`, omits it from reviewer discovery, and rejects direct messages as cross-group.

**Files Needing Attention:** packages/intercom/broker/broker.ts, packages/intercom/broker/presence-handler.ts, packages/intercom/broker/send-handler.ts, packages/intercom/broker/group-isolation.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced proof for a posted P1 finding.
- T-Rex linked the proof to the corresponding review comment to surface finding details.
- Artifacts were gathered to support the proof, including the broker regression harness source, the broker regression output, and the current broker source excerpts.

<a href="https://app.greptile.com/trex/runs/21224229/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `packages/intercom/broker/presence-handler.ts`, line 63 ([link](https://github.com/bastani-inc/atomic/blob/08467a3b989ea6c91bcc5272fe7efa457f4775e7/packages/intercom/broker/presence-handler.ts#L63)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Ran node trex-artifacts/groups-runtime-01-before.mjs, a temporary Unix-socket harness t...**

   - **Bug**
     - Ran node trex-artifacts/groups-runtime-01-before.mjs, a temporary Unix-socket harness that starts the real broker and sends groups-only registration, groups-only presence, discovery, and routing frames. The target supplied groups: "reviewers" without group; the broker listed it in default, acknowledged presence as default, omitted it from reviewer discovery, and rejected a direct message with Target session is in a different intercom group. This confirms that broker registration and presence processing ignore the new membership array.
   - **Cause**
     - T-Rex reproduced this while running the changed behavior, but it did not return a separate root-cause sentence.
   - **Fix**
     - Update the changed code so this failing path is handled, then rerun the same T-Rex check to confirm it passes.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Focused broker runtime validation source for groups-only membership](https://app.greptile.com/trex/artifacts/af5e95b4-8ca7-454c-8b4e-23df3b500eb7)**

   - Authored and executed a temporary-socket client harness that starts the real broker and sends groups-only registration, presence, discovery, and routing frames; it is the exact source used to prove the behavior.

   **[Broker runtime output for groups-only membership](https://app.greptile.com/trex/artifacts/dbd2a4b1-2167-446e-93a4-6821dca01485)**

   - Captured output from \`node trex-artifacts/groups-runtime-01-before.mjs\` in \`/home/user/repo\`, exiting 0; it shows default-group registration and presence, failed reviewer discovery, and rejected routing, confirming the bug.

   <a href="https://app.greptile.com/trex/runs/21211404/artifacts?artifact=af5e95b4-8ca7-454c-8b4e-23df3b500eb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Broker ignores groups-only memberships for registration and presence**

   - **Bug**
     - A typed client can send `groups: ["reviewers"]` while omitting the legacy `group`. In the executed broker flow, registration recorded the target as `group: "default"`; the subsequent groups-only presence update acknowledged `group: "default"`. A legacy reviewer in `reviewers` could not discover the target, and routing to its exact session ID failed because the broker treated it as cross-group.
   - **Cause**
     - The public protocol declares `SessionInfo.groups` and presence `groups`, but broker registration and presence processing read and normalize only `group`. Group-scoped list, broadcast, and routing paths also compare only `info.group`.
   - **Fix**
     - Normalize and retain `groups` at broker registration and presence handling, then make discovery, broadcasts, group isolation, and routing test membership against the normalized group set while preserving legacy `group` compatibility.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

3. `packages/intercom/broker/broker.ts`, line 602 ([link](https://github.com/bastani-inc/atomic/blob/08467a3b989ea6c91bcc5272fe7efa457f4775e7/packages/intercom/broker/broker.ts#L602)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Started the current Bun Intercom broker in an isolated temporary agent directory and co...**

   - **Bug**
     - Started the current Bun Intercom broker in an isolated temporary agent directory and connected a groups-only client plus a legacy group: "reviewers" client using the real framed Unix-socket protocol. The groups-only registration and later groups-only presence update were both treated as default; reviewer discovery omitted that session, and direct sends to its session ID were rejected as cross-group. This confirms that the newly declared groups protocol field is not persisted or used by broker discovery and routing.
   - **Cause**
     - T-Rex reproduced this while running the changed behavior, but it did not return a separate root-cause sentence.
   - **Fix**
     - Update the changed code so this failing path is handled, then rerun the same T-Rex check to confirm it passes.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Broker regression harness source](https://app.greptile.com/trex/artifacts/93de47ff-4c4d-4754-8b45-f90b81708e1a)**

   - This artifact contains the exact executable harness used to start the broker and drive the groups-only and legacy protocol clients, with the takeaway that the runtime test is reproducible.

   **[Broker regression output](https://app.greptile.com/trex/artifacts/e50f5cfe-e164-4026-8a7e-86e0a2a7f11c)**

   - This artifact contains the executed command, working directory, exit code, and observed protocol responses, with the takeaway that groups-only membership is ignored by current broker behavior.

   **[Current broker source excerpts](https://app.greptile.com/trex/artifacts/f80c4f41-4542-49bf-9323-dc7d108f9959)**

   - This artifact captures the responsible registration, presence, discovery, broadcast, and send-routing source excerpts, with the takeaway that those paths use only the legacy scalar group.

   <a href="https://app.greptile.com/trex/runs/21224229/artifacts?artifact=93de47ff-4c4d-4754-8b45-f90b81708e1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["feat(intercom): model session group memb..."](https://github.com/bastani-inc/atomic/commit/08467a3b989ea6c91bcc5272fe7efa457f4775e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57857080)</sub>

<!-- /greptile_comment -->