### PR TITLE
feat(intercom): broker-side multi-group membership and routing

### DIFF
--- a/packages/intercom/broker/broker.ts
+++ b/packages/intercom/broker/broker.ts
@@ -17,8 +17,15 @@ import {
   type PendingStageRoute,
 } from "./send-handler.js";
 import { SupervisorChannelCache } from "./supervisor-channel.js";
-import { normalizeGroup } from "../group.js";
+import { hasGroup, normalizeGroup, normalizeGroups } from "../group.js";
 import { handleBrokerPresence } from "./presence-handler.js";
+import {
+	knownGroupSummaries,
+	sessionGroups,
+	sessionsInGroup,
+	sessionsVisibleTo,
+	setSessionGroups,
+} from "./group-membership.js";
 import { PendingQuestionIndex } from "./pending-question-index.js";
 
 const INTERCOM_DIR = getIntercomDirPath();
@@ -95,6 +102,11 @@ function isSessionRegistration(value: unknown): value is Omit<SessionInfo, "id">
     return false;
   }
 
+
+  if (session.groups !== undefined &&
+    (!Array.isArray(session.groups) || !session.groups.every((group) => typeof group === "string"))) {
+    return false;
+  }
   return session.status === undefined || typeof session.status === "string";
 }
 function isSupervisorRegistration(value: unknown): value is SupervisorRegistration {
@@ -247,7 +259,7 @@ class IntercomBroker {
       this.pendingStageRoutes.delete(route.runId);
       return false;
     }
-		if (route.liveTargetId === undefined && normalizeGroup(route.from.info.group) !== normalizeGroup(ownerRegistration.group)) {
+		if (route.liveTargetId === undefined && !hasGroup(sessionGroups(route.from.info), ownerRegistration.group)) {
       writeMessage(route.socket, {
         type: "delivery_failed",
         messageId: route.message.id,
@@ -490,7 +502,7 @@ class IntercomBroker {
 			target === undefined ||
 			target.info.id === currentId ||
 			normalizeGroup(target.registrationGroup) !== routeGroup ||
-			normalizeGroup(target.info.group) !== routeGroup
+			!hasGroup(sessionGroups(target.info), routeGroup)
 		) {
 			this.failPendingStageNotification(socket, message.id, attemptId, "Session not found");
 			return;
@@ -596,15 +608,17 @@ class IntercomBroker {
 
         const id = randomUUID();
         setId(id);
+        const initialGroups = normalizeGroups(clientMessage.session.groups, clientMessage.session.group);
+        const legacyGroup = normalizeGroup(clientMessage.session.group ?? initialGroups.values().next().value);
         const info: SessionInfo = {
           ...clientMessage.session,
           id,
-          group: normalizeGroup(clientMessage.session.group),
         };
+		setSessionGroups(info, initialGroups, legacyGroup);
         this.sessions.set(id, {
           socket,
           info,
-          registrationGroup: info.group,
+          registrationGroup: legacyGroup,
 			...(typeof info.name === "string" && info.name.trim().length > 0
 				? { registrationName: info.name.trim() }
 				: {}),
@@ -625,7 +639,7 @@ class IntercomBroker {
         writeMessage(socket, supervisorId
           ? { type: "registered", sessionId: id, supervisorSessionId: supervisorId }
           : { type: "registered", sessionId: id });
-        this.broadcastToGroup({ type: "session_joined", session: info }, info.group, id);
+        this.broadcastToMemberships({ type: "session_joined", session: info }, sessionGroups(info), id);
         break;
       }
 
@@ -645,13 +659,23 @@ class IntercomBroker {
         }
 
         const requester = currentId ? this.sessions.get(currentId) : undefined;
-        const effectiveGroup = normalizeGroup(
-          typeof clientMessage.group === "string" ? clientMessage.group : requester?.info.group,
-        );
-        const sessions = Array.from(this.sessions.values())
-          .map((s) => s.info)
-          .filter((info) => normalizeGroup(info.group) === effectiveGroup);
+		if (requester === undefined) throw new Error("Session not found");
+        const sessions = typeof clientMessage.group === "string"
+			? sessionsInGroup(this.sessions, clientMessage.group)
+			: sessionsVisibleTo(this.sessions, requester.info);
         writeMessage(socket, { type: "sessions", requestId: clientMessage.requestId, sessions });
+        break;
+      }
+
+	  case "list_groups": {
+		if (typeof clientMessage.requestId !== "string") throw new Error("Invalid list_groups message");
+		const requester = currentId ? this.sessions.get(currentId) : undefined;
+		if (requester === undefined) throw new Error("Session not found");
+		writeMessage(socket, {
+			type: "groups",
+			requestId: clientMessage.requestId,
+			groups: knownGroupSummaries(this.sessions, requester.info),
+		});
         break;
       }
 
@@ -815,7 +839,9 @@ class IntercomBroker {
 			break;
 		}
 
-      case "presence": {
+      case "presence":
+	  case "join_group":
+	  case "leave_group": {
         handleBrokerPresence(
           socket,
           clientMessage,
@@ -881,13 +907,12 @@ class IntercomBroker {
 		if (activation.sessionId === sessionId) this.liveWorkflowStageRouteActivations.delete(requestId);
 	}
 	this.sessions.delete(sessionId);
-	this.broadcastToGroup({ type: "session_left", sessionId }, departed.info.group, sessionId);
+	this.broadcastToMemberships({ type: "session_left", sessionId }, sessionGroups(departed.info), sessionId);
 	}
-  /** Deliver a broadcast only to sessions in the given (normalized) group. */
-  private broadcastToGroup(msg: BrokerMessage, group: string | undefined, exclude?: string): void {
-    const target = normalizeGroup(group);
+  /** Deliver a broadcast once to each session represented in any given group. */
+  private broadcastToMemberships(msg: BrokerMessage, groups: ReadonlySet<string>, exclude?: string): void {
     for (const [id, session] of this.sessions) {
-      if (id !== exclude && normalizeGroup(session.info.group) === target) {
+      if (id !== exclude && [...groups].some((group) => hasGroup(sessionGroups(session.info), group))) {
         writeMessage(session.socket, msg);
       }
     }

--- a/packages/intercom/broker/group-isolation.ts
+++ b/packages/intercom/broker/group-isolation.ts
@@ -1,10 +1,10 @@
 import type { SessionInfo } from "../types.js";
-import { normalizeGroup } from "../group.js";
 import type { SupervisorChannelCache } from "./supervisor-channel.js";
+import { sessionsShareGroup } from "./group-membership.js";
 
-/** Two sessions share a group when their normalized group ids are equal. */
+/** Two sessions share a group when any normalized membership intersects. */
 export function sameGroup(a: SessionInfo, b: SessionInfo): boolean {
-  return normalizeGroup(a.group) === normalizeGroup(b.group);
+	return sessionsShareGroup(a, b);
 }
 
 export interface VerticalBypassInput {

--- a/packages/intercom/broker/group-membership.ts
+++ b/packages/intercom/broker/group-membership.ts
@@ -1,0 +1,55 @@
+import { hasGroup, normalizeGroup, normalizeGroups } from "../group.js";
+import type { GroupSummary, SessionInfo } from "../types.js";
+import type { BrokerConnectedSession } from "./send-handler.js";
+
+/** Return the normalized memberships carried by a wire session. */
+export function sessionGroups(session: SessionInfo): Set<string> {
+	return normalizeGroups(session.groups, session.group);
+}
+
+/** Persist normalized memberships while retaining the legacy single-group field. */
+export function setSessionGroups(session: SessionInfo, groups: ReadonlySet<string>, legacyGroup?: string): void {
+	const normalized = normalizeGroups(groups);
+	session.groups = [...normalized];
+	const firstGroup = normalized.values().next().value ?? normalizeGroup();
+	session.group = legacyGroup !== undefined && normalized.has(normalizeGroup(legacyGroup))
+		? normalizeGroup(legacyGroup)
+		: firstGroup;
+}
+
+/** Sessions can route to each other when any normalized membership intersects. */
+export function sessionsShareGroup(a: SessionInfo, b: SessionInfo): boolean {
+	const bGroups = sessionGroups(b);
+	return [...sessionGroups(a)].some((group) => bGroups.has(group));
+}
+
+/** Return each session visible through at least one of the requester's memberships. */
+export function sessionsVisibleTo(
+	sessions: ReadonlyMap<string, BrokerConnectedSession>,
+	requester: SessionInfo,
+): SessionInfo[] {
+	return [...sessions.values()].map(({ info }) => info).filter((info) => sessionsShareGroup(requester, info));
+}
+
+/** Return sessions that belong to one explicit group. */
+export function sessionsInGroup(
+	sessions: ReadonlyMap<string, BrokerConnectedSession>,
+	group: string | undefined,
+): SessionInfo[] {
+	return [...sessions.values()].map(({ info }) => info).filter((info) => hasGroup(sessionGroups(info), group));
+}
+
+/** Summarize every group currently represented by a connected session. */
+export function knownGroupSummaries(
+	sessions: ReadonlyMap<string, BrokerConnectedSession>,
+	requester: SessionInfo,
+): GroupSummary[] {
+	const counts = new Map<string, number>();
+	for (const { info } of sessions.values()) {
+		for (const group of sessionGroups(info)) counts.set(group, (counts.get(group) ?? 0) + 1);
+	}
+	const requesterGroups = sessionGroups(requester);
+	return [...counts]
+		.sort(([left], [right]) => left.localeCompare(right))
+		.map(([group, sessionCount]) => ({ group, sessionCount, member: requesterGroups.has(group) }));
+}

--- a/packages/intercom/broker/presence-handler.ts
+++ b/packages/intercom/broker/presence-handler.ts
@@ -1,6 +1,7 @@
 import type net from "node:net";
+import { addGroup, normalizeGroups, removeGroup, validateRuntimeGroup } from "../group.js";
 import type { BrokerMessage } from "../types.js";
-import { normalizeGroup, validateRuntimeGroup } from "../group.js";
+import { sessionGroups, sessionsShareGroup, setSessionGroups } from "./group-membership.js";
 import type { BrokerConnectedSession } from "./send-handler.js";
 
 interface PresenceClientMessage extends Record<string, unknown> {
@@ -9,22 +10,28 @@ interface PresenceClientMessage extends Record<string, unknown> {
 
 type WriteMessage = (socket: net.Socket, message: BrokerMessage) => void;
 
-function broadcastToGroup(
+function broadcastMembershipChange(
 	sessions: Map<string, BrokerConnectedSession>,
 	write: WriteMessage,
-	message: BrokerMessage,
-	group: string | undefined,
-	exclude?: string,
+	session: BrokerConnectedSession,
+	previous: ReadonlySet<string>,
 ): void {
-	const target = normalizeGroup(group);
-	for (const [id, session] of sessions) {
-		if (id !== exclude && normalizeGroup(session.info.group) === target) {
-			write(session.socket, message);
+	const previousInfo = { ...session.info, groups: [...previous], group: previous.values().next().value };
+	for (const [id, peer] of sessions) {
+		if (id === session.info.id) continue;
+		const sharedBefore = sessionsShareGroup(previousInfo, peer.info);
+		const sharedAfter = sessionsShareGroup(session.info, peer.info);
+		if (!sharedBefore && sharedAfter) {
+			write(peer.socket, { type: "session_joined", session: session.info });
+		} else if (sharedBefore && !sharedAfter) {
+			write(peer.socket, { type: "session_left", sessionId: session.info.id });
+		} else if (sharedAfter) {
+			write(peer.socket, { type: "presence_update", session: session.info });
 		}
 	}
 }
 
-/** Apply one presence update and notify only the affected group members. */
+/** Apply one presence or membership update and notify every affected group member. */
 export function handleBrokerPresence(
 	socket: net.Socket,
 	clientMessage: PresenceClientMessage,
@@ -37,67 +44,72 @@ export function handleBrokerPresence(
 		throw new Error("Invalid presence requestId");
 	}
 	const requestId = typeof rawRequestId === "string" ? rawRequestId : undefined;
-	if (currentId === null) {
-		if (requestId !== undefined) {
-			write(socket, { type: "presence_failed", requestId, reason: "Session not found" });
-		}
-		return;
-	}
-	const sessionId = currentId;
-	const session = sessions.get(sessionId);
+	const session = currentId === null ? undefined : sessions.get(currentId);
 	if (!session) {
-		if (requestId !== undefined) {
-			write(socket, { type: "presence_failed", requestId, reason: "Session not found" });
-		}
+		if (requestId !== undefined) write(socket, { type: "presence_failed", requestId, reason: "Session not found" });
 		return;
 	}
 
-	const fail = (reason: string): boolean => {
+	const fail = (reason: string): true => {
 		if (requestId === undefined) throw new Error(reason);
 		write(socket, { type: "presence_failed", requestId, reason });
 		return true;
 	};
+	const previousGroups = sessionGroups(session.info);
+	let nextGroups = new Set(previousGroups);
+	let legacyGroup = session.info.group;
 
-	const previousGroup = normalizeGroup(session.info.group);
-	let nextGroup = previousGroup;
-	const rawGroup = clientMessage.group;
-	if (rawGroup !== undefined) {
-		if (typeof rawGroup !== "string") {
-			if (fail("Invalid presence group")) return;
+	try {
+		if (clientMessage.type === "join_group") {
+			nextGroups = addGroup(previousGroups, clientMessage.group);
+		} else if (clientMessage.type === "leave_group") {
+			if (clientMessage.group === undefined) {
+				nextGroups = normalizeGroups(undefined, session.registrationGroup);
+				legacyGroup = session.registrationGroup;
+			} else {
+				if (typeof clientMessage.group !== "string") return void fail("Invalid presence group");
+				const group = validateRuntimeGroup(clientMessage.group);
+				nextGroups = removeGroup(previousGroups, group);
+				if (legacyGroup === group) legacyGroup = undefined;
+			}
 		} else {
-			try {
-				nextGroup = validateRuntimeGroup(rawGroup);
-			} catch (error) {
-				const reason = error instanceof Error ? error.message : String(error);
-				if (fail(`Invalid presence group: ${reason}`)) return;
+			const rawGroups = clientMessage.groups;
+			if (rawGroups !== undefined) {
+				if (!Array.isArray(rawGroups) || !rawGroups.every((group) => typeof group === "string")) {
+					return void fail("Invalid presence groups");
+				}
+				nextGroups = normalizeGroups(rawGroups.map(validateRuntimeGroup));
+				legacyGroup = nextGroups.values().next().value;
+			} else if (clientMessage.group !== undefined) {
+				if (typeof clientMessage.group !== "string") return void fail("Invalid presence group");
+				legacyGroup = validateRuntimeGroup(clientMessage.group);
+				nextGroups = new Set([legacyGroup]);
 			}
 		}
+	} catch (error) {
+		const reason = error instanceof Error ? error.message : String(error);
+		return void fail(`Invalid presence group: ${reason}`);
 	}
+
 	const name = clientMessage.name;
-	if (name !== undefined && typeof name !== "string") {
-		if (fail("Invalid presence name")) return;
-	}
+	if (name !== undefined && typeof name !== "string") return void fail("Invalid presence name");
 	const status = clientMessage.status;
-	if (status !== undefined && typeof status !== "string") {
-		if (fail("Invalid presence status")) return;
-	}
+	if (status !== undefined && typeof status !== "string") return void fail("Invalid presence status");
 	const model = clientMessage.model;
-	if (model !== undefined && typeof model !== "string") {
-		if (fail("Invalid presence model")) return;
-	}
+	if (model !== undefined && typeof model !== "string") return void fail("Invalid presence model");
 
 	if (typeof name === "string") session.info.name = name;
 	if (typeof status === "string") session.info.status = status;
 	if (typeof model === "string") session.info.model = model;
-	session.info.group = nextGroup;
+	setSessionGroups(session.info, nextGroups, legacyGroup);
 	session.info.lastActivity = Date.now();
-	if (nextGroup !== previousGroup) {
-		broadcastToGroup(sessions, write, { type: "session_left", sessionId }, previousGroup, sessionId);
-		broadcastToGroup(sessions, write, { type: "session_joined", session: session.info }, nextGroup, sessionId);
-	} else {
-		broadcastToGroup(sessions, write, { type: "presence_update", session: session.info }, nextGroup, sessionId);
-	}
+	broadcastMembershipChange(sessions, write, session, previousGroups);
+
 	if (requestId !== undefined) {
-		write(socket, { type: "presence_ack", requestId, group: nextGroup });
+		if (clientMessage.type === "join_group" || clientMessage.type === "leave_group") {
+			write(socket, { type: "membership_ack", requestId, groups: session.info.groups ?? [] });
+		} else {
+			write(socket, { type: "presence_ack", requestId, group: session.info.group ?? "default" });
+		}
 	}
 }

--- a/packages/intercom/broker/send-handler.ts
+++ b/packages/intercom/broker/send-handler.ts
@@ -6,7 +6,7 @@ import { DeliveredMessageCache } from "./delivered-message-cache.js";
 import { buildMessageSendSignature } from "./send-signature.js";
 import { SupervisorChannelCache } from "./supervisor-channel.js";
 import { isVerticalBypass, sameGroup } from "./group-isolation.js";
-import { normalizeGroup } from "../group.js";
+import { sessionsShareGroup } from "./group-membership.js";
 import { PendingQuestionIndex } from "./pending-question-index.js";
 
 export interface BrokerConnectedSession {
@@ -139,12 +139,11 @@ export function handleBrokerSend(
   // supervisor frame or an exact recorded reply may resolve across groups.
 	const liveWorkflowTarget = sessions.has(trimmedTo) ? undefined : resolveLiveWorkflowStage?.(trimmedTo);
 	const exactIdTarget = sessions.get(trimmedTo) ?? liveWorkflowTarget;
-  const senderGroup = normalizeGroup(fromSession.info.group);
   const reachableAcrossGroups = supervisorSend || Boolean(message.replyTo);
   const candidates = reachableAcrossGroups
     ? Array.from(sessions.values(), (session) => session.info)
     : Array.from(sessions.values(), (session) => session.info).filter(
-        (info) => normalizeGroup(info.group) === senderGroup,
+        (info) => sessionsShareGroup(info, fromSession.info),
       );
   const resolution = exactIdTarget
     ? ({ kind: "resolved", session: exactIdTarget.info } as const)

--- a/packages/intercom/types.ts
+++ b/packages/intercom/types.ts
@@ -13,6 +13,12 @@ export interface SessionInfo {
   group?: string;
 }
 
+export interface GroupSummary {
+	group: string;
+	sessionCount: number;
+	member: boolean;
+}
+
 export interface Message {
   id: string;
   timestamp: number;
@@ -55,6 +61,9 @@ export type ClientMessage =
 	  }
 	| { type: "unregister" }
   | { type: "list"; requestId: string; group?: string }
+	| { type: "list_groups"; requestId: string }
+	| { type: "join_group"; requestId: string; group: string }
+	| { type: "leave_group"; requestId: string; group?: string }
   | { type: "authorize_supervisor"; requestId: string; childName: string; capability?: string }
   | { type: "send" | "supervisor_send"; to: string; message: Message; attemptId?: string }
 	| {
@@ -99,6 +108,8 @@ export type BrokerMessage =
   | { type: "registered"; sessionId: string; supervisorSessionId?: string }
   | { type: "registration_failed"; reason: string }
   | { type: "sessions"; requestId: string; sessions: SessionInfo[] }
+	| { type: "groups"; requestId: string; groups: GroupSummary[] }
+	| { type: "membership_ack"; requestId: string; groups: string[] }
   | { type: "supervisor_authorized"; requestId: string; capability: string; supervisorSessionId: string; childName: string }
   | { type: "message"; from: SessionInfo; message: Message; channel?: "supervisor" }
 	| { type: "pending_stage_notification"; requestId: string; from: SessionInfo; message: Message }

--- a/packages/workflows/src/durable/dbos-metadata.ts
+++ b/packages/workflows/src/durable/dbos-metadata.ts
@@ -200,6 +200,7 @@ function serializePendingStageMessages(messages: readonly PendingStageMessage[])
 			id: entry.from.id,
 			...(entry.from.name !== undefined ? { name: entry.from.name } : {}),
 			...(entry.from.group !== undefined ? { group: entry.from.group } : {}),
+			...(entry.from.groups !== undefined ? { groups: [...entry.from.groups] } : {}),
 			...(entry.from.cwd !== undefined ? { cwd: entry.from.cwd } : {}),
 			...(entry.from.model !== undefined ? { model: entry.from.model } : {}),
 			...(entry.from.pid !== undefined ? { pid: entry.from.pid } : {}),
@@ -274,6 +275,8 @@ function isPendingStageSender(value: WorkflowSerializableValue | undefined): boo
 		typeof value.id === "string" &&
 		(value.name === undefined || typeof value.name === "string") &&
 		(value.group === undefined || typeof value.group === "string") &&
+		(value.groups === undefined ||
+			(Array.isArray(value.groups) && value.groups.every((group) => typeof group === "string"))) &&
 		(value.cwd === undefined || typeof value.cwd === "string") &&
 		(value.model === undefined || typeof value.model === "string") &&
 		(value.pid === undefined || typeof value.pid === "number") &&

--- a/packages/workflows/src/shared/store-types.ts
+++ b/packages/workflows/src/shared/store-types.ts
@@ -226,6 +226,7 @@ export interface PendingStageSender {
 	readonly id: string;
 	readonly name?: string;
 	readonly group?: string;
+	readonly groups?: readonly string[];
 	readonly cwd?: string;
 	readonly model?: string;
 	readonly pid?: number;

--- a/test/unit/intercom-broker-membership.test.ts
+++ b/test/unit/intercom-broker-membership.test.ts
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import type net from "node:net";
+import { test } from "vitest";
+import { DeliveredMessageCache } from "../../packages/intercom/broker/delivered-message-cache.js";
+import { knownGroupSummaries, sessionsVisibleTo } from "../../packages/intercom/broker/group-membership.js";
+import { handleBrokerPresence } from "../../packages/intercom/broker/presence-handler.js";
+import { type BrokerConnectedSession, handleBrokerSend } from "../../packages/intercom/broker/send-handler.js";
+import { SupervisorChannelCache } from "../../packages/intercom/broker/supervisor-channel.js";
+import type { BrokerMessage, Message } from "../../packages/intercom/types.js";
+
+function connected(
+	id: string,
+	groups: string[],
+	socket: net.Socket,
+	extra: Partial<BrokerConnectedSession> = {},
+): BrokerConnectedSession {
+	return {
+		socket,
+		info: {
+			id,
+			name: id,
+			cwd: "/tmp",
+			model: "test",
+			pid: 1,
+			startedAt: 1,
+			lastActivity: 1,
+			groups,
+			group: groups[0],
+		},
+		registrationGroup: groups[0],
+		...extra,
+	};
+}
+
+function wireMessage(id: string, extra: Partial<Message> = {}): Message {
+	return { id, timestamp: 1, content: { text: "hello" }, ...extra };
+}
+
+function setup(definitions: Array<[string, string[]]>): {
+	sessions: Map<string, BrokerConnectedSession>;
+	sockets: Record<string, net.Socket>;
+	writes: Array<{ socket: net.Socket; message: BrokerMessage }>;
+	presence(id: string, message: Record<string, unknown>): void;
+	send(id: string, to: string, message: Message, type?: "send" | "supervisor_send"): void;
+} {
+	const sessions = new Map<string, BrokerConnectedSession>();
+	const sockets: Record<string, net.Socket> = {};
+	for (const [id, groups] of definitions) {
+		const socket = {} as net.Socket;
+		sockets[id] = socket;
+		sessions.set(id, connected(id, groups, socket));
+	}
+	const writes: Array<{ socket: net.Socket; message: BrokerMessage }> = [];
+	const write = (socket: net.Socket, message: BrokerMessage): void => {
+		writes.push({ socket, message });
+	};
+	return {
+		sessions,
+		sockets,
+		writes,
+		presence: (id, message) => handleBrokerPresence(sockets[id]!, message as never, id, sessions, write),
+		send: (id, to, message, type = "send") =>
+			handleBrokerSend(
+				sockets[id]!,
+				{ type, to, message },
+				id,
+				sessions,
+				new DeliveredMessageCache(),
+				write,
+				new SupervisorChannelCache(),
+			),
+	};
+}
+
+test("joining adds a membership and broadcasts presence in both groups", () => {
+	const h = setup([
+		["member", ["alpha"]],
+		["alpha-peer", ["alpha"]],
+		["beta-peer", ["beta"]],
+		["outside", ["outside"]],
+	]);
+
+	h.presence("member", { type: "join_group", group: "beta", requestId: "join-1" });
+
+	assert.deepEqual(h.sessions.get("member")?.info.groups, ["alpha", "beta"]);
+	assert.equal(
+		h.writes.some(({ socket, message }) => socket === h.sockets["alpha-peer"] && message.type === "presence_update"),
+		true,
+	);
+	assert.equal(
+		h.writes.some(({ socket, message }) => socket === h.sockets["beta-peer"] && message.type === "session_joined"),
+		true,
+	);
+	assert.equal(
+		h.writes.some(({ socket }) => socket === h.sockets.outside),
+		false,
+	);
+});
+
+test("named leave removes only that group and unnamed leave returns to the home group", () => {
+	const h = setup([
+		["member", ["home", "alpha", "beta"]],
+		["home-peer", ["home"]],
+		["alpha-peer", ["alpha"]],
+		["beta-peer", ["beta"]],
+	]);
+	h.sessions.set("member", { ...h.sessions.get("member")!, registrationGroup: "home" });
+
+	h.presence("member", { type: "leave_group", group: "alpha", requestId: "leave-alpha" });
+	assert.deepEqual(h.sessions.get("member")?.info.groups, ["home", "beta"]);
+	assert.equal(
+		h.writes.some(({ socket, message }) => socket === h.sockets["alpha-peer"] && message.type === "session_left"),
+		true,
+	);
+
+	h.writes.length = 0;
+	h.presence("member", { type: "leave_group", requestId: "leave-home" });
+	assert.deepEqual(h.sessions.get("member")?.info.groups, ["home"]);
+	assert.equal(
+		h.writes.some(({ socket, message }) => socket === h.sockets["beta-peer"] && message.type === "session_left"),
+		true,
+	);
+	assert.equal(
+		h.writes.some(({ socket, message }) => socket === h.sockets["home-peer"] && message.type === "presence_update"),
+		true,
+	);
+});
+
+test("routing and list visibility use intersecting membership sets", () => {
+	const h = setup([
+		["bridge", ["alpha", "beta"]],
+		["alpha-peer", ["alpha"]],
+		["beta-peer", ["beta"]],
+		["outside", ["outside"]],
+	]);
+
+	assert.deepEqual(
+		sessionsVisibleTo(h.sessions, h.sessions.get("bridge")!.info)
+			.map((session) => session.id)
+			.sort(),
+		["alpha-peer", "beta-peer", "bridge"],
+	);
+	h.send("bridge", "alpha-peer", wireMessage("to-alpha"));
+	h.send("bridge", "beta-peer", wireMessage("to-beta"));
+	h.send("bridge", "outside", wireMessage("to-outside"));
+	assert.equal(
+		h.writes.some(({ socket, message }) => socket === h.sockets["alpha-peer"] && message.type === "message"),
+		true,
+	);
+	assert.equal(
+		h.writes.some(({ socket, message }) => socket === h.sockets["beta-peer"] && message.type === "message"),
+		true,
+	);
+	assert.equal(
+		h.writes.some(({ socket, message }) => socket === h.sockets.outside && message.type === "message"),
+		false,
+	);
+});
+
+test("supervisor routing still crosses non-overlapping memberships", () => {
+	const h = setup([
+		["child", ["alpha", "beta"]],
+		["supervisor", ["outside"]],
+	]);
+	h.sessions.get("child")!.supervisorId = "supervisor";
+
+	h.send("child", "supervisor", wireMessage("supervisor-message"), "supervisor_send");
+
+	assert.equal(
+		h.writes.some(({ socket, message }) => socket === h.sockets.supervisor && message.type === "message"),
+		true,
+	);
+});
+
+test("all-groups summaries include every active group, counts, and requester membership", () => {
+	const h = setup([
+		["requester", ["alpha", "beta"]],
+		["alpha-peer", ["alpha"]],
+		["outside", ["outside"]],
+	]);
+
+	assert.deepEqual(knownGroupSummaries(h.sessions, h.sessions.get("requester")!.info), [
+		{ group: "alpha", sessionCount: 2, member: true },
+		{ group: "beta", sessionCount: 1, member: true },
+		{ group: "outside", sessionCount: 1, member: false },
+	]);
+});
+
+test("legacy single-group presence keeps replacement behavior", () => {
+	const h = setup([
+		["legacy", ["alpha"]],
+		["alpha-peer", ["alpha"]],
+		["beta-peer", ["beta"]],
+	]);
+
+	h.presence("legacy", { type: "presence", group: "beta", requestId: "legacy-presence" });
+
+	assert.deepEqual(h.sessions.get("legacy")?.info.groups, ["beta"]);
+	assert.equal(h.sessions.get("legacy")?.info.group, "beta");
+	assert.equal(
+		h.writes.some(({ socket, message }) => socket === h.sockets["alpha-peer"] && message.type === "session_left"),
+		true,
+	);
+	assert.equal(
+		h.writes.some(({ socket, message }) => socket === h.sockets["beta-peer"] && message.type === "session_joined"),
+		true,
+	);
+});

--- a/test/unit/intercom-broker-peer-disconnect.test.ts
+++ b/test/unit/intercom-broker-peer-disconnect.test.ts
@@ -355,3 +355,42 @@ test("broker joins several groups, routes through each, and lists every group", 
 		"default",
 	]);
 });
+
+test("broker honors groups-only registration and presence for discovery and direct routing", async () => {
+	const target = new WireClient();
+	const reviewer = new WireClient();
+	await target.connected();
+	target.send({
+		type: "register",
+		session: { ...session, name: "groups-only-target", groups: ["intake"] },
+	});
+	const targetId = (await target.next("registered")).sessionId;
+	await reviewer.connected();
+	reviewer.send({
+		type: "register",
+		session: { ...session, name: "legacy-reviewer", group: "reviewers" },
+	});
+	const reviewerId = (await reviewer.next("registered")).sessionId;
+
+	target.send({ type: "presence", groups: ["reviewers"], requestId: "groups-only-presence" });
+	assert.deepEqual(await target.next("presence_ack", (frame) => frame.requestId === "groups-only-presence"), {
+		type: "presence_ack",
+		requestId: "groups-only-presence",
+		group: "reviewers",
+	});
+
+	reviewer.send({ type: "list", requestId: "reviewer-discovery", group: "reviewers" });
+	const visibleIds = (
+		await reviewer.next("sessions", (frame) => frame.requestId === "reviewer-discovery")
+	).sessions.map(({ id }) => id);
+	assert.equal(visibleIds.includes(targetId), true);
+
+	reviewer.send({
+		type: "send",
+		to: targetId,
+		message: { id: "groups-only-direct", timestamp: 3, content: { text: "review" } },
+	});
+	await reviewer.next("delivered", (frame) => frame.messageId === "groups-only-direct");
+	const delivered = await target.next("message", (frame) => frame.message.id === "groups-only-direct");
+	assert.equal(delivered.from.id, reviewerId);
+});

--- a/test/unit/intercom-broker-peer-disconnect.test.ts
+++ b/test/unit/intercom-broker-peer-disconnect.test.ts
@@ -283,3 +283,75 @@ test("real client rejects the exact waiter when its target disconnects", async (
 	});
 	await asker.disconnect();
 });
+
+test("broker joins several groups, routes through each, and lists every group", async () => {
+	const bridge = new WireClient();
+	const alpha = new WireClient();
+	const beta = new WireClient();
+	const outside = new WireClient();
+	const bridgeId = await register(bridge, "multi-group-bridge");
+	const alphaId = await register(alpha, "multi-group-alpha");
+	const betaId = await register(beta, "multi-group-beta");
+	const outsideId = await register(outside, "multi-group-outside");
+
+	alpha.send({ type: "presence", group: "alpha", requestId: "alpha-group" });
+	await alpha.next("presence_ack", (frame) => frame.requestId === "alpha-group");
+	beta.send({ type: "presence", group: "beta", requestId: "beta-group" });
+	await beta.next("presence_ack", (frame) => frame.requestId === "beta-group");
+	outside.send({ type: "presence", group: "outside", requestId: "outside-group" });
+	await outside.next("presence_ack", (frame) => frame.requestId === "outside-group");
+
+	bridge.send({ type: "join_group", group: "alpha", requestId: "join-alpha" });
+	assert.deepEqual(await bridge.next("membership_ack", (frame) => frame.requestId === "join-alpha"), {
+		type: "membership_ack",
+		requestId: "join-alpha",
+		groups: ["default", "alpha"],
+	});
+	bridge.send({ type: "join_group", group: "beta", requestId: "join-beta" });
+	assert.deepEqual(await bridge.next("membership_ack", (frame) => frame.requestId === "join-beta"), {
+		type: "membership_ack",
+		requestId: "join-beta",
+		groups: ["default", "alpha", "beta"],
+	});
+
+	bridge.send({ type: "list", requestId: "visible-sessions" });
+	const visibleIds = (await bridge.next("sessions", (frame) => frame.requestId === "visible-sessions")).sessions.map(
+		({ id }) => id,
+	);
+	assert.equal(visibleIds.includes(alphaId), true);
+	assert.equal(visibleIds.includes(betaId), true);
+	assert.equal(visibleIds.includes(bridgeId), true);
+	assert.equal(visibleIds.includes(outsideId), false);
+
+	bridge.send({ type: "list_groups", requestId: "all-groups" });
+	const summaries = (await bridge.next("groups", (frame) => frame.requestId === "all-groups")).groups;
+	assert.deepEqual(
+		summaries.filter(({ group }) => ["alpha", "beta", "outside"].includes(group)),
+		[
+			{ group: "alpha", sessionCount: 2, member: true },
+			{ group: "beta", sessionCount: 2, member: true },
+			{ group: "outside", sessionCount: 1, member: false },
+		],
+	);
+
+	bridge.send({
+		type: "send",
+		to: alphaId,
+		message: { id: "bridge-alpha", timestamp: 1, content: { text: "alpha" } },
+	});
+	await bridge.next("delivered", (frame) => frame.messageId === "bridge-alpha");
+	await alpha.next("message", (frame) => frame.from.id === bridgeId);
+	bridge.send({ type: "send", to: betaId, message: { id: "bridge-beta", timestamp: 2, content: { text: "beta" } } });
+	await bridge.next("delivered", (frame) => frame.messageId === "bridge-beta");
+	await beta.next("message", (frame) => frame.from.id === bridgeId);
+
+	bridge.send({ type: "leave_group", group: "alpha", requestId: "leave-alpha" });
+	assert.deepEqual((await bridge.next("membership_ack", (frame) => frame.requestId === "leave-alpha")).groups, [
+		"default",
+		"beta",
+	]);
+	bridge.send({ type: "leave_group", requestId: "leave-home" });
+	assert.deepEqual((await bridge.next("membership_ack", (frame) => frame.requestId === "leave-home")).groups, [
+		"default",
+	]);
+});

--- a/test/unit/intercom-protocol-groups.test.ts
+++ b/test/unit/intercom-protocol-groups.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
-import type { ClientMessage, SessionInfo } from "../../packages/intercom/types.js";
+import type { BrokerMessage, ClientMessage, SessionInfo } from "../../packages/intercom/types.js";
 
 const BASE_SESSION = {
 	id: "session-1",
@@ -49,4 +49,22 @@ test("legacy single-group clients remain valid protocol clients", () => {
 	assert.equal(session.group, "reviewers");
 	assert.equal(registration.session.group, "reviewers");
 	assert.equal(presence.group, "reviewers");
+});
+
+test("the broker protocol carries membership commands and all-group summaries", () => {
+	const join: ClientMessage = { type: "join_group", requestId: "join", group: "reviewers" };
+	const leave: ClientMessage = { type: "leave_group", requestId: "leave", group: "reviewers" };
+	const leaveHome: ClientMessage = { type: "leave_group", requestId: "home" };
+	const listGroups: ClientMessage = { type: "list_groups", requestId: "groups" };
+	const summaries: BrokerMessage = {
+		type: "groups",
+		requestId: "groups",
+		groups: [{ group: "reviewers", sessionCount: 2, member: true }],
+	};
+
+	assert.equal(join.type, "join_group");
+	assert.equal(leave.type, "leave_group");
+	assert.equal(leaveHome.type, "leave_group");
+	assert.equal(listGroups.type, "list_groups");
+	assert.deepEqual(summaries.groups, [{ group: "reviewers", sessionCount: 2, member: true }]);
 });

--- a/test/unit/workflows-pending-stage-delivery-store.test.ts
+++ b/test/unit/workflows-pending-stage-delivery-store.test.ts
@@ -704,6 +704,25 @@ describe("durable workflow stage messages metadata", () => {
 		assert.deepEqual(parsed?.pendingStageMessages, accepted.messages);
 	});
 
+	test("metadata round-trip preserves all sender memberships", () => {
+		const senderGroups = ["planning", RUN_GROUP];
+		const accepted = queueStageMessage(
+			[],
+			pendingMessage("membership", {
+				from: { id: "sender-1", name: "planner", group: "planning", groups: senderGroups },
+			}),
+			RUN_GROUP,
+			RUN_GROUP,
+		);
+		assert.equal(accepted.ok, true);
+		if (!accepted.ok) return;
+		const parsed = parseCurrentMetadataRecord(
+			{ stepName: "__atomic_metadata:2:test", output: encodeMetadata(metadata(accepted.messages)) },
+			RUN_ID,
+		);
+		assert.deepEqual(parsed?.pendingStageMessages?.[0]?.from.groups, senderGroups);
+	});
+
 	test("accepts legacy durable messages without a return address", () => {
 		const accepted = queueStageMessage([], pendingMessage("legacy"), RUN_GROUP, RUN_GROUP);
 		assert.equal(accepted.ok, true);


### PR DESCRIPTION
Slice 2 of the multi-group Intercom stack (supersedes #2741, which GitHub pinned to a degenerate head==base state).

Join adds a group rather than replacing it; leave removes a named group. Routing, presence, and `list` test set membership instead of equality, so a session in groups A and B is visible in both. Adds the broker request that returns every known group with its session count and a membership flag.

`contact_supervisor` still crosses group boundaries. Single-group sessions are unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2745"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790505915&installation_model_id=10562&pr_number=2745&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2745&signature=691e03ae229b119db147e213e10c66a0a14def25b394412ba17ef91dccadd68d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change extends the Intercom broker from single-group routing to normalized multi-group membership, adding join, leave, and group-summary messages while keeping legacy single-group clients compatible. It also persists sender membership sets for durable workflow-stage delivery.

A real Unix-socket broker flow verified that sessions without a shared group cannot discover or directly message one another. It also verified that join and leave operations update discovery and routing immediately, groups-only clients interoperate with legacy clients, and pending-stage delivery follows the sender's active membership. The focused Intercom and workflow metadata test suite passed all 33 tests across 4 files.

No defects were found.

<h3>Confidence Score: 5/5</h3>

The multi-group routing and isolation behavior exercised against the real broker behaved as intended, with no defects reproduced.

The review exercised membership isolation, join and leave transitions, legacy protocol compatibility, and pending-stage authorization through the wire protocol, then confirmed the focused broker, protocol, and durable-metadata tests pass.

**Files Needing Attention:** No files need follow-up from this review.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the authored wire-level broker harness against a real Unix-socket broker to validate end-to-end behavior.
- Observed that alpha and beta sessions with no shared membership could neither discover nor directly message one another during the baseline run.
- Validated the membership flow showed that joining and leaving immediately changed routing and visibility, that groups-only and legacy clients interoperated, and that pending-stage authorization followed active memberships.
- Executed the focused Vitest suite for broker membership, peer disconnect, protocol groups, and workflow pending-stage metadata and confirmed all tests passed.
- Review of the targeted Vitest suite log confirmed 33/33 tests passed for the focused suite, with exit code 0.

<a href="https://app.greptile.com/trex/runs/21224228/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(intercom): preserve broker group mem..."](https://github.com/bastani-inc/atomic/commit/5f50689fb7c48c1cc4d02a7afa1d567d1a047091) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57882769)</sub>

<!-- /greptile_comment -->