### PR TITLE
feat(intercom): multi-group client state and tool surface

### DIFF
--- a/packages/coding-agent/docs/intercom.md
+++ b/packages/coding-agent/docs/intercom.md
@@ -10,9 +10,9 @@ description: "Direct messaging between Atomic sessions on the same machine"
 Atomic bundles `@bastani/intercom`, a first-party extension for direct 1:1 messaging between Atomic sessions on the same machine. Send context, findings, or requests from one session to another — whether you're driving the conversation or letting agents coordinate. Connections are lazy and tool-driven: the extension registers its commands and tools at startup, but a session does not connect until you or the model actually invoke Intercom. No separate install is needed.
 
 **Key capabilities:**
-- **Session messaging** - `send`, `ask` (blocking, 10-minute timeout), `reply`, `pending`, `list`, and `status` via the `intercom` tool
-- **Runtime groups** - `join` or `leave` named groups without restarting; joined sessions keep their broker IDs and subagents inherit the joined group
-- **Session discovery** - List connected sessions with name, full session ID, working directory, model, and live status
+- **Session messaging** - `send`, `ask` (blocking, 10-minute timeout), `reply`, `pending`, `list`, `groups`, and `status` via the `intercom` tool
+- **Runtime groups** - Add or remove named memberships without restarting; joined sessions keep their broker IDs and later subagents inherit the most recently joined membership
+- **Session and group discovery** - List connected sessions or every available group, including session counts and membership markers
 - **Keyboard overlay** - ALT+M or `/intercom` opens a session picker and compose overlay
 - **Attachments** - Share `file`, `snippet`, and `context` payloads between sessions
 - **Subagent escalation** - Delegated children get a `contact_supervisor` tool for decisions, structured interviews, and progress updates
@@ -138,33 +138,34 @@ Name sessions with `/name` so they can target each other (for example `/name pla
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `action` | string | `"list"`, `"join"`, `"leave"`, `"send"`, `"ask"`, `"reply"`, `"pending"`, or `"status"` |
+| `action` | string | `"list"`, `"groups"`, `"join"`, `"leave"`, `"send"`, `"ask"`, `"reply"`, `"pending"`, or `"status"` |
 | `to` | string | Exact session name/full session ID, or `<runId>:<stageKey>` for `send` to a not-yet-started workflow stage (for send/ask, or targeted reply) |
 | `message` | string | Message text (for send/ask/reply) |
 | `attachments` | array | Optional `file`, `snippet`, or `context` attachments |
 | `replyTo` | string | Optional message ID for threading or replying to an `ask` |
-| `group` | string | Group name for `join`; read-only group filter for `list`/`status`. `send`/`ask` stay locked to the current group. |
+| `group` | string | Group name for `join` or an optional targeted `leave`; read-only group filter for `list`/`status`. `send`/`ask` remain limited to shared memberships. |
 
 ### Actions
 
 | Action | Behavior |
 |--------|----------|
-| `join` | Moves the session into a trimmed named group and creates it if needed. The action waits for broker acknowledgement before changing local inheritance state. `default` is the shared group; `true` and `auto` are reserved for subagent auto-groups. |
-| `leave` | Returns the session to its resolved home group from startup. It takes no `group` parameter. |
-| `list` | Returns the current session plus other active intercom-connected sessions with name, full session ID, working directory, model, and live status (`idle`, `thinking`, or `tool:<name>`, derived from lifecycle events). Every displayed full session ID is a valid target. |
+| `join` | Adds a trimmed named group membership and creates the group if needed. The action waits for broker acknowledgement and reports the complete resulting membership set. `default` is shared; `true` and `auto` are reserved for subagent auto-groups. |
+| `leave` | With `group`, removes only that membership and keeps all others. Without `group`, resets the session to its resolved startup home group. Both forms report the resulting membership set. |
+| `groups` | Lists every group represented by a connected session, with its session count and a marker for each group this session belongs to. Use it to discover names rather than guessing. |
+| `list` | Keeps session-listing semantics: returns the current session plus every active session sharing at least one membership, with name, full session ID, working directory, model, and live status. Pass `group` for a read-only view of one group. |
 | `send` | Fire-and-forget delivery through ordinary Intercom. A live workflow-stage session receives the message immediately and returns `delivered`. A known workflow stage whose session has not initialized is addressed as `<runId>:<stageKey>`; Atomic persists the message and returns the distinct `queued` result with its FIFO position. Unknown stage identities retain the ordinary unknown-target failure. Requires `to` and `message`; cannot message the current session. |
 | `ask` | Sends a message and blocks until a live recipient replies (10-minute timeout). An ask to a known workflow stage whose session has not initialized is refused with `pending_stage_ask_unsupported` and recommends ordinary `send`; holding a waiter until a stage eventually starts would be unbounded. A live recipient disconnect fails promptly. From a foreground child to its launching parent, the existing fresh-subagent handoff path remains unchanged. |
 | `reply` | Replies to the intercom-triggered message of the current turn; otherwise falls back to the single unresolved inbound ask. With multiple pending asks, pass `to` or inspect with `pending` first. |
 | `pending` | Lists unresolved inbound asks with sender, message ID, elapsed time, and a short preview. |
-| `status` | Shows connection status, session ID, current group, and the count of active sessions in that group. A `group` filter remains a read-only peek. |
+| `status` | Shows connection status, session ID, every group this session belongs to, and the count of active sessions visible through those memberships. A `group` filter remains a read-only peek. |
 
-To put two plain chat sessions in a private named group, have both call:
+To give two plain chat sessions a private shared membership, have both call:
 
 ```typescript
 intercom({ action: "join", group: "api-review" })
 ```
 
-The broker updates presence in place and sends a `session_left` event to the old group and a `session_joined` event to the new one. Session IDs do not change. A session that stays in `default` cannot list, resolve, or message the joined peers. Use `intercom({ action: "leave" })` to return to the home group resolved at startup; rejected or unacknowledged changes leave the local membership state unchanged. Joining a group does not widen isolation; `contact_supervisor` remains the only capability-based cross-group path.
+Joining is additive: existing memberships remain active, and the broker updates presence without changing the session ID. Use `intercom({ action: "groups" })` to discover all available names and membership markers. `intercom({ action: "leave", group: "api-review" })` removes only that membership; `intercom({ action: "leave" })` resets to the home group resolved at startup. Rejected or unacknowledged changes leave client and inheritance state unchanged. Ordinary delivery requires a shared membership, while `contact_supervisor` retains its capability-based cross-group path.
 
 Sent and received messages are recorded in session history as `intercom_sent` / `intercom_received` entries.
 
@@ -182,13 +183,16 @@ Only a session in the workflow run's Intercom group can queue a message; a cross
 
 ### Groups
 
-Every session belongs to exactly one intercom **group**. Sessions with no group configured share the implicit `"default"` group (so ungrouped sessions all see and message each other, exactly as before). A session in group G can **only** message sessions in group G — cross-group sends are rejected by the broker, not merely hidden from discovery:
+Every session belongs to a non-empty set of intercom **groups**. Sessions with no group configured retain exactly the legacy behavior: they belong only to the implicit `"default"` group and can see and message each other. A session can ordinarily discover, resolve, and message another session when their membership sets intersect; exact-ID sends with no shared membership are rejected by the broker.
 
-- A cross-group target name is unresolvable (`list`/targeting only consider your own group), and a cross-group send by exact session ID is rejected with `"Target session is in a different intercom group"`.
-- `list`/`status` show your own group and only same-group peers. Pass `group: "name"` to `list`/`status` for a **read-only** peek at another group's membership. `send`/`ask` are always locked to your own group and error if you pass a different `group`.
-- `session_joined`/`session_left`/`presence_update` are group-scoped, so you never see peers outside your group appear or disappear.
+- `list` still lists sessions. Without a filter it returns the union of sessions visible through any of your memberships; with `group`, it gives a read-only view of that one group.
+- `groups` lists every currently available group, its connected-session count, and whether this session is a member.
+- `join` adds one membership. `leave` removes the named membership, while bare `leave` resets the complete set to the startup home group.
+- `status` reports the complete membership set. `session_joined`/`session_left`/`presence_update` events are delivered whenever a membership change affects visibility.
 
-A session's home group is resolved with this precedence: explicit stage/task/subagent group > runtime-owned workflow invocation group or inherited launching-session group > env `ATOMIC_INTERCOM_GROUP` (legacy `PI_INTERCOM_GROUP`) > Intercom `config.json` `"group"` > `"default"`. Each top-level workflow invocation gets a stable non-default group from its persistent run identity; Intercom-capable stages, nested workflows, and their delegated subagents inherit it without authors threading IDs. Explicit `group: "default"` opts back into the shared group. Boolean `true` and the trimmed, case-insensitive strings `"true"`/`"auto"` request an automatically generated subgroup; those string names are reserved. Stages and children without Intercom access receive no group. See [workflows.md](/workflows) for workflow-stage rules. The subagent-only `contact_supervisor` path can cross groups only after a broker capability binds the registered child socket to the issuing supervisor session. The broker, not the client, marks validated traffic as `supervisor`; ordinary `send` frames remain isolated even if a raw client forges that flag, and replies cross back only through an exact broker-recorded `replyTo` match. Parent-held authorization state is restored after broker reconnects. Before an Intercom-enabled foreground child first runs, the parent wrapper may lazy-load and connect the broker provider to mint that exact child's capability; queued children request no capability. The child still connects only when it uses an Intercom delivery path, and claimed decisions or interviews terminally hand off before child send or waiter admission. A claimed provider failure aborts launch, while runtimes with no provider omit supervisor metadata and do not expose a broken channel.
+A session's home group is resolved with this precedence: explicit stage/task/subagent group > runtime-owned workflow invocation group or inherited launching-session group > env `ATOMIC_INTERCOM_GROUP` (legacy `PI_INTERCOM_GROUP`) > Intercom `config.json` `"group"` > `"default"`. Each top-level workflow invocation gets a stable non-default group from its persistent run identity; Intercom-capable stages, nested workflows, and their delegated subagents inherit it without authors threading IDs. Explicit `group: "default"` opts into the shared group. Boolean `true` and the trimmed, case-insensitive strings `"true"`/`"auto"` request an automatically generated subgroup; those string names are reserved. Stages and children without Intercom access receive no group. See [workflows.md](/workflows) for workflow-stage rules. The subagent-only `contact_supervisor` path remains capability-based and can cross group boundaries; ordinary `send`, `ask`, and replies cannot use it as a bypass.
+
+The broker, not the client, marks validated supervisor traffic. Ordinary `send` frames remain membership-isolated even if a raw client forges a supervisor marker, and replies cross back only through an exact broker-recorded `replyTo` match. Parent-held authorization state is restored after reconnects. Before an Intercom-enabled foreground child first runs, the parent wrapper may lazy-load and connect the broker provider to mint that exact child's capability; queued children request no capability. The child still connects only when it uses an Intercom delivery path, and claimed decisions or interviews terminally hand off before child send or waiter admission. A claimed provider failure aborts launch, while runtimes with no provider omit supervisor metadata and do not expose a broken channel.
 
 ### send vs ask vs reply
 
@@ -381,7 +385,7 @@ The `subagent` tool's `control` options select which control events notify the p
 - **`notifyOn`** — defaults to `["active_long_running", "needs_attention"]`
 - **`notifyChannels`** — defaults to `["event", "intercom"]` (all that are available)
 
-Detached subagent result delivery over Intercom is confirmation-based and preserves a successful delivery phase across watcher replacement. Each delegated child gets a deterministic Intercom target derived from its run/agent/index identity, and run results report those targets ("Run intercom target" / "Previous intercom target"; targets may be inactive after completion). `intercom({ action: "status" })` reports connection state and the resolved group for the current session.
+Detached subagent result delivery over Intercom is confirmation-based and preserves a successful delivery phase across watcher replacement. Each delegated child gets a deterministic Intercom target derived from its run/agent/index identity, and run results report those targets ("Run intercom target" / "Previous intercom target"; targets may be inactive after completion). `intercom({ action: "status" })` reports connection state and every membership for the current session.
 
 If live peer coordination is needed, invoke `intercom({ action: "status" })` in the parent before launching; the child connects on its first ordinary Intercom call. A claimed `contact_supervisor` decision or interview can yield before child broker connection because typed admission already identifies the launching parent. Fresh child sessions receive the bundled Intercom wrapper through normal package discovery unless an explicit `extensions` allowlist excludes it.
 

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+### Added
+
+- Intercom sessions can now hold multiple group memberships. Runtime `join` is additive, targeted `leave` removes one membership, bare `leave` resets to the startup home group, and the new `groups` action discovers every available group with session counts and membership markers. `list` remains session discovery, `status` reports the complete membership set, legacy single-group clients retain their existing behavior, and `contact_supervisor` keeps its capability-based cross-group route.
+
 ## [0.9.16-alpha.8] - 2026-08-27
 
 ### Added

--- a/packages/intercom/README.md
+++ b/packages/intercom/README.md
@@ -82,13 +82,15 @@ intercom({ action: "list" })
 // → **Other sessions:**
 // → • research (6332faab-1111-4222-8333-123456789abc) — ~/projects/api (claude-sonnet-4) [same cwd, thinking]
 
-// Join a named group (it is created if no session is there yet)
+// Add a named membership (it is created if no session is there yet)
 intercom({ action: "join", group: "api-review" })
-// → Joined intercom group "api-review".
+// → Joined intercom group "api-review". Memberships: default, api-review.
 
-// Return to the group's home resolved at session start
-intercom({ action: "leave" })
-// → Returned to home intercom group "default".
+// Discover all available groups and see which ones you belong to
+intercom({ action: "groups" })
+
+// Leave one membership, or omit group to reset to the startup home group
+intercom({ action: "leave", group: "api-review" })
 
 // Send a message
 intercom({ action: "send", to: "research", message: "Check if UserService.validate() handles null" })
@@ -181,7 +183,7 @@ intercom({
 // Worker continues implementing with the answer, same turn, full context.
 ```
 
-To coordinate two plain chat sessions without changing their startup config, have each one call `intercom({ action: "join", group: "NAME" })`. Joining updates broker presence in place, so the broker broadcasts a leave to the old group and a join to `NAME` without changing the session ID; the tool reports success only after the broker acknowledges the new group. Calls to `list`, `status`, `send`, and `ask` then use `NAME`; sessions that stay in `default` cannot discover or message the joined peers. Call `intercom({ action: "leave" })` to return to the original resolved home group. `contact_supervisor` keeps its dedicated capability-based cross-group behavior.
+To coordinate two plain chat sessions without changing startup config, have each call `intercom({ action: "join", group: "NAME" })`. Joining adds a membership without changing the session ID or removing existing memberships. Calls to `list`, `send`, and `ask` can then reach any session sharing at least one membership. Use `intercom({ action: "groups" })` to discover every available name, connected-session count, and membership marker. Call `intercom({ action: "leave", group: "NAME" })` to remove one membership while keeping the others, or bare `leave` to reset to the original home group. `contact_supervisor` keeps its dedicated capability-based cross-group behavior.
 
 **Worker finds something unexpected — escalates and waits:**
 ```typescript
@@ -333,12 +335,12 @@ The supervisor can reply with plain JSON or a fenced `json` block. If the reply 
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `action` | string | `"list"`, `"join"`, `"leave"`, `"send"`, `"ask"`, `"reply"`, `"pending"`, or `"status"` |
+| `action` | string | `"list"`, `"groups"`, `"join"`, `"leave"`, `"send"`, `"ask"`, `"reply"`, `"pending"`, or `"status"` |
 | `to` | string | Exact session name/full session ID, or `<runId>:<stageKey>` for `send` to a not-yet-started workflow stage (for send/ask, or targeted reply) |
 | `message` | string | Message text (for send/ask/reply) |
 | `attachments` | array | Optional `file`, `snippet`, or `context` attachments |
 | `replyTo` | string | Optional message ID for threading or replying to an `ask` |
-| `group` | string | Group name for `join`; read-only group filter for `list`/`status`. `send`/`ask` stay locked to the current group. |
+| `group` | string | Group name for `join` or optional targeted `leave`; read-only filter for `list`/`status`. `send`/`ask` require a shared membership. |
 
 ### contact_supervisor
 
@@ -358,11 +360,13 @@ Only registered in sessions where `pi-subagents` supplied the required child bri
 
 ### intercom actions
 
-**`join`** — Moves this session into the trimmed named group and creates that group when no peer is there yet. `default` is the shared default group. The names `true` and `auto` are reserved for subagent auto-groups and are rejected. Subagents launched after the join inherit the joined group.
+**`join`** — Adds a trimmed named membership and creates that group when no peer is there yet. The result reports the complete membership set. `default` is shared; `true` and `auto` remain reserved.
 
-**`leave`** — Moves this session back to the resolved home group from session startup. It takes no `group` parameter.
+**`leave`** — With `group`, removes only that membership. Without `group`, resets the complete set to the startup home group. The result reports the memberships that remain.
 
-**`list`** — Returns the current session plus other active intercom-connected sessions with name, full session ID, working directory, model, and live status. Every displayed full session ID can be passed directly to `send`, `ask`, or targeted `reply`.
+**`groups`** — Lists every group represented by a connected session, with session counts and membership markers, so callers can discover names instead of guessing.
+
+**`list`** — Keeps session-listing semantics: returns the current session and every active session sharing at least one membership. Pass `group` for a read-only view of one group.
 
 Live target lookup accepts only an exact full session ID or an exact case-insensitive session name. Ordinary `send` also accepts `<runId>:<stageKey>` for a known workflow stage whose session has not initialized. The run ID is a full UUID and the stage key is exact. Unknown runs and stages retain the ordinary unknown-target failure. All targeting remains **group-scoped** — see [Groups](#groups) below.
 
@@ -376,7 +380,7 @@ Live target lookup accepts only an exact full session ID or an exact case-insens
 
 `contact_supervisor` decisions and interviews are deliberately exclusive per child: one supervisor wait may coexist with ordinary peer asks, but a second concurrent supervisor wait receives `Already waiting for a supervisor reply`. Claimed foreground parent handoffs remain first-claim-wins and do not allocate a waiter. Multiple children can contact the same parent independently because inbound asks and handoffs are keyed by child/message identity. Mutual peer asks are supported, but each side must process inbound work to reply; the per-waiter timeout remains the deadlock backstop.
 
-**`status`** — Shows connection status, session ID, current group, and the total count of active sessions in that group. A `group` filter remains a read-only peek.
+**`status`** — Shows connection status, session ID, every current membership, and the total visible-session count. A `group` filter remains a read-only peek.
 
 ## Keyboard Shortcuts
 

--- a/packages/intercom/broker/client.ts
+++ b/packages/intercom/broker/client.ts
@@ -3,12 +3,14 @@ import net from "net";
 import { randomUUID } from "crypto";
 import { writeMessage, createMessageReader } from "./framing.js";
 import { getBrokerSocketPath } from "./paths.js";
-import type { SessionInfo, Message, Attachment, SupervisorRegistration } from "../types.js";
+import type { SessionInfo, Message, Attachment, GroupSummary, SupervisorRegistration } from "../types.js";
 import { buildSendSignature, PendingSendRegistry } from "./pending-send-registry.js";
 import { readSubagentMessageSource } from "../source-ownership.js";
 import { isMessage, isSessionInfo } from "./client-message-validation.js";
+import { normalizeGroups } from "../group.js";
 
 const BROKER_SOCKET = getBrokerSocketPath();
+const GROUP_REQUEST_TIMEOUT_MS = 5000;
 const PRESENCE_ACK_TIMEOUT_MS = 5000;
 
 
@@ -58,6 +60,7 @@ export interface PresenceUpdates {
   name?: string;
   status?: string;
   model?: string;
+  groups?: string[];
   group?: string;
 }
 
@@ -79,8 +82,15 @@ export class IntercomClient extends EventEmitter {
   /** Source identity is captured once at connect, never read from env per message. */
   private _messageSource: Message["source"] | undefined;
   private pendingSends = new PendingSendRegistry();
+  private pendingGroupLists = new Map<string, { resolve: (groups: GroupSummary[]) => void; reject: (error: Error) => void }>();
   private pendingLists = new Map<string, { resolve: (sessions: SessionInfo[]) => void; reject: (e: Error) => void }>();
-  private pendingPresence = new Map<string, { resolve: (group: string) => void; reject: (error: Error) => void }>();
+  private pendingPresence = new Map<string, {
+    resolve: (group: string) => void;
+    reject: (error: Error) => void;
+    groups?: string[];
+  }>();
+  private pendingMemberships = new Map<string, { resolve: (groups: string[]) => void; reject: (error: Error) => void }>();
+  private _groups = normalizeGroups();
   private pendingLiveWorkflowStageRoutes = new Map<string, { resolve(): void; reject(error: Error): void }>();
 
   private pendingSupervisorAuthorizations = new Map<string, {
@@ -98,13 +108,17 @@ export class IntercomClient extends EventEmitter {
 
   private failPending(error: Error): void {
     this.pendingSends.rejectAll(error);
+    for (const pending of this.pendingGroupLists.values()) pending.reject(error);
     for (const pending of this.pendingLists.values()) pending.reject(error);
     for (const pending of this.pendingSupervisorAuthorizations.values()) pending.reject(error);
     for (const pending of this.pendingPresence.values()) pending.reject(error);
+    for (const pending of this.pendingMemberships.values()) pending.reject(error);
     for (const pending of this.pendingLiveWorkflowStageRoutes.values()) pending.reject(error);
     this.pendingLists.clear();
+    this.pendingGroupLists.clear();
     this.pendingSupervisorAuthorizations.clear();
     this.pendingPresence.clear();
+    this.pendingMemberships.clear();
     this.pendingLiveWorkflowStageRoutes.clear();
   }
 
@@ -115,6 +129,10 @@ export class IntercomClient extends EventEmitter {
   get supervisorSessionId(): string | null {
     return this._supervisorSessionId;
   }
+  get groups(): string[] {
+    return [...this._groups];
+  }
+
 
 
   isConnected(): boolean {
@@ -149,6 +167,7 @@ export class IntercomClient extends EventEmitter {
       return Promise.reject(new Error("Already connected"));
     }
     this._messageSource = messageSource ?? readSubagentMessageSource();
+    this._groups = normalizeGroups(session.groups, session.group);
 
     return new Promise((resolve, reject) => {
       const socket = net.connect(BROKER_SOCKET);
@@ -323,6 +342,27 @@ export class IntercomClient extends EventEmitter {
         pending.resolve(sessions);
         break;
       }
+      case "groups": {
+        const { requestId, groups } = brokerMessage;
+        if (
+          typeof requestId !== "string" ||
+          !Array.isArray(groups) ||
+          !groups.every((summary) =>
+            typeof summary === "object" &&
+            summary !== null &&
+            typeof summary.group === "string" &&
+            typeof summary.sessionCount === "number" &&
+            typeof summary.member === "boolean"
+          )
+        ) {
+          throw new Error("Invalid groups message");
+        }
+        const pending = this.pendingGroupLists.get(requestId);
+        if (!pending) return;
+        this.pendingGroupLists.delete(requestId);
+        pending.resolve(groups as GroupSummary[]);
+        break;
+      }
       case "supervisor_authorized": {
         const { requestId, capability, supervisorSessionId, childName } = brokerMessage;
         if (typeof requestId !== "string" || typeof capability !== "string"
@@ -465,17 +505,39 @@ export class IntercomClient extends EventEmitter {
         const pending = this.pendingPresence.get(brokerMessage.requestId);
         if (!pending) return;
         this.pendingPresence.delete(brokerMessage.requestId);
+        this._groups = pending.groups === undefined
+          ? normalizeGroups(undefined, brokerMessage.group)
+          : normalizeGroups(pending.groups);
         pending.resolve(brokerMessage.group);
+        break;
+      }
+      case "membership_ack": {
+        const { requestId, groups } = brokerMessage;
+        if (typeof requestId !== "string" || !Array.isArray(groups) || !groups.every((group) => typeof group === "string")) {
+          throw new Error("Invalid membership_ack message");
+        }
+        const pending = this.pendingMemberships.get(requestId);
+        if (!pending) return;
+        this.pendingMemberships.delete(requestId);
+        const normalizedGroups = [...normalizeGroups(groups)];
+        this._groups = new Set(normalizedGroups);
+        pending.resolve(normalizedGroups);
         break;
       }
       case "presence_failed": {
         if (typeof brokerMessage.requestId !== "string" || typeof brokerMessage.reason !== "string") {
           throw new Error("Invalid presence_failed message");
         }
-        const pending = this.pendingPresence.get(brokerMessage.requestId);
-        if (!pending) return;
-        this.pendingPresence.delete(brokerMessage.requestId);
-        pending.reject(new Error(brokerMessage.reason));
+        const presence = this.pendingPresence.get(brokerMessage.requestId);
+        if (presence) {
+          this.pendingPresence.delete(brokerMessage.requestId);
+          presence.reject(new Error(brokerMessage.reason));
+          break;
+        }
+        const membership = this.pendingMemberships.get(brokerMessage.requestId);
+        if (!membership) return;
+        this.pendingMemberships.delete(brokerMessage.requestId);
+        membership.reject(new Error(brokerMessage.reason));
         break;
       }
       case "peer_disconnected": {
@@ -573,6 +635,69 @@ export class IntercomClient extends EventEmitter {
       }
     });
   }
+  listGroups(): Promise<GroupSummary[]> {
+    let socket: net.Socket;
+    try {
+      socket = this.requireActiveSocket();
+    } catch (error) {
+      return Promise.reject(toError(error));
+    }
+    const requestId = randomUUID();
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        if (!this.pendingGroupLists.delete(requestId)) return;
+        reject(new Error("List groups timeout"));
+      }, GROUP_REQUEST_TIMEOUT_MS);
+      this.pendingGroupLists.set(requestId, {
+        resolve: (groups) => { clearTimeout(timeout); resolve(groups); },
+        reject: (error) => { clearTimeout(timeout); reject(error); },
+      });
+      try {
+        writeMessage(socket, { type: "list_groups", requestId });
+      } catch (error) {
+        clearTimeout(timeout);
+        this.pendingGroupLists.delete(requestId);
+        reject(toError(error));
+      }
+    });
+  }
+
+  joinGroup(group: string): Promise<string[]> {
+    return this.updateMembership("join_group", group);
+  }
+
+  leaveGroup(group?: string): Promise<string[]> {
+    return this.updateMembership("leave_group", group);
+  }
+
+  private updateMembership(type: "join_group" | "leave_group", group?: string): Promise<string[]> {
+    let socket: net.Socket;
+    try {
+      socket = this.requireActiveSocket();
+    } catch (error) {
+      return Promise.reject(toError(error));
+    }
+    const requestId = randomUUID();
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        if (!this.pendingMemberships.delete(requestId)) return;
+        reject(new Error("Membership update timeout"));
+      }, GROUP_REQUEST_TIMEOUT_MS);
+      this.pendingMemberships.set(requestId, {
+        resolve: (groups) => { clearTimeout(timeout); resolve(groups); },
+        reject: (error) => { clearTimeout(timeout); reject(error); },
+      });
+      try {
+        writeMessage(socket, group === undefined ? { type, requestId } : { type, requestId, group });
+      } catch (error) {
+        clearTimeout(timeout);
+        this.pendingMemberships.delete(requestId);
+        reject(toError(error));
+      }
+    });
+  }
+
+
   authorizeSupervisorChild(childName: string, capability?: string): Promise<SupervisorAuthorization> {
     let socket: net.Socket;
     try {
@@ -728,6 +853,8 @@ export class IntercomClient extends EventEmitter {
       return false;
     }
     writeMessage(socket, { type: "presence", ...updates });
+    if (updates.groups !== undefined) this._groups = normalizeGroups(updates.groups, updates.group);
+    else if (updates.group !== undefined) this._groups = normalizeGroups(undefined, updates.group);
     return true;
   }
 
@@ -752,7 +879,11 @@ export class IntercomClient extends EventEmitter {
         if (!this.pendingPresence.delete(requestId)) return;
         reject(new Error("Presence update timeout"));
       }, PRESENCE_ACK_TIMEOUT_MS);
-      this.pendingPresence.set(requestId, { resolve: wrappedResolve, reject: wrappedReject });
+      this.pendingPresence.set(requestId, {
+        resolve: wrappedResolve,
+        reject: wrappedReject,
+        ...(updates.groups === undefined ? {} : { groups: [...updates.groups] }),
+      });
       try {
         writeMessage(socket, { type: "presence", ...updates, requestId });
       } catch (error) {

--- a/packages/intercom/index-heavy.ts
+++ b/packages/intercom/index-heavy.ts
@@ -38,7 +38,7 @@ import { admitWorkflowStageInbound } from "./workflow-stage-admission.js";
 import { bindWorkflowReplyTracker, preserveWorkflowReplyTracker } from "./workflow-reply-tracker.js";
 import { routeClosedWorkflowStageMessage } from "./closed-workflow-stage-message.js";
 import { createWorkflowStageDeliveryFailureHandler } from "./workflow-stage-delivery-failure.js";
-import { normalizeGroup, resolveHomeGroup } from "./group.js";
+import { normalizeGroup, normalizeGroups, resolveHomeGroup } from "./group.js";
 import { clearRuntimeIntercomGroup, setRuntimeIntercomGroup } from "./runtime-group.js";
 import { reconnectDelayMs } from "./reconnect-backoff.js";
 import { SupervisorAuthorizationRegistry } from "./supervisor-authorization-registry.js";
@@ -143,7 +143,7 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
   let runtimeGeneration = 0;
   let agentRunning = false;
   let sessionHomeGroup: string | null = null;
-  let joinedGroup: string | null = null;
+  let joinedGroups: Set<string> | null = null;
   const activeTools = new Map<string, string>();
   let replyTracker = new ReplyTracker();
   const replyWaiters = new ReplyWaiterRegistry(DEFAULT_REPLY_TIMEOUT_MS, config.maxPendingAsks);
@@ -191,18 +191,22 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
   function resolveSessionHomeGroup(): string {
     return sessionHomeGroup ?? resolveHomeGroup(config, getLiveContext());
   }
+  function currentIntercomGroups(): Set<string> {
+    return joinedGroups === null
+      ? normalizeGroups(undefined, resolveSessionHomeGroup())
+      : new Set(joinedGroups);
+  }
   function currentIntercomGroup(): string {
-    return joinedGroup ?? resolveSessionHomeGroup();
+    return [...currentIntercomGroups()].at(-1) ?? resolveSessionHomeGroup();
   }
-  function setJoinedGroup(group: string): void {
+  function setJoinedGroups(groups: readonly string[]): void {
+    joinedGroups = normalizeGroups(groups);
     const sessionId = currentSessionId;
-    if (!sessionId) return;
-    setRuntimeIntercomGroup(sessionId, group);
-    joinedGroup = group;
+    if (sessionId) setRuntimeIntercomGroup(sessionId, currentIntercomGroup());
   }
-  function clearJoinedGroup(): void {
+  function clearJoinedGroups(): void {
+    joinedGroups = null;
     const sessionId = currentSessionId;
-    joinedGroup = null;
     if (sessionId) clearRuntimeIntercomGroup(sessionId);
   }
   function buildRegistration(): Omit<SessionInfo, "id"> {
@@ -219,6 +223,7 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
       startedAt: sessionStartedAt,
       lastActivity: Date.now(),
       status: currentStatus(),
+      groups: [...currentIntercomGroups()],
       group: currentIntercomGroup(),
     };
   }
@@ -701,7 +706,7 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
       state.client = nextClient;
       attachPendingStageRouteClientHandlers(runId, state, nextClient);
       await nextClient.connect(
-        { ...buildRegistration(), name: undefined, group: normalizeGroup(route.group) },
+        { ...buildRegistration(), name: undefined, groups: [normalizeGroup(route.group)], group: normalizeGroup(route.group) },
         undefined,
         undefined,
         readSubagentMessageSource(runtimeContext?.subagentPolicy),
@@ -906,7 +911,7 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
     clearReconnectTimer,
     setRuntimeContext: (value) => {
       if (value === null) {
-        clearJoinedGroup();
+        clearJoinedGroups();
         sessionHomeGroup = null;
       } else {
         sessionHomeGroup = resolveHomeGroup(config, value);
@@ -962,8 +967,8 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
     beginReplyWait: (from, replyTo, signal) => replyWaiters.begin(from, replyTo, signal),
     confirmSend: config.confirmSend,
     homeGroup: resolveSessionHomeGroup,
-    setJoinedGroup,
-    clearJoinedGroup,
+    setJoinedGroups,
+    clearJoinedGroups,
     replyTracker: () => replyTracker,
   });
   registerIntercomOverlay(pi, {

--- a/packages/intercom/intercom-tool.ts
+++ b/packages/intercom/intercom-tool.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "crypto";
 import { Type } from "typebox";
 import { Text } from "@earendil-works/pi-tui";
 import type { IntercomClient } from "./broker/client.js";
+import type { SessionInfo } from "./types.js";
 import { requestParentAskHandoff } from "./parent-ask-handoff.js";
 import type { ReplyWait, ReplyWaitAdmission } from "./reply-waiter.ts";
 import { renderIntercomResult } from "./result-renderers.js";
@@ -16,7 +17,7 @@ import {
 } from "./intercom-utils.js";
 import type { ReplyTracker } from "./reply-tracker.js";
 import { resolveSessionTargetId } from "./session-target.js";
-import { normalizeGroup, validateRuntimeGroup } from "./group.js";
+import { normalizeGroup, normalizeGroups, validateRuntimeGroup } from "./group.js";
 
 interface IntercomToolDeps {
   childOrchestratorMetadata?: ChildOrchestratorMetadata | null | (() => ChildOrchestratorMetadata | null);
@@ -24,8 +25,8 @@ interface IntercomToolDeps {
   syncPresenceIdentity(sessionId: string): void;
   resolveSessionTarget?(activeClient: IntercomClient, nameOrId: string): Promise<string | null>;
   homeGroup(): string;
-  setJoinedGroup(group: string): void;
-  clearJoinedGroup(): void;
+  setJoinedGroups(groups: readonly string[]): void;
+  clearJoinedGroups(): void;
   confirmSend: boolean;
   /** Atomically reserves one correlation-keyed reply waiter. */
   beginReplyWait(from: string, replyTo: string, signal?: AbortSignal): ReplyWaitAdmission;
@@ -54,25 +55,27 @@ workflow stage, use the exact \`<runId>:<stageKey>\` target; send messages to pe
 queue automatically.
 
 Usage:
-  intercom({ action: "list" })                    → List sessions in your group
-  intercom({ action: "list", group: "name" })     → Read-only peek at another group's sessions
-  intercom({ action: "join", group: "name" })     → Join or create a named group
+  intercom({ action: "list" })                    → List sessions visible through your groups
+  intercom({ action: "list", group: "name" })     → Read-only peek at one group's sessions
+  intercom({ action: "groups" })                  → Discover every available group and your memberships
+  intercom({ action: "join", group: "name" })     → Add a named group membership
+  intercom({ action: "leave", group: "name" })    → Leave one named group
   intercom({ action: "leave" })                   → Return to your resolved home group
-  intercom({ action: "send", to: "session-name", message: "..." })  → Send message (own group only)
+  intercom({ action: "send", to: "session-name", message: "..." })  → Send message (shared group only)
   intercom({ action: "ask", to: "session-name", message: "..." })   → Ask and wait for reply
   intercom({ action: "reply", message: "..." })                      → Reply to the active or exact pending ask
   intercom({ action: "pending" })                                      → List unresolved inbound asks
-  intercom({ action: "status" })                  → Show connection status and your group
+  intercom({ action: "status" })                  → Show connection status and all your groups
 
-The "join" action changes this session's group in place. "default" is the shared
-default group; "true" and "auto" are reserved for subagent auto-groups. Joining
-does not grant cross-group access: contact_supervisor is the only cross-group path.`,
+The "join" action is additive. "default" is the shared default group; "true" and
+"auto" are reserved for subagent auto-groups. Ordinary delivery requires at least
+one shared membership; contact_supervisor remains the only cross-group path.`,
     promptSnippet:
-      "Use to coordinate with other local agent sessions in your intercom group: list peers, send updates, ask for help, or check intercom connectivity. Groups are isolated; you can only message sessions in your own group.",
+      "Use to coordinate with other local agent sessions that share an intercom group: discover groups or peers, send updates, ask for help, or check connectivity. Ordinary messages require a shared membership.",
 
     parameters: Type.Object({
       action: Type.String({
-        description: "Action: 'list', 'join', 'leave', 'send', 'ask', 'reply', 'pending', or 'status'",
+        description: "Action: 'list', 'groups', 'join', 'leave', 'send', 'ask', 'reply', 'pending', or 'status'",
       }),
       to: Type.Optional(Type.String({
         description: "Live session name, exact full session ID, or exact `<runId>:<stageKey>` for a known workflow stage; send messages to pending stages queue automatically (for 'send', 'ask', or targeted 'reply')",
@@ -90,7 +93,7 @@ does not grant cross-group access: contact_supervisor is the only cross-group pa
         description: "Exact pending-ask message ID; disambiguates concurrent asks, including asks from one sender",
       })),
       group: Type.Optional(Type.String({
-        description: "Group name for 'join'; read-only group filter for 'list'/'status'. 'send'/'ask' are locked to your own group.",
+        description: "Group name for 'join' or optional targeted 'leave'; read-only group filter for 'list'/'status'. 'send'/'ask' use shared memberships.",
       })),
     }),
 
@@ -108,17 +111,19 @@ does not grant cross-group access: contact_supervisor is the only cross-group pa
 
       syncPresenceIdentity(ctx.sessionManager.getSessionId());
       const { action, to, message, attachments, replyTo, group } = params;
-      const requestedGroup = typeof group === "string" && group.trim() ? normalizeGroup(group) : undefined;
-      const resolveOwnGroup = async (): Promise<string> => {
-        const sessions = await connectedClient.listSessions();
-        const self = sessions.find((s) => s.id === connectedClient.sessionId);
-        return normalizeGroup(self?.group);
+      const resolveOwnGroups = (sessions?: readonly SessionInfo[]): string[] => {
+        if (Array.isArray(connectedClient.groups)) {
+          return connectedClient.groups.map((membership) => normalizeGroup(membership));
+        }
+        const self = sessions?.find((session) => session.id === connectedClient.sessionId);
+        return [...normalizeGroups(self?.groups, self?.group)];
       };
+      const requestedGroup = typeof group === "string" && group.trim() ? normalizeGroup(group) : undefined;
       if ((action === "send" || action === "ask") && requestedGroup) {
-        const ownGroup = await resolveOwnGroup();
-        if (requestedGroup !== ownGroup) {
+        const ownGroups = resolveOwnGroups();
+        if (!ownGroups.includes(requestedGroup)) {
           return {
-            content: [{ type: "text", text: `The 'group' parameter is read-only for 'list'/'status'. '${action}' is always locked to your own group ("${ownGroup}"); it cannot target group "${requestedGroup}".` }],
+            content: [{ type: "text", text: `The 'group' parameter is read-only for 'list'/'status'. '${action}' is always locked to your groups (${ownGroups.join(", ")}); it cannot target group "${requestedGroup}".` }],
             isError: true,
             details: { error: true },
           };
@@ -138,15 +143,12 @@ does not grant cross-group access: contact_supervisor is the only cross-group pa
             };
           }
           try {
-            const acknowledgedGroup = await connectedClient.updatePresenceAcked({ group: targetGroup });
-            if (acknowledgedGroup !== targetGroup) {
-              throw new Error(`Broker acknowledged group "${acknowledgedGroup}" instead of "${targetGroup}"`);
-            }
-            deps.setJoinedGroup(targetGroup);
+            const groups = await connectedClient.joinGroup(targetGroup);
+            deps.setJoinedGroups(groups);
             return {
-              content: [{ type: "text", text: `Joined intercom group "${targetGroup}".` }],
+              content: [{ type: "text", text: `Joined intercom group "${targetGroup}". Memberships: ${groups.join(", ")}.` }],
               isError: false,
-              details: { group: targetGroup },
+              details: { group: targetGroup, groups },
             };
           } catch (error) {
             return {
@@ -158,16 +160,13 @@ does not grant cross-group access: contact_supervisor is the only cross-group pa
         }
 
         case "leave": {
-          if (typeof group === "string" && group.trim().length > 0) {
-            return {
-              content: [{ type: "text", text: "The 'leave' action does not accept a group; it returns to the resolved home group." }],
-              isError: true,
-              details: { error: true },
-            };
-          }
-          let targetGroup: string;
+          let targetGroup: string | undefined;
+          let homeGroup: string | undefined;
           try {
-            targetGroup = validateRuntimeGroup(deps.homeGroup());
+            targetGroup = typeof group === "string" && group.trim().length > 0
+              ? validateRuntimeGroup(group)
+              : undefined;
+            if (targetGroup === undefined) homeGroup = validateRuntimeGroup(deps.homeGroup());
           } catch (error) {
             return {
               content: [{ type: "text", text: `Cannot leave intercom group: ${getErrorMessage(error)}` }],
@@ -176,15 +175,23 @@ does not grant cross-group access: contact_supervisor is the only cross-group pa
             };
           }
           try {
-            const acknowledgedGroup = await connectedClient.updatePresenceAcked({ group: targetGroup });
-            if (acknowledgedGroup !== targetGroup) {
-              throw new Error(`Broker acknowledged group "${acknowledgedGroup}" instead of "${targetGroup}"`);
+            let groups: string[];
+            if (targetGroup === undefined) {
+              if (homeGroup === undefined) throw new Error("Intercom home group is unavailable");
+              await connectedClient.updatePresenceAcked({ groups: [homeGroup] });
+              groups = connectedClient.groups;
+              deps.clearJoinedGroups();
+            } else {
+              groups = await connectedClient.leaveGroup(targetGroup);
+              deps.setJoinedGroups(groups);
             }
-            deps.clearJoinedGroup();
+            const text = targetGroup === undefined
+              ? `Returned to home intercom membership. Memberships: ${groups.join(", ")}.`
+              : `Left intercom group "${targetGroup}". Memberships: ${groups.join(", ")}.`;
             return {
-              content: [{ type: "text", text: `Returned to home intercom group "${targetGroup}".` }],
+              content: [{ type: "text", text }],
               isError: false,
-              details: { group: targetGroup },
+              details: { groups },
             };
           } catch (error) {
             return {
@@ -195,12 +202,31 @@ does not grant cross-group access: contact_supervisor is the only cross-group pa
           }
         }
 
+        case "groups": {
+          try {
+            const groups = await connectedClient.listGroups();
+            const lines = groups.map(({ group: groupName, sessionCount, member }) =>
+              `- ${groupName} — ${sessionCount} session${sessionCount === 1 ? "" : "s"}${member ? " [member]" : ""}`
+            );
+            return {
+              content: [{ type: "text", text: `**Intercom groups:**\n${lines.join("\n")}` }],
+              isError: false,
+              details: { groups },
+            };
+          } catch (error) {
+            return {
+              content: [{ type: "text", text: `Failed to list groups: ${getErrorMessage(error)}` }],
+              isError: true,
+              details: { error: true },
+            };
+          }
+        }
+
         case "list": {
           try {
             const mySessionId = connectedClient.sessionId;
             const ownSessions = await connectedClient.listSessions();
-            const currentSession = ownSessions.find(s => s.id === mySessionId);
-
+            const currentSession = ownSessions.find((session) => session.id === mySessionId);
             if (!currentSession) {
               return {
                 content: [{ type: "text", text: "Current session is missing from intercom session list." }],
@@ -208,30 +234,29 @@ does not grant cross-group access: contact_supervisor is the only cross-group pa
                 details: { error: true },
               };
             }
-            const ownGroup = normalizeGroup(currentSession.group);
-
-            if (requestedGroup && requestedGroup !== ownGroup) {
+            const ownGroups = resolveOwnGroups(ownSessions);
+            if (requestedGroup) {
               const peeked = await connectedClient.listSessions(requestedGroup);
               const section = peeked.length === 0
                 ? `**Group [${requestedGroup}] (read-only peek):**\nNo sessions in this group.`
-                : `**Group [${requestedGroup}] (read-only peek):**\n${peeked.map(s => formatSessionListRow(s, currentSession.cwd, s.id === mySessionId)).join("\n")}`;
+                : `**Group [${requestedGroup}] (read-only peek):**\n${peeked.map((session) => formatSessionListRow(session, currentSession.cwd, session.id === mySessionId)).join("\n")}`;
               return {
-                content: [{ type: "text", text: `Your group: ${ownGroup}\n\n${section}` }],
+                content: [{ type: "text", text: `Your groups: ${ownGroups.join(", ")}\n\n${section}` }],
                 isError: false,
-                details: { group: ownGroup, peekGroup: requestedGroup },
+                details: { group: ownGroups.at(-1), groups: ownGroups, peekGroup: requestedGroup },
               };
             }
 
-            const otherSessions = ownSessions.filter(s => s.id !== mySessionId);
-            const currentSection = `**Current session** (group: ${ownGroup}):\n${formatSessionListRow(currentSession, currentSession.cwd, true)}`;
+            const otherSessions = ownSessions.filter((session) => session.id !== mySessionId);
+            const currentSection = `**Current session** (groups: ${ownGroups.join(", ")}):\n${formatSessionListRow(currentSession, currentSession.cwd, true)}`;
             const otherSection = otherSessions.length === 0
-              ? `**Other sessions:**\nNo other sessions in your group (${ownGroup}).`
-              : `**Other sessions** (group: ${ownGroup}):\n${otherSessions.map(s => formatSessionListRow(s, currentSession.cwd, false)).join("\n")}`;
+              ? "**Other sessions:**\nNo other sessions share any of your groups."
+              : `**Other visible sessions:**\n${otherSessions.map((session) => formatSessionListRow(session, currentSession.cwd, false)).join("\n")}`;
 
             return {
               content: [{ type: "text", text: `${currentSection}\n\n${otherSection}` }],
               isError: false,
-              details: { group: ownGroup },
+              details: { group: ownGroups.at(-1), groups: ownGroups },
             };
           } catch (error) {
             return {
@@ -568,23 +593,30 @@ does not grant cross-group access: contact_supervisor is the only cross-group pa
             details: {},
           };
         }
-
         case "status": {
           try {
             const mySessionId = connectedClient.sessionId;
             const sessions = await connectedClient.listSessions();
-            const self = sessions.find((s) => s.id === mySessionId);
-            const ownGroup = normalizeGroup(self?.group);
-            const peekSection = requestedGroup && requestedGroup !== ownGroup
-              ? `\nPeeked group [${requestedGroup}]: ${(await connectedClient.listSessions(requestedGroup)).length} session(s)`
-              : "";
+            const ownGroups = resolveOwnGroups(sessions);
+            const selectedGroupSessions = requestedGroup === undefined
+              ? undefined
+              : await connectedClient.listSessions(requestedGroup);
+            const selectedSection = selectedGroupSessions === undefined
+              ? ""
+              : `\nSelected group [${requestedGroup}]: ${selectedGroupSessions.length} session(s)`;
             return {
               content: [{
                 type: "text",
-                text: `**Intercom Status:**\nConnected: Yes\nSession ID: ${mySessionId}\nGroup: ${ownGroup}\nActive sessions in group: ${sessions.length}${peekSection}`,
+                text: `**Intercom Status:**\nConnected: Yes\nSession ID: ${mySessionId}\nGroups: ${ownGroups.join(", ")}\nActive visible sessions: ${sessions.length}${selectedSection}`,
               }],
               isError: false,
-              details: { group: ownGroup },
+              details: {
+                group: ownGroups.at(-1),
+                groups: ownGroups,
+                ...(requestedGroup === undefined
+                  ? {}
+                  : { selectedGroup: requestedGroup, selectedGroupSessionCount: selectedGroupSessions?.length ?? 0 }),
+              },
             };
           } catch (error) {
             return {

--- a/packages/intercom/intercom-tool.ts
+++ b/packages/intercom/intercom-tool.ts
@@ -118,6 +118,8 @@ one shared membership; contact_supervisor remains the only cross-group path.`,
         const self = sessions?.find((session) => session.id === connectedClient.sessionId);
         return [...normalizeGroups(self?.groups, self?.group)];
       };
+      const isOnlyOwnGroup = (candidate: string | undefined, ownGroups: readonly string[]): boolean =>
+        candidate !== undefined && ownGroups.length === 1 && ownGroups[0] === candidate;
       const requestedGroup = typeof group === "string" && group.trim() ? normalizeGroup(group) : undefined;
       if ((action === "send" || action === "ask") && requestedGroup) {
         const ownGroups = resolveOwnGroups();
@@ -191,7 +193,7 @@ one shared membership; contact_supervisor remains the only cross-group path.`,
             return {
               content: [{ type: "text", text }],
               isError: false,
-              details: { groups },
+              details: targetGroup === undefined ? { group: homeGroup, groups } : { groups },
             };
           } catch (error) {
             return {
@@ -235,7 +237,7 @@ one shared membership; contact_supervisor remains the only cross-group path.`,
               };
             }
             const ownGroups = resolveOwnGroups(ownSessions);
-            if (requestedGroup) {
+            if (requestedGroup && !isOnlyOwnGroup(requestedGroup, ownGroups)) {
               const peeked = await connectedClient.listSessions(requestedGroup);
               const section = peeked.length === 0
                 ? `**Group [${requestedGroup}] (read-only peek):**\nNo sessions in this group.`
@@ -598,12 +600,13 @@ one shared membership; contact_supervisor remains the only cross-group path.`,
             const mySessionId = connectedClient.sessionId;
             const sessions = await connectedClient.listSessions();
             const ownGroups = resolveOwnGroups(sessions);
-            const selectedGroupSessions = requestedGroup === undefined
+            const selectedGroup = isOnlyOwnGroup(requestedGroup, ownGroups) ? undefined : requestedGroup;
+            const selectedGroupSessions = selectedGroup === undefined
               ? undefined
-              : await connectedClient.listSessions(requestedGroup);
+              : await connectedClient.listSessions(selectedGroup);
             const selectedSection = selectedGroupSessions === undefined
               ? ""
-              : `\nSelected group [${requestedGroup}]: ${selectedGroupSessions.length} session(s)`;
+              : `\nSelected group [${selectedGroup}]: ${selectedGroupSessions.length} session(s)`;
             return {
               content: [{
                 type: "text",
@@ -613,9 +616,9 @@ one shared membership; contact_supervisor remains the only cross-group path.`,
               details: {
                 group: ownGroups.at(-1),
                 groups: ownGroups,
-                ...(requestedGroup === undefined
+                ...(selectedGroup === undefined
                   ? {}
-                  : { selectedGroup: requestedGroup, selectedGroupSessionCount: selectedGroupSessions?.length ?? 0 }),
+                  : { selectedGroup, selectedGroupSessionCount: selectedGroupSessions?.length ?? 0 }),
               },
             };
           } catch (error) {

--- a/packages/intercom/skills/intercom/SKILL.md
+++ b/packages/intercom/skills/intercom/SKILL.md
@@ -94,18 +94,21 @@ The stage receives the ordinary inbound Intercom message before its first model 
 
 ### Runtime named groups
 
-Plain chat sessions can create or join a group without restarting:
+Plain chat sessions can add and remove group memberships without restarting:
 
 ```typescript
-// Join or create the named group. Both sessions should run this call.
+// Add a membership. Existing memberships remain active.
 intercom({ action: "join", group: "api-review" })
-intercom({ action: "list" }) // now shows only peers in api-review
 
-// Leave the named group and return to the resolved startup home group.
+// Discover every available group and see membership markers.
+intercom({ action: "groups" })
+
+// Remove one membership, or reset to home by omitting group.
+intercom({ action: "leave", group: "api-review" })
 intercom({ action: "leave" })
 ```
 
-Joining changes broker presence without changing the session ID. `default` is the shared group. The names `true` and `auto` are reserved for subagent auto-groups and are rejected. Subagents launched after a join inherit the joined group. Ordinary `send`/`ask` calls remain group-isolated; only an authorized `contact_supervisor` call can cross groups.
+`list` still lists sessions: without a filter it returns every peer sharing at least one membership. `default` remains shared, while `true` and `auto` remain reserved. Later subagents inherit the most recently joined membership. Ordinary `send`/`ask` requires a shared membership; only authorized `contact_supervisor` traffic crosses group boundaries.
 
 ### Pattern 3: Reply Naturally
 
@@ -243,14 +246,15 @@ In Atomic workflows, each invocation has its own Intercom group, and parallel st
 
 | Action | Behavior | Use When |
 |--------|----------|----------|
-| `join` | Joins or creates a named group in place | Two plain chat sessions need a private group |
-| `leave` | Returns to the resolved home group | Restore the session's startup group |
+| `join` | Adds or creates a named membership in place | Sessions need another shared routing group |
+| `leave` | Removes one named membership, or resets to home when omitted | Stop sharing one group or restore startup membership |
+| `groups` | Lists every available group with counts and membership markers | Discover a group instead of guessing its name |
 | `send` | Fire-and-forget to a live session, or durable `queued` delivery to `<runId>:<stageKey>` before a workflow stage starts | You don't need a response |
 | `ask` | Blocks until a live recipient replies (10 min timeout); refused for an unstarted stage | You need an answer to continue |
 | `reply` | Responds to the active or pending inbound ask; `to` accepts an exact full session ID or exact session name | You were asked something and need to answer naturally |
 | `pending` | Lists unresolved inbound asks | You need to see who is waiting before replying |
-| `list` | Returns all sessions in the current group with full session IDs and live status | You need to discover targets or choose an idle peer |
-| `status` | Returns your connection state and current group | Troubleshooting |
+| `list` | Returns all sessions sharing any membership, with full IDs and live status | Discover targets or choose an idle peer |
+| `status` | Returns connection state and every current membership | Troubleshooting |
 
 Inside workflows, `ask` may target a sibling stage that has already completed. If that stage retains a valid conversation, Atomic automatically schedules a post-mortem turn there and preserves the exact child-to-child reply thread; do not send a separate workflow follow-up. Missing, deleted, non-resumable, or failed-to-reopen completed targets return an actionable error. A parent or unrelated session cannot satisfy the pending ask.
 

--- a/test/unit/intercom-client-channel.test.ts
+++ b/test/unit/intercom-client-channel.test.ts
@@ -66,6 +66,7 @@ test("client sends runtime group changes as presence updates", () => {
 		type: "presence",
 		group: "named",
 	});
+	assert.deepEqual(client.groups, ["named"]);
 });
 
 test("client resolves acknowledged runtime group changes", async () => {
@@ -92,4 +93,137 @@ test("client resolves acknowledged runtime group changes", async () => {
 	assert.equal(typeof frame.requestId, "string");
 	internals.handleBrokerMessage({ type: "presence_ack", requestId: frame.requestId, group: "named" });
 	assert.equal(await result, "named");
+	assert.deepEqual(client.groups, ["named"]);
+});
+
+test("client preserves all memberships from an acknowledged multi-group presence update", async () => {
+	const client = new IntercomClient();
+	const frames: Buffer[] = [];
+	const internals = client as unknown as {
+		socket: { destroyed: boolean; writableEnded: boolean; writable: boolean; write(data: Buffer): boolean };
+		_sessionId: string;
+		handleBrokerMessage(message: unknown): void;
+	};
+	internals.socket = {
+		destroyed: false,
+		writableEnded: false,
+		writable: true,
+		write(data) {
+			frames.push(data);
+			return true;
+		},
+	};
+	internals._sessionId = "self";
+
+	const result = client.updatePresenceAcked({ groups: ["alpha", "beta"] });
+	const frame = JSON.parse(frames[0]!.subarray(4).toString("utf8")) as { requestId: string };
+	internals.handleBrokerMessage({ type: "presence_ack", requestId: frame.requestId, group: "alpha" });
+
+	assert.equal(await result, "alpha");
+	assert.deepEqual(client.groups, ["alpha", "beta"]);
+});
+
+test("client joins groups additively and tracks the acknowledged membership set", async () => {
+	const client = new IntercomClient();
+	const frames: Buffer[] = [];
+	const internals = client as unknown as {
+		socket: { destroyed: boolean; writableEnded: boolean; writable: boolean; write(data: Buffer): boolean };
+		_sessionId: string;
+		handleBrokerMessage(message: unknown): void;
+	};
+	internals.socket = {
+		destroyed: false,
+		writableEnded: false,
+		writable: true,
+		write(data) {
+			frames.push(data);
+			return true;
+		},
+	};
+	internals._sessionId = "self";
+
+	const joined = client.joinGroup("reviewers");
+	const frame = JSON.parse(frames[0]!.subarray(4).toString("utf8")) as { requestId: string };
+	assert.deepEqual(
+		{ ...frame, requestId: "request" },
+		{
+			type: "join_group",
+			requestId: "request",
+			group: "reviewers",
+		},
+	);
+	internals.handleBrokerMessage({
+		type: "membership_ack",
+		requestId: frame.requestId,
+		groups: ["default", "reviewers"],
+	});
+
+	assert.deepEqual(await joined, ["default", "reviewers"]);
+	assert.deepEqual(client.groups, ["default", "reviewers"]);
+});
+
+test("client leaves one group while retaining its other memberships", async () => {
+	const client = new IntercomClient();
+	const frames: Buffer[] = [];
+	const internals = client as unknown as {
+		socket: { destroyed: boolean; writableEnded: boolean; writable: boolean; write(data: Buffer): boolean };
+		_sessionId: string;
+		handleBrokerMessage(message: unknown): void;
+	};
+	internals.socket = {
+		destroyed: false,
+		writableEnded: false,
+		writable: true,
+		write(data) {
+			frames.push(data);
+			return true;
+		},
+	};
+	internals._sessionId = "self";
+
+	const left = client.leaveGroup("reviewers");
+	const frame = JSON.parse(frames[0]!.subarray(4).toString("utf8")) as { requestId: string };
+	assert.deepEqual(
+		{ ...frame, requestId: "request" },
+		{
+			type: "leave_group",
+			requestId: "request",
+			group: "reviewers",
+		},
+	);
+	internals.handleBrokerMessage({ type: "membership_ack", requestId: frame.requestId, groups: ["default", "build"] });
+
+	assert.deepEqual(await left, ["default", "build"]);
+	assert.deepEqual(client.groups, ["default", "build"]);
+});
+
+test("client lists every broker group with membership markers", async () => {
+	const client = new IntercomClient();
+	const frames: Buffer[] = [];
+	const internals = client as unknown as {
+		socket: { destroyed: boolean; writableEnded: boolean; writable: boolean; write(data: Buffer): boolean };
+		_sessionId: string;
+		handleBrokerMessage(message: unknown): void;
+	};
+	internals.socket = {
+		destroyed: false,
+		writableEnded: false,
+		writable: true,
+		write(data) {
+			frames.push(data);
+			return true;
+		},
+	};
+	internals._sessionId = "self";
+
+	const listed = client.listGroups();
+	const frame = JSON.parse(frames[0]!.subarray(4).toString("utf8")) as { requestId: string };
+	assert.deepEqual({ ...frame, requestId: "request" }, { type: "list_groups", requestId: "request" });
+	const groups = [
+		{ group: "build", sessionCount: 1, member: false },
+		{ group: "default", sessionCount: 2, member: true },
+	];
+	internals.handleBrokerMessage({ type: "groups", requestId: frame.requestId, groups });
+
+	assert.deepEqual(await listed, groups);
 });

--- a/test/unit/intercom-tool-groups.test.ts
+++ b/test/unit/intercom-tool-groups.test.ts
@@ -45,12 +45,14 @@ function fixture(homeGroup = "default") {
 	let cleared = 0;
 	const leaveCalls: Array<string | undefined> = [];
 	const homeResetCalls: string[][] = [];
+	const listSessionCalls: Array<string | undefined> = [];
 	const client = {
 		sessionId: current.id,
 		get groups(): string[] {
 			return [...(current.groups ?? [current.group ?? "default"])];
 		},
 		async listSessions(group?: string): Promise<SessionInfo[]> {
+			listSessionCalls.push(group);
 			const peer = (id: string, membership: string): SessionInfo => ({
 				...current,
 				id,
@@ -124,6 +126,7 @@ function fixture(homeGroup = "default") {
 		tool,
 		joinedGroups,
 		leaveCalls,
+		listSessionCalls,
 		homeResetCalls,
 		get cleared() {
 			return cleared;
@@ -167,10 +170,46 @@ test("join is additive and leave without a group returns home", async () => {
 
 	const left = await current.tool.execute("leave", { action: "leave" }, undefined, undefined, context);
 	assert.equal(left.isError, false, left.content[0]?.text);
+	assert.equal(left.details?.group, "default");
 	assert.deepEqual(current.current.groups, ["default"]);
 	assert.deepEqual(current.leaveCalls, []);
 	assert.deepEqual(current.homeResetCalls, [["default"]]);
 	assert.equal(current.cleared, 1);
+});
+
+test("status treats a single membership's own group as an unfiltered status request", async () => {
+	const current = fixture();
+
+	const result = await current.tool.execute(
+		"status",
+		{ action: "status", group: "default" },
+		undefined,
+		undefined,
+		context,
+	);
+
+	assert.equal(result.isError, false, result.content[0]?.text);
+	assert.doesNotMatch(result.content[0]?.text ?? "", /Selected group/);
+	assert.deepEqual(result.details, { group: "default", groups: ["default"] });
+	assert.deepEqual(current.listSessionCalls, [undefined]);
+});
+
+test("list treats a single membership's own group as the unfiltered session list", async () => {
+	const current = fixture();
+
+	const result = await current.tool.execute(
+		"list",
+		{ action: "list", group: "default" },
+		undefined,
+		undefined,
+		context,
+	);
+
+	assert.equal(result.isError, false, result.content[0]?.text);
+	assert.match(result.content[0]?.text ?? "", /Current session/);
+	assert.doesNotMatch(result.content[0]?.text ?? "", /read-only peek/);
+	assert.deepEqual(result.details, { group: "default", groups: ["default"] });
+	assert.deepEqual(current.listSessionCalls, [undefined]);
 });
 
 test("status applies a group filter even when the session belongs to that group", async () => {

--- a/test/unit/intercom-tool-groups.test.ts
+++ b/test/unit/intercom-tool-groups.test.ts
@@ -3,7 +3,7 @@ import { test } from "vitest";
 import { registerIntercomTool } from "../../packages/intercom/intercom-tool.js";
 import { ReplyTracker } from "../../packages/intercom/reply-tracker.js";
 import { ReplyWaiterRegistry } from "../../packages/intercom/reply-waiter.js";
-import type { SessionInfo } from "../../packages/intercom/types.js";
+import type { GroupSummary, SessionInfo } from "../../packages/intercom/types.js";
 
 type ToolResult = {
 	content: Array<{ text: string }>;
@@ -33,6 +33,7 @@ function session(group: string): SessionInfo {
 		startedAt: 1,
 		lastActivity: 1,
 		status: "idle",
+		groups: [group],
 		group,
 	};
 }
@@ -40,24 +41,55 @@ function session(group: string): SessionInfo {
 function fixture(homeGroup = "default") {
 	let current = session(homeGroup);
 	let tool: Tool | undefined;
-	const presenceGroups: string[] = [];
-	const joinedGroups: string[] = [];
+	const joinedGroups: string[][] = [];
 	let cleared = 0;
+	const leaveCalls: Array<string | undefined> = [];
+	const homeResetCalls: string[][] = [];
 	const client = {
 		sessionId: current.id,
-		async listSessions(): Promise<SessionInfo[]> {
-			return [current];
+		get groups(): string[] {
+			return [...(current.groups ?? [current.group ?? "default"])];
 		},
-		updatePresence(updates: { group?: string }): boolean {
-			if (updates.group !== undefined) {
-				current = { ...current, group: updates.group };
-				presenceGroups.push(updates.group);
-			}
+		async listSessions(group?: string): Promise<SessionInfo[]> {
+			const peer = (id: string, membership: string): SessionInfo => ({
+				...current,
+				id,
+				name: id,
+				groups: [membership],
+				group: membership,
+			});
+			if (group === "default") return [current];
+			if (group !== undefined) return [current, peer(`${group}-peer`, group)];
+			return [current, peer("team-a-peer", "team-a"), peer("other-peer", "other")];
+		},
+		async listGroups(): Promise<GroupSummary[]> {
+			return [
+				{ group: "build", sessionCount: 1, member: current.groups?.includes("build") ?? false },
+				...(current.groups ?? [])
+					.filter((group) => group !== "build")
+					.map((group) => ({ group, sessionCount: 1, member: true })),
+			];
+		},
+		async joinGroup(group: string): Promise<string[]> {
+			const groups = [...new Set([...(current.groups ?? []), group])];
+			current = { ...current, groups };
+			return groups;
+		},
+		async leaveGroup(group?: string): Promise<string[]> {
+			leaveCalls.push(group);
+			const groups =
+				group === undefined ? [homeGroup] : (current.groups ?? []).filter((membership) => membership !== group);
+			current = { ...current, groups: groups.length > 0 ? groups : ["default"] };
+			return current.groups ?? ["default"];
+		},
+		async updatePresenceAcked(updates: { groups?: string[] }): Promise<string> {
+			const groups = updates.groups ?? [homeGroup];
+			homeResetCalls.push([...groups]);
+			current = { ...current, groups };
+			return groups[0] ?? "default";
+		},
+		updatePresence(): boolean {
 			return true;
-		},
-		async updatePresenceAcked(updates: { group?: string }): Promise<string> {
-			if (!client.updatePresence(updates)) throw new Error("connection is not writable");
-			return current.group ?? "default";
 		},
 		async send() {
 			return { id: "message-id", delivered: true };
@@ -75,10 +107,10 @@ function fixture(homeGroup = "default") {
 			ensureConnected: async () => client,
 			syncPresenceIdentity() {},
 			homeGroup: () => homeGroup,
-			setJoinedGroup(group: string) {
-				joinedGroups.push(group);
+			setJoinedGroups(groups: readonly string[]) {
+				joinedGroups.push([...groups]);
 			},
-			clearJoinedGroup() {
+			clearJoinedGroups() {
 				cleared += 1;
 			},
 			confirmSend: false,
@@ -90,8 +122,9 @@ function fixture(homeGroup = "default") {
 	assert.ok(tool);
 	return {
 		tool,
-		presenceGroups,
 		joinedGroups,
+		leaveCalls,
+		homeResetCalls,
 		get cleared() {
 			return cleared;
 		},
@@ -114,7 +147,7 @@ test("heavy tool guidance teaches exact known workflow-stage targets without rep
 	assert.match(guidance, /live session/i);
 });
 
-test("join changes the broker presence group and leave returns to home", async () => {
+test("join is additive and leave without a group returns home", async () => {
 	const current = fixture();
 
 	const joined = await current.tool.execute(
@@ -125,28 +158,78 @@ test("join changes the broker presence group and leave returns to home", async (
 		context,
 	);
 	assert.equal(joined.isError, false, joined.content[0]?.text);
-	assert.equal(current.current.group, "team-a");
-	assert.deepEqual(current.joinedGroups, ["team-a"]);
+	assert.deepEqual(current.joinedGroups, [["default", "team-a"]]);
+	assert.deepEqual(joined.details?.groups, ["default", "team-a"]);
 
 	const status = await current.tool.execute("status", { action: "status" }, undefined, undefined, context);
 	assert.equal(status.isError, false, status.content[0]?.text);
-	assert.match(status.content[0]?.text ?? "", /Group: team-a/);
+	assert.match(status.content[0]?.text ?? "", /Groups: default, team-a/);
 
 	const left = await current.tool.execute("leave", { action: "leave" }, undefined, undefined, context);
 	assert.equal(left.isError, false, left.content[0]?.text);
-	assert.equal(current.current.group, "default");
-	assert.deepEqual(current.presenceGroups, ["team-a", "default"]);
+	assert.deepEqual(current.current.groups, ["default"]);
+	assert.deepEqual(current.leaveCalls, []);
+	assert.deepEqual(current.homeResetCalls, [["default"]]);
 	assert.equal(current.cleared, 1);
 });
 
-test("join rejects reserved auto-group sentinels without changing presence", async () => {
+test("status applies a group filter even when the session belongs to that group", async () => {
+	const current = fixture();
+	await current.tool.execute("join", { action: "join", group: "team-a" }, undefined, undefined, context);
+
+	const status = await current.tool.execute(
+		"status",
+		{ action: "status", group: "default" },
+		undefined,
+		undefined,
+		context,
+	);
+
+	assert.equal(status.isError, false, status.content[0]?.text);
+	assert.match(status.content[0]?.text ?? "", /Active visible sessions: 3/);
+	assert.deepEqual(current.homeResetCalls, []);
+	assert.match(status.content[0]?.text ?? "", /Selected group \[default\]: 1 session/);
+});
+
+test("leave removes only the named membership and keeps the others", async () => {
+	const current = fixture();
+	await current.tool.execute("join", { action: "join", group: "reviewers" }, undefined, undefined, context);
+	await current.tool.execute("join", { action: "join", group: "build" }, undefined, undefined, context);
+
+	const left = await current.tool.execute(
+		"leave",
+		{ action: "leave", group: "reviewers" },
+		undefined,
+		undefined,
+		context,
+	);
+
+	assert.equal(left.isError, false, left.content[0]?.text);
+	assert.deepEqual(left.details?.groups, ["default", "build"]);
+	assert.deepEqual(current.current.groups, ["default", "build"]);
+	assert.deepEqual(current.leaveCalls, ["reviewers"]);
+});
+
+test("groups discovers every available group and marks this session's memberships", async () => {
+	const current = fixture();
+	await current.tool.execute("join", { action: "join", group: "reviewers" }, undefined, undefined, context);
+
+	const result = await current.tool.execute("groups", { action: "groups" }, undefined, undefined, context);
+
+	assert.equal(result.isError, false, result.content[0]?.text);
+	assert.match(result.content[0]?.text ?? "", /build.*1 session/);
+	assert.match(result.content[0]?.text ?? "", /default.*member/);
+	assert.match(result.content[0]?.text ?? "", /reviewers.*member/);
+});
+
+test("join rejects reserved auto-group sentinels without changing membership", async () => {
 	const current = fixture();
 
 	const result = await current.tool.execute("join", { action: "join", group: "AUTO" }, undefined, undefined, context);
 
 	assert.equal(result.isError, true);
 	assert.match(result.content[0]?.text ?? "", /reserved/);
-	assert.deepEqual(current.presenceGroups, []);
+	assert.deepEqual(current.current.groups, ["default"]);
 });
 
 test("leave rejects a reserved home group without sending a broker update", async () => {
@@ -156,5 +239,5 @@ test("leave rejects a reserved home group without sending a broker update", asyn
 
 	assert.equal(result.isError, true);
 	assert.match(result.content[0]?.text ?? "", /reserved/);
-	assert.deepEqual(current.presenceGroups, []);
+	assert.deepEqual(current.leaveCalls, []);
 });


### PR DESCRIPTION
Slice 3 of the multi-group Intercom stack (supersedes #2743, which stopped receiving workflow runs after the stack recovery).

Tracks the full membership set in the Intercom client and exposes it through the tool: `join` is additive and reports resulting membership, `leave` takes an optional group name, and a new `groups` action lists every available group with membership markers so a group can be discovered rather than guessed. `status` reports all groups the session is in.

Single-group sessions behave exactly as before.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790509096&installation_model_id=10562&pr_number=2746&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2746&signature=5e744b112e9142507b699374ec3e863c65ae1dbb4b6db2d214638d4083b28b60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change lets Intercom sessions hold multiple group memberships. Joining adds a membership, targeted leave removes only the selected membership, bare leave restores the startup home group, and the new group listing exposes available groups and membership markers.

The exercised failure paths were disproved by an isolated real-broker run with four clients: targeted leave retained the remaining membership, reconnect registration retained the complete acknowledged membership set, shared-group recipients were visible and received messages, and an unrelated client was refused delivery. The focused Intercom unit suites also passed all 17 tests.

No issues were found, and the change is safe to merge.

<h3>Confidence Score: 5/5</h3>

The multi-group membership behavior preserves delivery isolation and reconnect state in the exercised real-broker flow.

No publishable findings remain after focused unit coverage and an isolated broker run exercised membership changes, reconnect registration, visibility, allowed delivery, and denied outsider delivery.

**Files Needing Attention:** No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused Intercom client and tool unit suites; all 17 tests passed.
- Ran an executable Vitest harness against an isolated real broker with bridge, alpha, beta, and outsider clients; messages were delivered to alpha and beta, while the outsider delivery returned delivered: false and emitted no outsider message event, confirming membership-preservation and isolation paths.
- The bridge client progressed from alpha to alpha,beta, briefly left beta while retaining alpha, then rejoined beta, with final visibility to alpha, beta, and bridge.
- A new real client registered using the prior acknowledged groups and retained alpha,beta, with visibility to alpha, beta, and itself.
- Isolation was confirmed: messages to alpha and beta were delivered, while an outsider message attempted delivery returned delivered: false and produced no outsider event.

<a href="https://app.greptile.com/trex/runs/21224232/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(intercom): preserve single-group too..."](https://github.com/bastani-inc/atomic/commit/e1146aba1cb23500da2dcd6e26d6a13859f98972) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57882779)</sub>

<!-- /greptile_comment -->