### PR TITLE
test(intercom): wait for the condition, not the clock

### DIFF
--- a/test/unit/intercom-concurrent-ask.test.ts
+++ b/test/unit/intercom-concurrent-ask.test.ts
@@ -9,6 +9,35 @@ import { type ReplyWaiterRecord, ReplyWaiterRegistry } from "../../packages/inte
 import type { SessionInfo } from "../../packages/intercom/types.js";
 import { sleep } from "../helpers/runtime.js";
 
+/**
+ * The fixture's scripted send delay, and the budget a test gives work that must
+ * finish after it.
+ *
+ * These tests used to sleep a fixed wall-clock span and then assert the work had
+ * finished — `sleep(20)` against a 15 ms send left five milliseconds of headroom.
+ * vitest runs test files in parallel, so on a loaded machine that margin vanishes
+ * and the assertion fails for a reason that has nothing to do with the code under
+ * test. AGENTS.md is explicit that a test which only passes on an idle machine is
+ * a bug in that test.
+ *
+ * `settles` waits for the condition instead of for the clock: it returns as soon
+ * as the predicate holds, so an idle machine is faster than the old fixed sleep,
+ * and a loaded one waits up to SETTLE_BUDGET_MS rather than failing. The budget is
+ * two orders of magnitude above the work it covers, so exhausting it means the
+ * condition is genuinely unreachable, not merely late.
+ */
+const SEND_DELAY_MS = 15;
+const SETTLE_BUDGET_MS = 2_000;
+const SETTLE_POLL_MS = 1;
+
+async function settles(condition: () => boolean, description: string): Promise<void> {
+	const deadline = Date.now() + SETTLE_BUDGET_MS;
+	while (!condition()) {
+		assert.ok(Date.now() < deadline, `timed out after ${SETTLE_BUDGET_MS}ms waiting until ${description}`);
+		await sleep(SETTLE_POLL_MS);
+	}
+}
+
 type ToolResult = { content: Array<{ text: string }>; isError: boolean };
 type Tool = {
 	execute(
@@ -160,15 +189,14 @@ describe("concurrent blocking intercom requests", () => {
 		const resolveGate = new Promise<void>((resolve) => {
 			release = resolve;
 		});
-		const current = fixture({ send: { delayMs: 15 }, resolveGate });
+		const current = fixture({ send: { delayMs: SEND_DELAY_MS }, resolveGate });
 
 		// Start both in the same tick, as parallel sibling tool calls do.
 		const first = current.ask();
 		const second = current.ask();
 		await sleep(0);
 		release();
-		await sleep(20);
-		assert.equal(current.sent.length, 2, "both asks send their questions");
+		await settles(() => current.sent.length === 2, "both asks send their questions");
 		current.replyToPending();
 		current.replyToPending();
 		for (const result of await Promise.all([first, second])) {
@@ -182,14 +210,16 @@ describe("concurrent blocking intercom requests", () => {
 		const resolveGate = new Promise<void>((resolve) => {
 			release = resolve;
 		});
-		const current = fixture({ send: { delayMs: 15 }, resolveGate });
+		const current = fixture({ send: { delayMs: SEND_DELAY_MS }, resolveGate });
 
 		const askExecution = current.ask();
 		const superviseExecution = current.supervise();
 		await sleep(0);
 		release();
-		await sleep(20);
-		assert.equal(current.slot.size(), 2);
+		await settles(
+			() => current.slot.size() === 2 && current.sent.length === 2,
+			"the peer ask and the supervisor wait are both admitted and sent",
+		);
 		current.replyToPending();
 		current.replyToPending();
 
@@ -205,8 +235,10 @@ describe("concurrent blocking intercom requests", () => {
 		const loser = await current.supervise();
 		assert.equal(loser.isError, true);
 		assert.match(loser.content[0]?.text ?? "", /Already waiting for a supervisor reply/);
-		await sleep(15);
-		assert.equal(current.slot.size(), 1);
+		await settles(
+			() => current.slot.size() === 1 && current.sent.length === 1,
+			"only the winning supervisor wait remains, and it has sent",
+		);
 		current.replyToPending();
 		assert.equal((await winner).isError, false);
 	});
@@ -238,10 +270,9 @@ describe("concurrent blocking intercom requests", () => {
 		};
 		const children = [0, 1, 2].map((childIndex) => fixture({ claimParent: claimOnce, childIndex }));
 		const executions = children.map((child) => child.supervise());
-		await sleep(5);
-		assert.deepEqual(
-			children.map((child) => child.slot.size()),
-			[0, 1, 1],
+		await settles(
+			() => children.every((child, index) => child.slot.size() === (index === 0 ? 0 : 1)),
+			"the claiming child holds no waiter and each loser holds exactly one",
 		);
 		assert.match((await executions[0]!).content[0]?.text ?? "", /Parent ask claimed/);
 		const loserIds = children.slice(1).map((child) => child.slot.pending()[0]!.replyTo);
@@ -261,7 +292,7 @@ describe("concurrent blocking intercom requests", () => {
 
 		const retryable = fixture();
 		const retried = retryable.ask();
-		await sleep(5);
+		await settles(() => retryable.slot.has(), "the retried ask reserves the slot");
 		retryable.replyToPending();
 		assert.equal((await retried).isError, false);
 	});
@@ -270,8 +301,7 @@ describe("concurrent blocking intercom requests", () => {
 		const current = fixture();
 		const controller = new AbortController();
 		const execution = current.ask(controller.signal);
-		await sleep(5);
-		assert.ok(current.slot.has(), "the ask is waiting before cancellation");
+		await settles(() => current.slot.has(), "the ask is waiting before cancellation");
 		controller.abort();
 		const result = await execution;
 		assert.equal(result.isError, true);
@@ -279,7 +309,7 @@ describe("concurrent blocking intercom requests", () => {
 		assert.equal(current.slot.has(), false);
 
 		const next = current.ask();
-		await sleep(5);
+		await settles(() => current.slot.has(), "the next ask reserves the freed slot");
 		current.replyToPending();
 		assert.equal((await next).isError, false);
 	});
@@ -288,7 +318,7 @@ describe("concurrent blocking intercom requests", () => {
 		const current = fixture();
 		const controller = new AbortController();
 		const execution = current.supervise(controller.signal);
-		await sleep(5);
+		await settles(() => current.slot.has(), "the supervisor wait is registered before cancellation");
 		controller.abort();
 		const result = await execution;
 		assert.equal(result.isError, true);
@@ -306,10 +336,9 @@ describe("concurrent blocking intercom requests", () => {
 		const loser = current.ask();
 		await sleep(0);
 		release();
-		await sleep(5);
+		await settles(() => current.slot.size() === 2, "both asks are admitted");
 
 		const waiter = current.slot.pending();
-		assert.ok(waiter);
 		const misrouted = routeIncomingReply(waiter, from, {
 			id: "unrelated",
 			timestamp: Date.now(),
@@ -339,9 +368,7 @@ describe("concurrent blocking intercom requests", () => {
 		const firstB = current.ask(undefined, "b");
 		const secondB = current.ask(undefined, "b");
 		const onlyC = current.ask(undefined, "c");
-		await sleep(5);
-
-		assert.equal(current.slot.size(), 3);
+		await settles(() => current.slot.size() === 3, "all three asks are admitted");
 		const bWaiters = current.slot.pending().filter((waiter) => waiter.from === "b");
 		const cWaiter = current.slot.pending().find((waiter) => waiter.from === "c");
 		assert.equal(bWaiters.length, 2);
@@ -392,15 +419,12 @@ describe("concurrent blocking intercom requests", () => {
 		const controller = new AbortController();
 
 		const first = current.ask(controller.signal);
-		await sleep(5);
-		assert.ok(current.slot.has(), "the first ask reserves the slot before it is aborted");
+		await settles(() => current.slot.has(), "the first ask reserves the slot before it is aborted");
 		controller.abort();
-		await sleep(0);
-		assert.equal(current.slot.has(), false, "aborting mid-send releases the reservation");
+		await settles(() => !current.slot.has(), "aborting mid-send releases the reservation");
 
 		const second = current.ask();
-		await sleep(5);
-		assert.ok(current.slot.has(), "a second ask reserves the freed slot");
+		await settles(() => current.slot.has(), "a second ask reserves the freed slot");
 
 		const firstResult = await first;
 		assert.equal(firstResult.isError, true);


### PR DESCRIPTION
## The failure

`test/unit/intercom-concurrent-ask.test.ts` failed a CI gate with a message that says nothing about the code under test:

```
× two concurrent asks are both admitted and complete independently
  AssertionError: both asks send their questions — 1 !== 2
```

The test slept a fixed wall-clock span and then asserted the work had finished. The narrowest margin in the file was five milliseconds — the fixture sends with `delayMs: 15`, and the test does `await sleep(20)` before asserting both sends landed.

vitest runs test files in parallel and this repository deliberately sets no `pool`, `maxWorkers`, `poolOptions`, or `fileParallelism`. Five milliseconds is not margin under that. `AGENTS.md` is explicit:

> A test that only passes on an idle machine is a bug in that test. Fix it where it lives.

## The fix

Every `sleep(N)`-then-assert becomes `settles(condition, description)`, which polls until the condition holds and fails only after `SETTLE_BUDGET_MS`:

```ts
const SEND_DELAY_MS = 15;
const SETTLE_BUDGET_MS = 2_000;
const SETTLE_POLL_MS = 1;

async function settles(condition: () => boolean, description: string): Promise<void> {
	const deadline = Date.now() + SETTLE_BUDGET_MS;
	while (!condition()) {
		assert.ok(Date.now() < deadline, `timed out after ${SETTLE_BUDGET_MS}ms waiting until ${description}`);
		await sleep(SETTLE_POLL_MS);
	}
}
```

This waits for the condition rather than for the clock, so an idle machine finishes **sooner** than the old fixed sleep and a loaded one waits instead of failing. The budget sits two orders of magnitude above the work it covers, so exhausting it means the condition is genuinely unreachable rather than merely late.

Thirteen call sites across the file carried the same pattern, not just the one that failed. All are converted.

## The assertions still mean what they meant

Where a fixed sleep *also* implied the send had completed, the condition now says so rather than inferring it from elapsed time:

```ts
await settles(
	() => current.slot.size() === 2 && current.sent.length === 2,
	"the peer ask and the supervisor wait are both admitted and sent",
);
```

Nothing is skipped, weakened, retried, or serialized, and no `--timeout` or per-test budget is introduced.

## Evidence

The point is that the dependency on wall-clock ordering is **gone**, not widened. Raising the scripted send above the old fixed sleep separates the two:

| Scripted send | Old test | New test |
| --- | --- | --- |
| 15 ms (as shipped) | passes | passes |
| 25 ms | **fails** — `sleep(20)` expires first | passes |

The old version fails deterministically at 25 ms because its correctness depended on the send finishing inside a fixed window. The new version does not have a window.

Also run: `npx biome check` clean, `npx tsc --noEmit` clean, and the file passes three consecutive runs and one run under twelve saturating busy loops.

## Scope

Test-only. No shipped package behaviour changes, so no changelog entry — `AGENTS.md` reserves `packages/*/CHANGELOG.md` for user-facing release notes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790525255&installation_model_id=10562&pr_number=2747&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2747&signature=6906196eb9f0a834e34337aa18dc21b97dbae5d39742c53706811362586e3457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change replaces fixed sleeps in concurrent Intercom tests with condition-based waiting. The parallel-child test still advances after reply waiters are registered, before the two losing children finish their delayed sends. A focused execution reproduced that state with the expected waiter slots and zero recorded sends, so the following send-count assertion can fail under normal asynchronous scheduling.

<h3>Confidence Score: 4/5</h3>

The change is not ready to merge because the updated wait condition can allow its following assertion to run before the required send operations complete.

Focused execution of the real handoff, waiter-registration, and delayed-send path deterministically reached the current condition with zero completed loser sends, then showed the count reaches two only after explicitly waiting for sends.

**Files Needing Attention:** test/unit/intercom-concurrent-ask.test.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a focused reproduction for the slot-only wait race tied to the posted P1 finding, including a focused reproduction source and a Vitest configuration.
- A second P1 finding proof was posted; no artifacts were attached to this proof.
- For the general-contract-validation-proof, T-Rex validated the behavior by showing that waiter admission precedes the await and that after capture releasing delayed sends yields two sent events, satisfying the missing condition for the assertion.

<a href="https://app.greptile.com/trex/runs/21262578/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Slot-only wait can race the loser send-count assertion**

   - **Bug**
     - In `test/unit/intercom-concurrent-ask.test.ts:273-280`, `settles` returns as soon as child slot sizes are `[0,1,1]`, but it does not require the two loser `sendToSupervisor` calls to have completed. The following `sent.length` sum can consequently be 0, 1, or 2. The executed reproduction deterministically observed the predicate true with `sent: 0`, and verified that an equivalent immediate assertion for 2 throws.
   - **Cause**
     - `packages/intercom/contact-supervisor-tool.ts:249-265` synchronously registers a reply waiter at line 249 before awaiting `sendToSupervisor` at line 261. Slot size therefore signals waiter admission, not send completion.
   - **Fix**
     - Extend the predicate at `test/unit/intercom-concurrent-ask.test.ts:274` to also require `children[1]!.sent.length + children[2]!.sent.length === 2` (or wait for that equivalent explicit condition) before the line-280 assertion.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
test/unit/intercom-concurrent-ask.test.ts:273-276
**Wait omits send completion**

This condition becomes true once the losing children register their reply waiters, but waiter registration occurs before their delayed `sendToSupervisor` calls append to `sent`. The following assertion can therefore run with zero or one completed sends and fail intermittently. Also require `children[1]!.sent.length + children[2]!.sent.length === 2` before proceeding.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(intercom): wait for the condition, ..."](https://github.com/bastani-inc/atomic/commit/0f86c5fd6e154cc198141d37ad21c9ed11b1281c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57960002)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->