### PR TITLE
docs(changelog): prepare 0.9.16-alpha.10 release notes

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,8 @@ This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history at t
 
 ## [Unreleased]
 
+## [0.9.16-alpha.10] - 2026-08-28
+
 ### Fixed
 
 - Fixed fragmented Mistral tool calls splitting when continuation chunks omit the tool-call ID ([#8387](https://github.com/earendil-works/pi/issues/8387)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.16-alpha.10] - 2026-08-28
+
 ### Breaking Changes
 
 - `AgentSession` now invokes a caller-supplied `Agent.shouldStopAfterTurn` callback before `prepareNextTurn` or `prepareNextTurnWithContext`. Preparation runs only after the loop or a non-empty steering/follow-up queue establishes that another assistant turn will start; it no longer runs after final responses, terminating tool batches without queued work, or a stop callback that returns `true`. For a post-tool threshold crossing, Atomic compacts first, passes that compacted context to preparation, and uses the caller's complete returned replacement for the next provider request. Callers that used preparation as an after-every-turn notification must move that work to `shouldStopAfterTurn` or session events ([#6879](https://github.com/earendil-works/pi/issues/6879)).

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.16-alpha.10] - 2026-08-28
+
 ### Added
 
 - Intercom sessions can now hold multiple group memberships. Runtime `join` is additive, targeted `leave` removes one membership, bare `leave` resets to the startup home group, and the new `groups` action discovers every available group with session counts and membership markers. `list` remains session discovery, `status` reports the complete membership set, legacy single-group clients retain their existing behavior, and `contact_supervisor` keeps its capability-based cross-group route.

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.16-alpha.10] - 2026-08-28
+
 ### Changed
 
 - Added the full and Flash GLM-5.3 direct Z.AI, Z.AI Coding Plan, Baseten, and OpenRouter routes to every built-in subagent fallback chain.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.16-alpha.10] - 2026-08-28
+
 ### Changed
 
 - Added the full and Flash GLM-5.3 direct Z.AI, Z.AI Coding Plan, Baseten, and OpenRouter routes to every built-in Goal, Ralph, and Open Claude Design fallback chain.


### PR DESCRIPTION
## Summary

Prepares the package changelogs for the `0.9.16-alpha.10` prerelease by moving the accumulated `[Unreleased]` entries into dated release sections. This changelog-only PR must merge before the release tag is cut.

## Changes

- Records the `AgentSession` turn-boundary changes, compaction fixes, and queued continuation stop behavior.
- Records direct GLM-5.3 model and fallback-chain updates for Atomic, subagents, and workflows.
- Records Intercom multi-group membership and workflow-stage routing guidance.
- Records the Mistral fragmented tool-call fix and stale workflow persistence-port handling.

## Scope

The diff contains only these files:

- `packages/ai/CHANGELOG.md`
- `packages/coding-agent/CHANGELOG.md`
- `packages/intercom/CHANGELOG.md`
- `packages/subagents/CHANGELOG.md`
- `packages/workflows/CHANGELOG.md`

All eight package manifests, workspace lock entries, Cargo metadata, and generated native version checks remain at `0.0.0`. The target version appears nowhere outside package changelogs.

`main` stays versionless. After this PR merges, `scripts/cut-release.ts` will stamp `0.9.16-alpha.10` only on the detached release commit. Pushing that tag starts `publish.yml`; this PR does not tag or publish.

## Validation

- `bun run check`
- `bun run vitest --run --project unit test/unit/build-release-notes.test.ts test/unit/changelog.test.ts test/unit/package-metadata.test.ts test/unit/bump-version-script.test.ts` (35 tests passed)
- `bun run scripts/build-release-notes.ts 0.9.16-alpha.10`
- Bun-based versionless invariant check across package manifests, `package-lock.json`, Cargo metadata, and `packages/natives/native/index.js`
- `git diff --check`

Assistant-model: GPT-5.6 Sol

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790541994&installation_model_id=10562&pr_number=2753&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2753&signature=c47030f25aeee5ef52c23eb120f7d5f622a55025baff1aa4c46d04a6551e0d1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds dated `0.9.16-alpha.10` release sections to the AI, coding-agent, Intercom, subagents, and workflows changelogs. The release-notes generator successfully included all entries from the five new sections and emitted no `Unreleased` content. No defects were found.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the new release headings are accepted by the repository’s release-note generation flow and include the intended package entries.

The release-note command completed successfully against the edited changelogs, with explicit checks confirming that all five package sections were included and not attributed to Unreleased.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Removed the five 0.9.16-alpha.10 headings in a temporary fixture and ran the release-notes generator; it exited with its explicit missing-version error.
- Ran the release-notes generator against the repository’s actual changelogs for 0.9.16-alpha.10; the run completed successfully and produced merged notes for Breaking Changes, Added, Changed, and Fixed.
- Compared the generated output with the edited changelog and confirmed that all five package sections were included and there was no Unreleased attribution.
- Validated the before/after behavior described in the control: removing the headings caused an explicit no-version exit, while the after state produced exit code 0 with explicit per-package inclusion passes, and no repository files were modified; only command-output captures were created in trex-artifacts.

<a href="https://app.greptile.com/trex/runs/21314873/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.16-alpha.10..."](https://github.com/bastani-inc/atomic/commit/347080cf75c7576b70362e68ba9b2d048802c802) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58059431)</sub>

<!-- /greptile_comment -->