### PR TITLE
fix(workflows): align package module loading

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed workflow discovery helpers from Git-installed production-only packages by making the workflow module loader resolve the same supported TypeBox runtime aliases as extension loading, including `typebox/compile`, `typebox/value`, and legacy `@sinclair/typebox` subpaths.
+
 ## [0.9.16-alpha.10] - 2026-08-28
 
 ### Breaking Changes

--- a/packages/coding-agent/docs/packages.md
+++ b/packages/coding-agent/docs/packages.md
@@ -177,7 +177,7 @@ If no app manifest (`atomic`, or legacy `pi`) is present, Atomic auto-discovers 
 - `skills/` recursively finds `SKILL.md` folders and loads top-level `.md` files as skills
 - `prompts/` loads `.md` files
 - `themes/` loads `.json` files
-- `workflows/` loads workflow SDK files (`.ts`, `.js`, `.mjs`, `.cjs`); `workflow/` is also accepted as a singular alias. Workflow files import `workflow` from `@bastani/atomic/workflows`, import `Type` from `typebox`, and export the definition returned by `workflow({ ... })`. TypeScript resolves the published `@bastani/atomic/workflows` specifier through the `@bastani/atomic` package. Atomic resolves that workflow specifier to its in-memory SDK when it loads the workflow at runtime. See Programmatic Usage in the workflows guide.
+- `workflows/` loads workflow SDK files (`.ts`, `.js`, `.mjs`, `.cjs`); `workflow/` is also accepted as a singular alias. Workflow files import `workflow` from `@bastani/atomic/workflows`, import `Type` from `typebox`, and export the definition returned by `workflow({ ... })`. TypeScript resolves the published `@bastani/atomic/workflows` specifier through the `@bastani/atomic` package. Atomic resolves that workflow specifier and the supported TypeBox root, `typebox/compile`, `typebox/value`, and legacy `@sinclair/typebox` aliases to in-memory host modules when it loads the workflow at runtime. See Programmatic Usage in the workflows guide.
 
 When a package manifest exists, declared resource arrays normally define what loads. Workflows are the exception: if `atomic.workflows` / legacy `pi.workflows` is omitted, Atomic still checks conventional `workflows/` and `workflow/` directories.
 

--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -3741,9 +3741,9 @@ Workflow stage sessions inherit the same package and temporary `-e` resource dis
 
 ## Programmatic usage
 
-`@bastani/atomic/workflows` is Atomic's published workflow SDK. Import `workflow` from that specifier, import `Type` from `typebox`, and export the definition returned by `workflow({...})`. Keep runtime helpers such as widget factories and shared utilities in a subdirectory outside the top-level discovery scan, such as `.atomic/workflows/lib/`; see [Workflow Locations](#workflow-locations).
+`@bastani/atomic/workflows` is Atomic's published workflow SDK. Import `workflow` from that specifier, import `Type` from `typebox`, and export the definition returned by `workflow({...})`. Workflow helpers may also import the host TypeBox runtime subpaths `typebox/compile` and `typebox/value`; the legacy `@sinclair/typebox` root and matching subpaths remain supported. Keep runtime helpers such as widget factories and shared utilities in a subdirectory outside the top-level discovery scan, such as `.atomic/workflows/lib/`; see [Workflow Locations](#workflow-locations).
 
-Package authors list both `@bastani/atomic` and `typebox` in `peerDependencies`. The `@bastani/atomic` package publishes compiled JavaScript and declarations for `@bastani/atomic/workflows`, `@bastani/atomic/workflows/builtin`, and each `@bastani/atomic/workflows/builtin/*` module. TypeScript resolves those exports directly under `moduleResolution: NodeNext`. When Atomic executes a workflow file, its runtime loader resolves the same published specifiers to Atomic's in-memory SDK.
+Package authors list both `@bastani/atomic` and `typebox` in `peerDependencies`. The `@bastani/atomic` package publishes compiled JavaScript and declarations for `@bastani/atomic/workflows`, `@bastani/atomic/workflows/builtin`, and each `@bastani/atomic/workflows/builtin/*` module. TypeScript resolves those exports directly under `moduleResolution: NodeNext`. When Atomic executes a workflow file or an imported helper, its runtime loader resolves the workflow SDK and supported TypeBox aliases to the same in-memory host modules. It intentionally does not expose extension-only host modules such as the agent core, UI, provider transport, or lockfile implementation.
 
 ```ts
 import { workflow } from "@bastani/atomic/workflows";

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Git-installed workflow discovery when production-only package installs omit local TypeBox by resolving `typebox/compile`, `typebox/value`, and supported legacy `@sinclair/typebox` aliases through the host loader for workflow files and their helpers.
+
 ## [0.9.16-alpha.10] - 2026-08-28
 
 ### Changed

--- a/packages/workflows/src/extension/workflow-module-loader.ts
+++ b/packages/workflows/src/extension/workflow-module-loader.ts
@@ -8,6 +8,8 @@
 
 import { createJiti } from "jiti/static";
 import * as typeboxModule from "typebox";
+import * as typeboxCompileModule from "typebox/compile";
+import * as typeboxValueModule from "typebox/value";
 import adversarialVerification from "../../builtin/adversarial-verification.js";
 import classifyAndAct from "../../builtin/classify-and-act.js";
 import fanOutAndSynthesize from "../../builtin/fan-out-and-synthesize.js";
@@ -60,11 +62,30 @@ function createWorkflowVirtualModules(moduleSpecifier: string): Record<string, u
 		[`${builtinModuleSpecifier}/steering-context`]: steeringContext,
 	};
 }
+// Workflow modules share the host's TypeBox peer instance. The other host
+// virtual modules are extension execution dependencies (agent core, UI, model
+// transport, and lockfile handling), not workflow-authoring dependencies, so
+// they intentionally stay out of this loader.
+const TYPEBOX_COMPILE_MODULE: Record<string, unknown> = {
+	...typeboxCompileModule,
+};
+const TYPEBOX_VALUE_MODULE: Record<string, unknown> = {
+	...typeboxValueModule,
+};
 
 const WORKFLOWS_VIRTUAL_MODULES: Record<string, unknown> = {
 	...createWorkflowVirtualModules(WORKFLOWS_MODULE_SPECIFIER),
 	...createWorkflowVirtualModules(LEGACY_WORKFLOWS_MODULE_SPECIFIER),
 	[TYPEBOX_MODULE_SPECIFIER]: TYPEBOX_MODULE,
+	"typebox/compile": TYPEBOX_COMPILE_MODULE,
+	"typebox/value": TYPEBOX_VALUE_MODULE,
+	"@sinclair/typebox": TYPEBOX_MODULE,
+	"@sinclair/typebox/compile": TYPEBOX_COMPILE_MODULE,
+	"@sinclair/typebox/value": TYPEBOX_VALUE_MODULE,
+};
+
+export const workflowModuleLoaderTestHooks = {
+	getVirtualModuleSpecifiers: (): string[] => Object.keys(WORKFLOWS_VIRTUAL_MODULES),
 };
 
 const workflowModuleLoader = createJiti(import.meta.url, {

--- a/test/unit/workflow-module-discovery.test.ts
+++ b/test/unit/workflow-module-discovery.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, test } from "vitest";
-import { extensionLoaderTestHooks } from "../../packages/coding-agent/src/core/extensions/loader-virtual-modules.ts";
+import { extensionLoaderTestHooks } from "../../packages/coding-agent/src/core/extensions/loader-virtual-modules.js";
 import {
 	loadWorkflowModule,
 	validateWorkflowDefinitionShape,

--- a/test/unit/workflow-module-discovery.test.ts
+++ b/test/unit/workflow-module-discovery.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, test } from "vitest";
+import { extensionLoaderTestHooks } from "../../packages/coding-agent/src/core/extensions/loader-virtual-modules.ts";
+import {
+	loadWorkflowModule,
+	validateWorkflowDefinitionShape,
+	workflowModuleLoaderTestHooks,
+} from "../../packages/workflows/src/extension/workflow-module-loader.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function tempDir(prefix: string): string {
+	const dir = mkdtempSync(join(tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+function isTypeBoxAlias(specifier: string): boolean {
+	return (
+		specifier === "typebox" ||
+		specifier.startsWith("typebox/") ||
+		specifier === "@sinclair/typebox" ||
+		specifier.startsWith("@sinclair/typebox/")
+	);
+}
+
+describe("workflow module host-peer aliases", () => {
+	test("keeps TypeBox aliases in parity without importing extension-only host modules", async () => {
+		const extensionVirtualAliases = Object.keys(await extensionLoaderTestHooks.loadVirtualModules());
+		const extensionNodeAliases = Object.keys(extensionLoaderTestHooks.getAliases());
+		const workflowAliases = workflowModuleLoaderTestHooks.getVirtualModuleSpecifiers();
+		const workflowTypeBoxAliases = workflowAliases.filter(isTypeBoxAlias).sort();
+
+		assert.deepEqual(
+			workflowTypeBoxAliases,
+			extensionVirtualAliases.filter(isTypeBoxAlias).sort(),
+			"workflow aliases diverged from the extension loader's bundled/virtual path",
+		);
+		assert.deepEqual(
+			workflowTypeBoxAliases,
+			extensionNodeAliases.filter(isTypeBoxAlias).sort(),
+			"workflow aliases diverged from the extension loader's Node/development path",
+		);
+		const workflowSpecificAliases = workflowAliases.filter((specifier) => !isTypeBoxAlias(specifier));
+		assert.ok(workflowSpecificAliases.length > 0);
+		assert.ok(
+			workflowSpecificAliases.every(
+				(specifier) =>
+					specifier === "@bastani/atomic/workflows" ||
+					specifier.startsWith("@bastani/atomic/workflows/") ||
+					specifier === "@bastani/workflows" ||
+					specifier.startsWith("@bastani/workflows/"),
+			),
+		);
+		for (const extensionAliases of [extensionVirtualAliases, extensionNodeAliases]) {
+			const sharedNonTypeBoxAliases = workflowAliases.filter(
+				(specifier) => extensionAliases.includes(specifier) && !isTypeBoxAlias(specifier),
+			);
+			assert.deepEqual(sharedNonTypeBoxAliases, []);
+		}
+		assert.ok(extensionVirtualAliases.includes("@bastani/pi-ai"));
+		assert.ok(extensionNodeAliases.includes("@bastani/pi-ai"));
+	});
+});
+
+test("executes every TypeBox alias while discovering a production-only Git package workflow", () => {
+	const packageRoot = tempDir("atomic-git-workflow-module-");
+	const workflowsDir = join(packageRoot, "workflows");
+	mkdirSync(workflowsDir, { recursive: true });
+	writeFileSync(
+		join(packageRoot, "package.json"),
+		JSON.stringify({
+			name: "production-only-workflow-package",
+			peerDependencies: { typebox: "*" },
+			devDependencies: { typebox: "*" },
+		}),
+		"utf-8",
+	);
+	writeFileSync(
+		join(workflowsDir, "typebox-aliases.ts"),
+		[
+			'import { Type as CanonicalType } from "typebox";',
+			'import { Compile as CanonicalCompile } from "typebox/compile";',
+			'import { Check as CanonicalCheck } from "typebox/value";',
+			'import { Type as LegacyType } from "@sinclair/typebox";',
+			'import { Compile as LegacyCompile } from "@sinclair/typebox/compile";',
+			'import { Check as LegacyCheck } from "@sinclair/typebox/value";',
+			"const canonicalSchema = CanonicalType.String();",
+			"const legacySchema = LegacyType.String();",
+			"export const aliasResults = {",
+			"  canonicalRoot: canonicalSchema.type === 'string',",
+			"  canonicalCompile: CanonicalCompile(canonicalSchema).Check('ok'),",
+			"  canonicalValue: CanonicalCheck(canonicalSchema, 'ok'),",
+			"  legacyRoot: legacySchema.type === 'string',",
+			"  legacyCompile: LegacyCompile(legacySchema).Check('ok'),",
+			"  legacyValue: LegacyCheck(legacySchema, 'ok'),",
+			"};",
+		].join("\n"),
+		"utf-8",
+	);
+	const workflowPath = join(workflowsDir, "discovered.ts");
+	writeFileSync(
+		workflowPath,
+		[
+			'import { Type } from "typebox";',
+			'import { workflow } from "@bastani/atomic/workflows";',
+			'import { aliasResults } from "./typebox-aliases.js";',
+			"export { aliasResults };",
+			"export default workflow({ name: 'Production-only import', description: 'test', inputs: { value: Type.String() }, outputs: {}, run: async () => ({}) });",
+		].join("\n"),
+		"utf-8",
+	);
+
+	const loaded = loadWorkflowModule(workflowPath);
+	const definition = loaded.default;
+	assert.equal(validateWorkflowDefinitionShape(definition), null);
+	assert.deepEqual(loaded.aliasResults, {
+		canonicalRoot: true,
+		canonicalCompile: true,
+		canonicalValue: true,
+		legacyRoot: true,
+		legacyCompile: true,
+		legacyValue: true,
+	});
+});

--- a/test/unit/workflow-stage-bundled-resources.test.ts
+++ b/test/unit/workflow-stage-bundled-resources.test.ts
@@ -2,7 +2,7 @@
 
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -24,6 +24,7 @@ import { type PackageSource, SettingsManager } from "../../packages/coding-agent
 import { discoverAgentsAll } from "../../packages/subagents/src/agents/agents.js";
 import type { Details } from "../../packages/subagents/src/shared/types.js";
 import {
+	buildRuntimeAdapters,
 	type PiCodingAgentSdk,
 	type PiSdkResourceLoader,
 	type PiSdkSettingsManager,
@@ -65,6 +66,10 @@ function restoreEnv(snapshot: ReadonlyMap<string, string | undefined>): void {
 		else process.env[key] = value;
 	}
 }
+type InspectableStageSession = StageSessionRuntime & {
+	getAllTools(): Array<{ name: string }>;
+	getActiveToolNames(): string[];
+};
 
 class StageDefaultResourceLoader extends DefaultResourceLoader implements PiSdkResourceLoader {
 	constructor(options: {
@@ -454,4 +459,87 @@ describe("workflow stage bundled resources", () => {
 			session.dispose();
 		}
 	});
+	test(
+		"inherits package extension tools through the real workflow stage session factory",
+		async () => {
+			const savedNodeEnv = process.env.NODE_ENV;
+			const savedNodeTestContext = process.env.NODE_TEST_CONTEXT;
+			const cwd = tempDir("atomic-workflow-stage-package-extension-cwd-");
+			const agentDir = join(cwd, "agent");
+			const packageDir = tempDir("atomic-workflow-stage-package-extension-");
+			mkdirSync(join(packageDir, ".atomic", "extensions"), { recursive: true });
+			writeFileSync(
+				join(packageDir, "package.json"),
+				JSON.stringify({ name: "workflow-stage-package-extension" }),
+				"utf-8",
+			);
+			writeFileSync(
+				join(packageDir, ".atomic", "extensions", "index.ts"),
+				[
+					"export default function register(pi) {",
+					"  pi.on('session_start', () => {",
+					"    for (const name of ['package_tool_alpha', 'package_tool_beta']) {",
+					"      pi.registerTool({ name, label: name, description: name, parameters: { type: 'object', properties: {} }, execute: async () => ({ content: [{ type: 'text', text: 'ok' }], details: {} }) });",
+					"    }",
+					"  });",
+					"}",
+				].join("\n"),
+				"utf-8",
+			);
+
+			const parentSettingsManager = SettingsManager.inMemory();
+			const parentLoader = new DefaultResourceLoader({
+				cwd,
+				agentDir,
+				settingsManager: parentSettingsManager,
+				additionalExtensionPaths: [packageDir],
+				builtinPackagePaths: getBuiltinPackagePaths(),
+			});
+			await parentLoader.reload({ resolveBorrowedProjectTrust: async () => true });
+			const { session: parentSession } = await createAgentSession({
+				cwd,
+				agentDir,
+				model: getModel("anthropic", "claude-sonnet-4-5")!,
+				settingsManager: parentSettingsManager,
+				resourceLoader: parentLoader,
+				sessionManager: SessionManager.inMemory(cwd),
+			});
+			await parentSession.bindExtensions({});
+			const parentToolNames = parentSession.getAllTools().map((tool) => tool.name);
+			assert.ok(parentToolNames.includes("package_tool_alpha"));
+			assert.ok(parentToolNames.includes("package_tool_beta"));
+
+			delete process.env.NODE_ENV;
+			delete process.env.NODE_TEST_CONTEXT;
+			try {
+				const adapters = buildRuntimeAdapters({
+					getResourceLoaderInheritanceSnapshot: () => parentLoader.getInheritanceSnapshot(),
+				});
+				const result = await adapters.agentSession!.create({
+					cwd,
+					agentDir,
+					model: getModel("anthropic", "claude-sonnet-4-5")!,
+					tools: ["package_tool_alpha", "package_tool_beta"],
+					sessionManager: SessionManager.inMemory(cwd),
+				});
+				const session = ("session" in result ? result.session : result) as InspectableStageSession;
+				try {
+					const allToolNames = session.getAllTools().map((tool) => tool.name);
+					const activeToolNames = session.getActiveToolNames();
+					assert.ok(allToolNames.includes("package_tool_alpha"), `registered tools: ${allToolNames.join(", ")}`);
+					assert.ok(allToolNames.includes("package_tool_beta"), `registered tools: ${allToolNames.join(", ")}`);
+					assert.deepEqual(activeToolNames.sort(), ["package_tool_alpha", "package_tool_beta"]);
+				} finally {
+					session.dispose();
+				}
+			} finally {
+				if (savedNodeEnv === undefined) delete process.env.NODE_ENV;
+				else process.env.NODE_ENV = savedNodeEnv;
+				if (savedNodeTestContext === undefined) delete process.env.NODE_TEST_CONTEXT;
+				else process.env.NODE_TEST_CONTEXT = savedNodeTestContext;
+				parentSession.dispose();
+			}
+		},
+		REAL_WORKFLOW_STAGE_RESOURCE_TIMEOUT_MS,
+	);
 });


### PR DESCRIPTION
## Summary

Fix workflow package loading so supported host-provided TypeBox modules resolve consistently in production-only Git installations, and add runtime coverage for package extension tools inherited by workflow stage sessions.

## Changes

- Add workflow-loader support for `typebox/compile`, `typebox/value`, and the matching legacy compatibility aliases.
- Add a parity test against both normal extension-loader implementations and execute every supported TypeBox alias through real workflow discovery.
- Add a real workflow child-session test that checks package extension tools are both registered and active.
- Document the host-module boundary and update unreleased changelogs.

## Validation

- `AGENT=1 bun test test/unit/workflow-module-discovery.test.ts test/unit/workflow-stage-bundled-resources.test.ts test/unit/resource-loader-inheritance.test.ts test/unit/wiring-adapters.test.ts` — 38 passed, 0 failed.
- `npm run typecheck` — passed.
- `npm run check` — passed, including shrinkwrap verification.
- Independent final review — approved.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790553719&installation_model_id=10562&pr_number=2756&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2756&signature=2a717b128cf280237861361a11a52dc74a7a9b5a670d8bad38dfdd528aea843d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Workflow discovery now resolves supported canonical and legacy TypeBox runtime aliases through host-provided modules, allowing production-only packages and imported workflow helpers to load successfully. The focused discovery test passed while exercising every supported alias.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

No accepted blocking findings remain after exercising the production-only workflow discovery path.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran AGENT=1 npx vitest --run --project unit test/unit/trex-typebox-git-package.test.ts against the pre-PR commit 8789f208 and observed a failure caused by the imported helper resolving typebox/compile.
- I then ran AGENT=1 npx vitest --run --project unit test/unit/workflow-module-discovery.test.ts at the PR head and confirmed both tests passed, including the production-only package and all TypeBox alias scenarios.
- This sequence confirms that the updated workflow loader resolves the previously failing helper-import path.
- Artifacts documenting the before/after runs and the reproduction test were uploaded to support review.

<a href="https://app.greptile.com/trex/runs/21346426/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(workflows): use runtime import spec..."](https://github.com/bastani-inc/atomic/commit/4153b95d9da6502b6e0c6076e29cb3f27f1fc792) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58113789)</sub>

<!-- /greptile_comment -->