### PR TITLE
fix(ui): make fast mode copy provider-neutral

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Fixed workflow discovery helpers from Git-installed production-only packages by making the workflow module loader resolve the same supported TypeBox runtime aliases as extension loading, including `typebox/compile`, `typebox/value`, and legacy `@sinclair/typebox` subpaths.
 - Fixed independent workflow launches appearing indefinitely as empty `running` runs when another workflow's DBOS write stalled. Durable write ordering and errors are isolated per root workflow without weakening the global shutdown drain.
+- Fixed `/fast` command and selector copy that still described fast mode as OpenAI/Codex-only after GitHub Copilot fast variants became eligible.
 
 ## [0.9.16-alpha.10] - 2026-08-28
 

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -318,7 +318,7 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "tree", description: "Navigate session tree (switch branches)" },
 	{ name: "thinking", description: "Set thinking level", argumentHint: "<level>" },
 	{ name: "scoped-models", description: "Enable/disable models for ctrl+p cycling" },
-	{ name: "fast", description: "Configure OpenAI fast mode for chat and workflows in supported models" },
+	{ name: "fast", description: "Configure fast mode for chat and workflows on supported models" },
 	{ name: "export", description: "Export session (HTML default, or specify path: .html/.jsonl)" },
 	{ name: "import", description: "Import and resume a session from a JSONL file" },
 	{ name: "share", description: "Share session as a secret GitHub gist" },

--- a/packages/coding-agent/src/modes/interactive/components/fast-mode-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/fast-mode-selector.ts
@@ -15,7 +15,7 @@ export type FastModeRow = keyof FastModeSelectorConfig;
 
 const ROWS: readonly FastModeRow[] = ["chat", "workflow"];
 const LABEL_WIDTH = 16;
-const DESCRIPTION = "Priority tier for supported OpenAI and shared ChatGPT Codex transports.";
+const DESCRIPTION = "Use faster routing for the selected model when supported by its provider.";
 const ROW_DETAILS: Record<FastModeRow, { label: string; scope: string }> = {
 	chat: {
 		label: "Chat",
@@ -40,7 +40,7 @@ export class FastModeSelectorComponent {
 	invalidate(): void {}
 
 	render(width: number): string[] {
-		const lines: string[] = [truncateToWidth(theme.bold(theme.fg("accent", "Codex fast mode")), width)];
+		const lines: string[] = [truncateToWidth(theme.bold(theme.fg("accent", "Fast mode")), width)];
 		for (const line of wrapTextWithAnsi(DESCRIPTION, Math.max(20, width))) {
 			lines.push(theme.fg("muted", line));
 		}

--- a/packages/coding-agent/src/modes/interactive/interactive-selectors.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-selectors.ts
@@ -47,7 +47,7 @@ InteractiveModeBase.prototype.showSelector = function (
 
 InteractiveModeBase.prototype.showFastModeSelector = function (this: InteractiveModeBase): void {
 	if (!this.hasCodexFastModeSupportedModels()) {
-		this.showWarning("Codex fast mode requires a supported OpenAI or shared ChatGPT Codex transport model.");
+		this.showWarning("Fast mode isn't available for any configured model.");
 		return;
 	}
 

--- a/packages/coding-agent/test/fast-mode-selector.test.ts
+++ b/packages/coding-agent/test/fast-mode-selector.test.ts
@@ -19,8 +19,8 @@ describe("FastModeSelectorComponent", () => {
 
 		const rendered = plainRender(selector);
 
-		expect(rendered).toContain("Codex fast mode");
-		expect(rendered).toContain("Priority tier for supported OpenAI and shared ChatGPT Codex transports.");
+		expect(rendered).toContain("Fast mode");
+		expect(rendered).toContain("Use faster routing for the selected model when supported by its provider.");
 		expect(rendered).toContain("Chat");
 		expect(rendered).toContain("Workflow stages");
 		expect(rendered).toContain("[○ OFF]");


### PR DESCRIPTION
## Summary

Make `/fast` UI copy provider-neutral now that fast mode supports both OpenAI routing and GitHub Copilot fast model variants.

## Changes

- Rename the selector heading from "Codex fast mode" to "Fast mode"
- Describe fast mode in terms of the selected model and provider
- Generalize the unavailable warning and slash-command description
- Update selector coverage and the package changelog

## Testing

- `npx vitest --run test/fast-mode-selector.test.ts`
- `npx biome check src/modes/interactive/components/fast-mode-selector.ts src/modes/interactive/interactive-selectors.ts src/core/slash-commands.ts test/fast-mode-selector.test.ts CHANGELOG.md`
- `npm run check` via commit hooks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790578223&installation_model_id=10562&pr_number=2762&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2762&signature=6b5a70af22adc7ba07b3bc1367c34ad32f8c95a7b7ff71bce02491cb69e8f90f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change updates `/fast` and the fast-mode selector so users see provider-neutral wording. The focused selector test passed, and a runtime check confirmed that the selector renders “Fast mode” with the new description and that the registered `/fast` command no longer mentions OpenAI, Codex, or ChatGPT.

The potential regression that the updated copy would not render or would leave provider-specific command wording was disproved by the executed selector rendering and slash-command checks. No defects were found; the change is safe to merge.

<h3>Confidence Score: 5/5</h3>

The updated command and interactive selector copy render as intended and retain the existing fast-mode selector behavior.

Focused automated coverage passed, and a runtime assertion compared the parent and updated revisions to confirm the intended provider-neutral wording in both the slash command and rendered selector.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before the change, the /fast surface rendered Codex fast mode copy, as described in the general contract validation context.
- After the change, the /fast surface now shows the message 'Configure fast mode for chat and workflows on supported models' and the selector heading, description, and provider-neutral checks pass.
- The implementation areas were reviewed and confirmed to include the referenced files slash-commands.ts and fast-mode-selector.ts at the cited lines, aligning with the validation described in the proof.

<a href="https://app.greptile.com/trex/runs/21372717/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): make fast mode copy provider-ne..."](https://github.com/bastani-inc/atomic/commit/68ac0f0a7408ce62fa0f4781d79db6cf0f2e74f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58174211)</sub>

<!-- /greptile_comment -->