### PR TITLE
docs(changelog): prepare 0.9.16-alpha.11 release notes

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,8 @@ This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history at t
 
 ## [Unreleased]
 
+## [0.9.16-alpha.11] - 2026-08-28
+
 ### Added
 
 - Added the Meta Muse Image and Recraft V4 Styles, V4 Styles Pro, V4 Styles Pro Vector, and V4 Styles Vector image models to the generated OpenRouter catalog.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.16-alpha.11] - 2026-08-28
+
 ### Added
 
 - Added JSON-only terminal capability overrides for hyperlinks, Kitty/iTerm2 images, and truecolor, plus a live `fullscreenCopyOnSelect` setting. With automatic selection copying disabled, Ctrl+X copies the retained fullscreen selection before falling back to the last assistant message, while `/copy` keeps its last-message behavior and workflow/scoped-selector hierarchy transitions retain precedence.

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.16-alpha.11] - 2026-08-28
+
 ### Changed
 
 - Intercom can no longer be disabled with `enabled: false`; Atomic always loads and registers the lightweight ordinary `intercom` tool while keeping broker connection and heavy initialization lazy. `contact_supervisor` remains subagent-only.

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.16-alpha.11] - 2026-08-28
+
 ### Changed
 
 - Explicit child extension allowlists and legacy `enabled: false` Intercom config no longer remove ordinary `intercom` or suppress authorized subagent supervisor bridging. `contact_supervisor` remains admitted only to delegated children.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.16-alpha.11] - 2026-08-28
+
 ### Changed
 
 - Every workflow model stage now retains ordinary `intercom` and its invocation group through `tools`, `excludedTools`, `noTools`, extension restrictions, and reload. Restrictions on every other tool and workflow group isolation are unchanged.


### PR DESCRIPTION
## Summary

Prepares the package changelogs for the `0.9.16-alpha.11` prerelease by moving the accumulated `[Unreleased]` entries into dated release sections. This changelog-only PR must merge before the release tag is cut.

## Changes

- Records JSON-only terminal capability overrides, live `fullscreenCopyOnSelect`, and the Pi 0.84.4 runtime bump.
- Records ordinary bundled `intercom` as a mandatory runtime tool, including Intercom always-on loading and subagent/workflow retention of the ordinary tool and invocation group.
- Records Git-installed workflow TypeBox loader discovery and isolation of hung durable writes across independent workflows.
- Records Copilot fast-mode copy, subagent fast-mode inheritance, and resolved-alias API metadata on Codex Responses.

## Scope

The diff contains only these files:

- `packages/ai/CHANGELOG.md`
- `packages/coding-agent/CHANGELOG.md`
- `packages/intercom/CHANGELOG.md`
- `packages/subagents/CHANGELOG.md`
- `packages/workflows/CHANGELOG.md`

All eight package manifests, workspace lock entries, Cargo metadata, and generated native version checks remain at `0.0.0`. The target version appears nowhere outside package changelogs.

`main` stays versionless. After this PR merges, `scripts/cut-release.ts` will stamp `0.9.16-alpha.11` only on the detached release commit. Pushing that tag starts `publish.yml`; this PR does not tag or publish.

## Validation

- `bun run check`
- `bun run vitest --run --project unit test/unit/build-release-notes.test.ts test/unit/changelog.test.ts test/unit/package-metadata.test.ts test/unit/bump-version-script.test.ts` (35 tests passed)
- `bun run scripts/build-release-notes.ts 0.9.16-alpha.11`
- Bun-based versionless invariant check across package manifests, `package-lock.json`, Cargo metadata, and `packages/natives/native/index.js`
- `git diff --check`

Assistant-model: Grok 4.6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790578607&installation_model_id=10562&pr_number=2763&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2763&signature=22976a07516ba26b95bfbd8c763c85fb9cebc7663693090e79885313a8396cc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change promotes the accumulated package release notes into dated `0.9.16-alpha.11` sections for AI, coding-agent, Intercom, subagents, and workflows.

The release-note generator was exercised against both the parent revision and this revision. The parent correctly has no notes for this version, while this revision generates one merged release note containing entries from all five packages. The promoted entries are no longer included under `Unreleased`.

No defects were found, and the documentation change is safe to merge.

<h3>Confidence Score: 5/5</h3>

The documentation-only release preparation is safe to merge.

The repository's release-note generator was run against both the parent revision and this revision, confirming that the new version is discovered, merged, and complete across every changed package.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification, but its local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.16-alpha.11..."](https://github.com/bastani-inc/atomic/commit/53940c04bbb89018cd9b677b804d1fa8580b5e46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58174955)</sub>

<!-- /greptile_comment -->